### PR TITLE
feat(auth): two-tier JWT scopes via emailVerified claim (closes WARN #2)

### DIFF
--- a/client-tenant/.gitignore
+++ b/client-tenant/.gitignore
@@ -4,3 +4,4 @@ dist-ssr
 *.local
 .vite
 .DS_Store
+tsconfig.tsbuildinfo

--- a/client-tenant/src/App.tsx
+++ b/client-tenant/src/App.tsx
@@ -4,6 +4,7 @@ import { Layout } from '@/components/Layout';
 import { Login } from '@/pages/Login';
 import { Apply } from '@/pages/Apply';
 import { AuthCallback } from '@/pages/AuthCallback';
+import { VerifyPending } from '@/pages/VerifyPending';
 import { Dashboard } from '@/pages/Dashboard';
 import { Pay } from '@/pages/Pay';
 import { Ledger } from '@/pages/Ledger';
@@ -22,6 +23,7 @@ export default function App() {
       <Route path="/login" element={<Login />} />
       <Route path="/apply" element={<Apply />} />
       <Route path="/auth/callback" element={<AuthCallback />} />
+      <Route path="/verify-pending" element={<VerifyPending />} />
 
       <Route element={<AuthGuard />}>
         <Route element={<Layout />}>

--- a/client-tenant/src/api/client.ts
+++ b/client-tenant/src/api/client.ts
@@ -37,6 +37,18 @@ async function request<T>(
 
   if (!res.ok) {
     const body = await res.json().catch(() => ({ error: res.statusText }));
+    // WARN #2: an unverified applicant hitting a gated route gets 403 +
+    // code "EMAIL_UNVERIFIED". Bounce to the verify-pending page rather
+    // than surfacing a raw error — the user just needs to click their link.
+    if (
+      res.status === 403 &&
+      body?.code === "EMAIL_UNVERIFIED" &&
+      typeof window !== "undefined" &&
+      !window.location.pathname.startsWith("/verify-pending")
+    ) {
+      window.location.href = "/verify-pending";
+      throw new Error("Email verification required");
+    }
     let msg = body.error || `Request failed: ${res.status}`;
     if (Array.isArray(body.details) && body.details.length > 0) {
       const fields = body.details

--- a/client-tenant/src/pages/Apply.tsx
+++ b/client-tenant/src/pages/Apply.tsx
@@ -1,7 +1,8 @@
-import { useState } from 'react';
-import { useNavigate, Link } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import { useNavigate, useSearchParams, Link } from 'react-router-dom';
 import { api, setToken } from '@/api/client';
-import { CheckCircle } from 'lucide-react';
+import { requestMagicLink } from '@/api/auth';
+import { CheckCircle, Mail } from 'lucide-react';
 
 interface Property {
   id: string;
@@ -11,11 +12,13 @@ interface Property {
   state?: string;
 }
 
-type Step = 1 | 2;
+// Step 1: register → Step "verify": check email (polls /auth/me) → Step 2: details.
+type Step = 1 | 'verify' | 2;
 
 export function Apply() {
   const navigate = useNavigate();
-  const [step, setStep] = useState<Step>(1);
+  const [search] = useSearchParams();
+  const [step, setStep] = useState<Step>(search.get('step') === '2' ? 2 : 1);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [done, setDone] = useState(false);
@@ -26,7 +29,7 @@ export function Apply() {
   const [lastName, setLastName] = useState('');
   const [phone, setPhone] = useState('');
 
-  // Properties for dropdown
+  // Properties for dropdown (loaded in step 2)
   const [properties, setProperties] = useState<Property[]>([]);
   const [propertiesLoading, setPropertiesLoading] = useState(false);
   const [propertiesFailed, setPropertiesFailed] = useState(false);
@@ -46,32 +49,70 @@ export function Apply() {
   const [householdSize, setHouseholdSize] = useState('1');
   const [moveInDate, setMoveInDate] = useState('');
 
+  // Verify-stage state
+  const [resending, setResending] = useState(false);
+  const [resent, setResent] = useState(false);
+
+  // Poll /auth/me while in the verify stage; advance when the server reports
+  // emailVerified=true (the user clicked the magic link, here or in another tab).
+  useEffect(() => {
+    if (step !== 'verify') return;
+    let cancelled = false;
+    async function check() {
+      try {
+        const res = await api.get<{ user?: { email: string; emailVerified: boolean } }>('/auth/me');
+        if (cancelled) return;
+        if (res.user?.emailVerified) setStep(2);
+      } catch {
+        // ignored — 401 will be handled by client.ts redirect
+      }
+    }
+    check();
+    const interval = setInterval(check, 5000);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, [step]);
+
+  // Once we land on step 2 (either via verify polling or via ?step=2 deep link),
+  // fetch properties so the applicant can pick one.
+  useEffect(() => {
+    if (step !== 2 || properties.length > 0 || propertiesLoading) return;
+    let cancelled = false;
+    (async () => {
+      setPropertiesLoading(true);
+      try {
+        const data = await api.get<{ properties: Property[] } | Property[]>('/applicants/properties');
+        if (cancelled) return;
+        const list = Array.isArray(data) ? data : (data as { properties: Property[] }).properties ?? [];
+        setProperties(list);
+      } catch {
+        if (!cancelled) setPropertiesFailed(true);
+      } finally {
+        if (!cancelled) setPropertiesLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [step, properties.length, propertiesLoading]);
+
   async function handleStep1(e: React.FormEvent) {
     e.preventDefault();
     setError(null);
     setLoading(true);
     try {
-      const res = await api.post<any>('/applicants/register', {
+      const res = await api.post<{ token?: string }>('/applicants/register', {
         email,
         firstName,
         lastName,
         phone: phone || undefined,
       });
       if (res.token) setToken(res.token);
-
-      // Fetch properties now that we have a token
-      setPropertiesLoading(true);
-      try {
-        const data = await api.get<{ properties: Property[] } | Property[]>('/applicants/properties');
-        const list = Array.isArray(data) ? data : (data as any).properties ?? [];
-        setProperties(list);
-      } catch {
-        setPropertiesFailed(true);
-      } finally {
-        setPropertiesLoading(false);
-      }
-
-      setStep(2);
+      // The token is emailVerified=false — go to the verify stage. The user
+      // must click the magic link in their inbox before /apply will accept us.
+      setStep('verify');
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Registration failed');
     } finally {
@@ -92,7 +133,7 @@ export function Apply() {
     setError(null);
     setLoading(true);
     try {
-      await api.post<any>('/applicants/apply', {
+      await api.post('/applicants/apply', {
         propertyId: propertyId || undefined,
         unitNumber: unitNumber || undefined,
         firstName,
@@ -120,6 +161,20 @@ export function Apply() {
     }
   }
 
+  async function handleResend() {
+    if (!email) return;
+    setResending(true);
+    setError(null);
+    try {
+      await requestMagicLink(email);
+      setResent(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not resend link');
+    } finally {
+      setResending(false);
+    }
+  }
+
   if (done) {
     return (
       <div className="flex min-h-screen items-center justify-center bg-gray-50 p-4">
@@ -132,18 +187,22 @@ export function Apply() {
     );
   }
 
+  // Progress indicator — verify shares position with step 1 (it's a sub-state
+  // of the "Account" phase, before the form details start).
+  const progressActive: 1 | 2 = step === 2 ? 2 : 1;
+
   return (
     <div className="min-h-screen bg-gray-50 p-4">
       <div className="mx-auto max-w-md space-y-6 py-8">
         {/* Progress */}
         <div className="flex items-center gap-2">
-          {([1, 2] as Step[]).map(s => (
+          {([1, 2] as const).map(s => (
             <div key={s} className="flex items-center gap-2">
               <div className={`flex h-7 w-7 items-center justify-center rounded-full text-xs font-bold
-                ${step === s ? 'bg-emerald-600 text-white' : step > s ? 'bg-emerald-100 text-emerald-700' : 'bg-gray-200 text-gray-500'}`}>
+                ${progressActive === s ? 'bg-emerald-600 text-white' : progressActive > s ? 'bg-emerald-100 text-emerald-700' : 'bg-gray-200 text-gray-500'}`}>
                 {s}
               </div>
-              <span className={`text-xs ${step === s ? 'font-medium text-gray-900' : 'text-gray-400'}`}>
+              <span className={`text-xs ${progressActive === s ? 'font-medium text-gray-900' : 'text-gray-400'}`}>
                 {s === 1 ? 'Account' : 'Application'}
               </span>
               {s < 2 && <div className="mx-1 h-px w-8 bg-gray-300" />}
@@ -183,6 +242,39 @@ export function Apply() {
                 </button>
               </form>
             </>
+          )}
+
+          {step === 'verify' && (
+            <div className="space-y-4 text-center">
+              <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-xl bg-emerald-100">
+                <Mail className="h-6 w-6 text-emerald-700" />
+              </div>
+              <h1 className="text-xl font-bold text-gray-900">Check your email</h1>
+              <p className="text-sm text-gray-500">
+                We sent a verification link to{' '}
+                <span className="font-medium text-gray-900">{email}</span>. Click
+                it to continue your application. This page will advance
+                automatically.
+              </p>
+              {resent && (
+                <div className="rounded-lg bg-emerald-50 p-3 text-sm text-emerald-700">
+                  Link resent
+                </div>
+              )}
+              <button
+                onClick={handleResend}
+                disabled={resending || !email}
+                className="btn-primary w-full"
+              >
+                {resending ? 'Resending…' : 'Resend link'}
+              </button>
+              <button
+                onClick={() => setStep(1)}
+                className="text-sm text-gray-500 hover:text-gray-700 hover:underline"
+              >
+                Use a different email
+              </button>
+            </div>
           )}
 
           {step === 2 && (

--- a/client-tenant/src/pages/VerifyPending.tsx
+++ b/client-tenant/src/pages/VerifyPending.tsx
@@ -1,0 +1,114 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Mail, CheckCircle } from 'lucide-react';
+import { api, clearToken } from '@/api/client';
+import { requestMagicLink } from '@/api/auth';
+
+interface MeResponse {
+  user?: {
+    id: string;
+    email: string;
+    emailVerified: boolean;
+  };
+}
+
+export function VerifyPending() {
+  const navigate = useNavigate();
+  const [email, setEmail] = useState('');
+  const [resending, setResending] = useState(false);
+  const [resent, setResent] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Poll /auth/me every 5s. As soon as the server reports emailVerified=true
+  // (i.e. the user clicked the magic link in another tab), continue to the
+  // application form.
+  useEffect(() => {
+    let cancelled = false;
+    let interval: ReturnType<typeof setInterval> | null = null;
+
+    async function check() {
+      try {
+        const res = await api.get<MeResponse>('/auth/me');
+        if (cancelled) return;
+        if (res.user) {
+          setEmail(res.user.email);
+          if (res.user.emailVerified) {
+            if (interval) clearInterval(interval);
+            navigate('/apply?step=2');
+          }
+        }
+      } catch {
+        // 401 means token is gone — let client.ts redirect handle it.
+      }
+    }
+
+    check();
+    interval = setInterval(check, 5000);
+    return () => {
+      cancelled = true;
+      if (interval) clearInterval(interval);
+    };
+  }, [navigate]);
+
+  async function handleResend() {
+    if (!email) return;
+    setResending(true);
+    setError(null);
+    try {
+      await requestMagicLink(email);
+      setResent(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not resend link');
+    } finally {
+      setResending(false);
+    }
+  }
+
+  function handleSignOut() {
+    clearToken();
+    navigate('/login');
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gray-50 p-4">
+      <div className="w-full max-w-sm space-y-6 text-center">
+        <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-xl bg-emerald-600">
+          <Mail className="h-6 w-6 text-white" />
+        </div>
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">Check your email</h1>
+          <p className="mt-2 text-sm text-gray-500">
+            We sent a verification link to{' '}
+            <span className="font-medium text-gray-900">{email || 'your inbox'}</span>.
+            Click it to continue your application.
+          </p>
+        </div>
+
+        {resent && (
+          <div className="flex items-center justify-center gap-2 rounded-lg bg-emerald-50 p-3 text-sm text-emerald-700">
+            <CheckCircle className="h-4 w-4" />
+            Link resent
+          </div>
+        )}
+        {error && (
+          <div className="rounded-lg bg-red-50 p-3 text-sm text-red-700">{error}</div>
+        )}
+
+        <button
+          onClick={handleResend}
+          disabled={resending || !email}
+          className="btn-primary w-full"
+        >
+          {resending ? 'Resending…' : 'Resend link'}
+        </button>
+
+        <button
+          onClick={handleSignOut}
+          className="text-sm text-gray-500 hover:text-gray-700 hover:underline"
+        >
+          Use a different email
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/__tests__/adverse-action-routes.test.ts
+++ b/src/__tests__/adverse-action-routes.test.ts
@@ -56,6 +56,7 @@ const leasingAgent: AuthUser = {
   firstName: "Alice",
   lastName: "Agent",
   propertyIds: ["prop-001"],
+  emailVerified: true,
 };
 
 const seniorManager: AuthUser = {
@@ -65,6 +66,7 @@ const seniorManager: AuthUser = {
   firstName: "Bob",
   lastName: "Manager",
   propertyIds: ["prop-001"],
+  emailVerified: true,
 };
 
 const assetManager: AuthUser = {
@@ -74,6 +76,7 @@ const assetManager: AuthUser = {
   firstName: "Carol",
   lastName: "Asset",
   propertyIds: [],
+  emailVerified: true,
 };
 
 function tokenFor(user: AuthUser): string {

--- a/src/__tests__/applicants-routes-warn2.test.ts
+++ b/src/__tests__/applicants-routes-warn2.test.ts
@@ -1,0 +1,243 @@
+/**
+ * WARN #2 route-layer tests for src/modules/applicants/routes.ts.
+ *
+ * Covers the two-tier scope cutover:
+ *   - POST /applicants/register issues a token with emailVerified=false
+ *   - POST /applicants/apply is gated by requireEmailVerified (returns
+ *     403 + code "EMAIL_UNVERIFIED" for an unverified applicant)
+ *   - After verifyMagicLink stamps users.email_verified_at, /apply is
+ *     reachable and the application is created.
+ *
+ * Auth strategy: real JWTs decoded against the mocked users DB row.
+ * Service strategy: ApplicationService.create is mocked so this stays a
+ * route-layer test (service-level concerns are covered elsewhere).
+ */
+import express from "express";
+import request from "supertest";
+import jwt from "jsonwebtoken";
+import { generateToken, AuthUser } from "../middleware/auth";
+
+jest.mock("../config/database", () => ({ query: jest.fn(), transaction: jest.fn() }));
+jest.mock("../utils/logger", () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+const mockCreate = jest.fn();
+jest.mock("../modules/application/service", () => ({
+  ApplicationService: jest.fn().mockImplementation(() => ({
+    create: mockCreate,
+  })),
+}));
+
+// magic-link-service is invoked by /register — stub it so the route stops
+// at JWT issuance without touching the (mocked) DB-token flow.
+const mockCreateMagicLink = jest.fn();
+const mockLogMagicLink = jest.fn();
+jest.mock("../modules/auth/magic-link-service", () => ({
+  createMagicLink: mockCreateMagicLink,
+  logMagicLink: mockLogMagicLink,
+}));
+
+import { query } from "../config/database";
+import applicantsRouter from "../modules/applicants/routes";
+
+const mockQuery = query as jest.MockedFunction<typeof query>;
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/applicants", applicantsRouter);
+  return app;
+}
+const app = buildApp();
+
+function decode(token: string): any {
+  return jwt.decode(token);
+}
+
+/** Stub the users row that authenticate() reads. */
+function mockUsersRow(user: Partial<AuthUser> & { id: string; email: string; role: string }, emailVerifiedAt: Date | null) {
+  mockQuery.mockResolvedValueOnce({
+    rows: [
+      {
+        id: user.id,
+        email: user.email,
+        role: user.role,
+        first_name: user.firstName ?? "Test",
+        last_name: user.lastName ?? "User",
+        property_ids: user.propertyIds ?? [],
+        is_active: true,
+        email_verified_at: emailVerifiedAt,
+      },
+    ],
+  } as any);
+}
+
+describe("POST /applicants/register (WARN #2)", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("issues a JWT with emailVerified=false for a brand-new account", async () => {
+    // Existence check — no user yet.
+    mockQuery.mockResolvedValueOnce({ rows: [] } as any);
+    // INSERT users
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: "new-user-001" }] } as any);
+    // SELECT after insert (route reads the row to build AuthUser)
+    mockQuery.mockResolvedValueOnce({
+      rows: [{
+        id: "new-user-001",
+        email: "victim@example.com",
+        role: "applicant",
+        first_name: "Vic",
+        last_name: "Tim",
+      }],
+    } as any);
+    mockCreateMagicLink.mockResolvedValueOnce({ link: "http://localhost:5174/auth/callback?token=raw", userId: "new-user-001" });
+
+    const res = await request(app)
+      .post("/applicants/register")
+      .send({ email: "victim@example.com", firstName: "Vic", lastName: "Tim" });
+
+    expect(res.status).toBe(202);
+    expect(res.body.token).toBeDefined();
+    const claims = decode(res.body.token);
+    expect(claims.emailVerified).toBe(false);
+    expect(claims.id).toBe("new-user-001");
+    expect(claims.role).toBe("applicant");
+  });
+
+  it("never returns a token for a pre-existing applicant account", async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: "existing-001", role: "applicant", is_active: true }],
+    } as any);
+    mockCreateMagicLink.mockResolvedValueOnce({ link: "http://x/auth/callback?token=raw", userId: "existing-001" });
+
+    const res = await request(app)
+      .post("/applicants/register")
+      .send({ email: "existing@example.com", firstName: "Ex", lastName: "Ists" });
+
+    expect(res.status).toBe(202);
+    expect(res.body.token).toBeUndefined();
+  });
+});
+
+describe("POST /applicants/apply (WARN #2 gate)", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  const applicant: AuthUser = {
+    id: "applicant-001",
+    email: "a@x.com",
+    role: "applicant",
+    firstName: "Ann",
+    lastName: "App",
+    propertyIds: [],
+    emailVerified: false,
+  };
+
+  it("returns 403 with code EMAIL_UNVERIFIED when applicant has not verified", async () => {
+    mockUsersRow(applicant, null);
+    const token = generateToken(applicant, { emailVerified: false });
+    const res = await request(app)
+      .post("/applicants/apply")
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        propertyId: "550e8400-e29b-41d4-a716-446655440000",
+        firstName: "Ann",
+        lastName: "App",
+        ssn: "111-22-3333",
+        dateOfBirth: "1990-01-01",
+      });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toMatch(/verification/i);
+    expect(res.body.code).toBe("EMAIL_UNVERIFIED");
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it("ignores a forged emailVerified=true claim when DB says not verified", async () => {
+    mockUsersRow(applicant, null);
+    // Attacker claims verified — DB says no — DB wins.
+    const token = generateToken(applicant, { emailVerified: true });
+    const res = await request(app)
+      .post("/applicants/apply")
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        propertyId: "550e8400-e29b-41d4-a716-446655440000",
+        firstName: "Ann",
+        lastName: "App",
+        ssn: "111-22-3333",
+        dateOfBirth: "1990-01-01",
+      });
+
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe("EMAIL_UNVERIFIED");
+  });
+
+  it("accepts a verified applicant and delegates to ApplicationService.create", async () => {
+    mockUsersRow(applicant, new Date("2026-05-13T00:00:00Z"));
+    mockCreate.mockResolvedValueOnce({ id: "app-001", status: "draft", created_at: new Date() });
+    // INSERT user_applications join
+    mockQuery.mockResolvedValueOnce({ rows: [] } as any);
+
+    const token = generateToken(applicant, { emailVerified: false }); // stale token; DB upgrades it
+    const res = await request(app)
+      .post("/applicants/apply")
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        propertyId: "550e8400-e29b-41d4-a716-446655440000",
+        firstName: "Ann",
+        lastName: "App",
+        ssn: "111-22-3333",
+        dateOfBirth: "1990-01-01",
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body.id).toBe("app-001");
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("GET /applicants/me/applications (WARN #2 gate)", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  const tenant: AuthUser = {
+    id: "tenant-001",
+    email: "t@x.com",
+    role: "tenant",
+    firstName: "T",
+    lastName: "T",
+    propertyIds: [],
+    emailVerified: false,
+  };
+
+  it("returns 403 EMAIL_UNVERIFIED for unverified tenant", async () => {
+    mockUsersRow(tenant, null);
+    const token = generateToken(tenant, { emailVerified: false });
+    const res = await request(app)
+      .get("/applicants/me/applications")
+      .set("Authorization", `Bearer ${token}`);
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe("EMAIL_UNVERIFIED");
+  });
+
+  it("returns the application list when verified", async () => {
+    mockUsersRow(tenant, new Date());
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: "app-9", first_name: "T" }] } as any);
+    const token = generateToken(tenant, { emailVerified: true });
+    const res = await request(app)
+      .get("/applicants/me/applications")
+      .set("Authorization", `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(res.body.applications).toHaveLength(1);
+  });
+});
+
+describe("GET /applicants/properties (public, ungated)", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("does not require any authentication", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: "prop-1", name: "Sunny Hills" }] } as any);
+    const res = await request(app).get("/applicants/properties");
+    expect(res.status).toBe(200);
+    expect(res.body.properties).toHaveLength(1);
+  });
+});

--- a/src/__tests__/application-routes.test.ts
+++ b/src/__tests__/application-routes.test.ts
@@ -66,6 +66,7 @@ const testUser: AuthUser = {
   firstName: "Alice",
   lastName: "Agent",
   propertyIds: ["prop-001"],
+  emailVerified: true,
 };
 
 /** A valid senior_manager user. */
@@ -76,6 +77,7 @@ const managerUser: AuthUser = {
   firstName: "Bob",
   lastName: "Manager",
   propertyIds: ["prop-001"],
+  emailVerified: true,
 };
 
 function tokenFor(user: AuthUser): string {

--- a/src/__tests__/approval-routes.test.ts
+++ b/src/__tests__/approval-routes.test.ts
@@ -56,6 +56,7 @@ const leasingAgent: AuthUser = {
   firstName: "Alice",
   lastName: "Agent",
   propertyIds: ["prop-001"],
+  emailVerified: true,
 };
 
 const seniorManager: AuthUser = {
@@ -65,6 +66,7 @@ const seniorManager: AuthUser = {
   firstName: "Bob",
   lastName: "Manager",
   propertyIds: ["prop-001"],
+  emailVerified: true,
 };
 
 const regionalManager: AuthUser = {
@@ -74,6 +76,7 @@ const regionalManager: AuthUser = {
   firstName: "Carol",
   lastName: "Regional",
   propertyIds: ["prop-001"],
+  emailVerified: true,
 };
 
 const assetManager: AuthUser = {
@@ -83,6 +86,7 @@ const assetManager: AuthUser = {
   firstName: "Dave",
   lastName: "Asset",
   propertyIds: ["prop-001"],
+  emailVerified: true,
 };
 
 function tokenFor(user: AuthUser): string {

--- a/src/__tests__/auth-and-app-routes.test.ts
+++ b/src/__tests__/auth-and-app-routes.test.ts
@@ -58,6 +58,7 @@ const leasingAgent: AuthUser = {
   firstName: "Alice",
   lastName: "Agent",
   propertyIds: ["prop-001"],
+  emailVerified: true,
 };
 
 const seniorManager: AuthUser = {
@@ -67,6 +68,7 @@ const seniorManager: AuthUser = {
   firstName: "Bob",
   lastName: "Manager",
   propertyIds: ["prop-001"],
+  emailVerified: true,
 };
 
 const regionalManager: AuthUser = {
@@ -76,6 +78,7 @@ const regionalManager: AuthUser = {
   firstName: "Carol",
   lastName: "Regional",
   propertyIds: ["prop-001"],
+  emailVerified: true,
 };
 
 function tokenFor(user: AuthUser): string {

--- a/src/__tests__/auth-email-verified.test.ts
+++ b/src/__tests__/auth-email-verified.test.ts
@@ -1,0 +1,110 @@
+/**
+ * WARN #2 middleware-level tests: authenticate() emailVerified resolution.
+ *
+ * The contract:
+ *  - A token with no `emailVerified` claim resolves to false (legacy/forged).
+ *  - The DB column `users.email_verified_at` always wins over the token's claim
+ *    in BOTH directions:
+ *      * token says true, DB says null → req.user.emailVerified = false
+ *      * token says false, DB says timestamped → req.user.emailVerified = true
+ */
+import express from "express";
+import request from "supertest";
+import jwt from "jsonwebtoken";
+import { authenticate, AuthRequest, generateToken, AuthUser } from "../middleware/auth";
+
+jest.mock("../config/database", () => ({ query: jest.fn(), transaction: jest.fn() }));
+jest.mock("../utils/logger", () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+import { query } from "../config/database";
+const mockQuery = query as jest.MockedFunction<typeof query>;
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.get("/protected", authenticate, (req: AuthRequest, res) => {
+    res.json({ emailVerified: req.user?.emailVerified });
+  });
+  return app;
+}
+const app = buildApp();
+
+const user: AuthUser = {
+  id: "u-001",
+  email: "a@x.com",
+  role: "applicant",
+  firstName: "A",
+  lastName: "A",
+  propertyIds: [],
+  emailVerified: false,
+};
+
+function mockUsersRow(emailVerifiedAt: Date | null) {
+  mockQuery.mockResolvedValueOnce({
+    rows: [
+      {
+        id: user.id,
+        email: user.email,
+        role: user.role,
+        first_name: user.firstName,
+        last_name: user.lastName,
+        property_ids: user.propertyIds,
+        is_active: true,
+        email_verified_at: emailVerifiedAt,
+      },
+    ],
+  } as any);
+}
+
+describe("authenticate() emailVerified resolution (WARN #2)", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("DB null overrides a token claiming emailVerified=true", async () => {
+    mockUsersRow(null);
+    const token = generateToken(user, { emailVerified: true }); // attacker-forged or stale
+    const res = await request(app)
+      .get("/protected")
+      .set("Authorization", `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(res.body.emailVerified).toBe(false);
+  });
+
+  it("DB timestamped overrides a token claiming emailVerified=false (stale token upgrade)", async () => {
+    mockUsersRow(new Date("2026-05-13T12:00:00Z"));
+    const token = generateToken(user, { emailVerified: false });
+    const res = await request(app)
+      .get("/protected")
+      .set("Authorization", `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(res.body.emailVerified).toBe(true);
+  });
+
+  it("a legacy token with no emailVerified claim resolves from DB (here: false)", async () => {
+    mockUsersRow(null);
+    // Hand-craft a token without the emailVerified claim
+    const legacy = jwt.sign(
+      { id: user.id, email: user.email, role: user.role, firstName: user.firstName, lastName: user.lastName, propertyIds: [] },
+      "dev-secret-change-me",
+      { expiresIn: "1h" }
+    );
+    const res = await request(app)
+      .get("/protected")
+      .set("Authorization", `Bearer ${legacy}`);
+    expect(res.status).toBe(200);
+    expect(res.body.emailVerified).toBe(false);
+  });
+
+  it("generateToken with no opts defaults to authUser.emailVerified (false here)", () => {
+    const tok = generateToken({ ...user, emailVerified: false });
+    const decoded = jwt.decode(tok) as any;
+    expect(decoded.emailVerified).toBe(false);
+  });
+
+  it("generateToken with no opts and authUser.emailVerified=true emits true", () => {
+    const tok = generateToken({ ...user, emailVerified: true });
+    const decoded = jwt.decode(tok) as any;
+    expect(decoded.emailVerified).toBe(true);
+  });
+});

--- a/src/__tests__/decision-matrix-routes.test.ts
+++ b/src/__tests__/decision-matrix-routes.test.ts
@@ -59,6 +59,7 @@ const leasingAgent: AuthUser = {
   firstName: "Alice",
   lastName: "Agent",
   propertyIds: ["prop-001"],
+  emailVerified: true,
 };
 
 const seniorManager: AuthUser = {
@@ -68,6 +69,7 @@ const seniorManager: AuthUser = {
   firstName: "Bob",
   lastName: "Manager",
   propertyIds: ["prop-001"],
+  emailVerified: true,
 };
 
 const regionalManager: AuthUser = {
@@ -77,6 +79,7 @@ const regionalManager: AuthUser = {
   firstName: "Carol",
   lastName: "Regional",
   propertyIds: ["prop-001"],
+  emailVerified: true,
 };
 
 function tokenFor(user: AuthUser): string {

--- a/src/__tests__/fair-housing-routes.test.ts
+++ b/src/__tests__/fair-housing-routes.test.ts
@@ -50,6 +50,7 @@ const leasingAgent: AuthUser = {
   firstName: "Alice",
   lastName: "Agent",
   propertyIds: [],
+  emailVerified: true,
 };
 
 const seniorManager: AuthUser = {
@@ -59,6 +60,7 @@ const seniorManager: AuthUser = {
   firstName: "Bob",
   lastName: "Manager",
   propertyIds: [],
+  emailVerified: true,
 };
 
 const regionalManager: AuthUser = {
@@ -68,6 +70,7 @@ const regionalManager: AuthUser = {
   firstName: "Carol",
   lastName: "Regional",
   propertyIds: [],
+  emailVerified: true,
 };
 
 function tokenFor(user: AuthUser): string {

--- a/src/__tests__/lease-routes.test.ts
+++ b/src/__tests__/lease-routes.test.ts
@@ -52,6 +52,7 @@ const leasingAgent: AuthUser = {
   firstName: "Alice",
   lastName: "Agent",
   propertyIds: ["prop-001"],
+  emailVerified: true,
 };
 
 const seniorManager: AuthUser = {
@@ -61,6 +62,7 @@ const seniorManager: AuthUser = {
   firstName: "Bob",
   lastName: "Manager",
   propertyIds: ["prop-001"],
+  emailVerified: true,
 };
 
 const regionalManager: AuthUser = {
@@ -70,6 +72,7 @@ const regionalManager: AuthUser = {
   firstName: "Carol",
   lastName: "Regional",
   propertyIds: ["prop-001"],
+  emailVerified: true,
 };
 
 function tokenFor(user: AuthUser): string {

--- a/src/__tests__/magic-link-verify.test.ts
+++ b/src/__tests__/magic-link-verify.test.ts
@@ -1,0 +1,99 @@
+/**
+ * WARN #2: verifyMagicLink() stamps users.email_verified_at and re-issues
+ * a JWT with emailVerified=true.
+ *
+ * The contract we lock in:
+ *   1. Successful verify → UPDATE users SET email_verified_at = NOW() WHERE
+ *      id = $1 AND email_verified_at IS NULL  (idempotent — second click does not bump)
+ *   2. Returned token has emailVerified=true in its claims.
+ *   3. Returned AuthUser.emailVerified is true.
+ */
+import jwt from "jsonwebtoken";
+
+jest.mock("../config/database", () => ({ query: jest.fn(), transaction: jest.fn() }));
+jest.mock("../utils/logger", () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+import { query } from "../config/database";
+import { verifyMagicLink } from "../modules/auth/magic-link-service";
+
+const mockQuery = query as jest.MockedFunction<typeof query>;
+
+describe("verifyMagicLink (WARN #2)", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("stamps email_verified_at and returns a token with emailVerified=true", async () => {
+    const future = new Date(Date.now() + 10 * 60 * 1000);
+    // SELECT magic_link_tokens JOIN users
+    mockQuery.mockResolvedValueOnce({
+      rows: [{
+        token_id: "tok-1",
+        user_id: "user-1",
+        expires_at: future,
+        used_at: null,
+        email: "applicant@x.com",
+        role: "applicant",
+        first_name: "App",
+        last_name: "Licant",
+        is_active: true,
+      }],
+    } as any);
+    mockQuery.mockResolvedValueOnce({ rows: [] } as any); // UPDATE magic_link_tokens used_at
+    mockQuery.mockResolvedValueOnce({ rows: [] } as any); // UPDATE users last_login
+    mockQuery.mockResolvedValueOnce({ rows: [] } as any); // UPDATE users email_verified_at
+
+    const result = await verifyMagicLink("raw-token-abc123def456ghi789");
+    expect(result).not.toBeNull();
+
+    // The token-stamping UPDATE should match the design exactly.
+    const stampCall = mockQuery.mock.calls[3]!;
+    expect(stampCall[0]).toMatch(/UPDATE users SET email_verified_at = NOW\(\)/i);
+    expect(stampCall[0]).toMatch(/email_verified_at IS NULL/i);
+    expect(stampCall[1]).toEqual(["user-1"]);
+
+    const claims = jwt.decode(result!.token) as any;
+    expect(claims.emailVerified).toBe(true);
+    expect(result!.user.emailVerified).toBe(true);
+  });
+
+  it("returns null and does not stamp anything for an expired token", async () => {
+    const past = new Date(Date.now() - 60 * 1000);
+    mockQuery.mockResolvedValueOnce({
+      rows: [{
+        token_id: "tok-2",
+        user_id: "user-2",
+        expires_at: past,
+        used_at: null,
+        email: "x@x.com",
+        role: "applicant",
+        first_name: "X",
+        last_name: "Y",
+        is_active: true,
+      }],
+    } as any);
+
+    const result = await verifyMagicLink("raw-token-expired1234567");
+    expect(result).toBeNull();
+    expect(mockQuery).toHaveBeenCalledTimes(1); // only the SELECT
+  });
+
+  it("returns null for a previously used token (no double-stamp)", async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{
+        token_id: "tok-3",
+        user_id: "user-3",
+        expires_at: new Date(Date.now() + 60 * 1000),
+        used_at: new Date(),
+        email: "x@x.com",
+        role: "applicant",
+        first_name: "X",
+        last_name: "Y",
+        is_active: true,
+      }],
+    } as any);
+
+    const result = await verifyMagicLink("raw-token-already-used1234");
+    expect(result).toBeNull();
+  });
+});

--- a/src/__tests__/payment-routes.test.ts
+++ b/src/__tests__/payment-routes.test.ts
@@ -58,6 +58,7 @@ const leasingAgent: AuthUser = {
   firstName: "Alice",
   lastName: "Agent",
   propertyIds: ["prop-001"],
+  emailVerified: true,
 };
 
 const seniorManager: AuthUser = {
@@ -67,6 +68,7 @@ const seniorManager: AuthUser = {
   firstName: "Bob",
   lastName: "Manager",
   propertyIds: ["prop-001"],
+  emailVerified: true,
 };
 
 function tokenFor(user: AuthUser): string {

--- a/src/__tests__/property-routes.test.ts
+++ b/src/__tests__/property-routes.test.ts
@@ -56,6 +56,7 @@ const leasingAgent: AuthUser = {
   firstName: "Alice",
   lastName: "Agent",
   propertyIds: ["prop-001"],
+  emailVerified: true,
 };
 
 const seniorManager: AuthUser = {
@@ -65,6 +66,7 @@ const seniorManager: AuthUser = {
   firstName: "Bob",
   lastName: "Manager",
   propertyIds: ["prop-001"],
+  emailVerified: true,
 };
 
 const assetManager: AuthUser = {
@@ -74,6 +76,7 @@ const assetManager: AuthUser = {
   firstName: "Carol",
   lastName: "Asset",
   propertyIds: [],
+  emailVerified: true,
 };
 
 function tokenFor(user: AuthUser): string {

--- a/src/__tests__/screening-routes.test.ts
+++ b/src/__tests__/screening-routes.test.ts
@@ -63,6 +63,7 @@ const leasingAgent: AuthUser = {
   firstName: "Alice",
   lastName: "Agent",
   propertyIds: ["prop-001"],
+  emailVerified: true,
 };
 
 const seniorManager: AuthUser = {
@@ -72,6 +73,7 @@ const seniorManager: AuthUser = {
   firstName: "Bob",
   lastName: "Manager",
   propertyIds: ["prop-001"],
+  emailVerified: true,
 };
 
 const regionalManager: AuthUser = {
@@ -81,6 +83,7 @@ const regionalManager: AuthUser = {
   firstName: "Carol",
   lastName: "Regional",
   propertyIds: ["prop-001"],
+  emailVerified: true,
 };
 
 function tokenFor(user: AuthUser): string {

--- a/src/__tests__/user-routes.test.ts
+++ b/src/__tests__/user-routes.test.ts
@@ -59,6 +59,7 @@ const leasingAgent: AuthUser = {
   firstName: "Alice",
   lastName: "Agent",
   propertyIds: ["prop-001"],
+  emailVerified: true,
 };
 
 const seniorManager: AuthUser = {
@@ -68,6 +69,7 @@ const seniorManager: AuthUser = {
   firstName: "Bob",
   lastName: "Manager",
   propertyIds: ["prop-001"],
+  emailVerified: true,
 };
 
 const assetManager: AuthUser = {
@@ -77,6 +79,7 @@ const assetManager: AuthUser = {
   firstName: "Carol",
   lastName: "Asset",
   propertyIds: [],
+  emailVerified: true,
 };
 
 const systemAdmin: AuthUser = {
@@ -86,6 +89,7 @@ const systemAdmin: AuthUser = {
   firstName: "Dave",
   lastName: "Admin",
   propertyIds: [],
+  emailVerified: true,
 };
 
 function tokenFor(user: AuthUser): string {

--- a/src/__tests__/warn2-jwt-email-proof.test.ts
+++ b/src/__tests__/warn2-jwt-email-proof.test.ts
@@ -1,0 +1,166 @@
+/**
+ * WARN #2 — original attack rendered harmless.
+ *
+ * Pre-fix:
+ *   1. Attacker POSTs /applicants/register with {email: "victim@x"}.
+ *   2. Server creates the account (or finds it) and returns a full-scope JWT
+ *      bound to victim's email.
+ *   3. Attacker uses that JWT to call /applicants/apply or
+ *      /applicants/me/applications and walks away with PII / a planted
+ *      application — without ever clicking the magic link.
+ *
+ * Post-fix:
+ *   - /register still returns a JWT for brand-new accounts (W1 fix retained),
+ *     but that JWT carries emailVerified=false.
+ *   - /apply and /me/applications are gated by requireEmailVerified, so the
+ *     attacker's JWT is rejected with 403 EMAIL_UNVERIFIED.
+ *   - Staff (non-applicant/tenant) roles bypass the gate.
+ */
+import express from "express";
+import request from "supertest";
+import jwt from "jsonwebtoken";
+import { generateToken, AuthUser } from "../middleware/auth";
+
+jest.mock("../config/database", () => ({ query: jest.fn(), transaction: jest.fn() }));
+jest.mock("../utils/logger", () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+const mockCreate = jest.fn();
+jest.mock("../modules/application/service", () => ({
+  ApplicationService: jest.fn().mockImplementation(() => ({ create: mockCreate })),
+}));
+
+const mockCreateMagicLink = jest.fn();
+const mockLogMagicLink = jest.fn();
+jest.mock("../modules/auth/magic-link-service", () => ({
+  createMagicLink: mockCreateMagicLink,
+  logMagicLink: mockLogMagicLink,
+}));
+
+import { query } from "../config/database";
+import applicantsRouter from "../modules/applicants/routes";
+
+const mockQuery = query as jest.MockedFunction<typeof query>;
+
+const app = express();
+app.use(express.json());
+app.use("/applicants", applicantsRouter);
+
+function mockUsersRow(
+  partial: { id: string; email: string; role: string },
+  emailVerifiedAt: Date | null
+) {
+  mockQuery.mockResolvedValueOnce({
+    rows: [
+      {
+        id: partial.id,
+        email: partial.email,
+        role: partial.role,
+        first_name: "X",
+        last_name: "X",
+        property_ids: [],
+        is_active: true,
+        email_verified_at: emailVerifiedAt,
+      },
+    ],
+  } as any);
+}
+
+describe("WARN #2: pre-verification token is harmless on PII / state-changing routes", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("attacker registering victim@x cannot /apply with the returned token", async () => {
+    // ── Step 1: attacker hits /register ──
+    mockQuery.mockResolvedValueOnce({ rows: [] } as any);                      // SELECT users (none)
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: "victim-001" }] } as any); // INSERT users
+    mockQuery.mockResolvedValueOnce({                                          // SELECT after insert
+      rows: [{ id: "victim-001", email: "victim@x.com", role: "applicant", first_name: "V", last_name: "T" }],
+    } as any);
+    mockCreateMagicLink.mockResolvedValueOnce({ link: "http://x/auth/callback?token=raw", userId: "victim-001" });
+
+    const reg = await request(app)
+      .post("/applicants/register")
+      .send({ email: "victim@x.com", firstName: "V", lastName: "T" });
+
+    expect(reg.status).toBe(202);
+    expect(reg.body.token).toBeDefined();
+    const claims = jwt.decode(reg.body.token) as any;
+    expect(claims.emailVerified).toBe(false);
+
+    // ── Step 2: attacker tries to /apply with that token ──
+    mockUsersRow({ id: "victim-001", email: "victim@x.com", role: "applicant" }, null);
+
+    const apply = await request(app)
+      .post("/applicants/apply")
+      .set("Authorization", `Bearer ${reg.body.token}`)
+      .send({
+        propertyId: "550e8400-e29b-41d4-a716-446655440000",
+        firstName: "Attack",
+        lastName: "Er",
+        ssn: "999-99-9999",
+        dateOfBirth: "1990-01-01",
+      });
+
+    expect(apply.status).toBe(403);
+    expect(apply.body.code).toBe("EMAIL_UNVERIFIED");
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it("attacker cannot read /me/applications with the returned token", async () => {
+    mockUsersRow({ id: "victim-002", email: "v2@x.com", role: "applicant" }, null);
+    const token = generateToken(
+      {
+        id: "victim-002",
+        email: "v2@x.com",
+        role: "applicant",
+        firstName: "V",
+        lastName: "T",
+        propertyIds: [],
+        emailVerified: false,
+      },
+      { emailVerified: false }
+    );
+    const res = await request(app)
+      .get("/applicants/me/applications")
+      .set("Authorization", `Bearer ${token}`);
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe("EMAIL_UNVERIFIED");
+  });
+
+  it("staff roles bypass requireEmailVerified (here: leasing_agent calling /apply)", async () => {
+    mockUsersRow({ id: "staff-001", email: "agent@co.com", role: "leasing_agent" }, null);
+    mockCreate.mockResolvedValueOnce({ id: "app-staff", status: "draft", created_at: new Date() });
+    mockQuery.mockResolvedValueOnce({ rows: [] } as any); // user_applications INSERT
+
+    const staff: AuthUser = {
+      id: "staff-001",
+      email: "agent@co.com",
+      role: "leasing_agent",
+      firstName: "S",
+      lastName: "T",
+      propertyIds: ["prop-1"],
+      emailVerified: false, // even with email_verified_at null in DB, staff bypass
+    };
+    const token = generateToken(staff, { emailVerified: false });
+
+    const res = await request(app)
+      .post("/applicants/apply")
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        propertyId: "550e8400-e29b-41d4-a716-446655440000",
+        firstName: "Real",
+        lastName: "Applicant",
+        ssn: "111-22-3333",
+        dateOfBirth: "1990-01-01",
+      });
+
+    // Route's own role guard (line ~124): only applicant/tenant pass. So staff
+    // get a 403 from the in-route role check, NOT from requireEmailVerified.
+    // Distinguish: error message is "Applicant role required", NOT
+    // "Email verification required", and no EMAIL_UNVERIFIED code.
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBeUndefined();
+    expect(res.body.error).toMatch(/applicant role required/i);
+  });
+});

--- a/src/db/migrations/2026-05-13-email-verified-at.sql
+++ b/src/db/migrations/2026-05-13-email-verified-at.sql
@@ -1,0 +1,8 @@
+-- WARN #2: two-tier scopes — email verification proof (2026-05-13)
+-- Adds a persistent timestamp marking when a user's email was proven via magic-link.
+-- The /register endpoint issues a token with emailVerified=false; clicking the
+-- magic link is what stamps email_verified_at and re-issues emailVerified=true.
+-- Existing password-login users are backfilled as verified (they predate WARN #2).
+ALTER TABLE users ADD COLUMN IF NOT EXISTS email_verified_at TIMESTAMPTZ;
+UPDATE users SET email_verified_at = COALESCE(last_login, created_at)
+  WHERE password_hash IS NOT NULL AND email_verified_at IS NULL;

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -221,6 +221,9 @@ CREATE TYPE recertification_status AS ENUM (
 -- ============================================================
 
 -- Users (staff + applicants + tenants — magic-link users have null password_hash)
+-- email_verified_at is the persistent proof an account holder controls the email:
+-- stamped by verifyMagicLink (and by password-login backfill on existing accounts);
+-- gates state-changing/PII routes via requireEmailVerified middleware.
 CREATE TABLE users (
   id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
   email VARCHAR(255) UNIQUE NOT NULL,
@@ -232,6 +235,7 @@ CREATE TABLE users (
   phone VARCHAR(20),
   is_active BOOLEAN DEFAULT true,
   last_login TIMESTAMPTZ,
+  email_verified_at TIMESTAMPTZ,
   created_at TIMESTAMPTZ DEFAULT NOW(),
   updated_at TIMESTAMPTZ DEFAULT NOW()
 );

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -21,13 +21,26 @@ export interface AuthUser {
   firstName: string;
   lastName: string;
   propertyIds: string[];
+  // WARN #2: two-tier scope. False on freshly-registered accounts until the
+  // user clicks the magic link sent to their email; persisted on users.email_verified_at.
+  emailVerified: boolean;
 }
 
 export interface AuthRequest extends Request {
   user?: AuthUser;
 }
 
-export function generateToken(user: AuthUser): string {
+/**
+ * Issue a JWT for the given user. `emailVerified` may be overridden — callers
+ * that just issued a magic link pass `false`, callers that just verified one
+ * (or completed a password login) pass `true`. If omitted, falls back to
+ * `authUser.emailVerified ?? false` — never assume verified.
+ */
+export function generateToken(
+  user: AuthUser,
+  opts: { emailVerified?: boolean } = {}
+): string {
+  const emailVerified = opts.emailVerified ?? user.emailVerified ?? false;
   return jwt.sign(
     {
       id: user.id,
@@ -36,6 +49,7 @@ export function generateToken(user: AuthUser): string {
       firstName: user.firstName,
       lastName: user.lastName,
       propertyIds: user.propertyIds,
+      emailVerified,
     },
     JWT_SECRET,
     { expiresIn: process.env.JWT_EXPIRY || "8h" } as jwt.SignOptions
@@ -56,11 +70,21 @@ export async function authenticate(
   const token = authHeader.substring(7);
 
   try {
-    const decoded = jwt.verify(token, JWT_SECRET) as AuthUser;
+    jwt.verify(token, JWT_SECRET);
 
-    // Verify user still exists and is active
+    // Decode the (now-verified) payload so we can re-read the user from DB.
+    // The token's emailVerified claim is advisory — the DB value wins below,
+    // so a forged or stale token can never claim verification the user lacks,
+    // and the moment a user verifies, every previously-issued unverified token
+    // is upgraded on its next request.
+    const decoded = jwt.decode(token) as { id?: string } | null;
+    if (!decoded?.id) {
+      res.status(401).json({ error: "Invalid token" });
+      return;
+    }
+
     const result = await query(
-      "SELECT id, email, role, first_name, last_name, property_ids, is_active FROM users WHERE id = $1",
+      "SELECT id, email, role, first_name, last_name, property_ids, is_active, email_verified_at FROM users WHERE id = $1",
       [decoded.id]
     );
 
@@ -69,13 +93,15 @@ export async function authenticate(
       return;
     }
 
+    const row = result.rows[0];
     req.user = {
-      id: result.rows[0].id,
-      email: result.rows[0].email,
-      role: result.rows[0].role,
-      firstName: result.rows[0].first_name,
-      lastName: result.rows[0].last_name,
-      propertyIds: result.rows[0].property_ids || [],
+      id: row.id,
+      email: row.email,
+      role: row.role,
+      firstName: row.first_name,
+      lastName: row.last_name,
+      propertyIds: row.property_ids || [],
+      emailVerified: !!row.email_verified_at,
     };
 
     next();
@@ -93,7 +119,7 @@ export async function login(email: string, password: string): Promise<{ token: s
   const bcrypt = await import("bcrypt");
 
   const result = await query(
-    "SELECT id, email, password_hash, role, first_name, last_name, property_ids, is_active FROM users WHERE email = $1",
+    "SELECT id, email, password_hash, role, first_name, last_name, property_ids, is_active, email_verified_at FROM users WHERE email = $1",
     [email]
   );
 
@@ -115,6 +141,7 @@ export async function login(email: string, password: string): Promise<{ token: s
     firstName: user.first_name,
     lastName: user.last_name,
     propertyIds: user.property_ids || [],
+    emailVerified: !!user.email_verified_at,
   };
 
   return { token: generateToken(authUser), user: authUser };

--- a/src/middleware/scope.ts
+++ b/src/middleware/scope.ts
@@ -44,6 +44,41 @@ export async function scopeToOwnApplications(
 }
 
 /**
+ * Middleware: blocks applicants/tenants whose email hasn't been proven.
+ * Staff roles bypass — they authenticate by password (already a proof of
+ * account control). Returns 401 if unauthenticated, 403 with a stable
+ * `code: "EMAIL_UNVERIFIED"` if the user exists but hasn't verified.
+ *
+ * The truth for "verified" is `req.user.emailVerified`, which is sourced
+ * from `users.email_verified_at` in the DB by authenticate() — a stolen
+ * pre-verification token never gains verification status on re-issue.
+ */
+export function requireEmailVerified(
+  req: AuthRequest,
+  res: Response,
+  next: NextFunction
+): void {
+  if (!req.user) {
+    res.status(401).json({ error: "Authentication required" });
+    return;
+  }
+  // Staff bypass — non-applicant non-tenant roles authenticate via password,
+  // which is itself proof of account control.
+  if (!["applicant", "tenant"].includes(req.user.role)) {
+    next();
+    return;
+  }
+  if (!req.user.emailVerified) {
+    res.status(403).json({
+      error: "Email verification required",
+      code: "EMAIL_UNVERIFIED",
+    });
+    return;
+  }
+  next();
+}
+
+/**
  * Middleware: requires applicant or tenant role. Use on portal-only routes.
  */
 export function requireTenantRole(

--- a/src/modules/applicants/routes.ts
+++ b/src/modules/applicants/routes.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import rateLimit from "express-rate-limit";
 import { query, transaction } from "../../config/database";
 import { authenticate, AuthRequest, generateToken, AuthUser } from "../../middleware/auth";
+import { requireEmailVerified } from "../../middleware/scope";
 import { createMagicLink, logMagicLink } from "../auth/magic-link-service";
 import { ApplicationService } from "../application/service";
 import { createApplicationSchema } from "../application/validation";
@@ -72,7 +73,12 @@ router.post("/register", registerLimiter, async (req: Request, res: Response): P
     logger.info("Applicant registered", { userId, email, isNew });
 
     if (isNew) {
-      // Brand-new account: issue a session JWT so the applicant lands in the portal.
+      // Brand-new account: issue a session JWT so the applicant lands in the
+      // portal — but mark it emailVerified:false. The applicant can view
+      // public/account UI; PII + state-changing routes (/apply, /me/applications)
+      // are gated by requireEmailVerified until the magic link is clicked.
+      // This closes WARN #2: an attacker registering victim@x can no longer
+      // act as victim with the returned token.
       const userRow = await query(
         "SELECT id, email, role, first_name, last_name FROM users WHERE id = $1",
         [userId]
@@ -85,8 +91,9 @@ router.post("/register", registerLimiter, async (req: Request, res: Response): P
         firstName: u.first_name,
         lastName: u.last_name,
         propertyIds: [],
+        emailVerified: false,
       };
-      const token = generateToken(authUser);
+      const token = generateToken(authUser, { emailVerified: false });
       const payload: Record<string, unknown> = {
         ok: true,
         message: "If this email is registered, a verification link has been sent.",
@@ -116,9 +123,9 @@ router.post("/register", registerLimiter, async (req: Request, res: Response): P
   }
 });
 
-// Authenticated as applicant: submit the application form. Creates the
-// application via ApplicationService then links it to the user.
-router.post("/apply", authenticate, async (req: AuthRequest, res: Response): Promise<void> => {
+// Authenticated as applicant with a verified email: submit the application
+// form. requireEmailVerified gates this — see WARN #2.
+router.post("/apply", authenticate, requireEmailVerified, async (req: AuthRequest, res: Response): Promise<void> => {
   try {
     if (!req.user || !["applicant", "tenant"].includes(req.user.role)) {
       res.status(403).json({ error: "Applicant role required" });
@@ -168,8 +175,10 @@ router.get("/properties", async (_req: Request, res: Response): Promise<void> =>
   }
 });
 
-// Authenticated as applicant: list my applications.
-router.get("/me/applications", authenticate, async (req: AuthRequest, res: Response): Promise<void> => {
+// Authenticated as applicant with a verified email: list my applications.
+// PII surface — requireEmailVerified prevents enumeration via stolen
+// pre-verification token.
+router.get("/me/applications", authenticate, requireEmailVerified, async (req: AuthRequest, res: Response): Promise<void> => {
   try {
     if (!req.user || !["applicant", "tenant"].includes(req.user.role)) {
       res.status(403).json({ error: "Applicant role required" });

--- a/src/modules/auth/magic-link-service.ts
+++ b/src/modules/auth/magic-link-service.ts
@@ -58,6 +58,14 @@ export async function verifyMagicLink(rawToken: string): Promise<{ token: string
   );
   await query(`UPDATE users SET last_login = NOW() WHERE id = $1`, [row.user_id]);
 
+  // WARN #2: this is the moment email control is proven. Stamp it once —
+  // subsequent magic-link logins don't bump the timestamp.
+  await query(
+    `UPDATE users SET email_verified_at = NOW()
+     WHERE id = $1 AND email_verified_at IS NULL`,
+    [row.user_id]
+  );
+
   const authUser: AuthUser = {
     id: row.user_id,
     email: row.email,
@@ -65,9 +73,10 @@ export async function verifyMagicLink(rawToken: string): Promise<{ token: string
     firstName: row.first_name,
     lastName: row.last_name,
     propertyIds: [],
+    emailVerified: true,
   };
 
-  return { token: generateToken(authUser), user: authUser };
+  return { token: generateToken(authUser, { emailVerified: true }), user: authUser };
 }
 
 export function logMagicLink(email: string, link: string): void {

--- a/src/modules/auth/routes.ts
+++ b/src/modules/auth/routes.ts
@@ -2,6 +2,7 @@ import { Router } from "express";
 import { z } from "zod";
 import rateLimit from "express-rate-limit";
 import { createMagicLink, verifyMagicLink, logMagicLink } from "./magic-link-service";
+import { authenticate, AuthRequest } from "../../middleware/auth";
 import { logger } from "../../utils/logger";
 
 const router: Router = Router();
@@ -67,6 +68,14 @@ router.post("/magic-link/verify", async (req, res) => {
     logger.error("Magic-link verify failed", { error: (err as Error).message });
     res.status(500).json({ error: "Verification failed" });
   }
+});
+
+// WARN #2: lightweight self-check so the client can poll for verification
+// status during the post-register "check your email" stage. Returns the
+// resolved AuthUser from authenticate() — which reads email_verified_at
+// from the DB on every call, so verification status is always live.
+router.get("/me", authenticate, (req: AuthRequest, res) => {
+  res.json({ user: req.user });
 });
 
 export default router;


### PR DESCRIPTION
## Summary
- **Closes WARN #2** — registering with `victim@x` previously issued a full-scope applicant JWT before email verification. An attacker could obtain a usable session for any email they knew.
- **Approach:** two-tier scopes via `emailVerified` JWT claim + `email_verified_at TIMESTAMPTZ` column. DB is the source of truth; `authenticate()` re-reads it on every request and overrides stale token claims in both directions.
- **Surface:** new migration, schema column, `requireEmailVerified` middleware, gated `/apply` + `/me/applications`, magic-link stamping, client polling + `/verify-pending` page, new `GET /api/auth/me`, 19 new security tests.

## Audit
Forge-Audit (Opus) — **PASS, GO ship**.
- DB-vs-token precedence: correct both directions (forged-true token + NULL DB = unverified; stale-false token + timestamped DB = verified)
- Staff bypass: clean (whitelist applicant/tenant only; migration backfills password-login users)
- Migration: conservative (`WHERE password_hash IS NOT NULL` excludes magic-link-only applicants)
- Race-revoke / replay / cross-account / resend abuse: all neutralized
- W1 takeover fix preserved (no token issued for existing-email registers)

## Test plan
- [x] `npx tsc --noEmit` — PASS
- [x] `npx jest` — 742/757 (15 pre-existing skips, 0 failures)
- [x] `client-tenant && npm run build` — PASS
- [x] 19 new tests across 4 security suites cover the original attack scenario + bidirectional precedence + staff bypass + magic-link idempotency
- [ ] Manual: register → see verify-pending → click dev magic-link → land on /apply step 2
- [ ] Manual: forged `emailVerified:true` token with NULL DB row → /apply returns 403 `EMAIL_UNVERIFIED`

## Follow-up (non-blocking)
- Add `requireEmailVerified` to `/api/tenant/*` as explicit defense-in-depth (already neutralized by `scopeToOwnApplications`, but the gate makes the invariant explicit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)