### PR TITLE
feat(messaging): My Application + two-way staff↔applicant thread

### DIFF
--- a/client-tenant/src/App.tsx
+++ b/client-tenant/src/App.tsx
@@ -10,6 +10,7 @@ import { Pay } from '@/pages/Pay';
 import { Ledger } from '@/pages/Ledger';
 import { Maintenance } from '@/pages/Maintenance';
 import { Status } from '@/pages/Status';
+import { Application } from '@/pages/Application';
 import { getToken } from '@/api/client';
 
 function RootRedirect() {
@@ -28,6 +29,7 @@ export default function App() {
       <Route element={<AuthGuard />}>
         <Route element={<Layout />}>
           <Route path="/dashboard" element={<Dashboard />} />
+          <Route path="/application" element={<Application />} />
           <Route path="/pay" element={<Pay />} />
           <Route path="/ledger" element={<Ledger />} />
           <Route path="/maintenance" element={<Maintenance />} />

--- a/client-tenant/src/components/Layout.tsx
+++ b/client-tenant/src/components/Layout.tsx
@@ -4,12 +4,14 @@ import {
   DollarSign,
   Wrench,
   Receipt,
+  FileText,
   LogOut,
 } from 'lucide-react';
 import { clearToken } from '@/api/client';
 
 const navItems = [
   { to: '/dashboard', label: 'Home', icon: LayoutDashboard },
+  { to: '/application', label: 'My Application', icon: FileText },
   { to: '/pay', label: 'Pay', icon: DollarSign },
   { to: '/maintenance', label: 'Maintenance', icon: Wrench },
   { to: '/ledger', label: 'Ledger', icon: Receipt },
@@ -17,6 +19,7 @@ const navItems = [
 
 const mobileNavItems = [
   { to: '/dashboard', label: 'Home', icon: LayoutDashboard },
+  { to: '/application', label: 'App', icon: FileText },
   { to: '/pay', label: 'Pay', icon: DollarSign },
   { to: '/maintenance', label: 'Repairs', icon: Wrench },
   { to: '/ledger', label: 'Ledger', icon: Receipt },
@@ -86,7 +89,7 @@ export function Layout() {
 
       {/* Mobile bottom nav */}
       <nav className="fixed inset-x-0 bottom-0 z-10 border-t border-gray-200 bg-white md:hidden">
-        <div className="grid grid-cols-4">
+        <div className="grid grid-cols-5">
           {mobileNavItems.map(({ to, label, icon: Icon }) => (
             <NavLink
               key={to}

--- a/client-tenant/src/pages/Application.tsx
+++ b/client-tenant/src/pages/Application.tsx
@@ -1,0 +1,463 @@
+import { useEffect, useRef, useState, useCallback } from 'react';
+import { Link } from 'react-router-dom';
+import { api } from '@/api/client';
+import {
+  FileText,
+  AlertCircle,
+  Loader2,
+  Send,
+  Home,
+  Calendar,
+  CheckCircle2,
+} from 'lucide-react';
+
+interface ApplicationDetail {
+  id: string;
+  status: string;
+  first_name: string;
+  last_name: string;
+  email: string | null;
+  phone: string | null;
+  unit_number: string | null;
+  requested_rent_amount: number | null;
+  requested_move_in_date: string | null;
+  overall_screening_result: string | null;
+  onesite_lease_id: string | null;
+  loft_tenant_id: string | null;
+  auto_pay_enrolled: boolean;
+  submitted_at: string | null;
+  created_at: string;
+  property_id: string;
+  property_name: string;
+  property_address: string;
+}
+
+interface DashboardData {
+  user: { id: string; firstName: string; lastName: string };
+  activeApplication: ApplicationDetail | null;
+  applications: ApplicationDetail[];
+}
+
+interface Message {
+  id: string;
+  applicationId: string;
+  senderUserId: string;
+  senderRole: 'staff' | 'applicant' | 'tenant';
+  senderName: string;
+  body: string;
+  createdAt: string;
+  readAt: string | null;
+}
+
+interface MessagesResponse {
+  messages: Message[];
+}
+
+const STATUS_LABELS: Record<string, string> = {
+  draft: 'Draft',
+  submitted: 'Submitted',
+  screening: 'Screening',
+  screening_passed: 'Screening passed',
+  screening_failed: 'Screening failed',
+  tier1_review: 'Tier 1 Review',
+  tier1_approved: 'Tier 1 Approved',
+  tier1_denied: 'Tier 1 Denied',
+  tier2_review: 'Tier 2 Review',
+  tier2_approved: 'Tier 2 Approved',
+  tier2_denied: 'Tier 2 Denied',
+  tier3_review: 'Tier 3 Review',
+  tier3_approved: 'Tier 3 Approved',
+  tier3_denied: 'Tier 3 Denied',
+  lease_generated: 'Lease Ready',
+  onboarded: 'Onboarded',
+  cancelled: 'Cancelled',
+};
+
+const DENIED = new Set([
+  'screening_failed',
+  'tier1_denied',
+  'tier2_denied',
+  'tier3_denied',
+  'cancelled',
+]);
+
+function fmt(amount: number | null): string {
+  if (amount == null) return '—';
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+  }).format(amount);
+}
+
+function fmtDate(d: string | null | undefined): string {
+  if (!d) return '—';
+  return new Date(d).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
+function fmtTime(d: string): string {
+  const date = new Date(d);
+  const today = new Date();
+  const yest = new Date(today);
+  yest.setDate(today.getDate() - 1);
+  const sameDay = date.toDateString() === today.toDateString();
+  const wasYesterday = date.toDateString() === yest.toDateString();
+  if (sameDay) {
+    return date.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' });
+  }
+  if (wasYesterday) {
+    return `Yesterday ${date.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' })}`;
+  }
+  return date.toLocaleString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}
+
+export function Application() {
+  const [data, setData] = useState<DashboardData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Pull the dashboard once to discover the active application.
+  useEffect(() => {
+    api
+      .get<DashboardData>('/tenant/dashboard')
+      .then((d) => setData(d))
+      .catch((err) =>
+        setError(err instanceof Error ? err.message : 'Failed to load application'),
+      )
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <Loader2 className="h-7 w-7 animate-spin text-emerald-600" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="p-4">
+        <div className="flex items-center gap-2 rounded-lg bg-red-50 p-4 text-red-700">
+          <AlertCircle className="h-5 w-5 shrink-0" />
+          <p className="text-sm">{error}</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (!data || !data.activeApplication) {
+    return (
+      <div className="flex min-h-[60vh] flex-col items-center justify-center gap-4 p-6 text-center">
+        <FileText className="h-10 w-10 text-gray-300" />
+        <h2 className="text-lg font-semibold text-gray-900">No active application</h2>
+        <p className="text-sm text-gray-500">
+          Submit an application to track its progress and message staff here.
+        </p>
+        <Link to="/apply" className="btn-primary">
+          Start an application
+        </Link>
+      </div>
+    );
+  }
+
+  const app = data.activeApplication;
+  const userId = data.user.id;
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-5 p-4 pb-24 sm:p-6">
+      {/* Header */}
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h1 className="text-xl font-bold text-gray-900">My Application</h1>
+          <p className="mt-1 text-sm text-gray-500">
+            {app.property_name}
+            {app.unit_number ? ` · Unit ${app.unit_number}` : ''}
+          </p>
+        </div>
+        <StatusPill status={app.status} />
+      </div>
+
+      {/* Key dates */}
+      <section className="rounded-xl bg-white p-5 shadow-sm">
+        <h2 className="mb-3 flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-gray-500">
+          <Calendar className="h-4 w-4" /> Key dates
+        </h2>
+        <dl className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+          <Field label="Submitted" value={fmtDate(app.submitted_at)} />
+          <Field label="Requested move-in" value={fmtDate(app.requested_move_in_date)} />
+          <Field label="Last updated" value={fmtDate(app.created_at)} />
+        </dl>
+      </section>
+
+      {/* Property / lease snapshot */}
+      <section className="rounded-xl bg-white p-5 shadow-sm">
+        <h2 className="mb-3 flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-gray-500">
+          <Home className="h-4 w-4" /> Property
+        </h2>
+        <dl className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          <Field label="Property" value={app.property_name} />
+          <Field label="Address" value={app.property_address} />
+          <Field label="Unit" value={app.unit_number || 'TBD'} />
+          <Field label="Requested rent" value={fmt(app.requested_rent_amount)} />
+        </dl>
+      </section>
+
+      {/* Next steps */}
+      <NextStepsCard app={app} />
+
+      {/* Messages thread */}
+      <MessagesThread applicationId={app.id} userId={userId} />
+    </div>
+  );
+}
+
+function StatusPill({ status }: { status: string }) {
+  const label = STATUS_LABELS[status] ?? status;
+  const tone = DENIED.has(status)
+    ? 'bg-red-100 text-red-700'
+    : status === 'onboarded'
+    ? 'bg-emerald-100 text-emerald-700'
+    : 'bg-emerald-50 text-emerald-700';
+  return (
+    <span className={`shrink-0 rounded-full px-3 py-1 text-xs font-semibold ${tone}`}>
+      {label}
+    </span>
+  );
+}
+
+function Field({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <dt className="text-[11px] uppercase tracking-wider text-gray-400">{label}</dt>
+      <dd className="text-sm font-medium text-gray-900">{value}</dd>
+    </div>
+  );
+}
+
+function NextStepsCard({ app }: { app: ApplicationDetail }) {
+  const steps: { label: string; done: boolean }[] = [
+    { label: 'Application submitted', done: !!app.submitted_at },
+    {
+      label: 'Screening complete',
+      done:
+        !!app.overall_screening_result &&
+        ['pass', 'fail', 'review_required'].includes(app.overall_screening_result),
+    },
+    {
+      label: 'Approval decision',
+      done: ['tier1_approved', 'tier2_approved', 'tier3_approved', 'lease_generated', 'onboarded'].some(
+        (s) => app.status === s,
+      ),
+    },
+    {
+      label: 'Lease generated',
+      done: ['lease_generated', 'onboarded'].includes(app.status),
+    },
+    { label: 'Move-in / onboarded', done: app.status === 'onboarded' },
+  ];
+
+  return (
+    <section className="rounded-xl bg-white p-5 shadow-sm">
+      <h2 className="mb-3 text-xs font-semibold uppercase tracking-wider text-gray-500">
+        Next steps
+      </h2>
+      <ol className="space-y-2">
+        {steps.map((s) => (
+          <li key={s.label} className="flex items-center gap-2 text-sm">
+            <CheckCircle2
+              className={`h-4 w-4 ${s.done ? 'text-emerald-600' : 'text-gray-300'}`}
+            />
+            <span className={s.done ? 'text-gray-800' : 'text-gray-400'}>{s.label}</span>
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+}
+
+function MessagesThread({
+  applicationId,
+  userId,
+}: {
+  applicationId: string;
+  userId: string;
+}) {
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [draft, setDraft] = useState('');
+  const [sending, setSending] = useState(false);
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+
+  const fetchMessages = useCallback(async () => {
+    try {
+      const res = await api.get<MessagesResponse>(
+        `/tenant/applications/${applicationId}/messages`,
+      );
+      setMessages(res.messages);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load messages');
+    } finally {
+      setLoading(false);
+    }
+  }, [applicationId]);
+
+  // Scroll to bottom whenever message count changes
+  useEffect(() => {
+    const node = scrollRef.current;
+    if (node) {
+      node.scrollTop = node.scrollHeight;
+    }
+  }, [messages.length]);
+
+  // Initial load + visibility/focus refetch + 15s poll
+  useEffect(() => {
+    fetchMessages();
+    const interval = setInterval(fetchMessages, 15000);
+    const onFocus = () => fetchMessages();
+    window.addEventListener('focus', onFocus);
+    return () => {
+      clearInterval(interval);
+      window.removeEventListener('focus', onFocus);
+    };
+  }, [fetchMessages]);
+
+  async function handleSend(e: React.FormEvent) {
+    e.preventDefault();
+    const trimmed = draft.trim();
+    if (!trimmed || sending) return;
+
+    // Optimistic append
+    const optimistic: Message = {
+      id: `optimistic-${Date.now()}`,
+      applicationId,
+      senderUserId: userId,
+      senderRole: 'tenant',
+      senderName: 'You',
+      body: trimmed,
+      createdAt: new Date().toISOString(),
+      readAt: null,
+    };
+    setMessages((prev) => [...prev, optimistic]);
+    setDraft('');
+    setSending(true);
+    try {
+      const res = await api.post<{ message: Message }>(
+        `/tenant/applications/${applicationId}/messages`,
+        { body: trimmed },
+      );
+      // Replace optimistic with server version
+      setMessages((prev) =>
+        prev.map((m) => (m.id === optimistic.id ? res.message : m)),
+      );
+    } catch (err) {
+      // Revert
+      setMessages((prev) => prev.filter((m) => m.id !== optimistic.id));
+      setDraft(trimmed);
+      setError(err instanceof Error ? err.message : 'Failed to send');
+    } finally {
+      setSending(false);
+    }
+  }
+
+  return (
+    <section className="rounded-xl bg-white shadow-sm">
+      <header className="border-b border-gray-100 px-5 py-3">
+        <h2 className="text-sm font-semibold text-gray-900">Messages</h2>
+        <p className="text-xs text-gray-500">Talk directly to your leasing team.</p>
+      </header>
+
+      <div
+        ref={scrollRef}
+        className="max-h-[26rem] min-h-[12rem] space-y-3 overflow-y-auto px-5 py-4"
+      >
+        {loading ? (
+          <div className="flex items-center justify-center py-6 text-gray-400">
+            <Loader2 className="h-5 w-5 animate-spin" />
+          </div>
+        ) : messages.length === 0 ? (
+          <p className="py-6 text-center text-sm text-gray-400">
+            No messages yet. Send the first one below.
+          </p>
+        ) : (
+          messages.map((m) => <MessageBubble key={m.id} m={m} selfId={userId} />)
+        )}
+      </div>
+
+      {error && (
+        <div className="mx-5 mb-2 rounded-lg bg-red-50 px-3 py-2 text-xs text-red-700">
+          {error}
+        </div>
+      )}
+
+      <form
+        onSubmit={handleSend}
+        className="flex items-end gap-2 border-t border-gray-100 px-5 py-3"
+      >
+        <textarea
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          rows={2}
+          maxLength={4000}
+          placeholder="Type a message…"
+          className="flex-1 resize-none rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+              handleSend(e);
+            }
+          }}
+        />
+        <button
+          type="submit"
+          disabled={sending || draft.trim().length === 0}
+          className="flex items-center gap-1.5 rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-700 disabled:opacity-50"
+        >
+          <Send className="h-4 w-4" />
+          {sending ? 'Sending…' : 'Send'}
+        </button>
+      </form>
+    </section>
+  );
+}
+
+function MessageBubble({ m, selfId }: { m: Message; selfId: string }) {
+  const isMine = m.senderUserId === selfId;
+  return (
+    <div className={`flex ${isMine ? 'justify-end' : 'justify-start'}`}>
+      <div className={`max-w-[80%] ${isMine ? 'text-right' : 'text-left'}`}>
+        <div className="mb-1 flex items-center gap-2 text-[11px] text-gray-400">
+          {!isMine && <span className="font-medium text-gray-600">{m.senderName}</span>}
+          <span
+            className={`rounded-full px-1.5 py-0.5 text-[10px] font-medium ${
+              m.senderRole === 'staff'
+                ? 'bg-blue-100 text-blue-700'
+                : 'bg-emerald-100 text-emerald-700'
+            }`}
+          >
+            {isMine ? 'You' : m.senderRole === 'staff' ? 'Staff' : 'Tenant'}
+          </span>
+          <span>{fmtTime(m.createdAt)}</span>
+        </div>
+        <div
+          className={`whitespace-pre-wrap break-words rounded-2xl px-3 py-2 text-sm ${
+            isMine
+              ? 'bg-emerald-600 text-white'
+              : 'bg-gray-100 text-gray-900'
+          }`}
+        >
+          {m.body}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/ApplicationMessages.tsx
+++ b/client/src/components/ApplicationMessages.tsx
@@ -1,0 +1,235 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Send, Loader2 } from 'lucide-react';
+import { api } from '@/api/client';
+import { useAuth } from '@/hooks/useAuth';
+
+interface Message {
+  id: string;
+  applicationId: string;
+  senderUserId: string;
+  senderRole: 'staff' | 'applicant' | 'tenant';
+  senderName: string;
+  body: string;
+  createdAt: string;
+  readAt: string | null;
+}
+
+interface MessagesResponse {
+  messages: Message[];
+}
+
+function fmtTime(d: string): string {
+  const date = new Date(d);
+  const today = new Date();
+  const yest = new Date(today);
+  yest.setDate(today.getDate() - 1);
+  if (date.toDateString() === today.toDateString()) {
+    return date.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' });
+  }
+  if (date.toDateString() === yest.toDateString()) {
+    return `Yesterday ${date.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' })}`;
+  }
+  return date.toLocaleString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}
+
+export function ApplicationMessages({ applicationId }: { applicationId: string }) {
+  const { user } = useAuth();
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [draft, setDraft] = useState('');
+  const [sending, setSending] = useState(false);
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+
+  const fetchMessages = useCallback(async () => {
+    try {
+      const res = await api.get<MessagesResponse>(
+        `/api/applications/${applicationId}/messages`,
+      );
+      setMessages(res.messages);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load messages');
+    } finally {
+      setLoading(false);
+    }
+  }, [applicationId]);
+
+  // Mark incoming (applicant/tenant) messages as read on open / after fetch.
+  const markIncomingRead = useCallback(
+    async (msgs: Message[]) => {
+      const unread = msgs.filter(
+        (m) =>
+          (m.senderRole === 'applicant' || m.senderRole === 'tenant') && !m.readAt,
+      );
+      if (unread.length === 0) return;
+      await Promise.allSettled(
+        unread.map((m) =>
+          api.post(`/api/applications/${applicationId}/messages/${m.id}/read`),
+        ),
+      );
+    },
+    [applicationId],
+  );
+
+  useEffect(() => {
+    fetchMessages();
+    const interval = setInterval(fetchMessages, 15000);
+    const onFocus = () => fetchMessages();
+    window.addEventListener('focus', onFocus);
+    return () => {
+      clearInterval(interval);
+      window.removeEventListener('focus', onFocus);
+    };
+  }, [fetchMessages]);
+
+  // After messages are loaded/changed, mark any incoming applicant/tenant
+  // messages as read.
+  useEffect(() => {
+    if (!loading && messages.length > 0) {
+      markIncomingRead(messages);
+    }
+  }, [loading, messages, markIncomingRead]);
+
+  // Scroll to bottom on new message
+  useEffect(() => {
+    const node = scrollRef.current;
+    if (node) node.scrollTop = node.scrollHeight;
+  }, [messages.length]);
+
+  async function handleSend(e: React.FormEvent) {
+    e.preventDefault();
+    const trimmed = draft.trim();
+    if (!trimmed || sending || !user) return;
+
+    const optimistic: Message = {
+      id: `optimistic-${Date.now()}`,
+      applicationId,
+      senderUserId: user.id,
+      senderRole: 'staff',
+      senderName: `${user.firstName} ${user.lastName}`,
+      body: trimmed,
+      createdAt: new Date().toISOString(),
+      readAt: null,
+    };
+    setMessages((prev) => [...prev, optimistic]);
+    setDraft('');
+    setSending(true);
+    try {
+      const res = await api.post<{ message: Message }>(
+        `/api/applications/${applicationId}/messages`,
+        { body: trimmed },
+      );
+      setMessages((prev) => prev.map((m) => (m.id === optimistic.id ? res.message : m)));
+    } catch (err) {
+      setMessages((prev) => prev.filter((m) => m.id !== optimistic.id));
+      setDraft(trimmed);
+      setError(err instanceof Error ? err.message : 'Failed to send');
+    } finally {
+      setSending(false);
+    }
+  }
+
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white">
+      <header className="border-b border-gray-100 px-5 py-3">
+        <h2 className="text-sm font-medium uppercase tracking-wider text-gray-600">
+          Messages
+        </h2>
+        <p className="text-xs text-gray-500">
+          Two-way thread with the applicant / tenant.
+        </p>
+      </header>
+
+      <div
+        ref={scrollRef}
+        className="max-h-[28rem] min-h-[12rem] space-y-3 overflow-y-auto px-5 py-4"
+      >
+        {loading ? (
+          <div className="flex items-center justify-center py-6 text-gray-400">
+            <Loader2 className="h-5 w-5 animate-spin" />
+          </div>
+        ) : messages.length === 0 ? (
+          <p className="py-6 text-center text-sm text-gray-400">
+            No messages yet.
+          </p>
+        ) : (
+          messages.map((m) => (
+            <Bubble key={m.id} m={m} selfId={user?.id || ''} />
+          ))
+        )}
+      </div>
+
+      {error && (
+        <div className="mx-5 mb-2 rounded-lg bg-red-50 px-3 py-2 text-xs text-red-700">
+          {error}
+        </div>
+      )}
+
+      <form
+        onSubmit={handleSend}
+        className="flex items-end gap-2 border-t border-gray-100 px-5 py-3"
+      >
+        <textarea
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          rows={2}
+          maxLength={4000}
+          placeholder="Reply to the applicant…"
+          className="flex-1 resize-none rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+              handleSend(e);
+            }
+          }}
+        />
+        <button
+          type="submit"
+          disabled={sending || draft.trim().length === 0}
+          className="flex items-center gap-1.5 rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-700 disabled:opacity-50"
+        >
+          <Send className="h-4 w-4" />
+          {sending ? 'Sending…' : 'Send'}
+        </button>
+      </form>
+    </div>
+  );
+}
+
+function Bubble({ m, selfId }: { m: Message; selfId: string }) {
+  const isMine = m.senderUserId === selfId;
+  const isStaff = m.senderRole === 'staff';
+  return (
+    <div className={`flex ${isMine ? 'justify-end' : 'justify-start'}`}>
+      <div className={`max-w-[80%] ${isMine ? 'text-right' : 'text-left'}`}>
+        <div className="mb-1 flex items-center gap-2 text-[11px] text-gray-400">
+          {!isMine && <span className="font-medium text-gray-700">{m.senderName}</span>}
+          <span
+            className={`rounded-full px-1.5 py-0.5 text-[10px] font-medium ${
+              isStaff
+                ? 'bg-blue-100 text-blue-700'
+                : 'bg-emerald-100 text-emerald-700'
+            }`}
+          >
+            {isMine ? 'Staff' : isStaff ? 'Staff' : m.senderRole === 'tenant' ? 'Tenant' : 'Applicant'}
+          </span>
+          <span>{fmtTime(m.createdAt)}</span>
+        </div>
+        <div
+          className={`whitespace-pre-wrap break-words rounded-2xl px-3 py-2 text-sm ${
+            isMine
+              ? 'bg-blue-600 text-white'
+              : 'bg-gray-100 text-gray-900'
+          }`}
+        >
+          {m.body}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/ApplicationDetail.tsx
+++ b/client/src/pages/ApplicationDetail.tsx
@@ -4,6 +4,7 @@ import { ArrowLeft, Send, XCircle, CheckCircle, FileText, Home, AlertTriangle, R
 import { useApiQuery } from '@/hooks/useApiQuery';
 import { StatusBadge } from '@/components/StatusBadge';
 import { RoleGate } from '@/components/RoleGate';
+import { ApplicationMessages } from '@/components/ApplicationMessages';
 import { api } from '@/api/client';
 import type { Application, ApprovalStatus, ScreeningResult, LeaseStatus, AdverseActionNotice } from '@/types';
 
@@ -285,6 +286,9 @@ export function ApplicationDetail() {
           {app.submitted_at && <p>Submitted: {new Date(app.submitted_at).toLocaleString()}</p>}
         </div>
       </Card>
+
+      {/* Two-way messaging thread with applicant/tenant */}
+      {id && <ApplicationMessages applicationId={id} />}
     </div>
   );
 }

--- a/src/db/migrations/2026-05-14-application-messages.sql
+++ b/src/db/migrations/2026-05-14-application-messages.sql
@@ -1,0 +1,17 @@
+-- Application Messages migration (2026-05-14)
+-- Adds two-way thread between staff and applicant/tenant for a given
+-- application. Drives the "My Application" tenant-portal page and the
+-- messaging panel on the staff ApplicationDetail page.
+
+CREATE TABLE IF NOT EXISTS application_messages (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  application_id UUID NOT NULL REFERENCES applications(id) ON DELETE CASCADE,
+  sender_user_id UUID NOT NULL REFERENCES users(id),
+  sender_role TEXT NOT NULL CHECK (sender_role IN ('staff','applicant','tenant')),
+  body TEXT NOT NULL CHECK (length(trim(body)) > 0),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  read_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_application_messages_app_created
+  ON application_messages(application_id, created_at DESC);

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -705,6 +705,19 @@ CREATE TABLE recertifications (
   updated_at TIMESTAMPTZ DEFAULT NOW()
 );
 
+-- Application Messages (Module 16: My Application + two-way staff/applicant thread)
+CREATE TABLE application_messages (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  application_id UUID NOT NULL REFERENCES applications(id) ON DELETE CASCADE,
+  sender_user_id UUID NOT NULL REFERENCES users(id),
+  sender_role TEXT NOT NULL CHECK (sender_role IN ('staff','applicant','tenant')),
+  body TEXT NOT NULL CHECK (length(trim(body)) > 0),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  read_at TIMESTAMPTZ
+);
+CREATE INDEX idx_application_messages_app_created
+  ON application_messages(application_id, created_at DESC);
+
 -- Audit Log (immutable, append-only)
 CREATE TABLE audit_log (
   id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
@@ -863,6 +876,7 @@ CREATE TRIGGER trg_audit_log_immutable
 `;
 
 export const DROP_SCHEMA_SQL = `
+DROP TABLE IF EXISTS application_messages CASCADE;
 DROP TABLE IF EXISTS work_orders CASCADE;
 DROP TABLE IF EXISTS inspections CASCADE;
 DROP TABLE IF EXISTS move_outs CASCADE;

--- a/src/db/seed-demo.ts
+++ b/src/db/seed-demo.ts
@@ -76,6 +76,7 @@ export async function seedDemoData() {
       await query("DELETE FROM lease_violations WHERE application_id = $1", [row.id]);
       await query("DELETE FROM tenant_ledger WHERE application_id = $1", [row.id]);
       await query("DELETE FROM recertifications WHERE application_id = $1", [row.id]);
+      await query("DELETE FROM application_messages WHERE application_id = $1", [row.id]);
       await query("DELETE FROM applications WHERE id = $1", [row.id]);
     }
   }
@@ -617,6 +618,30 @@ export async function seedDemoData() {
        ON CONFLICT DO NOTHING`,
       [tomaszApp.rows[0].property_id, tomaszApp.rows[0].id, submittedBy]
     );
+
+    // Sample two-way message thread between staff and tenant
+    // (Module 16: My Application messaging)
+    await query(
+      `DELETE FROM application_messages WHERE application_id = $1`,
+      [tomaszApp.rows[0].id]
+    );
+    await query(
+      `INSERT INTO application_messages
+         (application_id, sender_user_id, sender_role, body, created_at, read_at)
+       VALUES
+         ($1, $2, 'staff',  $4, NOW() - INTERVAL '3 days', NOW() - INTERVAL '2 days 22 hours'),
+         ($1, $3, 'tenant', $5, NOW() - INTERVAL '2 days 18 hours', NOW() - INTERVAL '2 days 17 hours'),
+         ($1, $2, 'staff',  $6, NOW() - INTERVAL '1 day',  NULL)`,
+      [
+        tomaszApp.rows[0].id,
+        seniorId,
+        submittedBy,
+        "Hi Tomasz, we received your application. Please upload your last two pay stubs to your portal.",
+        "Hi, I uploaded them yesterday — let me know if anything else is needed.",
+        "Got them, thanks! We're reviewing now.",
+      ]
+    );
+
     portalSeeded++;
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ import moveoutRoutes from "./modules/moveout/routes";
 import authRoutes from "./modules/auth/routes";
 import applicantRoutes from "./modules/applicants/routes";
 import tenantRoutes from "./modules/tenant/routes";
+import messagesRoutes from "./modules/messages/routes";
 import { startScheduler } from "./scheduler";
 
 const app = express();
@@ -112,6 +113,9 @@ app.use("/api/leases", leaseRoutes);
 
 // FCRA Adverse action notices (nested under /api/applications)
 app.use("/api/applications", adverseActionRoutes);
+
+// Application messages — staff side (nested under /api/applications)
+app.use("/api/applications", messagesRoutes);
 
 // User management (system_admin: create/deactivate/reset-pw; senior_manager+: view)
 app.use("/api/users", userRoutes);

--- a/src/modules/messages/routes.ts
+++ b/src/modules/messages/routes.ts
@@ -1,0 +1,132 @@
+import { Router, Response } from "express";
+import { z } from "zod";
+import { authenticate, AuthRequest } from "../../middleware/auth";
+import { requirePermission } from "../../middleware/rbac";
+import { buildPropertyScope } from "../../middleware/scope";
+import { query } from "../../config/database";
+import { MessagesService } from "./service";
+import { logger } from "../../utils/logger";
+import { param } from "../../utils/params";
+
+const router: Router = Router();
+const service = new MessagesService();
+
+const bodySchema = z.object({
+  body: z.string().trim().min(1).max(4000),
+});
+
+/**
+ * Resolve property scope for a single application — staff may only see/post
+ * messages on applications whose property is in their property_ids (unless
+ * they are a global-scope role).
+ *
+ * Returns true if access allowed (response untouched), false after writing
+ * a 403/404 to res.
+ */
+async function assertStaffCanAccessApplication(
+  req: AuthRequest,
+  res: Response,
+  applicationId: string
+): Promise<boolean> {
+  const params: unknown[] = [applicationId];
+  const scope = buildPropertyScope(req, 2, "a.property_id");
+  if (scope.denyAll) {
+    res.status(403).json({ error: "Application not accessible" });
+    return false;
+  }
+  let sql = "SELECT 1 FROM applications a WHERE a.id = $1";
+  if (scope.sql) {
+    sql += ` AND ${scope.sql}`;
+    params.push(scope.param);
+  }
+  const result = await query(sql, params);
+  if (result.rows.length === 0) {
+    res.status(403).json({ error: "Application not accessible" });
+    return false;
+  }
+  return true;
+}
+
+// ---------------------------------------------------------------
+// GET /api/applications/:id/messages — staff list view
+// ---------------------------------------------------------------
+router.get(
+  "/:id/messages",
+  authenticate,
+  requirePermission("application:read"),
+  async (req: AuthRequest, res: Response): Promise<void> => {
+    try {
+      const applicationId = param(req.params.id);
+      if (!(await assertStaffCanAccessApplication(req, res, applicationId))) return;
+
+      const messages = await service.listForApplication(applicationId);
+      res.json({ messages });
+    } catch (err) {
+      logger.error("staff messages list failed", { error: (err as Error).message });
+      res.status(500).json({ error: "Failed to load messages" });
+    }
+  }
+);
+
+// ---------------------------------------------------------------
+// POST /api/applications/:id/messages — staff reply
+// ---------------------------------------------------------------
+router.post(
+  "/:id/messages",
+  authenticate,
+  requirePermission("application:read"),
+  async (req: AuthRequest, res: Response): Promise<void> => {
+    try {
+      const applicationId = param(req.params.id);
+      if (!(await assertStaffCanAccessApplication(req, res, applicationId))) return;
+
+      const parsed = bodySchema.safeParse(req.body);
+      if (!parsed.success) {
+        res
+          .status(400)
+          .json({ error: "Validation failed", details: parsed.error.errors });
+        return;
+      }
+
+      const message = await service.create({
+        applicationId,
+        senderUserId: req.user!.id,
+        senderRole: "staff",
+        body: parsed.data.body,
+      });
+      res.status(201).json({ message });
+    } catch (err) {
+      logger.error("staff message create failed", { error: (err as Error).message });
+      res.status(500).json({ error: "Failed to send message" });
+    }
+  }
+);
+
+// ---------------------------------------------------------------
+// POST /api/applications/:id/messages/:msgId/read — staff marks unread
+// applicant/tenant message as read
+// ---------------------------------------------------------------
+router.post(
+  "/:id/messages/:msgId/read",
+  authenticate,
+  requirePermission("application:read"),
+  async (req: AuthRequest, res: Response): Promise<void> => {
+    try {
+      const applicationId = param(req.params.id);
+      const messageId = param(req.params.msgId);
+      if (!(await assertStaffCanAccessApplication(req, res, applicationId))) return;
+
+      const ok = await service.markRead({
+        messageId,
+        readerUserId: req.user!.id,
+        readerRole: "staff",
+      });
+      res.json({ updated: ok });
+    } catch (err) {
+      logger.error("staff message mark-read failed", { error: (err as Error).message });
+      res.status(500).json({ error: "Failed to mark message read" });
+    }
+  }
+);
+
+export default router;

--- a/src/modules/messages/service.ts
+++ b/src/modules/messages/service.ts
@@ -1,0 +1,138 @@
+import { query, transaction } from "../../config/database";
+
+export type SenderRole = "staff" | "applicant" | "tenant";
+
+export interface MessageRecord {
+  id: string;
+  applicationId: string;
+  senderUserId: string;
+  senderRole: SenderRole;
+  senderName: string;
+  body: string;
+  createdAt: string;
+  readAt: string | null;
+}
+
+function rowToMessage(row: any): MessageRecord {
+  return {
+    id: row.id,
+    applicationId: row.application_id,
+    senderUserId: row.sender_user_id,
+    senderRole: row.sender_role,
+    senderName: [row.first_name, row.last_name].filter(Boolean).join(" ") || row.email || "Unknown",
+    body: row.body,
+    createdAt:
+      row.created_at instanceof Date ? row.created_at.toISOString() : row.created_at,
+    readAt:
+      row.read_at instanceof Date ? row.read_at.toISOString() : row.read_at || null,
+  };
+}
+
+export class MessagesService {
+  /**
+   * Return all messages for an application in chronological order with
+   * the sender's display name joined from users.
+   */
+  async listForApplication(applicationId: string): Promise<MessageRecord[]> {
+    const result = await query(
+      `SELECT m.id, m.application_id, m.sender_user_id, m.sender_role, m.body,
+              m.created_at, m.read_at,
+              u.first_name, u.last_name, u.email
+       FROM application_messages m
+       JOIN users u ON u.id = m.sender_user_id
+       WHERE m.application_id = $1
+       ORDER BY m.created_at ASC`,
+      [applicationId]
+    );
+    return result.rows.map(rowToMessage);
+  }
+
+  /**
+   * Insert a new message and return the hydrated record (with sender name).
+   */
+  async create(input: {
+    applicationId: string;
+    senderUserId: string;
+    senderRole: SenderRole;
+    body: string;
+  }): Promise<MessageRecord> {
+    const trimmed = input.body.trim();
+    return transaction(async (client) => {
+      const ins = await client.query(
+        `INSERT INTO application_messages
+           (application_id, sender_user_id, sender_role, body)
+         VALUES ($1, $2, $3, $4)
+         RETURNING id`,
+        [input.applicationId, input.senderUserId, input.senderRole, trimmed]
+      );
+      const id = ins.rows[0].id as string;
+      const hydrated = await client.query(
+        `SELECT m.id, m.application_id, m.sender_user_id, m.sender_role, m.body,
+                m.created_at, m.read_at,
+                u.first_name, u.last_name, u.email
+         FROM application_messages m
+         JOIN users u ON u.id = m.sender_user_id
+         WHERE m.id = $1`,
+        [id]
+      );
+      return rowToMessage(hydrated.rows[0]);
+    });
+  }
+
+  /**
+   * Mark a message as read by the recipient. Senders may not mark their
+   * own messages as read. Returns true if a row was updated.
+   *
+   * Allowed pairings:
+   *   - reader is 'staff' AND sender_role is 'applicant'|'tenant'
+   *   - reader is 'applicant'|'tenant' AND sender_role is 'staff'
+   */
+  async markRead(input: {
+    messageId: string;
+    readerUserId: string;
+    readerRole: SenderRole;
+  }): Promise<boolean> {
+    const isReaderStaff = input.readerRole === "staff";
+    // Recipient pairing predicate
+    const senderRoleCondition = isReaderStaff
+      ? "sender_role IN ('applicant','tenant')"
+      : "sender_role = 'staff'";
+
+    const result = await query(
+      `UPDATE application_messages
+         SET read_at = NOW()
+       WHERE id = $1
+         AND read_at IS NULL
+         AND sender_user_id <> $2
+         AND ${senderRoleCondition}
+       RETURNING id`,
+      [input.messageId, input.readerUserId]
+    );
+    return result.rowCount! > 0;
+  }
+
+  /**
+   * Count unread messages addressed TO the given user — i.e. messages from
+   * the opposite side of the conversation.
+   */
+  async unreadCountForUser(input: {
+    applicationId: string;
+    userId: string;
+    userRole: SenderRole;
+  }): Promise<number> {
+    const isStaff = input.userRole === "staff";
+    const senderRoleCondition = isStaff
+      ? "sender_role IN ('applicant','tenant')"
+      : "sender_role = 'staff'";
+    const result = await query(
+      `SELECT COUNT(*)::int AS n
+       FROM application_messages
+       WHERE application_id = $1
+         AND read_at IS NULL
+         AND sender_user_id <> $2
+         AND ${senderRoleCondition}`,
+      [input.applicationId, input.userId]
+    );
+    return result.rows[0]?.n || 0;
+  }
+}

--- a/src/modules/tenant/routes.ts
+++ b/src/modules/tenant/routes.ts
@@ -10,12 +10,14 @@ import {
 import { query } from "../../config/database";
 import { LedgerService } from "../ledger/service";
 import { MaintenanceService } from "../maintenance/service";
+import { MessagesService, SenderRole } from "../messages/service";
 import { logger } from "../../utils/logger";
 import { param } from "../../utils/params";
 
 const router: Router = Router();
 const ledger = new LedgerService();
 const maintenance = new MaintenanceService();
+const messages = new MessagesService();
 
 // All tenant routes require auth + applicant/tenant role + scope
 router.use(authenticate, requireTenantRole, scopeToOwnApplications);
@@ -327,6 +329,91 @@ router.get(
     } catch (err) {
       logger.error("tenant application detail failed", { error: (err as Error).message });
       res.status(500).json({ error: "Failed to load application" });
+    }
+  }
+);
+
+// ---------------------------------------------------------------
+// GET /api/tenant/applications/:applicationId/messages — list thread
+// ---------------------------------------------------------------
+router.get(
+  "/applications/:applicationId/messages",
+  async (req: AuthRequest, res: Response) => {
+    try {
+      const applicationId = param(req.params.applicationId);
+      if (!(await assertApplicationOwnership(req, res, applicationId))) return;
+
+      const list = await messages.listForApplication(applicationId);
+      res.json({ messages: list });
+    } catch (err) {
+      logger.error("tenant messages list failed", { error: (err as Error).message });
+      res.status(500).json({ error: "Failed to load messages" });
+    }
+  }
+);
+
+// ---------------------------------------------------------------
+// POST /api/tenant/applications/:applicationId/messages — reply to staff
+// ---------------------------------------------------------------
+const messageBodySchema = z.object({
+  body: z.string().trim().min(1).max(4000),
+});
+
+router.post(
+  "/applications/:applicationId/messages",
+  async (req: AuthRequest, res: Response) => {
+    try {
+      const applicationId = param(req.params.applicationId);
+      if (!(await assertApplicationOwnership(req, res, applicationId))) return;
+
+      const parsed = messageBodySchema.safeParse(req.body);
+      if (!parsed.success) {
+        res
+          .status(400)
+          .json({ error: "Validation failed", details: parsed.error.errors });
+        return;
+      }
+
+      // Derive sender_role from the authenticated user's portal role
+      // (applicant or tenant — staff cannot hit this path via requireTenantRole).
+      const senderRole = (req.user!.role === "tenant" ? "tenant" : "applicant") as SenderRole;
+
+      const message = await messages.create({
+        applicationId,
+        senderUserId: req.user!.id,
+        senderRole,
+        body: parsed.data.body,
+      });
+      res.status(201).json({ message });
+    } catch (err) {
+      logger.error("tenant message create failed", { error: (err as Error).message });
+      res.status(500).json({ error: "Failed to send message" });
+    }
+  }
+);
+
+// ---------------------------------------------------------------
+// POST /api/tenant/applications/:applicationId/messages/:msgId/read
+// — applicant/tenant marks staff message as read
+// ---------------------------------------------------------------
+router.post(
+  "/applications/:applicationId/messages/:msgId/read",
+  async (req: AuthRequest, res: Response) => {
+    try {
+      const applicationId = param(req.params.applicationId);
+      const messageId = param(req.params.msgId);
+      if (!(await assertApplicationOwnership(req, res, applicationId))) return;
+
+      const readerRole = (req.user!.role === "tenant" ? "tenant" : "applicant") as SenderRole;
+      const ok = await messages.markRead({
+        messageId,
+        readerUserId: req.user!.id,
+        readerRole,
+      });
+      res.json({ updated: ok });
+    } catch (err) {
+      logger.error("tenant message mark-read failed", { error: (err as Error).message });
+      res.status(500).json({ error: "Failed to mark message read" });
     }
   }
 );


### PR DESCRIPTION
## Summary

Adds the tenant "My Application" view and a two-way messaging thread between staff and applicants/tenants, demo-ready for Friday.

- **Schema**: new `application_messages` table (FK→applications ON DELETE CASCADE, `sender_role` CHECK, `body` non-empty trim, indexed by `(application_id, created_at DESC)`). Wired into `schema.ts`, a new timestamped migration, and the seed-demo cascade-delete list.
- **Backend**:
  - `MessagesService` — list/create/markRead/unreadCount with a recipient-only mark-read invariant (sender can never mark their own messages read).
  - **Tenant** routes (`/api/tenant/applications/:id/messages` GET/POST + `:msgId/read` POST), gated by existing `assertApplicationOwnership`. `sender_role` derived from authenticated role.
  - **Staff** routes (`/api/applications/:id/messages` GET/POST + `:msgId/read` POST), gated by `application:read` + property-scope check via `buildPropertyScope` (leasing agents can't see messages on out-of-scope properties).
  - Zod validation: `body` is trimmed, 1–4000 chars. All queries parameterized; `create` runs in a transaction.
- **Tenant client** (`client-tenant`):
  - New `Application.tsx` page — header (status badge + property + unit), Key Dates section, Property snapshot, Next-Steps checklist, full polling/optimistic chat thread.
  - Sidebar + mobile bottom nav add "My Application"; mobile grid bumped to `grid-cols-5`.
  - Route added at `/application`.
- **Staff client** (`client`):
  - New `ApplicationMessages` component embedded at the bottom of `ApplicationDetail.tsx`. Same thread UX with a Staff bubble; auto-marks incoming applicant/tenant messages as read on view.
- **Seed**: 3-message demo thread on Tomasz Kowalski's onboarded application (staff→tenant→staff), most recent message left unread.

## Test plan

- [ ] `npx tsc --noEmit` clean from repo root, `client/`, and `client-tenant/`
- [ ] `npm test` — 742 passed / 15 skipped / 33 suites (unchanged from main)
- [ ] Manual: log in as `demo-tenant@example.com`, click "My Application" — see status, dates, 3 seeded messages
- [ ] Manual: send a reply from the tenant, confirm it appears optimistically and persists after refresh
- [ ] Manual: log in as staff, open Tomasz's `/applications/:id` page, scroll to Messages, verify last applicant message marked read after open, reply, and confirm tenant sees it within 15s poll
- [ ] Manual: leasing agent with property_ids excluding Tomasz's property gets 403 on the staff messages endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)