### PR TITLE
feat(unit-claim): intent quiz → unit picker → claim flow; fix(auth): W6 enum closure + apply routing

### DIFF
--- a/PLAN-unit-claim-slice.md
+++ b/PLAN-unit-claim-slice.md
@@ -1,0 +1,181 @@
+# Unit-Claim Slice — Burn Plan
+
+**Created:** 2026-05-14
+**Status:** Migration shipped to local DB + schema.ts updated. Backend routes, seed, and frontend still pending.
+**Branch:** `feat/my-application-messaging`
+**Last commit:** `e928d9e` (applicant routing fix)
+**Dirty tree at pause:** `src/db/schema.ts` + `src/db/migrations/2026-05-14-units-and-intent.sql` (uncommitted)
+
+---
+
+## Why This Slice
+
+FTU on Frank-Pilot is an **applicant**, not a tenant. Conversion = get them to **plant a flag on a specific available unit** as early as possible. The claimed unit becomes psychologically theirs — every subsequent doc upload, income verification, and screening step is in service of *keeping* that unit. Skin in the game.
+
+See [memory: `project-ftu-unit-claim-carrot.md`].
+
+---
+
+## End-State Flow (post-slice)
+
+```
+/apply
+  │
+  ▼
+┌────────────────┐ POST /applicants/register
+│ STEP 1 ACCOUNT │ ───────────────────────►  magic-link email
+│ name + email   │
+└────────────────┘
+  │
+  ▼ magic-link verify  →  AuthCallback  →  /apply?step=intent
+┌────────────────┐                                 NEW
+│ STEP 2 INTENT  │  5 questions:
+│ quick quiz     │   1. Bedrooms wanted (Studio/1/2/3/4+)
+│                │   2. Monthly budget slider ($500-$3000)
+│                │   3. Target move-in date
+│                │   4. Household size (1-8)
+│                │   5. Property preference (optional)
+└────────────────┘
+  │  POST /applicants/intent
+  ▼
+┌────────────────┐                                 NEW
+│ STEP 3 PICK    │  GET /applicants/units?intent=…
+│ unit grid      │  Up to 12 cards w/ photos, rent, beds
+│                │  "Claim this unit" CTA
+└────────────────┘
+  │  POST /applicants/claim-unit/:id
+  ▼
+┌────────────────┐                                 NEW
+│ STEP 4 CLAIM   │  Modal: unit photo + 48h countdown
+│ confirmation   │  CTA: "Continue your application"
+└────────────────┘
+  │
+  ▼
+┌────────────────┐
+│ STEP 5 DETAILS │  Existing details form (SSN/DOB/income/etc)
+│ form + header  │  NEW: sticky header with claimed unit photo
+│                │  + live countdown timer
+└────────────────┘
+```
+
+---
+
+## Status: Phase 1 — Migration ✅ DONE
+
+Committed-ready (NOT yet committed):
+- `src/db/migrations/2026-05-14-units-and-intent.sql` — applied to local Postgres
+- `src/db/schema.ts` — `units` table added, applications got intent_* + claimed_unit_id + claim_expires_at columns
+
+```sql
+-- units table
+id, property_id (FK), unit_number, bedrooms, bathrooms, sqft, monthly_rent,
+status (available|held|leased|off_market), photo_url, description,
+available_from, created_at, updated_at
+UNIQUE (property_id, unit_number)
+indexes on (property_id, status), partial WHERE status='available', (bedrooms, monthly_rent)
+
+-- applications additions
+intent_bedrooms, intent_budget_min, intent_budget_max, intent_move_in_date,
+intent_household_size, claimed_unit_id (FK to units), claim_expires_at
+```
+
+**Next-burn action:** `git add src/db/migrations/2026-05-14-units-and-intent.sql src/db/schema.ts && git commit` with message `feat(db): units table + applicant intent/claim columns`.
+
+---
+
+## Next-Burn Checklist (sequenced)
+
+### Phase 2 — Seed (~20 min)
+**File:** `src/db/seed.ts` (extend) or new `src/db/seed-units.ts`
+- For each existing property: iterate `unit_mix` JSON (e.g. `{"1BR":40,"2BR":80}`)
+- Generate N units per bedroom type with deterministic unit numbers (e.g. `A-101`, `A-102`, …)
+- Pull `monthly_rent` from `properties.rent_schedule` JSON or fallback per-bedroom default
+- Status distribution: ~30% available, ~50% leased, ~20% held (with expired claim_expires_at so they re-appear available)
+- Photo URL: `https://picsum.photos/seed/${unit_id_short}/800/600` (deterministic Lorem Picsum) — replace with real photos later
+- Run `npm run seed:demo` to verify
+
+**Acceptance:** `SELECT count(*) FROM units WHERE status='available';` returns >50 across all properties.
+
+### Phase 3 — Backend routes (~60 min)
+**File:** `src/modules/applicants/routes.ts`
+
+#### `POST /applicants/intent` (authenticated, requireEmailVerified)
+Save the 5 quiz answers onto the user's current draft application (UPSERT — find draft, or create one). Returns the application id.
+
+#### `GET /applicants/units` (authenticated, requireEmailVerified)
+Query params: `bedrooms` (int), `maxRent` (numeric), `moveInBy` (date), `propertyId` (uuid, optional). Returns up to 12 units joined with property name, where:
+```sql
+status = 'available'
+OR (status = 'held' AND claim_expires_at < NOW())
+```
+Auto-expire stale holds in the query — don't need a cron.
+
+Response shape:
+```typescript
+{ units: Array<{
+    id, property_id, property_name, property_city, property_state,
+    unit_number, bedrooms, bathrooms, sqft, monthly_rent,
+    photo_url, available_from
+  }> }
+```
+
+#### `POST /applicants/claim-unit/:id` (authenticated, requireEmailVerified)
+Atomic transaction:
+1. `SELECT … FROM units WHERE id=:id FOR UPDATE`
+2. Verify `status='available'` OR (`status='held'` AND `claim_expires_at < NOW()`). Otherwise 409 `UNIT_UNAVAILABLE`.
+3. Release any existing claim by this user (free up unit if they're switching)
+4. `UPDATE units SET status='held'` for the new unit
+5. `UPDATE applications SET claimed_unit_id=:id, claim_expires_at=NOW()+'48 hours'` for the user's draft
+6. Return `{ unit, expires_at }`
+
+#### `DELETE /applicants/claim-unit` (authenticated, requireEmailVerified)
+Release the current user's claim — set unit back to `available`, clear application's claimed_unit_id + claim_expires_at.
+
+**Acceptance:** integration test in `src/__tests__/unit-claim.test.ts` covering: claim available → 200, claim held → 409, claim expired-held → 200 (treats as available), DELETE → unit back to available.
+
+### Phase 4 — Frontend (~120 min)
+**Files:**
+- `client-tenant/src/api/units.ts` — NEW: `fetchUnits(intent)`, `claimUnit(id)`, `releaseClaim()`
+- `client-tenant/src/pages/Apply.tsx` — extend the `Step` union: `1 | 'verify' | 'intent' | 'pick' | 'claim' | 2`
+- `client-tenant/src/pages/AuthCallback.tsx` — change `/apply?step=2` → `/apply?step=intent` for new applicants
+- `client-tenant/src/components/UnitCard.tsx` — NEW
+- `client-tenant/src/components/ClaimedUnitHeader.tsx` — NEW (sticky on step 2 / details)
+
+**Step 2 intent quiz UI:** big tappable button rows for bedrooms, range input for budget, native date input for move-in, select for household size. Single submit → save intent → advance.
+
+**Step 3 unit picker:** 2-col grid on desktop, 1-col on mobile. Each card: hero photo (16:9 cropped), property name + city/state, unit number, "$X/mo", bedrooms·bath·sqft pill, "Claim this unit" green button.
+
+**Step 4 claim confirmation:** centered modal-style card, large unit photo, "**Unit X is yours until [date+48h]**", live ticking countdown ("47:59:32"), CTA "Continue your application" → goes to step 2 (existing details form).
+
+**Step 2 (renamed to step 5 conceptually) sticky header:** thin pinned card at top of details form: thumbnail (64px), property + unit one-liner, "$X/mo", small countdown. Persistent reminder of what they're working toward.
+
+### Phase 5 — Polish (~30 min)
+- Wire claimed-unit data into existing `/application` status page so it shows the unit
+- Add "Release this unit" button on the status page so users can switch their claim
+- Consider: cron job to auto-expire claims older than 48h and set unit back to available (currently lazy-expire via query is fine for MVP)
+
+---
+
+## Open Product Questions (decide before next burn)
+
+1. **Claim hold duration**: 48h confirmed in plan. Should this be 24h to add urgency, or 72h to be forgiving? — Default 48h until told otherwise.
+2. **Multiple intents over time**: if user comes back next week, do their old intent answers prefill, or do they re-quiz? — Default: prefill, but allow edit.
+3. **Switching claims**: explicit DELETE + new POST (clean), or POST replaces silently? — Plan as-written: POST replaces (releases old claim atomically).
+4. **Photos**: Lorem Picsum placeholders for now. Real upload UI is a separate slice (Phase 2 of project map).
+5. **Optional password**: defer to Phase 2 of project map (out of scope for this slice).
+
+---
+
+## Project-Wide Roadmap (parent context)
+
+This slice is **Phase 1** of the full Frank-Pilot roadmap. The other phases (incremental docs + progress bar, staff workflow, tenant lifecycle, hardening backlog, public surface) are summarized in the most recent advisor diagram and tracked via memory `project-ftu-unit-claim-carrot.md`.
+
+---
+
+## Files Touched In This Burn
+
+```
+src/db/migrations/2026-05-14-units-and-intent.sql   NEW    (applied to local DB)
+src/db/schema.ts                                    EDIT   (units + applications cols)
+PLAN-unit-claim-slice.md                            NEW    (this file)
+```

--- a/client-tenant/src/api/units.ts
+++ b/client-tenant/src/api/units.ts
@@ -1,0 +1,59 @@
+import { api } from './client';
+
+export interface Intent {
+  bedrooms: number;
+  budget_min?: number;
+  budget_max: number;
+  move_in_date: string;
+  household_size: number;
+  property_id?: string;
+}
+
+export interface Unit {
+  id: string;
+  property_id: string;
+  unit_number: string;
+  bedrooms: number;
+  bathrooms: string | number;
+  sqft: number | null;
+  monthly_rent: string | number;
+  photo_url: string | null;
+  available_from: string | null;
+  property_name: string;
+  property_city: string | null;
+  property_state: string | null;
+}
+
+export interface ClaimResponse {
+  ok: true;
+  unit: Unit;
+  expires_at: string;
+  application_id: string;
+}
+
+export async function saveIntent(intent: Intent): Promise<{ ok: boolean; application_id: string }> {
+  return api.post('/applicants/intent', intent);
+}
+
+export async function fetchUnits(filter: {
+  bedrooms?: number;
+  maxRent?: number;
+  moveInBy?: string;
+  propertyId?: string;
+}): Promise<{ units: Unit[] }> {
+  const params = new URLSearchParams();
+  if (filter.bedrooms !== undefined) params.set('bedrooms', String(filter.bedrooms));
+  if (filter.maxRent !== undefined) params.set('maxRent', String(filter.maxRent));
+  if (filter.moveInBy) params.set('moveInBy', filter.moveInBy);
+  if (filter.propertyId) params.set('propertyId', filter.propertyId);
+  const qs = params.toString();
+  return api.get(`/applicants/units${qs ? `?${qs}` : ''}`);
+}
+
+export async function claimUnit(unitId: string): Promise<ClaimResponse> {
+  return api.post(`/applicants/claim-unit/${unitId}`);
+}
+
+export async function releaseClaim(): Promise<{ ok: boolean }> {
+  return api.del('/applicants/claim-unit');
+}

--- a/client-tenant/src/components/ClaimedUnitHeader.tsx
+++ b/client-tenant/src/components/ClaimedUnitHeader.tsx
@@ -1,0 +1,59 @@
+import { useEffect, useState } from 'react';
+import { Clock } from 'lucide-react';
+import type { Unit } from '@/api/units';
+
+interface Props {
+  unit: Unit;
+  expiresAt: string;
+}
+
+function formatRent(rent: string | number): string {
+  const n = typeof rent === 'string' ? Number(rent) : rent;
+  return `$${Math.round(n).toLocaleString()}/mo`;
+}
+
+function formatCountdown(ms: number): string {
+  if (ms <= 0) return '00:00:00';
+  const total = Math.floor(ms / 1000);
+  const h = String(Math.floor(total / 3600)).padStart(2, '0');
+  const m = String(Math.floor((total % 3600) / 60)).padStart(2, '0');
+  const s = String(total % 60).padStart(2, '0');
+  return `${h}:${m}:${s}`;
+}
+
+export function ClaimedUnitHeader({ unit, expiresAt }: Props) {
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    const interval = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const remaining = new Date(expiresAt).getTime() - now;
+  const photo = unit.photo_url || `https://picsum.photos/seed/${unit.id.slice(0, 8)}/200/200`;
+
+  return (
+    <div className="sticky top-0 z-20 -mx-4 mb-4 border-b border-emerald-200 bg-emerald-50/95 px-4 py-3 backdrop-blur">
+      <div className="mx-auto flex max-w-md items-center gap-3">
+        <img
+          src={photo}
+          alt=""
+          className="h-12 w-12 flex-shrink-0 rounded-lg object-cover"
+        />
+        <div className="min-w-0 flex-1">
+          <div className="truncate text-sm font-semibold text-gray-900">
+            {unit.property_name} · Unit {unit.unit_number}
+          </div>
+          <div className="text-xs text-gray-600">{formatRent(unit.monthly_rent)}</div>
+        </div>
+        <div className="flex flex-col items-end">
+          <div className="inline-flex items-center gap-1 text-xs text-emerald-800">
+            <Clock className="h-3 w-3" />
+            <span className="font-mono font-medium">{formatCountdown(remaining)}</span>
+          </div>
+          <div className="text-[10px] uppercase tracking-wide text-emerald-700">held</div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client-tenant/src/components/UnitCard.tsx
+++ b/client-tenant/src/components/UnitCard.tsx
@@ -1,0 +1,67 @@
+import { Bed, Bath, Square } from 'lucide-react';
+import type { Unit } from '@/api/units';
+
+interface Props {
+  unit: Unit;
+  onClaim: (unitId: string) => void;
+  claiming?: boolean;
+}
+
+function formatRent(rent: string | number): string {
+  const n = typeof rent === 'string' ? Number(rent) : rent;
+  return `$${Math.round(n).toLocaleString()}/mo`;
+}
+
+export function UnitCard({ unit, onClaim, claiming }: Props) {
+  const photo = unit.photo_url || `https://picsum.photos/seed/${unit.id.slice(0, 8)}/800/600`;
+  const location = [unit.property_city, unit.property_state].filter(Boolean).join(', ');
+
+  return (
+    <div className="overflow-hidden rounded-xl bg-white shadow-sm ring-1 ring-gray-200">
+      <div className="aspect-[16/9] w-full overflow-hidden bg-gray-100">
+        <img
+          src={photo}
+          alt={`Unit ${unit.unit_number}`}
+          className="h-full w-full object-cover"
+          loading="lazy"
+        />
+      </div>
+      <div className="space-y-3 p-4">
+        <div>
+          <h3 className="text-base font-semibold text-gray-900">
+            {unit.property_name} · Unit {unit.unit_number}
+          </h3>
+          {location && <p className="text-xs text-gray-500">{location}</p>}
+        </div>
+
+        <div className="text-lg font-bold text-emerald-700">{formatRent(unit.monthly_rent)}</div>
+
+        <div className="flex flex-wrap gap-2 text-xs text-gray-600">
+          <span className="inline-flex items-center gap-1 rounded-full bg-gray-100 px-2 py-1">
+            <Bed className="h-3 w-3" />
+            {unit.bedrooms === 0 ? 'Studio' : `${unit.bedrooms} bd`}
+          </span>
+          <span className="inline-flex items-center gap-1 rounded-full bg-gray-100 px-2 py-1">
+            <Bath className="h-3 w-3" />
+            {unit.bathrooms} ba
+          </span>
+          {unit.sqft != null && (
+            <span className="inline-flex items-center gap-1 rounded-full bg-gray-100 px-2 py-1">
+              <Square className="h-3 w-3" />
+              {unit.sqft} sqft
+            </span>
+          )}
+        </div>
+
+        <button
+          type="button"
+          onClick={() => onClaim(unit.id)}
+          disabled={claiming}
+          className="btn-primary w-full"
+        >
+          {claiming ? 'Claiming…' : 'Claim this unit'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/client-tenant/src/pages/Application.tsx
+++ b/client-tenant/src/pages/Application.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState, useCallback } from 'react';
 import { Link } from 'react-router-dom';
 import { api } from '@/api/client';
+import { releaseClaim } from '@/api/units';
 import {
   FileText,
   AlertCircle,
@@ -9,7 +10,23 @@ import {
   Home,
   Calendar,
   CheckCircle2,
+  Clock,
+  X,
 } from 'lucide-react';
+
+interface ClaimedUnit {
+  id: string;
+  property_id: string;
+  unit_number: string;
+  bedrooms: number;
+  bathrooms: string | number;
+  sqft: number | null;
+  monthly_rent: string | number;
+  photo_url: string | null;
+  property_name: string;
+  property_city: string | null;
+  property_state: string | null;
+}
 
 interface ApplicationDetail {
   id: string;
@@ -30,6 +47,8 @@ interface ApplicationDetail {
   property_id: string;
   property_name: string;
   property_address: string;
+  claimed_unit: ClaimedUnit | null;
+  claim_expires_at: string | null;
 }
 
 interface DashboardData {
@@ -124,16 +143,18 @@ export function Application() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  // Pull the dashboard once to discover the active application.
-  useEffect(() => {
-    api
+  const loadDashboard = useCallback(() => {
+    return api
       .get<DashboardData>('/tenant/dashboard')
       .then((d) => setData(d))
       .catch((err) =>
         setError(err instanceof Error ? err.message : 'Failed to load application'),
-      )
-      .finally(() => setLoading(false));
+      );
   }, []);
+
+  useEffect(() => {
+    loadDashboard().finally(() => setLoading(false));
+  }, [loadDashboard]);
 
   if (loading) {
     return (
@@ -186,6 +207,15 @@ export function Application() {
         <StatusPill status={app.status} />
       </div>
 
+      {/* Claimed unit (draft only — when an applicant has held a unit) */}
+      {app.claimed_unit && app.claim_expires_at && (
+        <ClaimedUnitCard
+          unit={app.claimed_unit}
+          expiresAt={app.claim_expires_at}
+          onReleased={loadDashboard}
+        />
+      )}
+
       {/* Key dates */}
       <section className="rounded-xl bg-white p-5 shadow-sm">
         <h2 className="mb-3 flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-gray-500">
@@ -217,6 +247,103 @@ export function Application() {
       {/* Messages thread */}
       <MessagesThread applicationId={app.id} userId={userId} />
     </div>
+  );
+}
+
+function formatRent(rent: string | number): string {
+  const n = typeof rent === 'string' ? Number(rent) : rent;
+  return `$${Math.round(n).toLocaleString()}/mo`;
+}
+
+function formatCountdown(ms: number): string {
+  if (ms <= 0) return '00:00:00';
+  const total = Math.floor(ms / 1000);
+  const h = String(Math.floor(total / 3600)).padStart(2, '0');
+  const m = String(Math.floor((total % 3600) / 60)).padStart(2, '0');
+  const s = String(total % 60).padStart(2, '0');
+  return `${h}:${m}:${s}`;
+}
+
+function ClaimedUnitCard({
+  unit,
+  expiresAt,
+  onReleased,
+}: {
+  unit: ClaimedUnit;
+  expiresAt: string;
+  onReleased: () => Promise<void> | void;
+}) {
+  const [now, setNow] = useState(() => Date.now());
+  const [releasing, setReleasing] = useState(false);
+  const [releaseError, setReleaseError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const interval = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const remaining = new Date(expiresAt).getTime() - now;
+  const photo =
+    unit.photo_url || `https://picsum.photos/seed/${unit.id.slice(0, 8)}/800/600`;
+
+  async function handleRelease() {
+    const ok = window.confirm(
+      `Release Unit ${unit.unit_number}? Someone else will be able to claim it.`,
+    );
+    if (!ok) return;
+    setReleasing(true);
+    setReleaseError(null);
+    try {
+      await releaseClaim();
+      await onReleased();
+    } catch (err) {
+      setReleaseError(err instanceof Error ? err.message : 'Failed to release unit');
+    } finally {
+      setReleasing(false);
+    }
+  }
+
+  return (
+    <section className="overflow-hidden rounded-xl bg-white shadow-sm ring-1 ring-emerald-100">
+      <div className="relative">
+        <img src={photo} alt="" className="h-40 w-full object-cover sm:h-48" />
+        <div className="absolute right-3 top-3 inline-flex items-center gap-1.5 rounded-full bg-white/95 px-2.5 py-1 text-xs font-semibold text-emerald-700 shadow-sm">
+          <Clock className="h-3.5 w-3.5" />
+          <span className="font-mono">{formatCountdown(remaining)}</span>
+        </div>
+      </div>
+      <div className="p-5">
+        <div className="text-[11px] font-semibold uppercase tracking-wider text-emerald-700">
+          You're holding this unit
+        </div>
+        <h3 className="mt-1 text-base font-semibold text-gray-900">
+          {unit.property_name} · Unit {unit.unit_number}
+        </h3>
+        <div className="mt-1 text-sm text-gray-600">
+          {unit.bedrooms} bd · {unit.bathrooms} ba
+          {unit.sqft ? ` · ${unit.sqft} sqft` : ''} · {formatRent(unit.monthly_rent)}
+        </div>
+        <p className="mt-3 text-xs text-gray-500">
+          Complete your application before the hold expires to keep this unit.
+        </p>
+        {releaseError && (
+          <div className="mt-3 rounded-lg bg-red-50 px-3 py-2 text-xs text-red-700">
+            {releaseError}
+          </div>
+        )}
+        <div className="mt-4 flex justify-end">
+          <button
+            type="button"
+            onClick={handleRelease}
+            disabled={releasing}
+            className="inline-flex items-center gap-1.5 rounded-lg border border-gray-200 px-3 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+          >
+            <X className="h-3.5 w-3.5" />
+            {releasing ? 'Releasing…' : 'Release this unit'}
+          </button>
+        </div>
+      </div>
+    </section>
   );
 }
 

--- a/client-tenant/src/pages/Apply.tsx
+++ b/client-tenant/src/pages/Apply.tsx
@@ -79,19 +79,31 @@ export function Apply() {
   }, [step]);
 
   // If we land on step 2 via a deep link (e.g. magic-link callback) the in-memory
-  // step-1 state is empty. Hydrate name/email from the authed session so the
-  // /applicants/apply submission has everything the schema needs.
+  // step-1 state is empty. Hydrate name/email from the authed session, and if
+  // there is a prior application, prefill the rest so returning users continue
+  // where they left off instead of facing a blank form.
   useEffect(() => {
     if (step !== 2) return;
     if (email && firstName && lastName) return;
     let cancelled = false;
     (async () => {
       try {
-        const res = await api.get<{ user?: { email: string; firstName: string; lastName: string } }>('/auth/me');
-        if (cancelled || !res.user) return;
-        if (!email) setEmail(res.user.email);
-        if (!firstName) setFirstName(res.user.firstName);
-        if (!lastName) setLastName(res.user.lastName);
+        const me = await api.get<{ user?: { email: string; firstName: string; lastName: string } }>('/auth/me');
+        if (cancelled || !me.user) return;
+        if (!email) setEmail(me.user.email);
+        if (!firstName) setFirstName(me.user.firstName);
+        if (!lastName) setLastName(me.user.lastName);
+
+        const apps = await api.get<{ applications?: Array<{
+          id: string;
+          property_id?: string;
+          unit_number?: string;
+          requested_rent_amount?: string | number;
+        }> }>('/applicants/me/applications');
+        const latest = apps.applications?.[0];
+        if (cancelled || !latest) return;
+        if (latest.property_id && !propertyId) setPropertyId(latest.property_id);
+        if (latest.unit_number && !unitNumber) setUnitNumber(latest.unit_number);
       } catch {
         // ignored — 401 will be handled by client.ts redirect
       }
@@ -99,7 +111,7 @@ export function Apply() {
     return () => {
       cancelled = true;
     };
-  }, [step, email, firstName, lastName]);
+  }, [step, email, firstName, lastName, propertyId, unitNumber]);
 
   // Once we land on step 2 (either via verify polling or via ?step=2 deep link),
   // fetch properties so the applicant can pick one.

--- a/client-tenant/src/pages/Apply.tsx
+++ b/client-tenant/src/pages/Apply.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useNavigate, useSearchParams, Link } from 'react-router-dom';
-import { api, setToken } from '@/api/client';
+import { api } from '@/api/client';
 import { requestMagicLink } from '@/api/auth';
 import { CheckCircle, Mail } from 'lucide-react';
 
@@ -52,6 +52,9 @@ export function Apply() {
   // Verify-stage state
   const [resending, setResending] = useState(false);
   const [resent, setResent] = useState(false);
+  // devLink is only populated in development when the server returns the raw
+  // magic link in the /register response — lets QA skip their inbox.
+  const [devLink, setDevLink] = useState<string | null>(null);
 
   // Poll /auth/me while in the verify stage; advance when the server reports
   // emailVerified=true (the user clicked the magic link, here or in another tab).
@@ -103,15 +106,15 @@ export function Apply() {
     setError(null);
     setLoading(true);
     try {
-      const res = await api.post<{ token?: string }>('/applicants/register', {
+      const res = await api.post<{ ok: boolean; devLink?: string }>('/applicants/register', {
         email,
         firstName,
         lastName,
         phone: phone || undefined,
       });
-      if (res.token) setToken(res.token);
-      // The token is emailVerified=false — go to the verify stage. The user
-      // must click the magic link in their inbox before /apply will accept us.
+      // W6: no token returned from /register. Client must wait for magic-link
+      // click; token+user are issued only by /auth/magic-link/verify.
+      if (res.devLink) setDevLink(res.devLink);
       setStep('verify');
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Registration failed');
@@ -268,6 +271,14 @@ export function Apply() {
               >
                 {resending ? 'Resending…' : 'Resend link'}
               </button>
+              {devLink && (
+                <a
+                  href={devLink}
+                  className="block rounded-lg border border-amber-300 bg-amber-50 px-4 py-2 text-center text-sm font-medium text-amber-800 hover:bg-amber-100"
+                >
+                  [Dev] Open magic link
+                </a>
+              )}
               <button
                 onClick={() => setStep(1)}
                 className="text-sm text-gray-500 hover:text-gray-700 hover:underline"

--- a/client-tenant/src/pages/Apply.tsx
+++ b/client-tenant/src/pages/Apply.tsx
@@ -78,6 +78,29 @@ export function Apply() {
     };
   }, [step]);
 
+  // If we land on step 2 via a deep link (e.g. magic-link callback) the in-memory
+  // step-1 state is empty. Hydrate name/email from the authed session so the
+  // /applicants/apply submission has everything the schema needs.
+  useEffect(() => {
+    if (step !== 2) return;
+    if (email && firstName && lastName) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await api.get<{ user?: { email: string; firstName: string; lastName: string } }>('/auth/me');
+        if (cancelled || !res.user) return;
+        if (!email) setEmail(res.user.email);
+        if (!firstName) setFirstName(res.user.firstName);
+        if (!lastName) setLastName(res.user.lastName);
+      } catch {
+        // ignored — 401 will be handled by client.ts redirect
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [step, email, firstName, lastName]);
+
   // Once we land on step 2 (either via verify polling or via ?step=2 deep link),
   // fetch properties so the applicant can pick one.
   useEffect(() => {

--- a/client-tenant/src/pages/Apply.tsx
+++ b/client-tenant/src/pages/Apply.tsx
@@ -2,7 +2,10 @@ import { useEffect, useState } from 'react';
 import { useNavigate, useSearchParams, Link } from 'react-router-dom';
 import { api } from '@/api/client';
 import { requestMagicLink } from '@/api/auth';
-import { CheckCircle, Mail } from 'lucide-react';
+import { saveIntent, fetchUnits, claimUnit, type Unit } from '@/api/units';
+import { UnitCard } from '@/components/UnitCard';
+import { ClaimedUnitHeader } from '@/components/ClaimedUnitHeader';
+import { CheckCircle, Mail, Loader2 } from 'lucide-react';
 
 interface Property {
   id: string;
@@ -12,16 +15,39 @@ interface Property {
   state?: string;
 }
 
-// Step 1: register → Step "verify": check email (polls /auth/me) → Step 2: details.
-type Step = 1 | 'verify' | 2;
+// Step 1: register → 'verify': check email → 'intent': quiz → 'pick': units grid
+// → 'claim': confirmation modal → 2: details form. Each step is a stable URL
+// param so deep links and back-button work.
+type Step = 1 | 'verify' | 'intent' | 'pick' | 'claim' | 2;
+
+function parseStep(raw: string | null): Step {
+  if (raw === '2') return 2;
+  if (raw === 'verify' || raw === 'intent' || raw === 'pick' || raw === 'claim') return raw;
+  return 1;
+}
+
+const BEDROOM_OPTIONS: Array<{ value: number; label: string }> = [
+  { value: 0, label: 'Studio' },
+  { value: 1, label: '1 BR' },
+  { value: 2, label: '2 BR' },
+  { value: 3, label: '3 BR' },
+  { value: 4, label: '4+ BR' },
+];
 
 export function Apply() {
   const navigate = useNavigate();
-  const [search] = useSearchParams();
-  const [step, setStep] = useState<Step>(search.get('step') === '2' ? 2 : 1);
+  const [search, setSearch] = useSearchParams();
+  const [step, setStepState] = useState<Step>(parseStep(search.get('step')));
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [done, setDone] = useState(false);
+
+  // Keep ?step= in sync with state so reloads land on the same step.
+  function setStep(next: Step) {
+    setStepState(next);
+    const value = next === 1 ? null : String(next);
+    setSearch(value ? { step: value } : {}, { replace: true });
+  }
 
   // Step 1 fields
   const [email, setEmail] = useState('');
@@ -29,7 +55,27 @@ export function Apply() {
   const [lastName, setLastName] = useState('');
   const [phone, setPhone] = useState('');
 
-  // Properties for dropdown (loaded in step 2)
+  // Verify
+  const [resending, setResending] = useState(false);
+  const [resent, setResent] = useState(false);
+  const [devLink, setDevLink] = useState<string | null>(null);
+
+  // Intent quiz
+  const [intentBedrooms, setIntentBedrooms] = useState<number | null>(null);
+  const [intentBudgetMax, setIntentBudgetMax] = useState<number>(2000);
+  const [intentMoveInDate, setIntentMoveInDate] = useState('');
+  const [intentHouseholdSize, setIntentHouseholdSize] = useState<number>(1);
+
+  // Pick
+  const [units, setUnits] = useState<Unit[]>([]);
+  const [unitsLoading, setUnitsLoading] = useState(false);
+  const [claimingUnitId, setClaimingUnitId] = useState<string | null>(null);
+
+  // Claim
+  const [claimedUnit, setClaimedUnit] = useState<Unit | null>(null);
+  const [claimExpiresAt, setClaimExpiresAt] = useState<string | null>(null);
+
+  // Properties for dropdown (step 2 fallback)
   const [properties, setProperties] = useState<Property[]>([]);
   const [propertiesLoading, setPropertiesLoading] = useState(false);
   const [propertiesFailed, setPropertiesFailed] = useState(false);
@@ -49,15 +95,7 @@ export function Apply() {
   const [householdSize, setHouseholdSize] = useState('1');
   const [moveInDate, setMoveInDate] = useState('');
 
-  // Verify-stage state
-  const [resending, setResending] = useState(false);
-  const [resent, setResent] = useState(false);
-  // devLink is only populated in development when the server returns the raw
-  // magic link in the /register response — lets QA skip their inbox.
-  const [devLink, setDevLink] = useState<string | null>(null);
-
-  // Poll /auth/me while in the verify stage; advance when the server reports
-  // emailVerified=true (the user clicked the magic link, here or in another tab).
+  // Verify-stage poll: advance when /auth/me reports emailVerified=true.
   useEffect(() => {
     if (step !== 'verify') return;
     let cancelled = false;
@@ -65,9 +103,9 @@ export function Apply() {
       try {
         const res = await api.get<{ user?: { email: string; emailVerified: boolean } }>('/auth/me');
         if (cancelled) return;
-        if (res.user?.emailVerified) setStep(2);
+        if (res.user?.emailVerified) setStep('intent');
       } catch {
-        // ignored — 401 will be handled by client.ts redirect
+        /* ignored — 401 redirect handled by client.ts */
       }
     }
     check();
@@ -78,12 +116,9 @@ export function Apply() {
     };
   }, [step]);
 
-  // If we land on step 2 via a deep link (e.g. magic-link callback) the in-memory
-  // step-1 state is empty. Hydrate name/email from the authed session, and if
-  // there is a prior application, prefill the rest so returning users continue
-  // where they left off instead of facing a blank form.
+  // Hydrate identity + intent prefill on entering 'intent'/'pick'/2 (deep links).
   useEffect(() => {
-    if (step !== 2) return;
+    if (step !== 'intent' && step !== 'pick' && step !== 2) return;
     if (email && firstName && lastName) return;
     let cancelled = false;
     (async () => {
@@ -98,25 +133,64 @@ export function Apply() {
           id: string;
           property_id?: string;
           unit_number?: string;
-          requested_rent_amount?: string | number;
+          intent_bedrooms?: number | null;
+          intent_budget_max?: string | number | null;
+          intent_move_in_date?: string | null;
+          intent_household_size?: number | null;
         }> }>('/applicants/me/applications');
         const latest = apps.applications?.[0];
         if (cancelled || !latest) return;
         if (latest.property_id && !propertyId) setPropertyId(latest.property_id);
         if (latest.unit_number && !unitNumber) setUnitNumber(latest.unit_number);
+        if (latest.intent_bedrooms != null && intentBedrooms === null) setIntentBedrooms(latest.intent_bedrooms);
+        if (latest.intent_budget_max != null) setIntentBudgetMax(Number(latest.intent_budget_max));
+        if (latest.intent_move_in_date) setIntentMoveInDate(latest.intent_move_in_date.slice(0, 10));
+        if (latest.intent_household_size != null) {
+          setIntentHouseholdSize(latest.intent_household_size);
+          setHouseholdSize(String(latest.intent_household_size));
+        }
       } catch {
-        // ignored — 401 will be handled by client.ts redirect
+        /* ignored */
       }
     })();
     return () => {
       cancelled = true;
     };
-  }, [step, email, firstName, lastName, propertyId, unitNumber]);
+  }, [step, email, firstName, lastName, propertyId, unitNumber, intentBedrooms]);
 
-  // Once we land on step 2 (either via verify polling or via ?step=2 deep link),
-  // fetch properties so the applicant can pick one.
+  // On entering 'pick': fetch units matching the intent. Bounce back to
+  // 'intent' if the quiz hasn't been answered.
   useEffect(() => {
-    if (step !== 2 || properties.length > 0 || propertiesLoading) return;
+    if (step !== 'pick') return;
+    if (intentBedrooms === null || !intentMoveInDate) {
+      setStep('intent');
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      setUnitsLoading(true);
+      setError(null);
+      try {
+        const res = await fetchUnits({
+          bedrooms: intentBedrooms,
+          maxRent: intentBudgetMax,
+          moveInBy: intentMoveInDate,
+        });
+        if (!cancelled) setUnits(res.units);
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : 'Could not load units');
+      } finally {
+        if (!cancelled) setUnitsLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [step, intentBedrooms, intentBudgetMax, intentMoveInDate]);
+
+  // Step 2 fallback: load properties if there's no claimed unit (rare path).
+  useEffect(() => {
+    if (step !== 2 || claimedUnit || properties.length > 0 || propertiesLoading) return;
     let cancelled = false;
     (async () => {
       setPropertiesLoading(true);
@@ -134,7 +208,7 @@ export function Apply() {
     return () => {
       cancelled = true;
     };
-  }, [step, properties.length, propertiesLoading]);
+  }, [step, claimedUnit, properties.length, propertiesLoading]);
 
   async function handleStep1(e: React.FormEvent) {
     e.preventDefault();
@@ -147,14 +221,52 @@ export function Apply() {
         lastName,
         phone: phone || undefined,
       });
-      // W6: no token returned from /register. Client must wait for magic-link
-      // click; token+user are issued only by /auth/magic-link/verify.
       if (res.devLink) setDevLink(res.devLink);
       setStep('verify');
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Registration failed');
     } finally {
       setLoading(false);
+    }
+  }
+
+  async function handleIntent(e: React.FormEvent) {
+    e.preventDefault();
+    if (intentBedrooms === null || !intentMoveInDate) return;
+    setError(null);
+    setLoading(true);
+    try {
+      await saveIntent({
+        bedrooms: intentBedrooms,
+        budget_max: intentBudgetMax,
+        move_in_date: intentMoveInDate,
+        household_size: intentHouseholdSize,
+      });
+      setHouseholdSize(String(intentHouseholdSize));
+      setMoveInDate(intentMoveInDate);
+      setStep('pick');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not save your preferences');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleClaim(unitId: string) {
+    setClaimingUnitId(unitId);
+    setError(null);
+    try {
+      const res = await claimUnit(unitId);
+      setClaimedUnit(res.unit);
+      setClaimExpiresAt(res.expires_at);
+      // Snap details-form fields to the chosen unit so the user can't desync them.
+      setPropertyId(res.unit.property_id);
+      setUnitNumber(res.unit.unit_number);
+      setStep('claim');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not claim this unit');
+    } finally {
+      setClaimingUnitId(null);
     }
   }
 
@@ -225,25 +337,38 @@ export function Apply() {
     );
   }
 
-  // Progress indicator — verify shares position with step 1 (it's a sub-state
-  // of the "Account" phase, before the form details start).
-  const progressActive: 1 | 2 = step === 2 ? 2 : 1;
+  // 3-phase progress: Account → Pick → Apply.
+  const phase: 1 | 2 | 3 =
+    step === 1 || step === 'verify' ? 1 :
+    step === 'intent' || step === 'pick' || step === 'claim' ? 2 : 3;
+  const phaseLabels: Array<{ n: 1 | 2 | 3; label: string }> = [
+    { n: 1, label: 'Account' },
+    { n: 2, label: 'Pick a unit' },
+    { n: 3, label: 'Apply' },
+  ];
+
+  // Wider container on the unit picker so the grid can breathe.
+  const containerWidth = step === 'pick' ? 'max-w-3xl' : 'max-w-md';
 
   return (
     <div className="min-h-screen bg-gray-50 p-4">
-      <div className="mx-auto max-w-md space-y-6 py-8">
+      <div className={`mx-auto ${containerWidth} space-y-6 py-8`}>
+        {step === 2 && claimedUnit && claimExpiresAt && (
+          <ClaimedUnitHeader unit={claimedUnit} expiresAt={claimExpiresAt} />
+        )}
+
         {/* Progress */}
         <div className="flex items-center gap-2">
-          {([1, 2] as const).map(s => (
-            <div key={s} className="flex items-center gap-2">
+          {phaseLabels.map(({ n, label }) => (
+            <div key={n} className="flex items-center gap-2">
               <div className={`flex h-7 w-7 items-center justify-center rounded-full text-xs font-bold
-                ${progressActive === s ? 'bg-emerald-600 text-white' : progressActive > s ? 'bg-emerald-100 text-emerald-700' : 'bg-gray-200 text-gray-500'}`}>
-                {s}
+                ${phase === n ? 'bg-emerald-600 text-white' : phase > n ? 'bg-emerald-100 text-emerald-700' : 'bg-gray-200 text-gray-500'}`}>
+                {n}
               </div>
-              <span className={`text-xs ${progressActive === s ? 'font-medium text-gray-900' : 'text-gray-400'}`}>
-                {s === 1 ? 'Account' : 'Application'}
+              <span className={`text-xs ${phase === n ? 'font-medium text-gray-900' : 'text-gray-400'}`}>
+                {label}
               </span>
-              {s < 2 && <div className="mx-1 h-px w-8 bg-gray-300" />}
+              {n < 3 && <div className="mx-1 h-px w-8 bg-gray-300" />}
             </div>
           ))}
         </div>
@@ -323,44 +448,208 @@ export function Apply() {
             </div>
           )}
 
+          {step === 'intent' && (
+            <>
+              <h1 className="mb-1 text-xl font-bold text-gray-900">What are you looking for?</h1>
+              <p className="mb-4 text-sm text-gray-500">A few quick questions so we can show you the right units.</p>
+              <form onSubmit={handleIntent} className="space-y-5">
+                <div>
+                  <label className="label">Bedrooms *</label>
+                  <div className="grid grid-cols-5 gap-2">
+                    {BEDROOM_OPTIONS.map(opt => (
+                      <button
+                        type="button"
+                        key={opt.value}
+                        onClick={() => setIntentBedrooms(opt.value)}
+                        className={`rounded-lg border px-2 py-3 text-sm font-medium transition
+                          ${intentBedrooms === opt.value
+                            ? 'border-emerald-600 bg-emerald-50 text-emerald-700'
+                            : 'border-gray-300 bg-white text-gray-700 hover:border-emerald-400'}`}
+                      >
+                        {opt.label}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+
+                <div>
+                  <label className="label" htmlFor="budget">
+                    Monthly budget: <span className="font-semibold text-gray-900">${intentBudgetMax.toLocaleString()}</span>
+                  </label>
+                  <input
+                    id="budget"
+                    type="range"
+                    min={500}
+                    max={5000}
+                    step={50}
+                    value={intentBudgetMax}
+                    onChange={e => setIntentBudgetMax(Number(e.target.value))}
+                    className="w-full accent-emerald-600"
+                  />
+                  <div className="mt-1 flex justify-between text-xs text-gray-400">
+                    <span>$500</span>
+                    <span>$5,000</span>
+                  </div>
+                </div>
+
+                <div>
+                  <label className="label" htmlFor="intentMoveIn">Target move-in *</label>
+                  <input
+                    id="intentMoveIn"
+                    type="date"
+                    className="input"
+                    required
+                    value={intentMoveInDate}
+                    onChange={e => setIntentMoveInDate(e.target.value)}
+                  />
+                </div>
+
+                <div>
+                  <label className="label" htmlFor="intentHousehold">Household size</label>
+                  <select
+                    id="intentHousehold"
+                    className="input"
+                    value={intentHouseholdSize}
+                    onChange={e => setIntentHouseholdSize(Number(e.target.value))}
+                  >
+                    {Array.from({ length: 8 }, (_, i) => i + 1).map(n => (
+                      <option key={n} value={n}>{n}</option>
+                    ))}
+                  </select>
+                </div>
+
+                <button
+                  type="submit"
+                  disabled={loading || intentBedrooms === null || !intentMoveInDate}
+                  className="btn-primary w-full"
+                >
+                  {loading ? 'Saving…' : 'Show me units'}
+                </button>
+              </form>
+            </>
+          )}
+
+          {step === 'pick' && (
+            <>
+              <h1 className="mb-1 text-xl font-bold text-gray-900">Pick your unit</h1>
+              <p className="mb-4 text-sm text-gray-500">
+                Claiming a unit holds it for you for 48 hours while you finish your application.
+              </p>
+              {unitsLoading ? (
+                <div className="flex items-center justify-center py-12 text-gray-400">
+                  <Loader2 className="mr-2 h-5 w-5 animate-spin" />
+                  Loading units…
+                </div>
+              ) : units.length === 0 ? (
+                <div className="rounded-lg bg-amber-50 p-4 text-sm text-amber-800">
+                  No units match your preferences right now.{' '}
+                  <button onClick={() => setStep('intent')} className="font-medium underline">
+                    Adjust your search
+                  </button>
+                </div>
+              ) : (
+                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                  {units.map(u => (
+                    <UnitCard
+                      key={u.id}
+                      unit={u}
+                      onClaim={handleClaim}
+                      claiming={claimingUnitId === u.id}
+                    />
+                  ))}
+                </div>
+              )}
+              <button
+                onClick={() => setStep('intent')}
+                className="mt-6 text-sm text-gray-500 hover:text-gray-700 hover:underline"
+              >
+                ← Edit preferences
+              </button>
+            </>
+          )}
+
+          {step === 'claim' && claimedUnit && claimExpiresAt && (
+            <div className="space-y-4 text-center">
+              <div className="overflow-hidden rounded-xl">
+                <img
+                  src={claimedUnit.photo_url || `https://picsum.photos/seed/${claimedUnit.id.slice(0, 8)}/800/600`}
+                  alt=""
+                  className="aspect-[16/9] w-full object-cover"
+                />
+              </div>
+              <div>
+                <h1 className="text-xl font-bold text-gray-900">
+                  Unit {claimedUnit.unit_number} is yours
+                </h1>
+                <p className="mt-1 text-sm text-gray-500">
+                  {claimedUnit.property_name}
+                  {claimedUnit.property_city && `, ${claimedUnit.property_city}`}
+                </p>
+              </div>
+              <ClaimCountdown expiresAt={claimExpiresAt} />
+              <button onClick={() => setStep(2)} className="btn-primary w-full">
+                Continue your application
+              </button>
+              <button
+                onClick={() => setStep('pick')}
+                className="text-sm text-gray-500 hover:text-gray-700 hover:underline"
+              >
+                Pick a different unit
+              </button>
+            </div>
+          )}
+
+          {step === 'claim' && (!claimedUnit || !claimExpiresAt) && (
+            <div className="space-y-4 text-center">
+              <p className="text-sm text-gray-500">No active claim — let's pick a unit.</p>
+              <button onClick={() => setStep('intent')} className="btn-primary w-full">
+                Start over
+              </button>
+            </div>
+          )}
+
           {step === 2 && (
             <>
               <h1 className="mb-4 text-xl font-bold text-gray-900">Application details</h1>
               <form onSubmit={handleStep2} className="space-y-4">
-                <div>
-                  <label className="label" htmlFor="propertyId">Property *</label>
-                  {propertiesLoading ? (
-                    <p className="text-sm text-gray-400">Loading properties…</p>
-                  ) : propertiesFailed || properties.length === 0 ? (
-                    <input
-                      id="propertyId"
-                      className="input"
-                      required
-                      placeholder="Property ID (UUID)"
-                      value={propertyId}
-                      onChange={e => setPropertyId(e.target.value)}
-                    />
-                  ) : (
-                    <select
-                      id="propertyId"
-                      className="input"
-                      required
-                      value={propertyId}
-                      onChange={e => setPropertyId(e.target.value)}
-                    >
-                      <option value="">Select a property…</option>
-                      {properties.map(p => (
-                        <option key={p.id} value={p.id}>
-                          {p.name}{p.city && p.state ? ` — ${p.city}, ${p.state}` : ''}
-                        </option>
-                      ))}
-                    </select>
-                  )}
-                </div>
-                <div>
-                  <label className="label" htmlFor="unitNumber">Unit number</label>
-                  <input id="unitNumber" className="input" value={unitNumber} onChange={e => setUnitNumber(e.target.value)} placeholder="Optional" />
-                </div>
+                {!claimedUnit && (
+                  <>
+                    <div>
+                      <label className="label" htmlFor="propertyId">Property *</label>
+                      {propertiesLoading ? (
+                        <p className="text-sm text-gray-400">Loading properties…</p>
+                      ) : propertiesFailed || properties.length === 0 ? (
+                        <input
+                          id="propertyId"
+                          className="input"
+                          required
+                          placeholder="Property ID (UUID)"
+                          value={propertyId}
+                          onChange={e => setPropertyId(e.target.value)}
+                        />
+                      ) : (
+                        <select
+                          id="propertyId"
+                          className="input"
+                          required
+                          value={propertyId}
+                          onChange={e => setPropertyId(e.target.value)}
+                        >
+                          <option value="">Select a property…</option>
+                          {properties.map(p => (
+                            <option key={p.id} value={p.id}>
+                              {p.name}{p.city && p.state ? ` — ${p.city}, ${p.state}` : ''}
+                            </option>
+                          ))}
+                        </select>
+                      )}
+                    </div>
+                    <div>
+                      <label className="label" htmlFor="unitNumber">Unit number</label>
+                      <input id="unitNumber" className="input" value={unitNumber} onChange={e => setUnitNumber(e.target.value)} placeholder="Optional" />
+                    </div>
+                  </>
+                )}
                 <div>
                   <label className="label" htmlFor="ssn">Social Security Number *</label>
                   <input
@@ -419,12 +708,16 @@ export function Apply() {
                   <input id="moveIn" type="date" className="input" value={moveInDate} onChange={e => setMoveInDate(e.target.value)} />
                 </div>
                 <div className="flex gap-3">
-                  <button type="button" onClick={() => setStep(1)} className="flex-1 rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50">
+                  <button
+                    type="button"
+                    onClick={() => setStep(claimedUnit ? 'claim' : 1)}
+                    className="flex-1 rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+                  >
                     Back
                   </button>
                   <button
                     type="submit"
-                    disabled={loading || !ssn || !!ssnError || !dateOfBirth || (!propertyId && !propertiesFailed)}
+                    disabled={loading || !ssn || !!ssnError || !dateOfBirth || (!claimedUnit && !propertyId && !propertiesFailed)}
                     className="btn-primary flex-1"
                   >
                     {loading ? 'Submitting…' : 'Submit application'}
@@ -439,6 +732,30 @@ export function Apply() {
           Already have an account?{' '}
           <Link to="/login" className="font-medium text-emerald-600 hover:underline">Sign in</Link>
         </p>
+      </div>
+    </div>
+  );
+}
+
+// Inline countdown for the claim-confirmation card. ClaimedUnitHeader has its
+// own copy for the sticky header context — this one is centered and large.
+function ClaimCountdown({ expiresAt }: { expiresAt: string }) {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const interval = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(interval);
+  }, []);
+  const remaining = new Date(expiresAt).getTime() - now;
+  const total = Math.max(0, Math.floor(remaining / 1000));
+  const h = String(Math.floor(total / 3600)).padStart(2, '0');
+  const m = String(Math.floor((total % 3600) / 60)).padStart(2, '0');
+  const s = String(total % 60).padStart(2, '0');
+  return (
+    <div className="rounded-lg bg-emerald-50 p-4">
+      <div className="text-xs uppercase tracking-wide text-emerald-700">Held until</div>
+      <div className="mt-1 font-mono text-2xl font-bold text-emerald-800">{h}:{m}:{s}</div>
+      <div className="mt-1 text-xs text-emerald-700">
+        Finish your application before the timer runs out to lock it in.
       </div>
     </div>
   );

--- a/client-tenant/src/pages/AuthCallback.tsx
+++ b/client-tenant/src/pages/AuthCallback.tsx
@@ -8,18 +8,18 @@ interface MeResponse {
   user?: { role: string; emailVerified: boolean };
 }
 
-// Applicants and tenants ALWAYS land on the application form after a magic-link
-// verify — the form is the carrot, not the dashboard. Returning users see their
-// prior submission prefilled (handled in Apply.tsx). Only staff/admin roles go
-// to /dashboard.
+// Applicants/tenants land on the intent quiz first — it's the entry to the
+// "plant a flag" flow that converts FTUs by getting them to claim a specific
+// unit before the heavier details form. Step 'intent' redirects forward on its
+// own if a claim already exists. Staff/admin go straight to /dashboard.
 async function resolvePostVerifyRoute(): Promise<string> {
   try {
     const me = await api.get<MeResponse>('/auth/me');
     const role = me.user?.role;
-    if (role === 'applicant' || role === 'tenant') return '/apply?step=2';
+    if (role === 'applicant' || role === 'tenant') return '/apply?step=intent';
     return '/dashboard';
   } catch {
-    return '/apply?step=2';
+    return '/apply?step=intent';
   }
 }
 

--- a/client-tenant/src/pages/AuthCallback.tsx
+++ b/client-tenant/src/pages/AuthCallback.tsx
@@ -1,7 +1,32 @@
 import { useEffect, useState } from 'react';
 import { useSearchParams, useNavigate, Link } from 'react-router-dom';
+import { api } from '@/api/client';
 import { verifyMagicLink } from '@/api/auth';
 import { Loader2 } from 'lucide-react';
+
+interface MeResponse {
+  user?: { role: string; emailVerified: boolean };
+}
+
+interface ApplicationsResponse {
+  applications?: Array<{ id: string }>;
+}
+
+// First-touch friction killer: a freshly-verified applicant with no submitted
+// application gets sent straight to /apply step 2 to finish in one sitting.
+// Anyone else (returning applicant, staff) lands on /dashboard.
+async function resolvePostVerifyRoute(): Promise<string> {
+  try {
+    const me = await api.get<MeResponse>('/auth/me');
+    const role = me.user?.role;
+    if (role !== 'applicant' && role !== 'tenant') return '/dashboard';
+    const apps = await api.get<ApplicationsResponse>('/applicants/me/applications');
+    if (!apps.applications || apps.applications.length === 0) return '/apply?step=2';
+    return '/dashboard';
+  } catch {
+    return '/dashboard';
+  }
+}
 
 export function AuthCallback() {
   const [searchParams] = useSearchParams();
@@ -16,7 +41,8 @@ export function AuthCallback() {
     }
 
     verifyMagicLink(token)
-      .then(() => navigate('/dashboard', { replace: true }))
+      .then(resolvePostVerifyRoute)
+      .then(dest => navigate(dest, { replace: true }))
       .catch(err => setError(err instanceof Error ? err.message : 'Invalid or expired link'));
   }, [searchParams, navigate]);
 

--- a/client-tenant/src/pages/AuthCallback.tsx
+++ b/client-tenant/src/pages/AuthCallback.tsx
@@ -8,23 +8,18 @@ interface MeResponse {
   user?: { role: string; emailVerified: boolean };
 }
 
-interface ApplicationsResponse {
-  applications?: Array<{ id: string }>;
-}
-
-// First-touch friction killer: a freshly-verified applicant with no submitted
-// application gets sent straight to /apply step 2 to finish in one sitting.
-// Anyone else (returning applicant, staff) lands on /dashboard.
+// Applicants and tenants ALWAYS land on the application form after a magic-link
+// verify — the form is the carrot, not the dashboard. Returning users see their
+// prior submission prefilled (handled in Apply.tsx). Only staff/admin roles go
+// to /dashboard.
 async function resolvePostVerifyRoute(): Promise<string> {
   try {
     const me = await api.get<MeResponse>('/auth/me');
     const role = me.user?.role;
-    if (role !== 'applicant' && role !== 'tenant') return '/dashboard';
-    const apps = await api.get<ApplicationsResponse>('/applicants/me/applications');
-    if (!apps.applications || apps.applications.length === 0) return '/apply?step=2';
+    if (role === 'applicant' || role === 'tenant') return '/apply?step=2';
     return '/dashboard';
   } catch {
-    return '/dashboard';
+    return '/apply?step=2';
   }
 }
 

--- a/src/__tests__/applicants-routes-warn2.test.ts
+++ b/src/__tests__/applicants-routes-warn2.test.ts
@@ -1,10 +1,11 @@
 /**
- * WARN #2 route-layer tests for src/modules/applicants/routes.ts.
+ * WARN #2 / W6 route-layer tests for src/modules/applicants/routes.ts.
  *
- * Covers the two-tier scope cutover:
- *   - POST /applicants/register issues a token with emailVerified=false
+ * Covers the response-shape invariant (W6) and the two-tier scope cutover (W2):
+ *   - POST /applicants/register returns ONLY { ok, message } for ALL paths —
+ *     no token or user ever leaks from /register (W6).
  *   - POST /applicants/apply is gated by requireEmailVerified (returns
- *     403 + code "EMAIL_UNVERIFIED" for an unverified applicant)
+ *     403 + code "EMAIL_UNVERIFIED" for an unverified applicant).
  *   - After verifyMagicLink stamps users.email_verified_at, /apply is
  *     reachable and the application is created.
  *
@@ -14,7 +15,6 @@
  */
 import express from "express";
 import request from "supertest";
-import jwt from "jsonwebtoken";
 import { generateToken, AuthUser } from "../middleware/auth";
 
 jest.mock("../config/database", () => ({ query: jest.fn(), transaction: jest.fn() }));
@@ -51,10 +51,6 @@ function buildApp() {
 }
 const app = buildApp();
 
-function decode(token: string): any {
-  return jwt.decode(token);
-}
-
 /** Stub the users row that authenticate() reads. */
 function mockUsersRow(user: Partial<AuthUser> & { id: string; email: string; role: string }, emailVerifiedAt: Date | null) {
   mockQuery.mockResolvedValueOnce({
@@ -73,24 +69,23 @@ function mockUsersRow(user: Partial<AuthUser> & { id: string; email: string; rol
   } as any);
 }
 
-describe("POST /applicants/register (WARN #2)", () => {
+describe("POST /applicants/register (W6 response-shape + WARN #2)", () => {
   beforeEach(() => jest.clearAllMocks());
 
-  it("issues a JWT with emailVerified=false for a brand-new account", async () => {
+  // Helper: assert the canonical register response shape.
+  function expectCanonicalShape(body: Record<string, unknown>) {
+    expect(body.ok).toBe(true);
+    expect(body.message).toBe("If this email is registered, a verification link has been sent.");
+    // W6: token and user must never appear in the /register response.
+    expect(body).not.toHaveProperty("token");
+    expect(body).not.toHaveProperty("user");
+  }
+
+  it("returns ONLY { ok, message } for a brand-new account — no token or user", async () => {
     // Existence check — no user yet.
     mockQuery.mockResolvedValueOnce({ rows: [] } as any);
     // INSERT users
     mockQuery.mockResolvedValueOnce({ rows: [{ id: "new-user-001" }] } as any);
-    // SELECT after insert (route reads the row to build AuthUser)
-    mockQuery.mockResolvedValueOnce({
-      rows: [{
-        id: "new-user-001",
-        email: "victim@example.com",
-        role: "applicant",
-        first_name: "Vic",
-        last_name: "Tim",
-      }],
-    } as any);
     mockCreateMagicLink.mockResolvedValueOnce({ link: "http://localhost:5174/auth/callback?token=raw", userId: "new-user-001" });
 
     const res = await request(app)
@@ -98,14 +93,10 @@ describe("POST /applicants/register (WARN #2)", () => {
       .send({ email: "victim@example.com", firstName: "Vic", lastName: "Tim" });
 
     expect(res.status).toBe(202);
-    expect(res.body.token).toBeDefined();
-    const claims = decode(res.body.token);
-    expect(claims.emailVerified).toBe(false);
-    expect(claims.id).toBe("new-user-001");
-    expect(claims.role).toBe("applicant");
+    expectCanonicalShape(res.body);
   });
 
-  it("never returns a token for a pre-existing applicant account", async () => {
+  it("returns ONLY { ok, message } for a pre-existing applicant account", async () => {
     mockQuery.mockResolvedValueOnce({
       rows: [{ id: "existing-001", role: "applicant", is_active: true }],
     } as any);
@@ -116,7 +107,59 @@ describe("POST /applicants/register (WARN #2)", () => {
       .send({ email: "existing@example.com", firstName: "Ex", lastName: "Ists" });
 
     expect(res.status).toBe(202);
-    expect(res.body.token).toBeUndefined();
+    expectCanonicalShape(res.body);
+  });
+
+  it("returns ONLY { ok, message } for a staff email (no enumeration leak)", async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: "staff-001", role: "leasing_agent", is_active: true }],
+    } as any);
+    // createMagicLink is not called for staff (route returns early)
+
+    const res = await request(app)
+      .post("/applicants/register")
+      .send({ email: "agent@property.com", firstName: "Ag", lastName: "Ent" });
+
+    expect(res.status).toBe(202);
+    expectCanonicalShape(res.body);
+  });
+
+  it("response shape is identical between new and existing applicant paths (same keys)", async () => {
+    // New account
+    mockQuery.mockResolvedValueOnce({ rows: [] } as any);
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: "n-001" }] } as any);
+    mockCreateMagicLink.mockResolvedValueOnce({ link: "http://x/auth/callback?token=raw", userId: "n-001" });
+
+    const newRes = await request(app)
+      .post("/applicants/register")
+      .send({ email: "new@example.com", firstName: "New", lastName: "User" });
+
+    // Existing account
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: "e-001", role: "applicant", is_active: true }],
+    } as any);
+    mockCreateMagicLink.mockResolvedValueOnce({ link: "http://x/auth/callback?token=raw2", userId: "e-001" });
+
+    const existingRes = await request(app)
+      .post("/applicants/register")
+      .send({ email: "existing@example.com", firstName: "Ex", lastName: "User" });
+
+    const newKeys = Object.keys(newRes.body).sort();
+    const existingKeys = Object.keys(existingRes.body).sort();
+    expect(newKeys).toEqual(existingKeys);
+  });
+
+  it("magic link IS created on the new-email path", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] } as any);
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: "n-002" }] } as any);
+    mockCreateMagicLink.mockResolvedValueOnce({ link: "http://x/auth/callback?token=raw", userId: "n-002" });
+
+    await request(app)
+      .post("/applicants/register")
+      .send({ email: "newone@example.com", firstName: "New", lastName: "One" });
+
+    expect(mockCreateMagicLink).toHaveBeenCalledTimes(1);
+    expect(mockCreateMagicLink).toHaveBeenCalledWith("newone@example.com");
   });
 });
 

--- a/src/__tests__/unit-claim.test.ts
+++ b/src/__tests__/unit-claim.test.ts
@@ -231,7 +231,7 @@ describe("POST /applicants/claim-unit/:id", () => {
     mockTxnWithQueue([
       { rows: [{ id: VALID_UNIT, property_id: PROPERTY_ID, status: "available", claim_expires_at: null }] },
       { rows: [{ id: "app-001", claimed_unit_id: null }] }, // SELECT draft
-      { rows: [{ expires_at: "2026-05-16T15:00:00Z" }] },   // UPDATE units RETURNING expires_at
+      { rows: [] },                                         // UPDATE units (held)
       { rows: [] },                                         // UPDATE applications
       {
         rows: [
@@ -239,6 +239,7 @@ describe("POST /applicants/claim-unit/:id", () => {
         ],
       },
     ]);
+    const before = Date.now();
     const token = generateToken(applicant);
     const res = await request(app)
       .post(`/applicants/claim-unit/${VALID_UNIT}`)
@@ -246,8 +247,11 @@ describe("POST /applicants/claim-unit/:id", () => {
     expect(res.status).toBe(200);
     expect(res.body.ok).toBe(true);
     expect(res.body.unit.id).toBe(VALID_UNIT);
-    expect(res.body.expires_at).toBe("2026-05-16T15:00:00Z");
     expect(res.body.application_id).toBe("app-001");
+    // expires_at is computed JS-side as now + 48h; verify it falls in that window.
+    const expiry = new Date(res.body.expires_at).getTime();
+    expect(expiry).toBeGreaterThanOrEqual(before + 48 * 3600 * 1000 - 1000);
+    expect(expiry).toBeLessThanOrEqual(Date.now() + 48 * 3600 * 1000 + 1000);
   });
 
   it("409 UNIT_UNAVAILABLE when unit is held by another user (not stale)", async () => {
@@ -270,8 +274,8 @@ describe("POST /applicants/claim-unit/:id", () => {
     mockTxnWithQueue([
       { rows: [{ id: VALID_UNIT, property_id: PROPERTY_ID, status: "held", claim_expires_at: pastExpiry }] },
       { rows: [{ id: "app-001", claimed_unit_id: null }] },
-      { rows: [{ expires_at: "2026-05-16T15:00:00Z" }] },
-      { rows: [] },
+      { rows: [] },                                         // UPDATE units (held)
+      { rows: [] },                                         // UPDATE applications
       { rows: [{ id: VALID_UNIT, unit_number: "A-101", property_name: "Sunny" }] },
     ]);
     const token = generateToken(applicant);
@@ -301,7 +305,7 @@ describe("POST /applicants/claim-unit/:id", () => {
         { rows: [{ id: VALID_UNIT, property_id: PROPERTY_ID, status: "available", claim_expires_at: null }] },
         { rows: [{ id: "app-001", claimed_unit_id: PRIOR_UNIT }] },
         { rows: [] },                                       // UPDATE prior unit → available
-        { rows: [{ expires_at: "2026-05-16T15:00:00Z" }] }, // UPDATE new unit → held
+        { rows: [] },                                       // UPDATE new unit → held
         { rows: [] },                                       // UPDATE applications
         { rows: [{ id: VALID_UNIT, unit_number: "A-101" }] },
       ];
@@ -319,7 +323,7 @@ describe("POST /applicants/claim-unit/:id", () => {
       .set("Authorization", `Bearer ${token}`);
     expect(res.status).toBe(200);
 
-    const releaseCall = calls.find(([sql]) => /UPDATE units SET status = 'available'/.test(sql));
+    const releaseCall = calls.find(([sql]) => /UPDATE units\s+SET status = 'available'/.test(sql));
     expect(releaseCall).toBeDefined();
     expect(releaseCall![1]).toEqual([PRIOR_UNIT]);
   });
@@ -331,7 +335,7 @@ describe("POST /applicants/claim-unit/:id", () => {
       { rows: [] }, // SELECT draft → none
       { rows: [{ id: "app-fresh-001" }] }, // INSERT application
       { rows: [] }, // INSERT user_applications
-      { rows: [{ expires_at: "2026-05-16T15:00:00Z" }] }, // UPDATE units
+      { rows: [] }, // UPDATE units (held)
       { rows: [] }, // UPDATE applications
       { rows: [{ id: VALID_UNIT, unit_number: "A-101" }] },
     ]);
@@ -371,7 +375,7 @@ describe("DELETE /applicants/claim-unit", () => {
     expect(res.status).toBe(200);
     expect(res.body.ok).toBe(true);
 
-    const unitUpdate = calls.find(([sql]) => /UPDATE units SET status = 'available'/.test(sql));
+    const unitUpdate = calls.find(([sql]) => /UPDATE units\s+SET status = 'available'/.test(sql));
     expect(unitUpdate![1]).toEqual(["unit-XYZ"]);
   });
 

--- a/src/__tests__/unit-claim.test.ts
+++ b/src/__tests__/unit-claim.test.ts
@@ -1,0 +1,390 @@
+/**
+ * Unit-claim slice route tests for src/modules/applicants/routes.ts.
+ *
+ * Covers POST /applicants/intent, GET /applicants/units, POST
+ * /applicants/claim-unit/:id, DELETE /applicants/claim-unit.
+ *
+ * Strategy: query() and transaction() are both mocked. transaction() invokes
+ * its callback with a fake client whose .query() pulls from a per-test queue.
+ */
+import express from "express";
+import request from "supertest";
+import { generateToken, AuthUser } from "../middleware/auth";
+
+jest.mock("../config/database", () => ({
+  query: jest.fn(),
+  transaction: jest.fn(),
+}));
+jest.mock("../utils/logger", () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+jest.mock("../modules/auth/magic-link-service", () => ({
+  createMagicLink: jest.fn(),
+  logMagicLink: jest.fn(),
+}));
+jest.mock("../modules/application/service", () => ({
+  ApplicationService: jest.fn().mockImplementation(() => ({ create: jest.fn() })),
+}));
+
+import { query, transaction } from "../config/database";
+import applicantsRouter from "../modules/applicants/routes";
+
+const mockQuery = query as jest.MockedFunction<typeof query>;
+const mockTransaction = transaction as jest.MockedFunction<typeof transaction>;
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/applicants", applicantsRouter);
+  return app;
+}
+const app = buildApp();
+
+/** Stub the users row that authenticate() reads from query(). */
+function mockUsersRow(user: AuthUser, emailVerifiedAt: Date | null) {
+  mockQuery.mockResolvedValueOnce({
+    rows: [
+      {
+        id: user.id,
+        email: user.email,
+        role: user.role,
+        first_name: user.firstName,
+        last_name: user.lastName,
+        property_ids: user.propertyIds ?? [],
+        is_active: true,
+        email_verified_at: emailVerifiedAt,
+      },
+    ],
+  } as any);
+}
+
+/**
+ * Wire transaction(fn) → fn(fakeClient) where fakeClient.query() pulls from
+ * the supplied results queue, in order.
+ */
+function mockTxnWithQueue(rows: Array<{ rows: any[] }>) {
+  const queue = [...rows];
+  mockTransaction.mockImplementationOnce(async (fn: any) => {
+    const client = {
+      query: jest.fn().mockImplementation(() => {
+        const next = queue.shift();
+        if (!next) throw new Error("test queue exhausted");
+        return Promise.resolve(next);
+      }),
+    };
+    return fn(client);
+  });
+}
+
+const applicant: AuthUser = {
+  id: "applicant-001",
+  email: "a@x.com",
+  role: "applicant",
+  firstName: "Ann",
+  lastName: "App",
+  propertyIds: [],
+  emailVerified: true,
+};
+
+const VERIFIED_AT = new Date("2026-05-13T00:00:00Z");
+
+describe("POST /applicants/intent", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("rejects unverified applicant with 403 EMAIL_UNVERIFIED", async () => {
+    mockUsersRow(applicant, null);
+    const token = generateToken(applicant, { emailVerified: false });
+    const res = await request(app)
+      .post("/applicants/intent")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ bedrooms: 2, budget_max: 2000, move_in_date: "2026-07-01", household_size: 2 });
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe("EMAIL_UNVERIFIED");
+  });
+
+  it("validates body — 400 on bad bedrooms", async () => {
+    mockUsersRow(applicant, VERIFIED_AT);
+    const token = generateToken(applicant);
+    const res = await request(app)
+      .post("/applicants/intent")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ bedrooms: 99, budget_max: 2000, move_in_date: "2026-07-01", household_size: 2 });
+    expect(res.status).toBe(400);
+  });
+
+  it("UPSERTs intent on the existing draft application and returns its id", async () => {
+    mockUsersRow(applicant, VERIFIED_AT);
+    mockTxnWithQueue([
+      { rows: [{ id: "app-existing-001" }] }, // SELECT draft
+      { rows: [] },                            // UPDATE applications
+    ]);
+    const token = generateToken(applicant);
+    const res = await request(app)
+      .post("/applicants/intent")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ bedrooms: 2, budget_max: 2000, move_in_date: "2026-07-01", household_size: 2 });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true, application_id: "app-existing-001" });
+  });
+
+  it("creates a draft application when none exists, picking a fallback property", async () => {
+    mockUsersRow(applicant, VERIFIED_AT);
+    mockTxnWithQueue([
+      { rows: [] },                            // SELECT draft → none
+      { rows: [{ id: "prop-fallback-001" }] }, // SELECT fallback property
+      { rows: [{ id: "app-new-001" }] },       // INSERT applications
+      { rows: [] },                            // INSERT user_applications
+    ]);
+    const token = generateToken(applicant);
+    const res = await request(app)
+      .post("/applicants/intent")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ bedrooms: 1, budget_max: 1500, move_in_date: "2026-08-01", household_size: 1 });
+    expect(res.status).toBe(200);
+    expect(res.body.application_id).toBe("app-new-001");
+  });
+
+  it("503 NO_PROPERTIES when seed is empty and no draft exists", async () => {
+    mockUsersRow(applicant, VERIFIED_AT);
+    mockTxnWithQueue([
+      { rows: [] }, // SELECT draft
+      { rows: [] }, // SELECT fallback property → none
+    ]);
+    const token = generateToken(applicant);
+    const res = await request(app)
+      .post("/applicants/intent")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ bedrooms: 1, budget_max: 1500, move_in_date: "2026-08-01", household_size: 1 });
+    expect(res.status).toBe(503);
+    expect(res.body.code).toBe("NO_PROPERTIES");
+  });
+});
+
+describe("GET /applicants/units", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns up to 12 units matching filters", async () => {
+    mockUsersRow(applicant, VERIFIED_AT);
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        { id: "u1", unit_number: "A-101", monthly_rent: 1500, bedrooms: 2 },
+        { id: "u2", unit_number: "A-102", monthly_rent: 1600, bedrooms: 2 },
+      ],
+    } as any);
+    const token = generateToken(applicant);
+    const res = await request(app)
+      .get("/applicants/units?bedrooms=2&maxRent=1700")
+      .set("Authorization", `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(res.body.units).toHaveLength(2);
+
+    const sql = mockQuery.mock.calls[1][0] as string;
+    expect(sql).toContain("u.bedrooms = $1");
+    expect(sql).toContain("u.monthly_rent <= $2");
+    expect(sql).toMatch(/status = 'available'.*OR.*status = 'held'.*claim_expires_at < NOW\(\)/s);
+    expect(sql).toContain("LIMIT 12");
+  });
+
+  it("ignores malformed propertyId (no SQL injection vector)", async () => {
+    mockUsersRow(applicant, VERIFIED_AT);
+    mockQuery.mockResolvedValueOnce({ rows: [] } as any);
+    const token = generateToken(applicant);
+    const res = await request(app)
+      .get("/applicants/units?propertyId=' OR '1'='1")
+      .set("Authorization", `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    const sql = mockQuery.mock.calls[1][0] as string;
+    const params = mockQuery.mock.calls[1][1] as unknown[] | undefined;
+    // The malformed value never reaches the WHERE clause: no filter param,
+    // and the WHERE has no property_id constraint.
+    expect(sql).not.toMatch(/WHERE[\s\S]*u\.property_id =/);
+    expect(params ?? []).toEqual([]);
+  });
+
+  it("rejects unverified user", async () => {
+    mockUsersRow(applicant, null);
+    const token = generateToken(applicant, { emailVerified: false });
+    const res = await request(app)
+      .get("/applicants/units")
+      .set("Authorization", `Bearer ${token}`);
+    expect(res.status).toBe(403);
+  });
+});
+
+describe("POST /applicants/claim-unit/:id", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  const VALID_UNIT = "550e8400-e29b-41d4-a716-446655440000";
+  const PROPERTY_ID = "550e8400-e29b-41d4-a716-446655440001";
+
+  it("400 on malformed unit id", async () => {
+    mockUsersRow(applicant, VERIFIED_AT);
+    const token = generateToken(applicant);
+    const res = await request(app)
+      .post("/applicants/claim-unit/not-a-uuid")
+      .set("Authorization", `Bearer ${token}`);
+    expect(res.status).toBe(400);
+  });
+
+  it("200 when unit is available — sets held + 48h expiry on the user's draft", async () => {
+    mockUsersRow(applicant, VERIFIED_AT);
+    mockTxnWithQueue([
+      { rows: [{ id: VALID_UNIT, property_id: PROPERTY_ID, status: "available", claim_expires_at: null }] },
+      { rows: [{ id: "app-001", claimed_unit_id: null }] }, // SELECT draft
+      { rows: [{ expires_at: "2026-05-16T15:00:00Z" }] },   // UPDATE units RETURNING expires_at
+      { rows: [] },                                         // UPDATE applications
+      {
+        rows: [
+          { id: VALID_UNIT, unit_number: "A-101", monthly_rent: 1500, property_name: "Sunny" },
+        ],
+      },
+    ]);
+    const token = generateToken(applicant);
+    const res = await request(app)
+      .post(`/applicants/claim-unit/${VALID_UNIT}`)
+      .set("Authorization", `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.unit.id).toBe(VALID_UNIT);
+    expect(res.body.expires_at).toBe("2026-05-16T15:00:00Z");
+    expect(res.body.application_id).toBe("app-001");
+  });
+
+  it("409 UNIT_UNAVAILABLE when unit is held by another user (not stale)", async () => {
+    mockUsersRow(applicant, VERIFIED_AT);
+    const futureExpiry = new Date(Date.now() + 60_000).toISOString();
+    mockTxnWithQueue([
+      { rows: [{ id: VALID_UNIT, property_id: PROPERTY_ID, status: "held", claim_expires_at: futureExpiry }] },
+    ]);
+    const token = generateToken(applicant);
+    const res = await request(app)
+      .post(`/applicants/claim-unit/${VALID_UNIT}`)
+      .set("Authorization", `Bearer ${token}`);
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe("UNIT_UNAVAILABLE");
+  });
+
+  it("200 when unit is held but claim is stale — treats as available", async () => {
+    mockUsersRow(applicant, VERIFIED_AT);
+    const pastExpiry = new Date(Date.now() - 60_000).toISOString();
+    mockTxnWithQueue([
+      { rows: [{ id: VALID_UNIT, property_id: PROPERTY_ID, status: "held", claim_expires_at: pastExpiry }] },
+      { rows: [{ id: "app-001", claimed_unit_id: null }] },
+      { rows: [{ expires_at: "2026-05-16T15:00:00Z" }] },
+      { rows: [] },
+      { rows: [{ id: VALID_UNIT, unit_number: "A-101", property_name: "Sunny" }] },
+    ]);
+    const token = generateToken(applicant);
+    const res = await request(app)
+      .post(`/applicants/claim-unit/${VALID_UNIT}`)
+      .set("Authorization", `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+
+  it("404 when unit doesn't exist", async () => {
+    mockUsersRow(applicant, VERIFIED_AT);
+    mockTxnWithQueue([{ rows: [] }]);
+    const token = generateToken(applicant);
+    const res = await request(app)
+      .post(`/applicants/claim-unit/${VALID_UNIT}`)
+      .set("Authorization", `Bearer ${token}`);
+    expect(res.status).toBe(404);
+  });
+
+  it("releases prior claim when switching units (atomic)", async () => {
+    mockUsersRow(applicant, VERIFIED_AT);
+    const PRIOR_UNIT = "550e8400-e29b-41d4-a716-446655440099";
+    const calls: Array<[string, any[] | undefined]> = [];
+    mockTransaction.mockImplementationOnce(async (fn: any) => {
+      const queue: Array<{ rows: any[] }> = [
+        { rows: [{ id: VALID_UNIT, property_id: PROPERTY_ID, status: "available", claim_expires_at: null }] },
+        { rows: [{ id: "app-001", claimed_unit_id: PRIOR_UNIT }] },
+        { rows: [] },                                       // UPDATE prior unit → available
+        { rows: [{ expires_at: "2026-05-16T15:00:00Z" }] }, // UPDATE new unit → held
+        { rows: [] },                                       // UPDATE applications
+        { rows: [{ id: VALID_UNIT, unit_number: "A-101" }] },
+      ];
+      const client = {
+        query: jest.fn().mockImplementation((sql: string, params?: any[]) => {
+          calls.push([sql, params]);
+          return Promise.resolve(queue.shift()!);
+        }),
+      };
+      return fn(client);
+    });
+    const token = generateToken(applicant);
+    const res = await request(app)
+      .post(`/applicants/claim-unit/${VALID_UNIT}`)
+      .set("Authorization", `Bearer ${token}`);
+    expect(res.status).toBe(200);
+
+    const releaseCall = calls.find(([sql]) => /UPDATE units SET status = 'available'/.test(sql));
+    expect(releaseCall).toBeDefined();
+    expect(releaseCall![1]).toEqual([PRIOR_UNIT]);
+  });
+
+  it("creates a draft when claiming with none yet", async () => {
+    mockUsersRow(applicant, VERIFIED_AT);
+    mockTxnWithQueue([
+      { rows: [{ id: VALID_UNIT, property_id: PROPERTY_ID, status: "available", claim_expires_at: null }] },
+      { rows: [] }, // SELECT draft → none
+      { rows: [{ id: "app-fresh-001" }] }, // INSERT application
+      { rows: [] }, // INSERT user_applications
+      { rows: [{ expires_at: "2026-05-16T15:00:00Z" }] }, // UPDATE units
+      { rows: [] }, // UPDATE applications
+      { rows: [{ id: VALID_UNIT, unit_number: "A-101" }] },
+    ]);
+    const token = generateToken(applicant);
+    const res = await request(app)
+      .post(`/applicants/claim-unit/${VALID_UNIT}`)
+      .set("Authorization", `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(res.body.application_id).toBe("app-fresh-001");
+  });
+});
+
+describe("DELETE /applicants/claim-unit", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("releases the user's current claim", async () => {
+    mockUsersRow(applicant, VERIFIED_AT);
+    const calls: Array<[string, any[] | undefined]> = [];
+    mockTransaction.mockImplementationOnce(async (fn: any) => {
+      const queue: Array<{ rows: any[] }> = [
+        { rows: [{ id: "app-001", claimed_unit_id: "unit-XYZ" }] }, // SELECT draft
+        { rows: [] }, // UPDATE units → available
+        { rows: [] }, // UPDATE applications → null
+      ];
+      const client = {
+        query: jest.fn().mockImplementation((sql: string, params?: any[]) => {
+          calls.push([sql, params]);
+          return Promise.resolve(queue.shift()!);
+        }),
+      };
+      return fn(client);
+    });
+    const token = generateToken(applicant);
+    const res = await request(app)
+      .delete("/applicants/claim-unit")
+      .set("Authorization", `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+
+    const unitUpdate = calls.find(([sql]) => /UPDATE units SET status = 'available'/.test(sql));
+    expect(unitUpdate![1]).toEqual(["unit-XYZ"]);
+  });
+
+  it("ok=true even when user has no active claim (idempotent)", async () => {
+    mockUsersRow(applicant, VERIFIED_AT);
+    mockTxnWithQueue([
+      { rows: [] }, // SELECT draft → none with claim
+    ]);
+    const token = generateToken(applicant);
+    const res = await request(app)
+      .delete("/applicants/claim-unit")
+      .set("Authorization", `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+});

--- a/src/__tests__/warn2-jwt-email-proof.test.ts
+++ b/src/__tests__/warn2-jwt-email-proof.test.ts
@@ -1,24 +1,19 @@
 /**
- * WARN #2 — original attack rendered harmless.
+ * WARN #2 + W6 — original attack rendered harmless (defence-in-depth).
  *
- * Pre-fix:
+ * Attack vector (pre-fix):
  *   1. Attacker POSTs /applicants/register with {email: "victim@x"}.
- *   2. Server creates the account (or finds it) and returns a full-scope JWT
- *      bound to victim's email.
- *   3. Attacker uses that JWT to call /applicants/apply or
- *      /applicants/me/applications and walks away with PII / a planted
- *      application — without ever clicking the magic link.
+ *   2. Server returned a JWT bound to victim's email.
+ *   3. Attacker used that JWT to call /apply or /me/applications and exfiltrated
+ *      PII — without ever clicking the magic link.
  *
- * Post-fix:
- *   - /register still returns a JWT for brand-new accounts (W1 fix retained),
- *     but that JWT carries emailVerified=false.
- *   - /apply and /me/applications are gated by requireEmailVerified, so the
- *     attacker's JWT is rejected with 403 EMAIL_UNVERIFIED.
- *   - Staff (non-applicant/tenant) roles bypass the gate.
+ * W6 closes the root cause: /register no longer returns a token or user at all.
+ * WARN #2 remains as second-layer defence: even if an attacker somehow obtained
+ * an unverified JWT (e.g. via a different path), /apply and /me/applications are
+ * gated by requireEmailVerified and return 403 EMAIL_UNVERIFIED.
  */
 import express from "express";
 import request from "supertest";
-import jwt from "jsonwebtoken";
 import { generateToken, AuthUser } from "../middleware/auth";
 
 jest.mock("../config/database", () => ({ query: jest.fn(), transaction: jest.fn() }));
@@ -67,16 +62,12 @@ function mockUsersRow(
   } as any);
 }
 
-describe("WARN #2: pre-verification token is harmless on PII / state-changing routes", () => {
+describe("WARN #2 + W6: /register exposes no token; unverified JWT is rejected on PII routes", () => {
   beforeEach(() => jest.clearAllMocks());
 
-  it("attacker registering victim@x cannot /apply with the returned token", async () => {
-    // ── Step 1: attacker hits /register ──
+  it("W6: /register returns no token for a new account — attacker has nothing to replay", async () => {
     mockQuery.mockResolvedValueOnce({ rows: [] } as any);                      // SELECT users (none)
     mockQuery.mockResolvedValueOnce({ rows: [{ id: "victim-001" }] } as any); // INSERT users
-    mockQuery.mockResolvedValueOnce({                                          // SELECT after insert
-      rows: [{ id: "victim-001", email: "victim@x.com", role: "applicant", first_name: "V", last_name: "T" }],
-    } as any);
     mockCreateMagicLink.mockResolvedValueOnce({ link: "http://x/auth/callback?token=raw", userId: "victim-001" });
 
     const reg = await request(app)
@@ -84,16 +75,32 @@ describe("WARN #2: pre-verification token is harmless on PII / state-changing ro
       .send({ email: "victim@x.com", firstName: "V", lastName: "T" });
 
     expect(reg.status).toBe(202);
-    expect(reg.body.token).toBeDefined();
-    const claims = jwt.decode(reg.body.token) as any;
-    expect(claims.emailVerified).toBe(false);
+    // W6: no token in response — the attacker cannot craft a replay attack.
+    expect(reg.body).not.toHaveProperty("token");
+    expect(reg.body).not.toHaveProperty("user");
+  });
 
-    // ── Step 2: attacker tries to /apply with that token ──
+  it("W2 defence-in-depth: a forged unverified JWT is rejected by /apply", async () => {
+    // Even if an attacker somehow constructs an unverified JWT (not via /register),
+    // the requireEmailVerified gate must block /apply.
     mockUsersRow({ id: "victim-001", email: "victim@x.com", role: "applicant" }, null);
+
+    const forgedToken = generateToken(
+      {
+        id: "victim-001",
+        email: "victim@x.com",
+        role: "applicant",
+        firstName: "V",
+        lastName: "T",
+        propertyIds: [],
+        emailVerified: false,
+      },
+      { emailVerified: false }
+    );
 
     const apply = await request(app)
       .post("/applicants/apply")
-      .set("Authorization", `Bearer ${reg.body.token}`)
+      .set("Authorization", `Bearer ${forgedToken}`)
       .send({
         propertyId: "550e8400-e29b-41d4-a716-446655440000",
         firstName: "Attack",

--- a/src/db/migrations/2026-05-14-units-and-intent.sql
+++ b/src/db/migrations/2026-05-14-units-and-intent.sql
@@ -12,6 +12,9 @@ CREATE TABLE IF NOT EXISTS units (
   monthly_rent NUMERIC(10,2) NOT NULL,
   -- available | held | leased | off_market
   status VARCHAR(20) NOT NULL DEFAULT 'available',
+  -- When status='held', the hold expires at this timestamp. Routes treat
+  -- (status='held' AND claim_expires_at < NOW()) as available, so cron isn't required.
+  claim_expires_at TIMESTAMPTZ,
   photo_url TEXT,
   description TEXT,
   available_from DATE,
@@ -20,9 +23,15 @@ CREATE TABLE IF NOT EXISTS units (
   UNIQUE (property_id, unit_number)
 );
 
+-- For pre-existing units rows from an earlier apply of this migration,
+-- ensure the column exists (no-op when it already does).
+ALTER TABLE units ADD COLUMN IF NOT EXISTS claim_expires_at TIMESTAMPTZ;
+
 CREATE INDEX IF NOT EXISTS idx_units_property_status ON units(property_id, status);
 CREATE INDEX IF NOT EXISTS idx_units_available ON units(status) WHERE status = 'available';
 CREATE INDEX IF NOT EXISTS idx_units_bedrooms_rent ON units(bedrooms, monthly_rent);
+-- Stale-hold scan support for the lazy-expire path in GET /applicants/units.
+CREATE INDEX IF NOT EXISTS idx_units_held_expires ON units(claim_expires_at) WHERE status = 'held';
 
 ALTER TABLE applications ADD COLUMN IF NOT EXISTS intent_bedrooms INT;
 ALTER TABLE applications ADD COLUMN IF NOT EXISTS intent_budget_min NUMERIC(10,2);

--- a/src/db/migrations/2026-05-14-units-and-intent.sql
+++ b/src/db/migrations/2026-05-14-units-and-intent.sql
@@ -1,0 +1,35 @@
+-- Units + applicant intent + unit claim (2026-05-14)
+-- Adds the unit-claim funnel: individual unit records, applicant intent quiz
+-- answers stored on applications, and a soft-reservation claim with expiry.
+
+CREATE TABLE IF NOT EXISTS units (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  property_id UUID NOT NULL REFERENCES properties(id) ON DELETE CASCADE,
+  unit_number VARCHAR(20) NOT NULL,
+  bedrooms INT NOT NULL,
+  bathrooms NUMERIC(3,1) NOT NULL DEFAULT 1.0,
+  sqft INT,
+  monthly_rent NUMERIC(10,2) NOT NULL,
+  -- available | held | leased | off_market
+  status VARCHAR(20) NOT NULL DEFAULT 'available',
+  photo_url TEXT,
+  description TEXT,
+  available_from DATE,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE (property_id, unit_number)
+);
+
+CREATE INDEX IF NOT EXISTS idx_units_property_status ON units(property_id, status);
+CREATE INDEX IF NOT EXISTS idx_units_available ON units(status) WHERE status = 'available';
+CREATE INDEX IF NOT EXISTS idx_units_bedrooms_rent ON units(bedrooms, monthly_rent);
+
+ALTER TABLE applications ADD COLUMN IF NOT EXISTS intent_bedrooms INT;
+ALTER TABLE applications ADD COLUMN IF NOT EXISTS intent_budget_min NUMERIC(10,2);
+ALTER TABLE applications ADD COLUMN IF NOT EXISTS intent_budget_max NUMERIC(10,2);
+ALTER TABLE applications ADD COLUMN IF NOT EXISTS intent_move_in_date DATE;
+ALTER TABLE applications ADD COLUMN IF NOT EXISTS intent_household_size INT;
+ALTER TABLE applications ADD COLUMN IF NOT EXISTS claimed_unit_id UUID REFERENCES units(id) ON DELETE SET NULL;
+ALTER TABLE applications ADD COLUMN IF NOT EXISTS claim_expires_at TIMESTAMPTZ;
+
+CREATE INDEX IF NOT EXISTS idx_applications_claimed_unit ON applications(claimed_unit_id);

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -414,6 +414,8 @@ CREATE TABLE units (
   sqft INTEGER,
   monthly_rent NUMERIC(10,2) NOT NULL,
   status VARCHAR(20) NOT NULL DEFAULT 'available',
+  -- Held-claim expiry; lazy-expired in GET /applicants/units.
+  claim_expires_at TIMESTAMPTZ,
   photo_url TEXT,
   description TEXT,
   available_from DATE,

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -387,9 +387,39 @@ CREATE TABLE applications (
   stripe_customer_id VARCHAR(100),
   stripe_payment_method_id VARCHAR(100),
 
+  -- Applicant intent (filled by the intent quiz before unit pick)
+  intent_bedrooms INTEGER,
+  intent_budget_min DECIMAL(10,2),
+  intent_budget_max DECIMAL(10,2),
+  intent_move_in_date DATE,
+  intent_household_size INTEGER,
+
+  -- Unit claim (soft reservation while applicant completes the application)
+  claimed_unit_id UUID,
+  claim_expires_at TIMESTAMPTZ,
+
   -- Metadata
   created_at TIMESTAMPTZ DEFAULT NOW(),
   updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Individual units, generated from properties.unit_mix. Status drives the
+-- unit-picker funnel: available → held (during applicant claim) → leased.
+CREATE TABLE units (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  property_id UUID NOT NULL REFERENCES properties(id) ON DELETE CASCADE,
+  unit_number VARCHAR(20) NOT NULL,
+  bedrooms INTEGER NOT NULL,
+  bathrooms NUMERIC(3,1) NOT NULL DEFAULT 1.0,
+  sqft INTEGER,
+  monthly_rent NUMERIC(10,2) NOT NULL,
+  status VARCHAR(20) NOT NULL DEFAULT 'available',
+  photo_url TEXT,
+  description TEXT,
+  available_from DATE,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE (property_id, unit_number)
 );
 
 -- Tenant/applicant join to applications (multiple users per application: primary, co-applicant, household member)

--- a/src/db/seed.ts
+++ b/src/db/seed.ts
@@ -194,6 +194,59 @@ async function seed() {
     }
     console.log("  AMI limits seeded for Las Vegas MSA (2025-2026)");
 
+    // ── Units (generated from properties.unit_mix) ───────────────────
+    // Letter prefix by bedroom type, floor-based unit numbering. Matches the
+    // numbering convention already used in seed-demo (A-102, B-205, etc.).
+    const BEDROOM_META: Record<string, { letter: string; bedrooms: number; bathrooms: number; sqft: number; floor: number }> = {
+      Studio: { letter: "S", bedrooms: 0, bathrooms: 1, sqft: 450, floor: 0 },
+      "1BR": { letter: "A", bedrooms: 1, bathrooms: 1, sqft: 650, floor: 1 },
+      "2BR": { letter: "B", bedrooms: 2, bathrooms: 1.5, sqft: 900, floor: 2 },
+      "3BR": { letter: "C", bedrooms: 3, bathrooms: 2, sqft: 1150, floor: 3 },
+      "4BR": { letter: "D", bedrooms: 4, bathrooms: 2.5, sqft: 1400, floor: 4 },
+    };
+
+    const slug = (s: string) => s.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/(^-|-$)/g, "");
+
+    let unitsCreated = 0;
+    for (const p of properties) {
+      const propRow = await query("SELECT id FROM properties WHERE name = $1", [p.name]);
+      if (propRow.rows.length === 0) continue;
+      const propertyId = propRow.rows[0].id;
+      const propSlug = slug(p.name);
+
+      for (const [mixKey, count] of Object.entries(p.unitMix)) {
+        const meta = BEDROOM_META[mixKey];
+        if (!meta) continue;
+
+        const rentKey = `${mixKey}_60AMI`;
+        const rent = (p.rentSchedule as unknown as Record<string, number>)[rentKey];
+        if (!rent) continue;
+
+        for (let i = 0; i < count; i++) {
+          const seq = String(i + 1).padStart(2, "0");
+          const unitNumber = meta.letter === "S"
+            ? `S-${String(i + 1).padStart(3, "0")}`
+            : `${meta.letter}-${meta.floor}${seq}`;
+
+          // Deterministic status distribution: 70% available, 30% leased.
+          // Skip 'held' — that gets created live when applicants claim.
+          const status = i % 10 < 7 ? "available" : "leased";
+          const photoUrl = `https://picsum.photos/seed/${propSlug}-${unitNumber}/800/600`;
+
+          await query(
+            `INSERT INTO units
+               (property_id, unit_number, bedrooms, bathrooms, sqft, monthly_rent, status, photo_url, available_from)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, CURRENT_DATE)
+             ON CONFLICT (property_id, unit_number) DO NOTHING`,
+            [propertyId, unitNumber, meta.bedrooms, meta.bathrooms, meta.sqft, rent, status, photoUrl]
+          );
+          unitsCreated++;
+        }
+      }
+    }
+    const availCount = await query("SELECT count(*)::int AS n FROM units WHERE status='available'");
+    console.log(`  Units: ${unitsCreated} generated across ${properties.length} properties (${availCount.rows[0].n} available)`);
+
     // Seed known problem addresses
     const problemAddresses = [
       { address: "999 Fraud Lane", city: "Las Vegas", state: "NV", zip: "89101", reason: "Multiple fraudulent applications originating from this address" },

--- a/src/modules/applicants/routes.ts
+++ b/src/modules/applicants/routes.ts
@@ -141,6 +141,368 @@ router.get("/properties", async (_req: Request, res: Response): Promise<void> =>
   }
 });
 
+const intentSchema = z.object({
+  bedrooms: z.number().int().min(0).max(6),
+  budget_min: z.number().min(0).max(20000).optional(),
+  budget_max: z.number().min(0).max(20000),
+  move_in_date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  household_size: z.number().int().min(1).max(12),
+  property_id: z.string().uuid().optional(),
+});
+
+// Save the 5-question intent quiz onto the user's draft application.
+// Creates a draft if none exists. Returns the application id so the next
+// step (unit picker) can attach the claim to it.
+router.post(
+  "/intent",
+  authenticate,
+  requireEmailVerified,
+  async (req: AuthRequest, res: Response): Promise<void> => {
+    try {
+      if (!req.user || !["applicant", "tenant"].includes(req.user.role)) {
+        res.status(403).json({ error: "Applicant role required" });
+        return;
+      }
+
+      const parsed = intentSchema.safeParse(req.body);
+      if (!parsed.success) {
+        res.status(400).json({ error: "Validation failed", details: parsed.error.errors });
+        return;
+      }
+      const intent = parsed.data;
+
+      const result = await transaction(async (client) => {
+        const draft = await client.query(
+          `SELECT a.id
+             FROM user_applications ua
+             JOIN applications a ON a.id = ua.application_id
+            WHERE ua.user_id = $1 AND a.status = 'draft'
+            ORDER BY a.created_at DESC
+            LIMIT 1`,
+          [req.user!.id]
+        );
+
+        let applicationId: string;
+        if (draft.rows.length > 0) {
+          applicationId = draft.rows[0].id;
+          await client.query(
+            `UPDATE applications
+                SET intent_bedrooms = $2,
+                    intent_budget_min = $3,
+                    intent_budget_max = $4,
+                    intent_move_in_date = $5,
+                    intent_household_size = $6,
+                    property_id = COALESCE($7, property_id),
+                    updated_at = NOW()
+              WHERE id = $1`,
+            [
+              applicationId,
+              intent.bedrooms,
+              intent.budget_min ?? null,
+              intent.budget_max,
+              intent.move_in_date,
+              intent.household_size,
+              intent.property_id ?? null,
+            ]
+          );
+        } else {
+          // Pick a property for the draft FK if the applicant didn't choose one.
+          // Any active property works — they'll narrow via the unit picker.
+          let propertyId = intent.property_id ?? null;
+          if (!propertyId) {
+            const fallback = await client.query(
+              `SELECT id FROM properties ORDER BY name ASC LIMIT 1`
+            );
+            if (fallback.rows.length === 0) {
+              throw new Error("NO_PROPERTIES_AVAILABLE");
+            }
+            propertyId = fallback.rows[0].id;
+          }
+
+          const insert = await client.query(
+            `INSERT INTO applications (
+                property_id, first_name, last_name, email, status,
+                intent_bedrooms, intent_budget_min, intent_budget_max,
+                intent_move_in_date, intent_household_size
+             ) VALUES ($1, $2, $3, $4, 'draft', $5, $6, $7, $8, $9)
+             RETURNING id`,
+            [
+              propertyId,
+              req.user!.firstName ?? "",
+              req.user!.lastName ?? "",
+              req.user!.email,
+              intent.bedrooms,
+              intent.budget_min ?? null,
+              intent.budget_max,
+              intent.move_in_date,
+              intent.household_size,
+            ]
+          );
+          applicationId = insert.rows[0].id;
+
+          await client.query(
+            `INSERT INTO user_applications (user_id, application_id, relationship)
+             VALUES ($1, $2, 'primary')
+             ON CONFLICT (user_id, application_id) DO NOTHING`,
+            [req.user!.id, applicationId]
+          );
+        }
+
+        return applicationId;
+      });
+
+      res.json({ ok: true, application_id: result });
+    } catch (err) {
+      const msg = (err as Error).message;
+      if (msg === "NO_PROPERTIES_AVAILABLE") {
+        res.status(503).json({ error: "No properties available", code: "NO_PROPERTIES" });
+        return;
+      }
+      logger.error("Applicant intent failed", { error: msg });
+      res.status(500).json({ error: "Failed to save intent" });
+    }
+  }
+);
+
+// List up to 12 units matching the applicant's intent. Treats stale-held units
+// (claim_expires_at < NOW()) as available so cron isn't required.
+router.get(
+  "/units",
+  authenticate,
+  requireEmailVerified,
+  async (req: AuthRequest, res: Response): Promise<void> => {
+    try {
+      if (!req.user || !["applicant", "tenant"].includes(req.user.role)) {
+        res.status(403).json({ error: "Applicant role required" });
+        return;
+      }
+
+      const bedrooms = req.query.bedrooms !== undefined ? Number(req.query.bedrooms) : undefined;
+      const maxRent = req.query.maxRent !== undefined ? Number(req.query.maxRent) : undefined;
+      const moveInBy = typeof req.query.moveInBy === "string" ? req.query.moveInBy : undefined;
+      const propertyId = typeof req.query.propertyId === "string" ? req.query.propertyId : undefined;
+
+      const conditions: string[] = [
+        "(u.status = 'available' OR (u.status = 'held' AND u.claim_expires_at < NOW()))",
+      ];
+      const params: unknown[] = [];
+
+      if (bedrooms !== undefined && Number.isFinite(bedrooms)) {
+        params.push(bedrooms);
+        conditions.push(`u.bedrooms = $${params.length}`);
+      }
+      if (maxRent !== undefined && Number.isFinite(maxRent)) {
+        params.push(maxRent);
+        conditions.push(`u.monthly_rent <= $${params.length}`);
+      }
+      if (moveInBy && /^\d{4}-\d{2}-\d{2}$/.test(moveInBy)) {
+        params.push(moveInBy);
+        conditions.push(`(u.available_from IS NULL OR u.available_from <= $${params.length})`);
+      }
+      if (propertyId && /^[0-9a-f-]{36}$/i.test(propertyId)) {
+        params.push(propertyId);
+        conditions.push(`u.property_id = $${params.length}`);
+      }
+
+      const result = await query(
+        `SELECT u.id, u.property_id, u.unit_number, u.bedrooms, u.bathrooms,
+                u.sqft, u.monthly_rent, u.photo_url, u.available_from,
+                p.name AS property_name, p.city AS property_city, p.state AS property_state
+           FROM units u
+           JOIN properties p ON p.id = u.property_id
+          WHERE ${conditions.join(" AND ")}
+          ORDER BY u.monthly_rent ASC, u.unit_number ASC
+          LIMIT 12`,
+        params
+      );
+
+      res.json({ units: result.rows });
+    } catch (err) {
+      logger.error("Failed to list units", { error: (err as Error).message });
+      res.status(500).json({ error: "Failed to list units" });
+    }
+  }
+);
+
+const CLAIM_DURATION_HOURS = 48;
+
+// Atomically claim a unit. Releases any prior claim by the same user.
+// 409 UNIT_UNAVAILABLE if the unit is held by someone else (and not stale).
+router.post(
+  "/claim-unit/:id",
+  authenticate,
+  requireEmailVerified,
+  async (req: AuthRequest, res: Response): Promise<void> => {
+    try {
+      if (!req.user || !["applicant", "tenant"].includes(req.user.role)) {
+        res.status(403).json({ error: "Applicant role required" });
+        return;
+      }
+      const unitId = String(req.params.id ?? "");
+      if (!/^[0-9a-f-]{36}$/i.test(unitId)) {
+        res.status(400).json({ error: "Invalid unit id" });
+        return;
+      }
+
+      const result = await transaction(async (client) => {
+        const locked = await client.query(
+          `SELECT id, property_id, status, claim_expires_at
+             FROM units
+            WHERE id = $1
+            FOR UPDATE`,
+          [unitId]
+        );
+        if (locked.rows.length === 0) {
+          return { error: "NOT_FOUND" as const };
+        }
+        const unit = locked.rows[0];
+        const isAvailable =
+          unit.status === "available" ||
+          (unit.status === "held" && unit.claim_expires_at && new Date(unit.claim_expires_at) < new Date());
+        if (!isAvailable) {
+          return { error: "UNIT_UNAVAILABLE" as const };
+        }
+
+        const draft = await client.query(
+          `SELECT a.id, a.claimed_unit_id
+             FROM user_applications ua
+             JOIN applications a ON a.id = ua.application_id
+            WHERE ua.user_id = $1 AND a.status = 'draft'
+            ORDER BY a.created_at DESC
+            LIMIT 1`,
+          [req.user!.id]
+        );
+
+        let applicationId: string;
+        let priorUnitId: string | null = null;
+        if (draft.rows.length > 0) {
+          applicationId = draft.rows[0].id;
+          priorUnitId = draft.rows[0].claimed_unit_id;
+        } else {
+          const created = await client.query(
+            `INSERT INTO applications (property_id, first_name, last_name, email, status)
+             VALUES ($1, $2, $3, $4, 'draft')
+             RETURNING id`,
+            [
+              unit.property_id,
+              req.user!.firstName ?? "",
+              req.user!.lastName ?? "",
+              req.user!.email,
+            ]
+          );
+          applicationId = created.rows[0].id;
+          await client.query(
+            `INSERT INTO user_applications (user_id, application_id, relationship)
+             VALUES ($1, $2, 'primary')
+             ON CONFLICT (user_id, application_id) DO NOTHING`,
+            [req.user!.id, applicationId]
+          );
+        }
+
+        if (priorUnitId && priorUnitId !== unitId) {
+          await client.query(
+            `UPDATE units SET status = 'available', updated_at = NOW() WHERE id = $1`,
+            [priorUnitId]
+          );
+        }
+
+        const expiresAtRow = await client.query(
+          `UPDATE units
+              SET status = 'held', updated_at = NOW()
+            WHERE id = $1
+            RETURNING (NOW() + INTERVAL '${CLAIM_DURATION_HOURS} hours') AS expires_at`,
+          [unitId]
+        );
+        const expiresAt = expiresAtRow.rows[0].expires_at;
+
+        await client.query(
+          `UPDATE applications
+              SET claimed_unit_id = $2,
+                  claim_expires_at = $3,
+                  property_id = $4,
+                  updated_at = NOW()
+            WHERE id = $1`,
+          [applicationId, unitId, expiresAt, unit.property_id]
+        );
+
+        const enriched = await client.query(
+          `SELECT u.id, u.property_id, u.unit_number, u.bedrooms, u.bathrooms,
+                  u.sqft, u.monthly_rent, u.photo_url, u.available_from,
+                  p.name AS property_name, p.city AS property_city, p.state AS property_state
+             FROM units u
+             JOIN properties p ON p.id = u.property_id
+            WHERE u.id = $1`,
+          [unitId]
+        );
+        return { ok: true as const, unit: enriched.rows[0], expires_at: expiresAt, application_id: applicationId };
+      });
+
+      if ("error" in result) {
+        if (result.error === "NOT_FOUND") {
+          res.status(404).json({ error: "Unit not found" });
+          return;
+        }
+        if (result.error === "UNIT_UNAVAILABLE") {
+          res.status(409).json({ error: "Unit is no longer available", code: "UNIT_UNAVAILABLE" });
+          return;
+        }
+      }
+
+      res.json(result);
+    } catch (err) {
+      logger.error("Failed to claim unit", { error: (err as Error).message });
+      res.status(500).json({ error: "Failed to claim unit" });
+    }
+  }
+);
+
+// Release the user's current claim (set unit back to available, clear app fields).
+router.delete(
+  "/claim-unit",
+  authenticate,
+  requireEmailVerified,
+  async (req: AuthRequest, res: Response): Promise<void> => {
+    try {
+      if (!req.user || !["applicant", "tenant"].includes(req.user.role)) {
+        res.status(403).json({ error: "Applicant role required" });
+        return;
+      }
+
+      await transaction(async (client) => {
+        const draft = await client.query(
+          `SELECT a.id, a.claimed_unit_id
+             FROM user_applications ua
+             JOIN applications a ON a.id = ua.application_id
+            WHERE ua.user_id = $1 AND a.status = 'draft' AND a.claimed_unit_id IS NOT NULL
+            ORDER BY a.created_at DESC
+            LIMIT 1`,
+          [req.user!.id]
+        );
+        if (draft.rows.length === 0) return;
+        const { id: applicationId, claimed_unit_id: unitId } = draft.rows[0];
+
+        await client.query(
+          `UPDATE units SET status = 'available', updated_at = NOW() WHERE id = $1`,
+          [unitId]
+        );
+        await client.query(
+          `UPDATE applications
+              SET claimed_unit_id = NULL,
+                  claim_expires_at = NULL,
+                  updated_at = NOW()
+            WHERE id = $1`,
+          [applicationId]
+        );
+      });
+
+      res.json({ ok: true });
+    } catch (err) {
+      logger.error("Failed to release claim", { error: (err as Error).message });
+      res.status(500).json({ error: "Failed to release claim" });
+    }
+  }
+);
+
 // Authenticated as applicant with a verified email: list my applications.
 // PII surface — requireEmailVerified prevents enumeration via stolen
 // pre-verification token.

--- a/src/modules/applicants/routes.ts
+++ b/src/modules/applicants/routes.ts
@@ -401,19 +401,25 @@ router.post(
 
         if (priorUnitId && priorUnitId !== unitId) {
           await client.query(
-            `UPDATE units SET status = 'available', updated_at = NOW() WHERE id = $1`,
+            `UPDATE units
+                SET status = 'available',
+                    claim_expires_at = NULL,
+                    updated_at = NOW()
+              WHERE id = $1`,
             [priorUnitId]
           );
         }
 
-        const expiresAtRow = await client.query(
+        const expiresAt = new Date(Date.now() + CLAIM_DURATION_HOURS * 60 * 60 * 1000);
+
+        await client.query(
           `UPDATE units
-              SET status = 'held', updated_at = NOW()
-            WHERE id = $1
-            RETURNING (NOW() + INTERVAL '${CLAIM_DURATION_HOURS} hours') AS expires_at`,
-          [unitId]
+              SET status = 'held',
+                  claim_expires_at = $2,
+                  updated_at = NOW()
+            WHERE id = $1`,
+          [unitId, expiresAt]
         );
-        const expiresAt = expiresAtRow.rows[0].expires_at;
 
         await client.query(
           `UPDATE applications
@@ -482,7 +488,11 @@ router.delete(
         const { id: applicationId, claimed_unit_id: unitId } = draft.rows[0];
 
         await client.query(
-          `UPDATE units SET status = 'available', updated_at = NOW() WHERE id = $1`,
+          `UPDATE units
+              SET status = 'available',
+                  claim_expires_at = NULL,
+                  updated_at = NOW()
+            WHERE id = $1`,
           [unitId]
         );
         await client.query(

--- a/src/modules/applicants/routes.ts
+++ b/src/modules/applicants/routes.ts
@@ -2,7 +2,7 @@ import { Router, Request, Response } from "express";
 import { z } from "zod";
 import rateLimit from "express-rate-limit";
 import { query, transaction } from "../../config/database";
-import { authenticate, AuthRequest, generateToken, AuthUser } from "../../middleware/auth";
+import { authenticate, AuthRequest } from "../../middleware/auth";
 import { requireEmailVerified } from "../../middleware/scope";
 import { createMagicLink, logMagicLink } from "../auth/magic-link-service";
 import { ApplicationService } from "../application/service";
@@ -72,43 +72,9 @@ router.post("/register", registerLimiter, async (req: Request, res: Response): P
 
     logger.info("Applicant registered", { userId, email, isNew });
 
-    if (isNew) {
-      // Brand-new account: issue a session JWT so the applicant lands in the
-      // portal — but mark it emailVerified:false. The applicant can view
-      // public/account UI; PII + state-changing routes (/apply, /me/applications)
-      // are gated by requireEmailVerified until the magic link is clicked.
-      // This closes WARN #2: an attacker registering victim@x can no longer
-      // act as victim with the returned token.
-      const userRow = await query(
-        "SELECT id, email, role, first_name, last_name FROM users WHERE id = $1",
-        [userId]
-      );
-      const u = userRow.rows[0];
-      const authUser: AuthUser = {
-        id: u.id,
-        email: u.email,
-        role: u.role,
-        firstName: u.first_name,
-        lastName: u.last_name,
-        propertyIds: [],
-        emailVerified: false,
-      };
-      const token = generateToken(authUser, { emailVerified: false });
-      const payload: Record<string, unknown> = {
-        ok: true,
-        message: "If this email is registered, a verification link has been sent.",
-        token,
-        user: authUser,
-      };
-      if (link && process.env.NODE_ENV === "development") {
-        payload.devLink = link.link;
-      }
-      res.status(202).json(payload);
-      return;
-    }
-
-    // Existing account: magic link already sent above for account recovery.
-    // Never reveal a token for a pre-existing account.
+    // W6: uniform response for all paths — no token or user ever returned from
+    // /register. The client must wait for the magic-link click; token+user are
+    // issued only by POST /auth/magic-link/verify.
     const payload: Record<string, unknown> = {
       ok: true,
       message: "If this email is registered, a verification link has been sent.",

--- a/src/modules/auth/routes.ts
+++ b/src/modules/auth/routes.ts
@@ -34,7 +34,9 @@ router.post("/magic-link/request", magicLinkLimiter, async (req, res) => {
     if (result) {
       logMagicLink(parsed.data.email, result.link);
       // In dev, surface the link in the response so it's clickable for demos.
-      if (process.env.NODE_ENV !== "production") {
+      // Fail-closed: only leak when NODE_ENV is explicitly "development".
+      // If the env var is unset on Railway, this stays redacted (WARN #3).
+      if (process.env.NODE_ENV === "development") {
         res.json({ ok: true, devLink: result.link });
         return;
       }

--- a/src/modules/tenant/routes.ts
+++ b/src/modules/tenant/routes.ts
@@ -57,15 +57,55 @@ router.get("/dashboard", async (req: ScopedAuthRequest, res: Response) => {
               a.requested_rent_amount, a.requested_move_in_date,
               a.onesite_lease_id, a.loft_tenant_id, a.auto_pay_enrolled,
               a.overall_screening_result, a.submitted_at, a.created_at,
-              p.id AS property_id, p.name AS property_name, p.address_line1 AS property_address
+              a.claimed_unit_id, a.claim_expires_at,
+              p.id AS property_id, p.name AS property_name, p.address_line1 AS property_address,
+              u.id AS cu_id, u.unit_number AS cu_unit_number, u.bedrooms AS cu_bedrooms,
+              u.bathrooms AS cu_bathrooms, u.sqft AS cu_sqft, u.monthly_rent AS cu_monthly_rent,
+              u.photo_url AS cu_photo_url, u.property_id AS cu_property_id,
+              cup.name AS cu_property_name, cup.city AS cu_property_city, cup.state AS cu_property_state
        FROM applications a
        JOIN properties p ON a.property_id = p.id
+       LEFT JOIN units u ON a.claimed_unit_id = u.id
+         AND a.claim_expires_at IS NOT NULL
+         AND a.claim_expires_at > NOW()
+       LEFT JOIN properties cup ON u.property_id = cup.id
        WHERE a.id = ANY($1::uuid[])
        ORDER BY a.created_at DESC`,
       [ids]
     );
 
-    const applications = appsRes.rows;
+    const applications = appsRes.rows.map((r) => {
+      const claimedUnit = r.cu_id
+        ? {
+            id: r.cu_id,
+            property_id: r.cu_property_id,
+            unit_number: r.cu_unit_number,
+            bedrooms: r.cu_bedrooms,
+            bathrooms: r.cu_bathrooms,
+            sqft: r.cu_sqft,
+            monthly_rent: r.cu_monthly_rent,
+            photo_url: r.cu_photo_url,
+            property_name: r.cu_property_name,
+            property_city: r.cu_property_city,
+            property_state: r.cu_property_state,
+          }
+        : null;
+      const {
+        cu_id: _cu_id,
+        cu_unit_number: _cu_un,
+        cu_bedrooms: _cu_b,
+        cu_bathrooms: _cu_ba,
+        cu_sqft: _cu_s,
+        cu_monthly_rent: _cu_m,
+        cu_photo_url: _cu_p,
+        cu_property_id: _cu_pi,
+        cu_property_name: _cu_pn,
+        cu_property_city: _cu_pc,
+        cu_property_state: _cu_ps,
+        ...app
+      } = r;
+      return { ...app, claimed_unit: claimedUnit };
+    });
 
     // Pick "active" application — onboarded > most recent
     const active =


### PR DESCRIPTION
## Summary

Adds the **unit-claim slice** — the carrot that pulls first-time applicants through the application. Branded "plant-a-flag" UX: claimed unit becomes psychologically theirs, so every subsequent doc upload / income verification / screening step is in service of *keeping* it. Skin in the game.

Also lands four auth + apply-routing fixes (W6 enum closure, NODE_ENV fail-closed, apply-routing for first-touch applicants).

Plan: [`PLAN-unit-claim-slice.md`](./PLAN-unit-claim-slice.md). Memory ref: `project-ftu-unit-claim-carrot`.

> _Note: the messaging slice that was originally drafted on this branch (4a1701f) shipped via #4 — that commit was auto-dropped on rebase._

## What's in this PR

### DB (new units table + applicant intent/claim columns)
- `src/db/migrations/2026-05-14-units-and-intent.sql` — `units` (1808 rows seeded from each property's `unit_mix`, ~70% available), plus `applications.intent_*` + `claimed_unit_id` + `claim_expires_at`
- `units.claim_expires_at` — held-hold expiry, with idempotent `ALTER … ADD COLUMN IF NOT EXISTS` for already-migrated DBs and a partial index `WHERE status='held'` for the lazy-expire scan
- `src/db/schema.ts` — corresponding Drizzle types
- `src/db/seed.ts` — deterministic seed: unit numbers by floor (`A-101`, `A-102`, …), rent from `properties.rent_schedule`, Lorem Picsum photos

### Backend (3 new endpoints on `src/modules/applicants/routes.ts`)
- `POST /applicants/intent` — 5-question quiz (bedrooms, budget min/max, move-in date, household size); UPSERTs onto current draft
- `GET /applicants/units?bedrooms=&maxRent=&moveInBy=&propertyId=` — up to 12 cards, lazy-expires stale 48h holds in-query (no cron)
- `POST /applicants/claim-unit/:id` — atomic `FOR UPDATE` transaction; releases prior claim if switching; 48h hold; sets `units.claim_expires_at`
- `DELETE /applicants/claim-unit` — explicit release; clears `units.claim_expires_at`

### Frontend (intent quiz → picker → claim modal → details)
- `client-tenant/src/api/units.ts` — `fetchUnits`, `claimUnit`, `releaseClaim`
- `client-tenant/src/components/UnitCard.tsx` — hero photo, rent, beds·baths·sqft, "Claim this unit" CTA
- `client-tenant/src/components/ClaimedUnitHeader.tsx` — sticky header with thumbnail + live 48h countdown on details form
- `client-tenant/src/pages/Apply.tsx` — extends Step union to `1 | 'verify' | 'intent' | 'pick' | 'claim' | 2`
- `client-tenant/src/pages/AuthCallback.tsx` — first-touch applicants land at `step=intent`, not `step=2`

### Status page (`client-tenant/src/pages/Application.tsx` + `src/modules/tenant/routes.ts`)
- `/tenant/dashboard` now LEFT JOINs `units` (+ unit's property) when `claim_expires_at > NOW()`, returning a `claimed_unit` object alongside `claim_expires_at`. Stale holds collapse to null in the query — no cron.
- Renders a `ClaimedUnitCard` above Key dates on the My Application page: hero photo, property + unit, beds/bath/rent, ticking 48h countdown, **Release this unit** button → `DELETE /applicants/claim-unit` → dashboard refetches.

### Auth fixes (W6 — backlogged in #5's earlier body)
- `src/modules/auth/routes.ts` — `POST /applicants/register` returns byte-identical `202 { ok, message }` on all three branches (new email / existing applicant / staff). No auto-JWT.
- `src/modules/auth/routes.ts` — fail-closed `NODE_ENV` check on `/magic-link/request` (dev-link only in dev)

## Tests

- `src/__tests__/unit-claim.test.ts` — **17 new tests**: happy path, claim taken unit (409), expired-held treated as available, claim wrong property (404), claim while already holding (releases old atomically), DELETE round-trip, no-auth guard
- `src/__tests__/applicants-routes-warn2.test.ts` — register enum closure
- `src/__tests__/warn2-jwt-email-proof.test.ts` — magic-link verify produces JWT with `emailVerified: true`
- Full suite: **763 passing / 35 suites** (was 746 / 34 pre-slice)
- `npx tsc --noEmit` — clean
- `client-tenant` build — clean (242 KB JS / 71 KB gzip)

## Out of scope (next phases)

- Auto-expire cron for stale 48h holds — currently lazy-expire in `GET /units` is sufficient for MVP
- Real photo upload UI — Lorem Picsum placeholders for now

## Audit notes carried over from W6 (backlog, not blockers)

- INFO-1: 3 distinct DB-write profiles across register branches → measurable timing side-channel; defer
- INFO-2: dev-only `devLink` re-opens enumeration if `NODE_ENV=development` reaches prod; verified Railway/Vercel set `production`
- INFO-3: client renders `devLink` whenever server sends it — add `import.meta.env.DEV` guard for defense-in-depth
- INFO-4: server `isNew` log line distinguishes staff vs applicant probes to log-aggregator viewers — internal threat model only

## Test plan

- [x] `npx tsc --noEmit` — pass
- [x] `npm test` — 763 passing (was 746)
- [x] `client-tenant` build — pass
- [x] Rebase clean against `main` (PR #4 + PR #6 absorbed; redundant 4a1701f dropped)
- [ ] Manual: new applicant → intent → picker → claim → details with sticky header
- [ ] Manual: claim a unit, claim another → first one auto-released, both unit statuses flip correctly
- [ ] Manual: status page shows ClaimedUnitCard while claim is live; Release button frees the unit and the card disappears
- [ ] Manual: 48h countdown ticks down, header thumbnail loads
- [ ] Manual: hold an available unit, wait past 48h, confirm it reappears in `GET /units` results without manual intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)