### PR TITLE
fix(auth): /register timing parity — call createMagicLink on staff branch (B2)

### DIFF
--- a/src/__tests__/applicants-routes-warn2.test.ts
+++ b/src/__tests__/applicants-routes-warn2.test.ts
@@ -114,7 +114,9 @@ describe("POST /applicants/register (W6 response-shape + WARN #2)", () => {
     mockQuery.mockResolvedValueOnce({
       rows: [{ id: "staff-001", role: "leasing_agent", is_active: true }],
     } as any);
-    // createMagicLink is not called for staff (route returns early)
+    // B2: createMagicLink IS called on the staff path for timing parity, but
+    // the service short-circuits internally and returns null (no token persisted).
+    mockCreateMagicLink.mockResolvedValueOnce(null);
 
     const res = await request(app)
       .post("/applicants/register")
@@ -122,6 +124,11 @@ describe("POST /applicants/register (W6 response-shape + WARN #2)", () => {
 
     expect(res.status).toBe(202);
     expectCanonicalShape(res.body);
+    expect(mockCreateMagicLink).toHaveBeenCalledTimes(1);
+    expect(mockCreateMagicLink).toHaveBeenCalledWith("agent@property.com");
+    // Critical: even though createMagicLink was called, NO link is logged for
+    // staff (the service returned null), so no real token is issued to staff.
+    expect(mockLogMagicLink).not.toHaveBeenCalled();
   });
 
   it("response shape is identical between new and existing applicant paths (same keys)", async () => {

--- a/src/modules/applicants/routes.ts
+++ b/src/modules/applicants/routes.ts
@@ -41,21 +41,20 @@ router.post("/register", registerLimiter, async (req: Request, res: Response): P
     const { email, firstName, lastName, phone } = parsed.data;
 
     const existing = await query("SELECT id, role, is_active FROM users WHERE email = $1", [email]);
-    let userId: string;
+    let userId: string | undefined;
     let isNew = false;
+    let isStaffEmail = false;
 
     if (existing.rows.length > 0) {
       const u = existing.rows[0];
-      // If existing account is staff, don't allow applicant registration on that email.
       if (!["applicant", "tenant"].includes(u.role)) {
-        // Don't leak — return the same normalized response as any other case.
-        res.status(202).json({
-          ok: true,
-          message: "If this email is registered, a verification link has been sent.",
-        });
-        return;
+        // Existing non-applicant role (staff). Don't onboard, don't issue a real
+        // link — but DO fall through to createMagicLink below so wall-clock cost
+        // matches the applicant/tenant branches (B2: timing-side-channel close).
+        isStaffEmail = true;
+      } else {
+        userId = u.id;
       }
-      userId = u.id;
     } else {
       const insertRes = await query(
         `INSERT INTO users (email, first_name, last_name, phone, role, is_active, password_hash)
@@ -67,10 +66,13 @@ router.post("/register", registerLimiter, async (req: Request, res: Response): P
       isNew = true;
     }
 
+    // Always call createMagicLink. The service short-circuits for staff /
+    // inactive / missing emails (returns null) but still pays the SELECT cost,
+    // so all three /register paths take comparable wall-clock time.
     const link = await createMagicLink(email);
     if (link) logMagicLink(email, link.link);
 
-    logger.info("Applicant registered", { userId, email, isNew });
+    logger.info("Applicant registered", { userId, email, isNew, isStaffEmail });
 
     // W6: uniform response for all paths — no token or user ever returned from
     // /register. The client must wait for the magic-link click; token+user are


### PR DESCRIPTION
## Summary
- Closes **B2** from PR #5 audit follow-ups: `POST /applicants/register` returned 202 on the staff path before `createMagicLink` ran, while applicant/tenant paths called it first — letting an attacker enumerate staff accounts via response-time.
- Fall through to `createMagicLink` on all three paths. The service already short-circuits internally for non-applicant roles (returns `null` without persisting a token), so no real link is issued for staff — but the SELECT cost is paid uniformly.
- Response payload remains identical (W6) — no token, no user object, no \`devLink\` for staff in dev.

## What changed
- \`src/modules/applicants/routes.ts\`: replace the staff-path early return with an \`isStaffEmail\` flag; always call \`createMagicLink\`; only \`logMagicLink\` when a real link came back.
- \`src/__tests__/applicants-routes-warn2.test.ts\`: update the staff-email test to assert \`createMagicLink\` IS called (with the staff email), AND assert \`logMagicLink\` is NOT called (no real token issued).

## Threat model addressed
| Path | Before (queries) | After (queries) |
|------|------------------|-----------------|
| Staff email | 1 (SELECT users) | 2 (SELECT users + SELECT in service) |
| Existing applicant/tenant | 3 | 3 |
| New applicant | 4 | 4 |

The new-vs-existing-applicant gap (one INSERT users on the new path) is a smaller residual leak documented as accepted in the W6 backlog — not part of B2's scope.

## Test plan
- [x] \`npx jest src/__tests__/applicants-routes-warn2.test.ts\` — 11/11 pass
- [x] \`npx jest src/__tests__/\` — 763 pass, 0 fail (15 unrelated skips)
- [x] \`npx tsc --noEmit\` — clean
- [ ] CI green on Node 18/20/22

🤖 Generated with [Claude Code](https://claude.com/claude-code)