### PR TITLE
fix: 3 ultrareview demo blockers (bug_001, bug_003, bug_014) + 5 issues filed

### DIFF
--- a/client-tenant/src/pages/Apply.tsx
+++ b/client-tenant/src/pages/Apply.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useNavigate, useSearchParams, Link } from 'react-router-dom';
-import { api } from '@/api/client';
+import { api, getToken } from '@/api/client';
 import { requestMagicLink } from '@/api/auth';
 import { saveIntent, fetchUnits, claimUnit, type Unit } from '@/api/units';
 import { UnitCard } from '@/components/UnitCard';
@@ -96,8 +96,13 @@ export function Apply() {
   const [moveInDate, setMoveInDate] = useState('');
 
   // Verify-stage poll: advance when /auth/me reports emailVerified=true.
+  // Post-W6 /register no longer issues a token, so an unauthenticated 401 here
+  // would trigger client.ts's global redirect to /login and eject the user
+  // from the "Check your email" screen. Skip the poll until the magic-link
+  // verify flow has stored a token.
   useEffect(() => {
     if (step !== 'verify') return;
+    if (!getToken()) return;
     let cancelled = false;
     async function check() {
       try {

--- a/src/db/migrations/2026-05-14-applications-drop-ssn-dob-not-null.sql
+++ b/src/db/migrations/2026-05-14-applications-drop-ssn-dob-not-null.sql
@@ -1,0 +1,11 @@
+-- Applications: SSN/DOB nullable for drafts (2026-05-14)
+-- The applicant self-serve flow creates a draft row before SSN/DOB are
+-- collected (intent quiz → unit picker → claim → form). Those columns are
+-- still required at submit-time, enforced by validation, but the NOT NULL
+-- on the table itself blocks every new applicant's /intent and /claim-unit
+-- calls with a 500. Relax the column-level constraint; keep enforcement
+-- at the boundary.
+
+ALTER TABLE applications ALTER COLUMN ssn_encrypted DROP NOT NULL;
+ALTER TABLE applications ALTER COLUMN ssn_hash DROP NOT NULL;
+ALTER TABLE applications ALTER COLUMN date_of_birth_encrypted DROP NOT NULL;

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -296,9 +296,12 @@ CREATE TABLE applications (
   -- Applicant PII (encrypted at rest)
   first_name VARCHAR(100) NOT NULL,
   last_name VARCHAR(100) NOT NULL,
-  ssn_encrypted TEXT NOT NULL,
-  ssn_hash VARCHAR(64) NOT NULL,
-  date_of_birth_encrypted TEXT NOT NULL,
+  -- Required at submit-time (validated in ApplicationService.create), but
+  -- NULL during the draft phase: applicant self-serve creates a draft row
+  -- from /intent and /claim-unit/:id before SSN/DOB are collected.
+  ssn_encrypted TEXT,
+  ssn_hash VARCHAR(64),
+  date_of_birth_encrypted TEXT,
   email VARCHAR(255),
   phone VARCHAR(20),
 

--- a/src/modules/applicants/routes.ts
+++ b/src/modules/applicants/routes.ts
@@ -103,15 +103,35 @@ router.post("/apply", authenticate, requireEmailVerified, async (req: AuthReques
     // Default email on the application to the authenticated user if not provided.
     if (!input.email) input.email = req.user.email;
 
-    const created = await applicationService.create(input, req.user.id, req.user.role);
-
-    // Link this user to the application as the primary applicant.
-    await query(
-      `INSERT INTO user_applications (user_id, application_id, relationship)
-       VALUES ($1, $2, 'primary')
-       ON CONFLICT (user_id, application_id) DO NOTHING`,
-      [req.user.id, created.id]
+    // If the user already has a draft from /intent or /claim-unit/:id, fill it
+    // in place. Inserting a second row would orphan the unit claim sitting on
+    // the first draft.
+    const existingDraft = await query(
+      `SELECT a.id FROM user_applications ua
+         JOIN applications a ON a.id = ua.application_id
+        WHERE ua.user_id = $1 AND a.status = 'draft'
+        ORDER BY a.created_at DESC
+        LIMIT 1`,
+      [req.user.id]
     );
+
+    let created;
+    if (existingDraft.rows.length > 0) {
+      created = await applicationService.fillDraft(
+        existingDraft.rows[0].id,
+        input,
+        req.user.id,
+        req.user.role
+      );
+    } else {
+      created = await applicationService.create(input, req.user.id, req.user.role);
+      await query(
+        `INSERT INTO user_applications (user_id, application_id, relationship)
+         VALUES ($1, $2, 'primary')
+         ON CONFLICT (user_id, application_id) DO NOTHING`,
+        [req.user.id, created.id]
+      );
+    }
 
     res.status(201).json(created);
   } catch (err: any) {

--- a/src/modules/application/service.ts
+++ b/src/modules/application/service.ts
@@ -99,6 +99,111 @@ export class ApplicationService {
     return result;
   }
 
+  // Fill an existing applicant-self-serve draft (created by /intent or
+  // /claim-unit/:id before SSN/DOB are collected) with the form payload from
+  // step 2 of /apply. Without this path, /apply would INSERT a second draft
+  // and orphan the unit claim sitting on the first one.
+  async fillDraft(
+    applicationId: string,
+    input: CreateApplicationInput,
+    submittedBy: string,
+    submitterRole: string
+  ): Promise<any> {
+    const ssnHash = hashSSN(input.ssn.replace(/\D/g, ""));
+    const ssnEncrypted = encrypt(input.ssn.replace(/\D/g, ""));
+    const dobEncrypted = encrypt(input.dateOfBirth);
+
+    const duplicateCheck = await this.fraudDetection.checkDuplicateSSN(ssnHash);
+
+    const result = await transaction(async (client) => {
+      const res = await client.query(
+        `UPDATE applications SET
+            property_id = $2, unit_number = $3,
+            first_name = $4, last_name = $5,
+            ssn_encrypted = $6, ssn_hash = $7, date_of_birth_encrypted = $8,
+            email = $9, phone = $10,
+            current_address_line1 = $11, current_address_line2 = $12,
+            current_city = $13, current_state = $14, current_zip = $15,
+            employer_name = $16, employer_phone = $17,
+            employment_start_date = $18, annual_income = $19, household_size = $20,
+            previous_landlord_name = $21, previous_landlord_phone = $22,
+            previous_rental_address = $23, previous_rental_duration_months = $24,
+            emergency_contact_name = $25, emergency_contact_phone = $26,
+            emergency_contact_relationship = $27,
+            requested_lease_term_months = $28, requested_rent_amount = $29,
+            requested_move_in_date = $30,
+            submitted_by = $31,
+            updated_at = NOW()
+          WHERE id = $1 AND status = 'draft'
+          RETURNING id, status, created_at`,
+        [
+          applicationId,
+          input.propertyId, input.unitNumber || null,
+          input.firstName, input.lastName, ssnEncrypted, ssnHash, dobEncrypted,
+          input.email || null, input.phone || null,
+          input.currentAddressLine1 || null, input.currentAddressLine2 || null,
+          input.currentCity || null, input.currentState || null, input.currentZip || null,
+          input.employerName || null, input.employerPhone || null,
+          input.employmentStartDate || null, input.annualIncome || null, input.householdSize,
+          input.previousLandlordName || null, input.previousLandlordPhone || null,
+          input.previousRentalAddress || null, input.previousRentalDurationMonths || null,
+          input.emergencyContactName || null, input.emergencyContactPhone || null,
+          input.emergencyContactRelationship || null,
+          input.requestedLeaseTermMonths, input.requestedRentAmount || null,
+          input.requestedMoveInDate || null,
+          submittedBy,
+        ]
+      );
+
+      if (res.rows.length === 0) {
+        throw new Error("DRAFT_NOT_FOUND");
+      }
+
+      if (duplicateCheck.isDuplicate) {
+        await this.fraudDetection.raiseFraudFlag(client, {
+          applicationId,
+          flagType: "duplicate_ssn",
+          description: `SSN matches existing application(s): ${duplicateCheck.existingApplicationIds.join(", ")}`,
+          severity: "high",
+        });
+      }
+
+      if (input.currentAddressLine1) {
+        await this.fraudDetection.checkAddressFraud(client, applicationId, {
+          addressLine1: input.currentAddressLine1,
+          city: input.currentCity,
+          state: input.currentState,
+          zip: input.currentZip,
+        });
+      }
+
+      return res.rows[0];
+    });
+
+    await writeAuditLog({
+      action: "application_created",
+      actorId: submittedBy,
+      actorRole: submitterRole,
+      applicationId: result.id,
+      resourceType: "application",
+      resourceId: result.id,
+      details: {
+        propertyId: input.propertyId,
+        applicantName: `${input.firstName} ${input.lastName}`,
+        ssn: maskSSN(input.ssn),
+        hasDuplicateSSN: duplicateCheck.isDuplicate,
+        filledDraft: true,
+      },
+    });
+
+    logger.info("Application draft filled", {
+      applicationId: result.id,
+      propertyId: input.propertyId,
+    });
+
+    return result;
+  }
+
   async submit(applicationId: string, submittedBy: string, submitterRole: string): Promise<any> {
     const result = await query(
       `UPDATE applications


### PR DESCRIPTION
## Summary

Closes the 3 demo-blocking bugs ultrareview surfaced against merged PR #5. The other 5 are filed as issues #15–19.

| Bug | Severity | Fix |
|---|---|---|
| `bug_001` — `INSERT INTO applications` 500s on real DB (NOT NULL on `ssn_encrypted`/`ssn_hash`/`date_of_birth_encrypted`) | normal / **blocker** | `f0dea35` — drop NOT NULL at column level + new migration; enforce at submit-time |
| `bug_003` — `/apply` orphans the unit claim by inserting a 2nd draft | normal / **blocker** | `c2ccc51` — `/apply` looks up existing draft; new `ApplicationService.fillDraft()` UPDATEs in place with encryption + fraud checks |
| `bug_014` — verify-stage `/auth/me` poll redirects user to `/login` after register | normal / **blocker** | `c2ccc51` — guard the poll on `getToken()` so post-W6 (no-token) flow doesn't hit the global 401 redirect |

## Why these are blockers, not follow-ups

All three break the documented happy path of PR #5's "plant a flag" UX:

- **bug_001**: every FTU's first `/intent` call 500s on a real Postgres. Tests pass only because `transaction()` is mocked in `unit-claim.test.ts`.
- **bug_014**: the moment a new applicant clicks Continue on step 1, they're dumped on `/login` instead of seeing "Check your email". Recovery requires the email link.
- **bug_003**: even after fixing the above, submitting the details form orphans the unit claim onto a now-invisible draft. The carrot disappears at the worst possible moment.

## Filed as follow-ups (non-blocking)

- #15 — `claim-unit` release lacks holder/expiry guard (cross-user clobber + same-user leak)
- #16 — `schema.ts` diverges from migration: missing `units` FK + 5 indexes
- #17 — Intent-quiz prefill is dead code (`/me/applications` SELECT missing `intent_*`)
- #18 — `AuthCallback` catch fallback sends staff to `/apply` on transient `/auth/me` failure
- #19 — Apply.tsx "4+ BR" filter sends `bedrooms=4`, backend uses strict equality (latent)

Plus the 8 audit follow-ups already filed as #7–14.

## Tests

- `npm test` — **763 passing / 35 suites** (no regressions)
- `npx tsc --noEmit` — clean (backend + `client-tenant`)
- `cd client-tenant && npm run build` — clean

## Out of scope

- New tests for `fillDraft` (the UPDATE path) and the verify-poll guard — file as #20
- Migration to backfill any in-flight orphaned drafts on prod (none expected; PR #5 hasn't shipped to a live tenant DB)

## Test plan

- [x] Backend tsc + tests pass
- [x] Frontend tsc + build pass
- [ ] Manual: new applicant → register → see "Check your email" (not /login)
- [ ] Manual: new applicant → intent → claim → details → confirm one draft, claim still on it, ClaimedUnitCard renders
- [ ] Manual: returning applicant → goes through /apply again → still one draft, no orphan unit

🤖 Generated with [Claude Code](https://claude.com/claude-code)