### PR TITLE
fix(apply): demo-killers — /auth/me probes, post-verify routing, intent prefill

### DIFF
--- a/client-tenant/src/api/client.ts
+++ b/client-tenant/src/api/client.ts
@@ -29,7 +29,13 @@ async function request<T>(
 
   const res = await fetch(fullPath, { ...options, headers });
 
-  if (res.status === 401 && !fullPath.includes('/auth/magic-link')) {
+  // /auth/me is the probe endpoint — callers (AuthCallback, VerifyPending,
+  // the Apply step='verify' poll) use it to discover auth state and handle
+  // 401 locally. A hard redirect here ejects users mid-flow from the
+  // verify-pending screen and the magic-link callback.
+  const isAuthProbe =
+    fullPath.includes('/auth/magic-link') || fullPath.includes('/auth/me');
+  if (res.status === 401 && !isAuthProbe) {
     clearToken();
     window.location.href = '/login';
     throw new Error('Session expired');

--- a/client-tenant/src/pages/Application.tsx
+++ b/client-tenant/src/pages/Application.tsx
@@ -207,8 +207,10 @@ export function Application() {
         <StatusPill status={app.status} />
       </div>
 
-      {/* Claimed unit (draft only — when an applicant has held a unit) */}
-      {app.claimed_unit && app.claim_expires_at && (
+      {/* Claimed unit — only relevant while the app is a draft. Once
+          submitted the hold is locked in via unit_number on the application,
+          and showing a 48h countdown timer would be misleading. */}
+      {app.status === 'draft' && app.claimed_unit && app.claim_expires_at && (
         <ClaimedUnitCard
           unit={app.claimed_unit}
           expiresAt={app.claim_expires_at}

--- a/client-tenant/src/pages/AuthCallback.tsx
+++ b/client-tenant/src/pages/AuthCallback.tsx
@@ -8,16 +8,49 @@ interface MeResponse {
   user?: { role: string; emailVerified: boolean };
 }
 
+interface MyAppsResponse {
+  applications?: Array<{ status: string }>;
+}
+
+// Anything past draft means the user has already submitted — sending them
+// back to the intent quiz would be the wrong screen entirely.
+const SUBMITTED_STATUSES = new Set([
+  'submitted',
+  'screening',
+  'screening_passed',
+  'screening_failed',
+  'tier1_review',
+  'tier1_approved',
+  'tier1_denied',
+  'tier2_review',
+  'tier2_approved',
+  'tier2_denied',
+  'tier3_review',
+  'tier3_approved',
+  'tier3_denied',
+  'lease_generated',
+  'onboarded',
+]);
+
 // Applicants/tenants land on the intent quiz first — it's the entry to the
 // "plant a flag" flow that converts FTUs by getting them to claim a specific
 // unit before the heavier details form. Step 'intent' redirects forward on its
 // own if a claim already exists. Staff/admin go straight to /dashboard.
+// Already-submitted/onboarded users skip the funnel entirely and land on the
+// status page.
 async function resolvePostVerifyRoute(): Promise<string> {
   try {
     const me = await api.get<MeResponse>('/auth/me');
     const role = me.user?.role;
-    if (role === 'applicant' || role === 'tenant') return '/apply?step=intent';
-    return '/dashboard';
+    if (role !== 'applicant' && role !== 'tenant') return '/dashboard';
+    try {
+      const apps = await api.get<MyAppsResponse>('/applicants/me/applications');
+      const hasSubmitted = apps.applications?.some((a) => SUBMITTED_STATUSES.has(a.status));
+      if (hasSubmitted) return '/application';
+    } catch {
+      // Fall through to the intent quiz if status lookup fails.
+    }
+    return '/apply?step=intent';
   } catch {
     return '/apply?step=intent';
   }

--- a/src/modules/applicants/routes.ts
+++ b/src/modules/applicants/routes.ts
@@ -1,6 +1,6 @@
 import { Router, Request, Response } from "express";
 import { z } from "zod";
-import rateLimit from "express-rate-limit";
+import rateLimit, { ipKeyGenerator } from "express-rate-limit";
 import { query, transaction } from "../../config/database";
 import { authenticate, AuthRequest } from "../../middleware/auth";
 import { requireEmailVerified } from "../../middleware/scope";
@@ -22,7 +22,7 @@ const registerSchema = z.object({
 const registerLimiter = rateLimit({
   windowMs: 60 * 1000,
   max: 5,
-  keyGenerator: (req) => `${req.ip}:${(req.body?.email ?? "").toLowerCase()}`,
+  keyGenerator: (req) => `${ipKeyGenerator(req.ip ?? "")}:${(req.body?.email ?? "").toLowerCase()}`,
   standardHeaders: true,
   legacyHeaders: false,
   message: { error: "Too many requests, try again in a minute" },

--- a/src/modules/applicants/routes.ts
+++ b/src/modules/applicants/routes.ts
@@ -545,7 +545,10 @@ router.get("/me/applications", authenticate, requireEmailVerified, async (req: A
     const result = await query(
       `SELECT a.id, a.first_name, a.last_name, a.email, a.status, a.submitted_at,
               a.created_at, a.property_id, a.unit_number, a.overall_screening_result,
-              a.requested_rent_amount, p.name AS property_name
+              a.requested_rent_amount,
+              a.intent_bedrooms, a.intent_budget_min, a.intent_budget_max,
+              a.intent_move_in_date, a.intent_household_size,
+              p.name AS property_name
        FROM user_applications ua
        JOIN applications a ON a.id = ua.application_id
        JOIN properties p ON p.id = a.property_id

--- a/src/modules/auth/routes.ts
+++ b/src/modules/auth/routes.ts
@@ -1,6 +1,6 @@
 import { Router } from "express";
 import { z } from "zod";
-import rateLimit from "express-rate-limit";
+import rateLimit, { ipKeyGenerator } from "express-rate-limit";
 import { createMagicLink, verifyMagicLink, logMagicLink } from "./magic-link-service";
 import { authenticate, AuthRequest } from "../../middleware/auth";
 import { logger } from "../../utils/logger";
@@ -14,7 +14,7 @@ const requestSchema = z.object({
 const magicLinkLimiter = rateLimit({
   windowMs: 60 * 1000,
   max: 5,
-  keyGenerator: (req) => `${req.ip}:${(req.body?.email ?? "").toLowerCase()}`,
+  keyGenerator: (req) => `${ipKeyGenerator(req.ip ?? "")}:${(req.body?.email ?? "").toLowerCase()}`,
   standardHeaders: true,
   legacyHeaders: false,
   message: { error: "Too many requests, try again in a minute" },


### PR DESCRIPTION
## Summary

Closes 5 ultrareview demo blockers on the applicant flow. Stacked on top of #21 (which closed bug_001).

- **bug_006** — `/auth/me` is the probe endpoint (`VerifyPending`, `AuthCallback`, Apply `step='verify'` poll). The global 401 redirect in `client-tenant/src/api/client.ts` fired before the caller's `try/catch` could see the error, ejecting users from the verify-pending screen and the magic-link callback. Whitelist `/auth/me` alongside `/auth/magic-link`.
- **bug_017** — `resolvePostVerifyRoute` always sent applicants/tenants to the intent quiz, even ones with a submitted/approved/onboarded application. Check `/applicants/me/applications` and route any non-draft status to `/application`.
- **bug_011** — `ClaimedUnitCard` rendered on `/application` for non-draft statuses, showing a 48h countdown over a locked-in unit. Gate on `app.status === 'draft'`.
- **bug_012** — `/applicants/me/applications` didn't `SELECT intent_*`, so `Apply.tsx` prefill from the hydration endpoint silently failed and returning applicants saw an empty intent quiz.
- **#14** — express-rate-limit v8 deprecated raw \`req.ip\` keyGenerators (\`ERR_ERL_KEY_GEN_IPV6\`). Switched \`/auth/magic-link/request\` and \`/applicants/intent\` to use the \`ipKeyGenerator\` helper so IPv6 clients can't share rate-limit buckets across addresses.

## Test plan
- [ ] Register a fresh applicant → see \`Check your email\`, no eject to \`/login\`
- [ ] Click magic link → AuthCallback routes to \`/apply?step=intent\` for fresh user
- [ ] Submit application → magic-link round-trip → AuthCallback routes to \`/application\`, no detour through intent quiz
- [ ] \`/application\` for an onboarded tenant: no ClaimedUnitCard, no 48h timer
- [ ] Apply → intent quiz → exit → re-enter \`/apply?step=intent\`: prefilled from last draft
- [ ] Backend starts clean (no ERR_ERL_KEY_GEN_IPV6 in logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)