### PR TITLE
fix(auth-callback): retry /auth/me on transient failure (closes #18)

### DIFF
--- a/client-tenant/src/pages/AuthCallback.tsx
+++ b/client-tenant/src/pages/AuthCallback.tsx
@@ -38,22 +38,31 @@ const SUBMITTED_STATUSES = new Set([
 // own if a claim already exists. Staff/admin go straight to /dashboard.
 // Already-submitted/onboarded users skip the funnel entirely and land on the
 // status page.
-async function resolvePostVerifyRoute(): Promise<string> {
+async function fetchMeWithRetry(): Promise<MeResponse> {
   try {
-    const me = await api.get<MeResponse>('/auth/me');
-    const role = me.user?.role;
-    if (role !== 'applicant' && role !== 'tenant') return '/dashboard';
-    try {
-      const apps = await api.get<MyAppsResponse>('/applicants/me/applications');
-      const hasSubmitted = apps.applications?.some((a) => SUBMITTED_STATUSES.has(a.status));
-      if (hasSubmitted) return '/application';
-    } catch {
-      // Fall through to the intent quiz if status lookup fails.
-    }
-    return '/apply?step=intent';
+    return await api.get<MeResponse>('/auth/me');
   } catch {
-    return '/apply?step=intent';
+    await new Promise(resolve => setTimeout(resolve, 500));
+    return api.get<MeResponse>('/auth/me');
   }
+}
+
+async function resolvePostVerifyRoute(): Promise<string> {
+  // Retry once on transient /auth/me failure. Defaulting to the intent quiz
+  // here misroutes staff (and any returning applicant) into the wrong screen.
+  // If both attempts fail, throw so the caller shows an error instead of
+  // silently misrouting.
+  const me = await fetchMeWithRetry();
+  const role = me.user?.role;
+  if (role !== 'applicant' && role !== 'tenant') return '/dashboard';
+  try {
+    const apps = await api.get<MyAppsResponse>('/applicants/me/applications');
+    const hasSubmitted = apps.applications?.some((a) => SUBMITTED_STATUSES.has(a.status));
+    if (hasSubmitted) return '/application';
+  } catch {
+    // Fall through to the intent quiz if status lookup fails.
+  }
+  return '/apply?step=intent';
 }
 
 export function AuthCallback() {
@@ -69,7 +78,16 @@ export function AuthCallback() {
     }
 
     verifyMagicLink(token)
-      .then(resolvePostVerifyRoute)
+      .then(async () => {
+        try {
+          return await resolvePostVerifyRoute();
+        } catch {
+          // Magic-link verify succeeded but /auth/me kept failing after retry.
+          // Don't guess the role — route to /login so AuthGuard can re-check
+          // once the user reloads with a working network.
+          return '/login';
+        }
+      })
       .then(dest => navigate(dest, { replace: true }))
       .catch(err => setError(err instanceof Error ? err.message : 'Invalid or expired link'));
   }, [searchParams, navigate]);


### PR DESCRIPTION
## Summary

Closes #18.

The outer \`catch\` in \`resolvePostVerifyRoute\` swallowed every \`/auth/me\` failure and defaulted to \`/apply?step=intent\`. A transient blip during magic-link verify would silently:

- Dump **staff** into the applicant intent quiz.
- Dump **returning applicants** past the unit-claim funnel back into the quiz.

## Fix

- Retry \`/auth/me\` once with a 500ms delay before giving up (\`fetchMeWithRetry\`).
- If the retry still fails, throw out of \`resolvePostVerifyRoute\`. The \`useEffect\` handler routes to \`/login\` so \`AuthGuard\` can re-check on the next page load instead of guessing a destination.
- The inner \`/applicants/me/applications\` catch stays — applicants without a submitted status genuinely belong on \`/apply\`, so falling through is correct there.

## Test plan
- [ ] Verify magic link with a working network → routes correctly (applicant→\`/apply?step=intent\` or \`/application\`, staff→\`/dashboard\`)
- [ ] Throttle network in DevTools → magic-link verify still routes correctly after retry succeeds
- [ ] Block \`/auth/me\` entirely (e.g. via DevTools request block) → user lands on \`/login\` (not on the wrong portal screen)

🤖 Generated with [Claude Code](https://claude.com/claude-code)