### PR TITLE
fix(applicants): inclusive bedroomsMin filter + drop unused property_id from /intent

### DIFF
--- a/client-tenant/src/api/units.ts
+++ b/client-tenant/src/api/units.ts
@@ -6,7 +6,6 @@ export interface Intent {
   budget_max: number;
   move_in_date: string;
   household_size: number;
-  property_id?: string;
 }
 
 export interface Unit {
@@ -37,12 +36,16 @@ export async function saveIntent(intent: Intent): Promise<{ ok: boolean; applica
 
 export async function fetchUnits(filter: {
   bedrooms?: number;
+  // Inclusive — use this for "N+ BR" semantics so the user actually sees
+  // units at higher bedroom counts (the dropdown's "4+ BR" option, etc.).
+  bedroomsMin?: number;
   maxRent?: number;
   moveInBy?: string;
   propertyId?: string;
 }): Promise<{ units: Unit[] }> {
   const params = new URLSearchParams();
-  if (filter.bedrooms !== undefined) params.set('bedrooms', String(filter.bedrooms));
+  if (filter.bedroomsMin !== undefined) params.set('bedroomsMin', String(filter.bedroomsMin));
+  else if (filter.bedrooms !== undefined) params.set('bedrooms', String(filter.bedrooms));
   if (filter.maxRent !== undefined) params.set('maxRent', String(filter.maxRent));
   if (filter.moveInBy) params.set('moveInBy', filter.moveInBy);
   if (filter.propertyId) params.set('propertyId', filter.propertyId);

--- a/client-tenant/src/pages/Apply.tsx
+++ b/client-tenant/src/pages/Apply.tsx
@@ -33,6 +33,9 @@ const BEDROOM_OPTIONS: Array<{ value: number; label: string }> = [
   { value: 3, label: '3 BR' },
   { value: 4, label: '4+ BR' },
 ];
+// The highest option uses "N+" semantics — it should match any unit with at
+// least that many bedrooms. Anything below is an exact bedroom-count match.
+const BEDROOMS_INCLUSIVE_MIN = BEDROOM_OPTIONS[BEDROOM_OPTIONS.length - 1].value;
 
 export function Apply() {
   const navigate = useNavigate();
@@ -177,7 +180,9 @@ export function Apply() {
       setError(null);
       try {
         const res = await fetchUnits({
-          bedrooms: intentBedrooms,
+          ...(intentBedrooms >= BEDROOMS_INCLUSIVE_MIN
+            ? { bedroomsMin: intentBedrooms }
+            : { bedrooms: intentBedrooms }),
           maxRent: intentBudgetMax,
           moveInBy: intentMoveInDate,
         });

--- a/src/__tests__/unit-claim.test.ts
+++ b/src/__tests__/unit-claim.test.ts
@@ -185,6 +185,40 @@ describe("GET /applicants/units", () => {
     expect(sql).toContain("LIMIT 12");
   });
 
+  // Regression for bug_010 (issue #19): the "4+ BR" filter sends bedrooms=4
+  // and previously matched u.bedrooms = $1 — meaning a 5BR or 6BR unit would
+  // silently fail the filter. New contract: callers send bedroomsMin for
+  // inclusive semantics, and it wins if both are sent.
+  it("uses inclusive >= when bedroomsMin is provided", async () => {
+    mockUsersRow(applicant, VERIFIED_AT);
+    mockQuery.mockResolvedValueOnce({ rows: [] } as any);
+    const token = generateToken(applicant);
+    const res = await request(app)
+      .get("/applicants/units?bedroomsMin=4")
+      .set("Authorization", `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    const sql = mockQuery.mock.calls[1][0] as string;
+    const params = mockQuery.mock.calls[1][1] as unknown[];
+    expect(sql).toContain("u.bedrooms >= $1");
+    expect(sql).not.toMatch(/u\.bedrooms = \$/);
+    expect(params).toEqual([4]);
+  });
+
+  it("bedroomsMin wins over bedrooms when both are sent", async () => {
+    mockUsersRow(applicant, VERIFIED_AT);
+    mockQuery.mockResolvedValueOnce({ rows: [] } as any);
+    const token = generateToken(applicant);
+    const res = await request(app)
+      .get("/applicants/units?bedrooms=2&bedroomsMin=4")
+      .set("Authorization", `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    const sql = mockQuery.mock.calls[1][0] as string;
+    const params = mockQuery.mock.calls[1][1] as unknown[];
+    expect(sql).toContain("u.bedrooms >= $1");
+    expect(sql).not.toMatch(/u\.bedrooms = \$/);
+    expect(params).toEqual([4]);
+  });
+
   it("ignores malformed propertyId (no SQL injection vector)", async () => {
     mockUsersRow(applicant, VERIFIED_AT);
     mockQuery.mockResolvedValueOnce({ rows: [] } as any);

--- a/src/modules/applicants/routes.ts
+++ b/src/modules/applicants/routes.ts
@@ -188,13 +188,16 @@ router.get("/properties", async (_req: Request, res: Response): Promise<void> =>
   }
 });
 
+// Intent quiz captures applicant preferences only — property_id is not part
+// of the quiz. The picker step (next) is what locks the applicant onto a
+// specific unit (and therefore property) via /claim-unit/:id. Accepting
+// property_id here would let a stale UI overwrite the claimed property.
 const intentSchema = z.object({
   bedrooms: z.number().int().min(0).max(6),
   budget_min: z.number().min(0).max(20000).optional(),
   budget_max: z.number().min(0).max(20000),
   move_in_date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
   household_size: z.number().int().min(1).max(12),
-  property_id: z.string().uuid().optional(),
 });
 
 // Save the 5-question intent quiz onto the user's draft application.
@@ -240,7 +243,6 @@ router.post(
                     intent_budget_max = $4,
                     intent_move_in_date = $5,
                     intent_household_size = $6,
-                    property_id = COALESCE($7, property_id),
                     updated_at = NOW()
               WHERE id = $1`,
             [
@@ -250,22 +252,19 @@ router.post(
               intent.budget_max,
               intent.move_in_date,
               intent.household_size,
-              intent.property_id ?? null,
             ]
           );
         } else {
-          // Pick a property for the draft FK if the applicant didn't choose one.
-          // Any active property works — they'll narrow via the unit picker.
-          let propertyId = intent.property_id ?? null;
-          if (!propertyId) {
-            const fallback = await client.query(
-              `SELECT id FROM properties ORDER BY name ASC LIMIT 1`
-            );
-            if (fallback.rows.length === 0) {
-              throw new Error("NO_PROPERTIES_AVAILABLE");
-            }
-            propertyId = fallback.rows[0].id;
+          // No draft yet — pick any active property for the FK. The applicant
+          // narrows down via the unit picker, and /claim-unit/:id updates
+          // applications.property_id to whichever unit they actually claim.
+          const fallback = await client.query(
+            `SELECT id FROM properties ORDER BY name ASC LIMIT 1`
+          );
+          if (fallback.rows.length === 0) {
+            throw new Error("NO_PROPERTIES_AVAILABLE");
           }
+          const propertyId = fallback.rows[0].id;
 
           const insert = await client.query(
             `INSERT INTO applications (
@@ -327,6 +326,8 @@ router.get(
       }
 
       const bedrooms = req.query.bedrooms !== undefined ? Number(req.query.bedrooms) : undefined;
+      const bedroomsMin =
+        req.query.bedroomsMin !== undefined ? Number(req.query.bedroomsMin) : undefined;
       const maxRent = req.query.maxRent !== undefined ? Number(req.query.maxRent) : undefined;
       const moveInBy = typeof req.query.moveInBy === "string" ? req.query.moveInBy : undefined;
       const propertyId = typeof req.query.propertyId === "string" ? req.query.propertyId : undefined;
@@ -336,7 +337,14 @@ router.get(
       ];
       const params: unknown[] = [];
 
-      if (bedrooms !== undefined && Number.isFinite(bedrooms)) {
+      // `bedroomsMin` is inclusive — used by the "N+ BR" filter option so the
+      // user actually sees units at higher bedroom counts. Falls back to
+      // `bedrooms` (exact match) when callers want a single bedroom count.
+      // `bedroomsMin` wins if both are sent.
+      if (bedroomsMin !== undefined && Number.isFinite(bedroomsMin)) {
+        params.push(bedroomsMin);
+        conditions.push(`u.bedrooms >= $${params.length}`);
+      } else if (bedrooms !== undefined && Number.isFinite(bedrooms)) {
         params.push(bedrooms);
         conditions.push(`u.bedrooms = $${params.length}`);
       }


### PR DESCRIPTION
## Summary

Two nits from ultrareview triage on the unit-claim slice (PR #5):

- **bug_010 (#19)** — "4+ BR" filter was doing an exact match (`u.bedrooms = 4`) and hiding 5+ BR units. Backend now accepts `?bedroomsMin=N` for inclusive matching (`u.bedrooms >= N`). Apply.tsx switches to `bedroomsMin` for the highest `BEDROOM_OPTIONS` value ("N+" semantics) and keeps exact match for everything below. `bedroomsMin` wins if both are sent.
- **bug_015** — `property_id` removed from the `/intent` quiz schema. The quiz captures preferences only; `/claim-unit/:id` is what locks the application onto a specific unit (and therefore property). Accepting `property_id` at `/intent` let a stale UI overwrite the claimed property. New drafts pick any active property for the FK; the picker step narrows it down.

+2 regression tests in `unit-claim.test.ts` asserting the SQL operator and `bedroomsMin` precedence.

Closes #19.

## Test plan
- [x] `npx jest --ci --forceExit` — 769 passed, 0 failed, 15 skipped
- [x] `npx tsc --noEmit` clean on backend
- [x] `cd client-tenant && npx tsc --noEmit` clean on frontend
- [ ] Smoke in browser: claim unit with intent.bedrooms=4, confirm 5+ BR units appear in picker
- [ ] Smoke in browser: `/intent` POST with stale `property_id` in body is silently ignored (not 400'd — extra keys are dropped by Zod)

🤖 Generated with [Claude Code](https://claude.com/claude-code)