### PR TITLE
feat(wiz): StepPayment + StepConfirm (Lane W3)

### DIFF
--- a/client-tenant/src/i18n/en/apply.json
+++ b/client-tenant/src/i18n/en/apply.json
@@ -12,5 +12,36 @@
   "fee": {
     "amount": "$35.95",
     "label": "Application fee"
+  },
+  "payment": {
+    "title": "Secure payment",
+    "subtitle": "Processed securely. Your info is encrypted.",
+    "payingFor": "Paying for",
+    "cardName": "Cardholder name",
+    "cardNumber": "Card number",
+    "exp": "Expiry",
+    "cvv": "CVV",
+    "zip": "ZIP code",
+    "payCta": "Pay",
+    "processing": "Processing…",
+    "encrypted": "🔒 Encrypted · PCI-DSS",
+    "error": "Payment failed. Please try again.",
+    "retry": "Retry"
+  },
+  "confirm": {
+    "title": "Application started!",
+    "subtitle": "We'll send your next steps by email and SMS.",
+    "paid": "Paid",
+    "ref": "Reference",
+    "refMissing": "—",
+    "queue": "Queue position",
+    "positionConfirmed": "position confirmed",
+    "whatsNextTitle": "What happens next",
+    "nextSteps": [
+      "Upload your documents (5 files, < 120 days).",
+      "A Property Manager reviews your application in 2–3 business days.",
+      "You sign your lease & addenda via DocuSign."
+    ],
+    "toDashboard": "Go to my dashboard →"
   }
 }

--- a/client-tenant/src/i18n/es/apply.json
+++ b/client-tenant/src/i18n/es/apply.json
@@ -12,5 +12,36 @@
   "fee": {
     "amount": "$35.95",
     "label": "Cuota de solicitud"
+  },
+  "payment": {
+    "title": "Pago seguro",
+    "subtitle": "Procesado de forma segura. Tu información está cifrada.",
+    "payingFor": "Pagando por",
+    "cardName": "Nombre en la tarjeta",
+    "cardNumber": "Número de tarjeta",
+    "exp": "Vence",
+    "cvv": "CVV",
+    "zip": "Código postal",
+    "payCta": "Pagar",
+    "processing": "Procesando…",
+    "encrypted": "🔒 Cifrado · PCI-DSS",
+    "error": "El pago falló. Intenta de nuevo.",
+    "retry": "Reintentar"
+  },
+  "confirm": {
+    "title": "¡Solicitud iniciada!",
+    "subtitle": "Te enviaremos el siguiente paso por email y SMS.",
+    "paid": "Pagado",
+    "ref": "Referencia",
+    "refMissing": "—",
+    "queue": "Posición en cola",
+    "positionConfirmed": "posición confirmada",
+    "whatsNextTitle": "¿Qué sigue?",
+    "nextSteps": [
+      "Sube tus documentos (5 archivos, < 120 días).",
+      "Un Property Manager revisa tu solicitud en 2–3 días hábiles.",
+      "Firmas tu contrato y addenda por DocuSign."
+    ],
+    "toDashboard": "Ir a mi panel →"
   }
 }

--- a/client-tenant/src/pages/apply/PayHeader.tsx
+++ b/client-tenant/src/pages/apply/PayHeader.tsx
@@ -1,0 +1,61 @@
+/**
+ * PayHeader — STUB per Contract 3 (W2 will replace with canonical).
+ *
+ * Props: { step, total, lang, onBack? }
+ * HF tokens + Tailwind only. No WF.*, no Hand/SBox/sketchy, no Kalam/Caveat.
+ */
+import { HF } from '@/styles/tokens';
+
+export interface PayHeaderProps {
+  step: number;
+  total: number;
+  lang?: 'en' | 'es';
+  onBack?: () => void;
+}
+
+export function PayHeader({ step, total, lang = 'en', onBack }: PayHeaderProps) {
+  const stepLabel = lang === 'es' ? `Paso ${step} de ${total}` : `Step ${step} of ${total}`;
+  const backLabel = lang === 'es' ? 'Atrás' : 'Back';
+
+  return (
+    <header
+      className="flex items-center justify-between px-4 py-3"
+      style={{
+        background: HF.cream,
+        borderBottom: `1px solid ${HF.border}`,
+        color: HF.ink,
+        fontFamily: HF.body,
+      }}
+    >
+      {onBack ? (
+        <button
+          type="button"
+          onClick={onBack}
+          aria-label={backLabel}
+          className="inline-flex items-center gap-1 px-2 py-1"
+          style={{
+            background: 'transparent',
+            color: HF.ink2,
+            fontSize: 13,
+            fontWeight: 600,
+            border: 'none',
+            cursor: 'pointer',
+          }}
+        >
+          ← {backLabel}
+        </button>
+      ) : (
+        <span style={{ width: 56 }} aria-hidden />
+      )}
+      <span
+        aria-label={stepLabel}
+        style={{ color: HF.ink3, fontSize: 12, fontWeight: 600, letterSpacing: 1 }}
+      >
+        {stepLabel.toUpperCase()}
+      </span>
+      <span style={{ width: 56 }} aria-hidden />
+    </header>
+  );
+}
+
+export default PayHeader;

--- a/client-tenant/src/pages/apply/context/ApplyContext.tsx
+++ b/client-tenant/src/pages/apply/context/ApplyContext.tsx
@@ -1,0 +1,96 @@
+/**
+ * ApplyContext — STUB per Contract 2 (W1/W2 will replace with canonical).
+ *
+ * Shape:
+ *  - adults: number (default 1)
+ *  - paymentTotal: string — computed as $35.95 × (adults + 1)
+ *  - paymentRef: string | null (default null)
+ *
+ * Persistence: sessionStorage key `frank_apply_state`.
+ *
+ * When Lane W1 lands, replace this file with the canonical context — the
+ * shape is frozen by Contract 2 so consumers should not change.
+ */
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import type { ReactNode } from 'react';
+
+const STORAGE_KEY = 'frank_apply_state';
+const FEE = 35.95;
+
+export interface ApplyState {
+  adults: number;
+  paymentTotal: string;
+  paymentRef: string | null;
+}
+
+interface ApplyContextValue {
+  state: ApplyState;
+  setPaymentRef: (ref: string) => void;
+  setAdults: (adults: number) => void;
+}
+
+function computeTotal(adults: number): string {
+  const total = FEE * (adults + 1);
+  return total.toFixed(2);
+}
+
+function load(): ApplyState {
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY);
+    if (raw) {
+      const parsed = JSON.parse(raw) as Partial<ApplyState>;
+      const adults = typeof parsed.adults === 'number' ? parsed.adults : 1;
+      return {
+        adults,
+        paymentTotal: parsed.paymentTotal ?? computeTotal(adults),
+        paymentRef: parsed.paymentRef ?? null,
+      };
+    }
+  } catch {
+    // ignore — fall through to default
+  }
+  return { adults: 1, paymentTotal: computeTotal(1), paymentRef: null };
+}
+
+const ApplyCtx = createContext<ApplyContextValue | null>(null);
+
+export function ApplyProvider({ children }: { children: ReactNode }) {
+  const [state, setState] = useState<ApplyState>(() => load());
+
+  useEffect(() => {
+    try {
+      sessionStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+    } catch {
+      // session storage may be unavailable in some test envs
+    }
+  }, [state]);
+
+  const setPaymentRef = useCallback((ref: string) => {
+    setState((s) => ({ ...s, paymentRef: ref }));
+  }, []);
+
+  const setAdults = useCallback((adults: number) => {
+    setState((s) => ({ ...s, adults, paymentTotal: computeTotal(adults) }));
+  }, []);
+
+  const value = useMemo(
+    () => ({ state, setPaymentRef, setAdults }),
+    [state, setPaymentRef, setAdults],
+  );
+
+  return <ApplyCtx.Provider value={value}>{children}</ApplyCtx.Provider>;
+}
+
+export function useApply(): ApplyContextValue {
+  const v = useContext(ApplyCtx);
+  if (!v) {
+    // Allow standalone usage in tests — synthesize a minimal default.
+    const adults = 1;
+    return {
+      state: { adults, paymentTotal: computeTotal(adults), paymentRef: null },
+      setPaymentRef: () => {},
+      setAdults: () => {},
+    };
+  }
+  return v;
+}

--- a/client-tenant/src/pages/apply/steps/StepConfirm.tsx
+++ b/client-tenant/src/pages/apply/steps/StepConfirm.tsx
@@ -1,0 +1,113 @@
+/**
+ * StepConfirm — terminal receipt for the apply wizard (Lane W3 scaffold).
+ *
+ * Shows paid amount, paymentRef, queue position (if waitlist summary
+ * available, else "position confirmed"), what-happens-next bullets,
+ * link to /dashboard.
+ */
+import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { HF } from '@/styles/tokens';
+import { CTA, Card } from '@/components/primitives';
+import { useApply } from '@/pages/apply/context/ApplyContext';
+import { PayHeader } from '@/pages/apply/PayHeader';
+
+interface WaitlistSummary {
+  position?: number | null;
+}
+
+export interface StepConfirmProps {
+  /** Optional pre-fetched waitlist summary (W1/W2 may inject) */
+  waitlist?: WaitlistSummary | null;
+}
+
+export function StepConfirm({ waitlist = null }: StepConfirmProps) {
+  const { t, i18n } = useTranslation('apply');
+  const lang = (i18n.language?.startsWith('es') ? 'es' : 'en') as 'en' | 'es';
+  const { state } = useApply();
+
+  const position = waitlist?.position;
+  const hasRef = !!state.paymentRef;
+
+  const nextSteps = t('confirm.nextSteps', { returnObjects: true }) as string[];
+
+  return (
+    <div style={{ background: HF.cream, minHeight: '100vh', color: HF.ink, fontFamily: HF.body }}>
+      <PayHeader step={5} total={5} lang={lang} />
+      <main className="mx-auto max-w-md p-4 flex flex-col gap-3" aria-label={t('confirm.title') as string}>
+        <div style={{ textAlign: 'center', padding: '10px 0 4px' }}>
+          <div
+            aria-hidden
+            style={{
+              width: 64, height: 64, borderRadius: 999, margin: '0 auto',
+              background: HF.okLo, border: `2px solid ${HF.ok}`,
+              display: 'grid', placeItems: 'center', fontSize: 28, color: HF.ok, fontWeight: 700,
+            }}
+          >
+            ✓
+          </div>
+        </div>
+        <h1 style={{ fontFamily: HF.display, fontSize: 24, fontWeight: 700, textAlign: 'center' }}>
+          {t('confirm.title')}
+        </h1>
+        <p style={{ textAlign: 'center', color: HF.ink3, fontSize: 13 }}>{t('confirm.subtitle')}</p>
+
+        <Card padding={14} style={{ borderColor: HF.ok }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline' }}>
+            <span style={{ color: HF.ink3, fontSize: 11, textTransform: 'uppercase', letterSpacing: 1, fontWeight: 600 }}>
+              {t('confirm.paid')}
+            </span>
+            <span style={{ fontFamily: HF.display, fontSize: 22, fontWeight: 700 }}>${state.paymentTotal}</span>
+          </div>
+          <div style={{ height: 8 }} />
+          <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 12, color: HF.ink2 }}>
+            <span style={{ color: HF.ink3, textTransform: 'uppercase', letterSpacing: 1, fontWeight: 600, fontSize: 11 }}>
+              {t('confirm.ref')}
+            </span>
+            <span style={{ fontFamily: HF.mono }} data-testid="payment-ref">
+              {hasRef ? state.paymentRef : t('confirm.refMissing')}
+            </span>
+          </div>
+          <div style={{ height: 8 }} />
+          <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 12, color: HF.ink2 }}>
+            <span style={{ color: HF.ink3, textTransform: 'uppercase', letterSpacing: 1, fontWeight: 600, fontSize: 11 }}>
+              {t('confirm.queue')}
+            </span>
+            <span style={{ fontWeight: 700 }}>
+              {typeof position === 'number' ? `#${position}` : (t('confirm.positionConfirmed') as string)}
+            </span>
+          </div>
+        </Card>
+
+        <Card padding={14}>
+          <h2 style={{ fontFamily: HF.display, fontSize: 14, fontWeight: 700, marginBottom: 8 }}>
+            {t('confirm.whatsNextTitle')}
+          </h2>
+          <ol style={{ display: 'flex', flexDirection: 'column', gap: 6, paddingLeft: 0, margin: 0, listStyle: 'none' }}>
+            {nextSteps.map((line, i) => (
+              <li key={i} style={{ display: 'flex', gap: 8, fontSize: 13, color: HF.ink2 }}>
+                <span
+                  aria-hidden
+                  style={{
+                    width: 20, height: 20, borderRadius: 999, flex: '0 0 20px',
+                    background: HF.accent, color: HF.paper, fontSize: 11, fontWeight: 700,
+                    display: 'grid', placeItems: 'center',
+                  }}
+                >
+                  {i + 1}
+                </span>
+                <span>{line}</span>
+              </li>
+            ))}
+          </ol>
+        </Card>
+
+        <Link to="/dashboard" style={{ textDecoration: 'none' }}>
+          <CTA tone="primary" size="lg" block>{t('confirm.toDashboard')}</CTA>
+        </Link>
+      </main>
+    </div>
+  );
+}
+
+export default StepConfirm;

--- a/client-tenant/src/pages/apply/steps/StepPayment.tsx
+++ b/client-tenant/src/pages/apply/steps/StepPayment.tsx
@@ -1,0 +1,146 @@
+// TODO(BP-08): replace stub submit with real Stripe PaymentIntents
+/**
+ * StepPayment — wizard step for payment capture (Lane W3 scaffold).
+ *
+ * NO real Stripe wiring. On submit:
+ *  1. Generate fake paymentRef (`pay_${Date.now()}_${random}`).
+ *  2. POST /api/tape/payment-init  → bp03b.payment_initiated
+ *  3. POST /api/tape/payment-success → bp03b.payment_succeeded
+ *  4. Persist paymentRef to ApplyContext.
+ *  5. Navigate ?step=2 (existing Step2Details).
+ *
+ * Beacons accept { session_id, adults, total }.  5xx → toast + retry.
+ */
+import { useCallback, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { HF } from '@/styles/tokens';
+import { CTA } from '@/components/primitives';
+import { useApply } from '@/pages/apply/context/ApplyContext';
+import { PayHeader } from '@/pages/apply/PayHeader';
+
+function sessionId(): string {
+  try {
+    const k = 'frank_apply_session_id';
+    let id = sessionStorage.getItem(k);
+    if (!id) {
+      id = `s_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
+      sessionStorage.setItem(k, id);
+    }
+    return id;
+  } catch {
+    return `s_${Date.now()}`;
+  }
+}
+
+async function fireBeacon(path: string, body: object): Promise<Response> {
+  return fetch(path, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+export function StepPayment() {
+  const { t, i18n } = useTranslation('apply');
+  const lang = (i18n.language?.startsWith('es') ? 'es' : 'en') as 'en' | 'es';
+  const navigate = useNavigate();
+  const { state, setPaymentRef } = useApply();
+
+  const [name, setName] = useState('');
+  const [number, setNumber] = useState('');
+  const [exp, setExp] = useState('');
+  const [cvv, setCvv] = useState('');
+  const [zip, setZip] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  const total = state.paymentTotal;
+  const sid = useMemo(() => sessionId(), []);
+
+  const submit = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault();
+      setErr(null);
+      setBusy(true);
+      const payload = { session_id: sid, adults: state.adults, total };
+      try {
+        const r1 = await fireBeacon('/api/tape/payment-init', payload);
+        if (!r1.ok) throw new Error(`init ${r1.status}`);
+        const ref = `pay_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+        const r2 = await fireBeacon('/api/tape/payment-success', { ...payload, paymentRef: ref });
+        if (!r2.ok) throw new Error(`success ${r2.status}`);
+        setPaymentRef(ref);
+        navigate('?step=2');
+      } catch {
+        setErr(t('payment.error') as string);
+      } finally {
+        setBusy(false);
+      }
+    },
+    [navigate, setPaymentRef, sid, state.adults, t, total],
+  );
+
+  return (
+    <div style={{ background: HF.cream, minHeight: '100vh', color: HF.ink, fontFamily: HF.body }}>
+      <PayHeader step={3} total={5} lang={lang} onBack={() => navigate(-1)} />
+      <form onSubmit={submit} className="mx-auto max-w-md p-4 flex flex-col gap-3" aria-label={t('payment.title') as string}>
+        <h1 style={{ fontFamily: HF.display, fontSize: 22, fontWeight: 700 }}>{t('payment.title')}</h1>
+        <p style={{ color: HF.ink3, fontSize: 13 }}>{t('payment.subtitle')}</p>
+
+        <div role="status" aria-live="polite" style={{ background: HF.paper, border: `1px solid ${HF.border}`, borderRadius: HF.r.md, padding: 12, display: 'flex', justifyContent: 'space-between' }}>
+          <span style={{ color: HF.ink3, fontSize: 12, textTransform: 'uppercase', letterSpacing: 1 }}>{t('payment.payingFor')}</span>
+          <span style={{ fontWeight: 700 }}>${total}</span>
+        </div>
+
+        <Field label={t('payment.cardName') as string} value={name} onChange={setName} required autoComplete="cc-name" />
+        <Field label={t('payment.cardNumber') as string} value={number} onChange={setNumber} required autoComplete="cc-number" inputMode="numeric" />
+        <div className="grid grid-cols-2 gap-3">
+          <Field label={t('payment.exp') as string} value={exp} onChange={setExp} required autoComplete="cc-exp" placeholder="MM/YY" />
+          <Field label={t('payment.cvv') as string} value={cvv} onChange={setCvv} required autoComplete="cc-csc" inputMode="numeric" />
+        </div>
+        <Field label={t('payment.zip') as string} value={zip} onChange={setZip} required autoComplete="postal-code" inputMode="numeric" />
+
+        {err && (
+          <div role="alert" style={{ background: HF.errLo, border: `1px solid ${HF.err}`, color: HF.err, padding: 10, borderRadius: HF.r.sm, fontSize: 13 }}>
+            {err}{' '}
+            <button type="submit" style={{ textDecoration: 'underline', background: 'none', border: 'none', color: HF.err, cursor: 'pointer' }}>
+              {t('payment.retry')}
+            </button>
+          </div>
+        )}
+
+        <CTA type="submit" tone="primary" size="lg" disabled={busy} block aria-busy={busy}>
+          {busy ? (t('payment.processing') as string) : `${t('payment.payCta')} $${total}`}
+        </CTA>
+        <p style={{ textAlign: 'center', color: HF.ink3, fontSize: 11 }}>{t('payment.encrypted')}</p>
+      </form>
+    </div>
+  );
+}
+
+function Field({
+  label, value, onChange, required, autoComplete, inputMode, placeholder,
+}: {
+  label: string; value: string; onChange: (v: string) => void; required?: boolean;
+  autoComplete?: string; inputMode?: 'numeric' | 'text'; placeholder?: string;
+}) {
+  const id = `f_${label.replace(/\s+/g, '_').toLowerCase()}`;
+  return (
+    <label htmlFor={id} className="flex flex-col gap-1">
+      <span style={{ color: HF.ink3, fontSize: 11, textTransform: 'uppercase', letterSpacing: 1, fontWeight: 600 }}>{label}</span>
+      <input
+        id={id}
+        value={value}
+        required={required}
+        autoComplete={autoComplete}
+        inputMode={inputMode}
+        placeholder={placeholder}
+        onChange={(e) => onChange(e.target.value)}
+        style={{ background: HF.paper, border: `1px solid ${HF.border}`, borderRadius: HF.r.sm, padding: '10px 12px', fontSize: 14, color: HF.ink, fontFamily: HF.body }}
+      />
+    </label>
+  );
+}
+
+export default StepPayment;

--- a/client-tenant/src/pages/apply/steps/__tests__/StepConfirm.test.tsx
+++ b/client-tenant/src/pages/apply/steps/__tests__/StepConfirm.test.tsx
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+import { describe, expect, it, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import axe from 'axe-core';
+import { StepConfirm } from '../StepConfirm';
+import { ApplyProvider } from '@/pages/apply/context/ApplyContext';
+
+function renderConfirm(opts?: { withRef?: boolean; position?: number | null }) {
+  if (opts?.withRef) {
+    sessionStorage.setItem(
+      'frank_apply_state',
+      JSON.stringify({ adults: 1, paymentTotal: '71.90', paymentRef: 'pay_test_abc123' }),
+    );
+  }
+  return render(
+    <MemoryRouter>
+      <ApplyProvider>
+        <StepConfirm waitlist={opts?.position != null ? { position: opts.position } : null} />
+      </ApplyProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe('StepConfirm', () => {
+  beforeEach(() => sessionStorage.clear());
+
+  it('renders paymentRef when set', () => {
+    renderConfirm({ withRef: true });
+    expect(screen.getByTestId('payment-ref')).toHaveTextContent('pay_test_abc123');
+  });
+
+  it('shows fallback when paymentRef missing', () => {
+    renderConfirm();
+    expect(screen.getByTestId('payment-ref')).toHaveTextContent('—');
+  });
+
+  it('shows numeric queue position when waitlist summary provided', () => {
+    renderConfirm({ withRef: true, position: 12 });
+    expect(screen.getByText('#12')).toBeInTheDocument();
+  });
+
+  it('falls back to "position confirmed" when no waitlist summary', () => {
+    renderConfirm({ withRef: true });
+    expect(screen.getByText(/position confirmed/i)).toBeInTheDocument();
+  });
+
+  it('links to /dashboard', () => {
+    renderConfirm({ withRef: true });
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', '/dashboard');
+  });
+
+  it('has no axe violations', async () => {
+    const { container } = renderConfirm({ withRef: true });
+    const results = await axe.run(container);
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/client-tenant/src/pages/apply/steps/__tests__/StepPayment.test.tsx
+++ b/client-tenant/src/pages/apply/steps/__tests__/StepPayment.test.tsx
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import axe from 'axe-core';
+import { StepPayment } from '../StepPayment';
+import { ApplyProvider } from '@/pages/apply/context/ApplyContext';
+
+const navigateSpy = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return { ...actual, useNavigate: () => navigateSpy };
+});
+
+function renderWithProviders() {
+  return render(
+    <MemoryRouter initialEntries={[`/apply?step=payment`]}>
+      <ApplyProvider>
+        <Routes>
+          <Route path="/apply" element={<StepPayment />} />
+        </Routes>
+      </ApplyProvider>
+    </MemoryRouter>,
+  );
+}
+
+function fillForm() {
+  const inputs = screen.getAllByRole('textbox') as HTMLInputElement[];
+  for (const input of inputs) fireEvent.change(input, { target: { value: '4242' } });
+}
+
+describe('StepPayment — beacons fire on submit', () => {
+  beforeEach(() => {
+    navigateSpy.mockReset();
+    sessionStorage.clear();
+  });
+
+  it('fires payment_initiated then payment_succeeded with correct payload, navigates to ?step=2', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch' as never)
+      .mockResolvedValue({ ok: true, status: 200, json: async () => ({}) } as Response);
+
+    renderWithProviders();
+    fillForm();
+
+    const submit = screen.getByRole('button', { name: /pay \$/i });
+    fireEvent.click(submit);
+
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(2));
+
+    const [initCall, successCall] = fetchSpy.mock.calls as unknown as Array<[string, RequestInit]>;
+    expect(initCall[0]).toBe('/api/tape/payment-init');
+    expect(successCall[0]).toBe('/api/tape/payment-success');
+
+    const initBody = JSON.parse(String(initCall[1].body));
+    expect(initBody).toMatchObject({ adults: 1, total: '71.90' });
+    expect(typeof initBody.session_id).toBe('string');
+
+    const successBody = JSON.parse(String(successCall[1].body));
+    expect(successBody.adults).toBe(1);
+    expect(successBody.total).toBe('71.90');
+    expect(typeof successBody.paymentRef).toBe('string');
+    expect(successBody.paymentRef).toMatch(/^pay_/);
+
+    await waitFor(() => expect(navigateSpy).toHaveBeenCalledWith('?step=2'));
+  });
+
+  it('shows retry on 5xx', async () => {
+    vi.spyOn(globalThis, 'fetch' as never).mockResolvedValue({
+      ok: false, status: 500, json: async () => ({}),
+    } as Response);
+
+    renderWithProviders();
+    fillForm();
+    fireEvent.click(screen.getByRole('button', { name: /pay \$/i }));
+
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
+  });
+});
+
+describe('StepPayment — a11y', () => {
+  beforeEach(() => sessionStorage.clear());
+  it('has no axe violations', async () => {
+    vi.spyOn(globalThis, 'fetch' as never).mockResolvedValue({ ok: true, status: 200 } as Response);
+    const { container } = renderWithProviders();
+    const results = await axe.run(container);
+    expect(results.violations).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- **StepPayment** — card form scaffold (name / number / exp / CVV / ZIP). No real Stripe (BP-08 owns that — visible TODO at top of file). On submit: fires `bp03b.payment_initiated` then `bp03b.payment_succeeded` via `POST /api/tape/payment-init` and `/api/tape/payment-success` with `{ session_id, adults, total }`, persists a fake `paymentRef` to `ApplyContext`, then navigates to `?step=2`. 5xx surfaces a retry alert.
- **StepConfirm** — terminal receipt: paid amount, paymentRef, queue position (waitlist summary or "position confirmed" fallback), what-next bullets, link to `/dashboard`.
- **PayHeader + ApplyContext** — Contract 2/3 stubs (W1/W2 will overwrite when merged; canonical paths line up).
- **i18n** — `payment.*` + `confirm.*` keys in EN + ES (`client-tenant/src/i18n/{en,es}/apply.json`).
- **Tests** — `StepPayment.test.tsx` asserts both beacons fire with correct payload, 5xx → alert, axe-clean. `StepConfirm.test.tsx` covers paymentRef render, fallback, queue position, dashboard link, axe-clean.

## Verification
- [x] Both files <150 lines (`StepPayment` 146, `StepConfirm` 113, `PayHeader` 61, `ApplyContext` 96)
- [x] HF tokens + Tailwind only — no WF.*, no Hand/SBox/sketchy, no Kalam/Caveat
- [x] No real Stripe call — `// TODO(BP-08)` at top of `StepPayment.tsx`
- [x] Both beacons asserted in test
- [x] ES toggle works (i18next language detection)
- [x] axe-core clean in both test suites
- [x] `npm test -- StepPayment StepConfirm` → 9/9 pass
- [x] `npm run build` → green

## Frozen contracts honoured
- Contract 1: payment → `?step=2` → confirm
- Contract 3: PayHeader props `{ step, total, lang, onBack? }`, <150 lines, HF + Tailwind
- Contract 4: beacons `bp03b.payment_initiated` / `bp03b.payment_succeeded` with `{ session_id, adults, total }`
- Contract 6: i18n keyspace `payment.*` + `confirm.*` in `apply` namespace

🤖 Generated with [Claude Code](https://claude.com/claude-code)