### PR TITLE
feat(wiz): StepReview + StepHousehold (Lane W2)

### DIFF
--- a/client-tenant/src/i18n/en/apply.json
+++ b/client-tenant/src/i18n/en/apply.json
@@ -12,5 +12,41 @@
   "fee": {
     "amount": "$35.95",
     "label": "Application fee"
+  },
+  "review": {
+    "title": "Confirm what you're applying for",
+    "subtitle": "Review the details before paying. You can edit any field.",
+    "applyingFor": "Applying for",
+    "edit": "edit",
+    "unit": "Unit",
+    "size": "Size",
+    "sqft": "sq ft",
+    "position": "Position",
+    "openVacancy": "Vacancy",
+    "lockedCriteria": "Your locked criteria",
+    "household": "Household of {{count}}",
+    "bed": "BR",
+    "confirmHeader": "Is this what you wanted?",
+    "confirmBody": "Your application and fee are tied exactly to this property and unit type.",
+    "cta": "Yes, continue →",
+    "fallback": {
+      "propertyName": "Selected property",
+      "address": "Address on file",
+      "studio": "Studio"
+    }
+  },
+  "household": {
+    "title": "Who will live here?",
+    "subtitle": "Your application fee (${{fee}} per adult 18+) reserves your spot on the waitlist.",
+    "adultsLabel": "Adults (18+)",
+    "adultsHint": "Each must pay their fee and sign.",
+    "adults": "adults",
+    "increment": "Add adult",
+    "decrement": "Remove adult",
+    "feeCalculator": "Fee calculator",
+    "processing": "Processing (included)",
+    "totalDue": "Total due",
+    "disclaimer": "Fee is non-refundable. Your spot is locked when you pay.",
+    "cta": "Continue to payment · {{total}} →"
   }
 }

--- a/client-tenant/src/i18n/es/apply.json
+++ b/client-tenant/src/i18n/es/apply.json
@@ -12,5 +12,41 @@
   "fee": {
     "amount": "$35.95",
     "label": "Cuota de solicitud"
+  },
+  "review": {
+    "title": "Confirma tu selección",
+    "subtitle": "Revisa los detalles antes de pagar. Puedes editar cualquier campo.",
+    "applyingFor": "Solicitas",
+    "edit": "editar",
+    "unit": "Unidad",
+    "size": "Tamaño",
+    "sqft": "pies²",
+    "position": "Posición",
+    "openVacancy": "Hay vacancia",
+    "lockedCriteria": "Tus criterios bloqueados",
+    "household": "Hogar de {{count}}",
+    "bed": "RC",
+    "confirmHeader": "¿Es esto lo que querías?",
+    "confirmBody": "Tu solicitud y tarifa están vinculadas exactamente a esta propiedad y unidad.",
+    "cta": "Sí, continuar →",
+    "fallback": {
+      "propertyName": "Propiedad seleccionada",
+      "address": "Dirección registrada",
+      "studio": "Estudio"
+    }
+  },
+  "household": {
+    "title": "¿Quiénes vivirán aquí?",
+    "subtitle": "Tu tarifa de solicitud (${{fee}} por adulto 18+) reserva tu lugar en la lista de espera.",
+    "adultsLabel": "Adultos (18+)",
+    "adultsHint": "Cada uno debe pagar su tarifa y firmar.",
+    "adults": "adultos",
+    "increment": "Agregar adulto",
+    "decrement": "Quitar adulto",
+    "feeCalculator": "Calculadora de tarifa",
+    "processing": "Procesamiento (incluido)",
+    "totalDue": "Total",
+    "disclaimer": "Tarifa no reembolsable. Reservas tu lugar al pagar.",
+    "cta": "Continuar al pago · {{total}} →"
   }
 }

--- a/client-tenant/src/pages/apply/ApplyContext.tsx
+++ b/client-tenant/src/pages/apply/ApplyContext.tsx
@@ -1,0 +1,109 @@
+/**
+ * ApplyContext — Lane W2 LOCAL STUB.
+ *
+ * NOTE: This file is a temporary stub matching Contract 2 exactly. Lane W1
+ * owns the canonical ApplyContext and will replace this. Imports in
+ * StepReview / StepHousehold use the canonical path `./ApplyContext` so the
+ * swap is a delete-and-replace once W1 lands.
+ *
+ * Contract 2 fields:
+ *   adults: number          — default 1
+ *   paymentTotal: string    — computed `$35.95 × (adults+1)`
+ *   paymentRef: string|null — default null
+ * Persisted to sessionStorage key `frank_apply_state`.
+ */
+import { createContext, useCallback, useContext, useEffect, useMemo, useState, type ReactNode } from 'react';
+
+export const APPLY_STATE_KEY = 'frank_apply_state';
+export const APPLICATION_FEE = 35.95;
+
+export interface ApplyState {
+  adults: number;
+  paymentRef: string | null;
+  // Optional shape so review screen can render a seed property/unit from
+  // upstream lanes. W1 may widen this.
+  property?: { id?: string; name?: string; photoUrl?: string; address?: string } | null;
+  unit?: { type?: string; bedrooms?: number; sqft?: number; waitlistPosition?: number | null } | null;
+  criteria?: { incomeBand?: string; householdSize?: number; moveInDate?: string } | null;
+}
+
+export interface ApplyStateWithComputed extends ApplyState {
+  /** Computed: $35.95 × (adults + 1). */
+  paymentTotal: string;
+}
+
+export interface ApplyContextValue {
+  state: ApplyStateWithComputed;
+  setAdults: (n: number) => void;
+  setPaymentRef: (ref: string | null) => void;
+  patch: (next: Partial<ApplyState>) => void;
+}
+
+const DEFAULT_STATE: ApplyState = { adults: 1, paymentRef: null };
+
+function formatTotal(adults: number): string {
+  return `$${(APPLICATION_FEE * (adults + 1)).toFixed(2)}`;
+}
+
+function loadState(): ApplyState {
+  try {
+    const raw = sessionStorage.getItem(APPLY_STATE_KEY);
+    if (!raw) return DEFAULT_STATE;
+    const parsed = JSON.parse(raw) as Partial<ApplyState>;
+    return { ...DEFAULT_STATE, ...parsed };
+  } catch {
+    return DEFAULT_STATE;
+  }
+}
+
+function saveState(s: ApplyState): void {
+  try {
+    sessionStorage.setItem(APPLY_STATE_KEY, JSON.stringify(s));
+  } catch {
+    /* ignore quota / disabled storage */
+  }
+}
+
+const ApplyCtx = createContext<ApplyContextValue | null>(null);
+
+export interface ApplyProviderProps {
+  children: ReactNode;
+  /** Test seed — used to bootstrap state without touching sessionStorage. */
+  initialState?: Partial<ApplyState>;
+}
+
+export function ApplyProvider({ children, initialState }: ApplyProviderProps) {
+  const [state, setState] = useState<ApplyState>(() => ({
+    ...loadState(),
+    ...(initialState ?? {}),
+  }));
+
+  useEffect(() => { saveState(state); }, [state]);
+
+  const setAdults = useCallback((n: number) => {
+    setState(prev => ({ ...prev, adults: Math.max(1, Math.min(12, Math.floor(n))) }));
+  }, []);
+
+  const setPaymentRef = useCallback((ref: string | null) => {
+    setState(prev => ({ ...prev, paymentRef: ref }));
+  }, []);
+
+  const patch = useCallback((next: Partial<ApplyState>) => {
+    setState(prev => ({ ...prev, ...next }));
+  }, []);
+
+  const value = useMemo<ApplyContextValue>(() => ({
+    state: { ...state, paymentTotal: formatTotal(state.adults) },
+    setAdults,
+    setPaymentRef,
+    patch,
+  }), [state, setAdults, setPaymentRef, patch]);
+
+  return <ApplyCtx.Provider value={value}>{children}</ApplyCtx.Provider>;
+}
+
+export function useApply(): ApplyContextValue {
+  const ctx = useContext(ApplyCtx);
+  if (!ctx) throw new Error('useApply must be used within <ApplyProvider>');
+  return ctx;
+}

--- a/client-tenant/src/pages/apply/steps/StepHousehold.tsx
+++ b/client-tenant/src/pages/apply/steps/StepHousehold.tsx
@@ -1,0 +1,135 @@
+/**
+ * StepHousehold — Lane W2. Adults stepper drives fee math.
+ *
+ * Fee: $35.95 × (adults + 1) — applicant + each additional adult. Computed in
+ * ApplyContext as `state.paymentTotal`. Adults range 1–12.
+ *
+ * WF → HF TOKEN MAP:
+ *   WF.ink    (#1a1814) → HF.ink
+ *   WF.ink2              → HF.ink2
+ *   WF.ink3              → HF.ink3
+ *   WF.accent (#c9492a) → HF.accent
+ *   WF.paper             → HF.paper
+ *   WF.cream / #e2dccc  → HF.cream / HF.border
+ *
+ * Source: /tmp/gpmglv-welcome/015caabf-c0ea-44e7-bb16-1ff144fe250e
+ *         ~lines 236–347 (HouseholdComposition). Hand/SBox/sketchy dropped;
+ *         HF primitives only. No WF.* / Kalam / Caveat.
+ */
+import { useSearchParams } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { Card, CTA } from '@/components/primitives';
+import { HF } from '@/styles/tokens';
+import { APPLICATION_FEE, useApply } from '../ApplyContext';
+
+const MIN = 1;
+const MAX = 12;
+
+export function StepHousehold() {
+  const { t } = useTranslation('apply');
+  const [, setSearch] = useSearchParams();
+  const { state, setAdults } = useApply();
+  const adults = state.adults;
+  const billable = adults + 1; // applicant + each additional adult
+  const total = state.paymentTotal;
+
+  return (
+    <div style={{ background: HF.cream, minHeight: '100vh', padding: 16 }}>
+      <div style={{ maxWidth: 420, margin: '0 auto', display: 'flex', flexDirection: 'column', gap: 12 }}>
+        <div>
+          <h1 style={{ fontFamily: HF.display, fontSize: 22, fontWeight: 700, color: HF.ink, margin: 0 }}>
+            {t('household.title')}
+          </h1>
+          <p style={{ color: HF.ink3, fontSize: 13, margin: '4px 0 0' }}>
+            {t('household.subtitle', { fee: APPLICATION_FEE.toFixed(2) })}
+          </p>
+        </div>
+
+        <Card padding={14}>
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+            <div>
+              <div style={{ fontFamily: HF.display, fontSize: 15, fontWeight: 700, color: HF.ink }}>
+                {t('household.adultsLabel')}
+              </div>
+              <div style={{ fontSize: 11, color: HF.ink3 }}>{t('household.adultsHint')}</div>
+            </div>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+              <StepBtn
+                ariaLabel={t('household.decrement')}
+                onClick={() => setAdults(adults - 1)}
+                disabled={adults <= MIN}
+              >−</StepBtn>
+              <span
+                aria-live="polite"
+                data-testid="adults-count"
+                style={{ fontFamily: HF.display, fontSize: 26, fontWeight: 700, color: HF.ink, minWidth: 28, textAlign: 'center' }}
+              >
+                {adults}
+              </span>
+              <StepBtn
+                ariaLabel={t('household.increment')}
+                onClick={() => setAdults(adults + 1)}
+                disabled={adults >= MAX}
+                primary
+              >+</StepBtn>
+            </div>
+          </div>
+        </Card>
+
+        <Card padding={14} style={{ background: HF.accentLo, borderColor: HF.accent }}>
+          <div style={{ fontFamily: HF.display, fontSize: 13, fontWeight: 700, color: HF.accentInk }}>
+            {t('household.feeCalculator')}
+          </div>
+          <div style={{ height: 6 }} />
+          <Row label={`$${APPLICATION_FEE.toFixed(2)} × ${billable} ${t('household.adults')}`}
+               value={`$${(APPLICATION_FEE * billable).toFixed(2)}`} />
+          <Row label={t('household.processing')} value="$0.00" muted />
+          <div style={{ marginTop: 6, paddingTop: 6, borderTop: `1.4px solid ${HF.accent}`,
+                        display: 'flex', justifyContent: 'space-between', alignItems: 'baseline' }}>
+            <span style={{ fontFamily: HF.display, fontSize: 14, fontWeight: 700, color: HF.ink }}>
+              {t('household.totalDue')}
+            </span>
+            <span data-testid="payment-total"
+                  style={{ fontFamily: HF.display, fontSize: 22, fontWeight: 700, color: HF.accent }}>
+              {total}
+            </span>
+          </div>
+          <div style={{ fontSize: 10, color: HF.ink3, marginTop: 4 }}>{t('household.disclaimer')}</div>
+        </Card>
+
+        <CTA variant="mobile" onClick={() => setSearch({ step: 'payment' }, { replace: true })}>
+          {t('household.cta', { total })}
+        </CTA>
+      </div>
+    </div>
+  );
+}
+
+function Row({ label, value, muted }: { label: string; value: string; muted?: boolean }) {
+  const color = muted ? HF.ink3 : HF.ink2;
+  return (
+    <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 12, color }}>
+      <span>{label}</span><span>{value}</span>
+    </div>
+  );
+}
+
+function StepBtn({ children, onClick, disabled, primary, ariaLabel }:
+                 { children: React.ReactNode; onClick: () => void; disabled?: boolean; primary?: boolean; ariaLabel: string }) {
+  return (
+    <button type="button" aria-label={ariaLabel} onClick={onClick} disabled={disabled}
+            style={{
+              width: 36, height: 36, borderRadius: HF.r.pill,
+              border: `1.4px solid ${primary ? HF.accent : HF.borderHi}`,
+              background: primary ? HF.accent : HF.paper,
+              color: primary ? HF.paper : HF.ink,
+              fontFamily: HF.display, fontSize: 18, fontWeight: 700,
+              cursor: disabled ? 'not-allowed' : 'pointer', opacity: disabled ? 0.4 : 1,
+              display: 'grid', placeItems: 'center',
+            }}>
+      {children}
+    </button>
+  );
+}
+
+export default StepHousehold;

--- a/client-tenant/src/pages/apply/steps/StepReview.tsx
+++ b/client-tenant/src/pages/apply/steps/StepReview.tsx
@@ -1,0 +1,119 @@
+/**
+ * StepReview — Lane W2. Boarding-pass recap of the applicant's selection.
+ *
+ * WF → HF TOKEN MAP:
+ *   WF.ink    (#1a1814) → HF.ink
+ *   WF.ink2              → HF.ink2
+ *   WF.ink3              → HF.ink3
+ *   WF.accent (#c9492a) → HF.accent
+ *   WF.paper             → HF.paper
+ *   WF.cream / #e2dccc  → HF.cream / HF.border
+ *
+ * Source: /tmp/gpmglv-welcome/015caabf-c0ea-44e7-bb16-1ff144fe250e
+ *         ~lines 58–231 (ReviewSelection). Semantics preserved; primitives
+ *         restyled to HF — Hand/SBox/sketchy dropped, no WF.* references,
+ *         no Kalam/Caveat.
+ */
+import { useSearchParams } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { Card, CTA, Pill } from '@/components/primitives';
+import { HF } from '@/styles/tokens';
+import { useApply } from '../ApplyContext';
+
+export function StepReview() {
+  const { t } = useTranslation('apply');
+  const [, setSearch] = useSearchParams();
+  const { state } = useApply();
+
+  const propName = state.property?.name ?? t('review.fallback.propertyName');
+  const propPhoto = state.property?.photoUrl;
+  const propAddress = state.property?.address ?? t('review.fallback.address');
+  const bed = state.unit?.bedrooms;
+  const bedLabel = bed == null ? t('review.fallback.studio')
+    : bed === 0 ? t('review.fallback.studio') : `${bed} ${t('review.bed')}`;
+  const sqft = state.unit?.sqft ?? 720;
+  const waitlistPos = state.unit?.waitlistPosition ?? null;
+  const incomeBand = state.criteria?.incomeBand ?? '50–60% AMI';
+  const householdSize = state.criteria?.householdSize ?? 1;
+  const moveIn = state.criteria?.moveInDate ?? '—';
+
+  return (
+    <div style={{ background: HF.cream, minHeight: '100vh', padding: 16 }}>
+      <div style={{ maxWidth: 420, margin: '0 auto', display: 'flex', flexDirection: 'column', gap: 12 }}>
+        <div>
+          <h1 style={{ fontFamily: HF.display, fontSize: 22, fontWeight: 700, color: HF.ink, margin: 0 }}>
+            {t('review.title')}
+          </h1>
+          <p style={{ color: HF.ink3, fontSize: 13, margin: '4px 0 0' }}>{t('review.subtitle')}</p>
+        </div>
+
+        <Card padding={0} style={{ overflow: 'hidden', borderColor: HF.borderHi }}>
+          {propPhoto && (
+            <img src={propPhoto} alt="" style={{ width: '100%', height: 140, objectFit: 'cover', display: 'block' }} />
+          )}
+          <div style={{ padding: 14, position: 'relative' }}>
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: 8 }}>
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{ fontSize: 9, color: HF.ink3, fontWeight: 600, letterSpacing: 1.5, textTransform: 'uppercase' }}>
+                  {t('review.applyingFor')}
+                </div>
+                <div style={{ fontFamily: HF.display, fontSize: 18, fontWeight: 700, color: HF.ink, marginTop: 2 }}>{propName}</div>
+                <div style={{ fontSize: 12, color: HF.ink3 }}>{propAddress}</div>
+              </div>
+              <button onClick={() => setSearch({ step: 'intent' }, { replace: true })}
+                      style={{ background: 'transparent', border: 'none', color: HF.accent, fontSize: 11, textDecoration: 'underline', cursor: 'pointer' }}>
+                {t('review.edit')}
+              </button>
+            </div>
+
+            <div style={{ height: 12 }} />
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: 8 }}>
+              <Stat label={t('review.unit')} value={bedLabel} accent />
+              <Stat label={t('review.size')} value={`${sqft} ${t('review.sqft')}`} />
+              <Stat label={t('review.position')} value={waitlistPos ? `#${waitlistPos}` : t('review.openVacancy')} />
+            </div>
+
+            <div style={{ marginTop: 12, paddingTop: 10, borderTop: `1px dashed ${HF.borderHi}` }}>
+              <div style={{ fontSize: 9, color: HF.ink3, fontWeight: 600, letterSpacing: 1, textTransform: 'uppercase' }}>
+                {t('review.lockedCriteria')}
+              </div>
+              <div style={{ display: 'flex', gap: 4, flexWrap: 'wrap', marginTop: 6 }}>
+                <Pill>{incomeBand}</Pill>
+                <Pill>{t('review.household', { count: householdSize })}</Pill>
+                <Pill>{moveIn}</Pill>
+                <button onClick={() => setSearch({ step: 'intent' }, { replace: true })}
+                        style={{ background: 'transparent', border: 'none', color: HF.accent, fontSize: 11, textDecoration: 'underline', cursor: 'pointer', marginLeft: 'auto' }}>
+                  {t('review.edit')}
+                </button>
+              </div>
+            </div>
+          </div>
+        </Card>
+
+        <Card padding={12} style={{ background: HF.accentLo, borderColor: HF.accent }}>
+          <div style={{ fontFamily: HF.display, fontSize: 13, fontWeight: 700, color: HF.accentInk }}>
+            {t('review.confirmHeader')}
+          </div>
+          <div style={{ fontSize: 11, color: HF.ink3, marginTop: 2 }}>{t('review.confirmBody')}</div>
+        </Card>
+
+        <CTA variant="mobile" onClick={() => setSearch({ step: 'household' }, { replace: true })}>
+          {t('review.cta')}
+        </CTA>
+      </div>
+    </div>
+  );
+}
+
+function Stat({ label, value, accent }: { label: string; value: string; accent?: boolean }) {
+  return (
+    <div>
+      <div style={{ fontSize: 9, color: HF.ink3, fontWeight: 600, letterSpacing: 1, textTransform: 'uppercase' }}>{label}</div>
+      <div style={{ fontFamily: HF.display, fontSize: 15, fontWeight: 700, color: accent ? HF.accent : HF.ink, lineHeight: 1.1, marginTop: 2 }}>
+        {value}
+      </div>
+    </div>
+  );
+}
+
+export default StepReview;

--- a/client-tenant/src/pages/apply/steps/__tests__/StepHousehold.test.tsx
+++ b/client-tenant/src/pages/apply/steps/__tests__/StepHousehold.test.tsx
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter, Route, Routes, useSearchParams } from 'react-router-dom';
+import axe from 'axe-core';
+import { ApplyProvider, useApply } from '../../ApplyContext';
+import { StepReview } from '../StepReview';
+import { StepHousehold } from '../StepHousehold';
+
+function StepProbe() {
+  const [search] = useSearchParams();
+  const { state } = useApply();
+  return (
+    <div>
+      <div data-testid="step-probe">{search.get('step') ?? 'review'}</div>
+      <div data-testid="state-adults">{state.adults}</div>
+      <div data-testid="state-total">{state.paymentTotal}</div>
+    </div>
+  );
+}
+
+function App() {
+  const [search] = useSearchParams();
+  const step = search.get('step') ?? 'review';
+  return (
+    <>
+      {step === 'review' && <StepReview />}
+      {step === 'household' && <StepHousehold />}
+      {step === 'payment' && <div>PAYMENT STEP</div>}
+      <StepProbe />
+    </>
+  );
+}
+
+function renderApp(initialStep = 'review') {
+  return render(
+    <MemoryRouter initialEntries={[`/apply?step=${initialStep}`]}>
+      <ApplyProvider initialState={{
+        property: { id: 'p1', name: 'Donna Louise 2', address: '2241 Sunrise' },
+        unit: { type: '2BR', bedrooms: 2, sqft: 820, waitlistPosition: null },
+        criteria: { incomeBand: '50–60% AMI', householdSize: 2, moveInDate: '2026-08-01' },
+      }}>
+        <Routes>
+          <Route path="/apply" element={<App />} />
+        </Routes>
+      </ApplyProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe('StepHousehold', () => {
+  it('defaults to 1 adult → total $71.90 (1 applicant + 1 self = (1+1) × 35.95)', () => {
+    renderApp('household');
+    expect(screen.getByTestId('adults-count').textContent).toBe('1');
+    expect(screen.getByTestId('payment-total').textContent).toBe('$71.90');
+  });
+
+  it('+ increments adults, fee total updates from context', () => {
+    renderApp('household');
+    const inc = screen.getByRole('button', { name: /add adult/i });
+    fireEvent.click(inc);
+    fireEvent.click(inc);
+    expect(screen.getByTestId('adults-count').textContent).toBe('3');
+    expect(screen.getByTestId('payment-total').textContent).toBe('$143.80');
+  });
+
+  it('− decrements but floors at 1', () => {
+    renderApp('household');
+    const dec = screen.getByRole('button', { name: /remove adult/i });
+    fireEvent.click(dec);
+    fireEvent.click(dec);
+    expect(screen.getByTestId('adults-count').textContent).toBe('1');
+  });
+
+  it('has no axe-core a11y violations', async () => {
+    const { container } = renderApp('household');
+    const results = await axe.run(container);
+    expect(results.violations).toEqual([]);
+  });
+});
+
+describe('Integration: review → household → payment', () => {
+  it('walks the flow, sets adults=3, asserts paymentTotal=$143.80', () => {
+    renderApp('review');
+
+    // Step 1: Review → Continue → household
+    fireEvent.click(screen.getByRole('button', { name: /yes, continue/i }));
+    expect(screen.getByTestId('step-probe').textContent).toBe('household');
+
+    // Step 2: bump adults to 3
+    const inc = screen.getByRole('button', { name: /add adult/i });
+    fireEvent.click(inc);
+    fireEvent.click(inc);
+
+    expect(screen.getByTestId('state-adults').textContent).toBe('3');
+    expect(screen.getByTestId('state-total').textContent).toBe('$143.80');
+
+    // Step 3: continue → payment
+    fireEvent.click(screen.getByRole('button', { name: /continue to payment/i }));
+    expect(screen.getByTestId('step-probe').textContent).toBe('payment');
+    expect(screen.getByText(/PAYMENT STEP/)).toBeInTheDocument();
+  });
+});

--- a/client-tenant/src/pages/apply/steps/__tests__/StepReview.test.tsx
+++ b/client-tenant/src/pages/apply/steps/__tests__/StepReview.test.tsx
@@ -1,0 +1,57 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter, Route, Routes, useSearchParams } from 'react-router-dom';
+import axe from 'axe-core';
+import { ApplyProvider } from '../../ApplyContext';
+import { StepReview } from '../StepReview';
+
+function StepProbe() {
+  const [search] = useSearchParams();
+  return <div data-testid="step-probe">{search.get('step') ?? 'review'}</div>;
+}
+
+function renderAt() {
+  return render(
+    <MemoryRouter initialEntries={['/apply?step=review']}>
+      <ApplyProvider initialState={{
+        property: { id: 'p1', name: 'Donna Louise 2', photoUrl: '', address: '2241 Sunrise Ave' },
+        unit: { type: '2BR', bedrooms: 2, sqft: 820, waitlistPosition: null },
+        criteria: { incomeBand: '50–60% AMI', householdSize: 2, moveInDate: '2026-08-01' },
+      }}>
+        <Routes>
+          <Route path="/apply" element={<><StepReview /><StepProbe /></>} />
+        </Routes>
+      </ApplyProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe('StepReview', () => {
+  it('renders boarding-pass recap with property + locked criteria', () => {
+    renderAt();
+    expect(screen.getByText(/Confirm what you're applying for/i)).toBeInTheDocument();
+    expect(screen.getByText(/Donna Louise 2/i)).toBeInTheDocument();
+    expect(screen.getByText(/50–60% AMI/)).toBeInTheDocument();
+  });
+
+  it('Continue advances to household via ?step=household', () => {
+    renderAt();
+    const cta = screen.getByRole('button', { name: /yes, continue/i });
+    fireEvent.click(cta);
+    expect(screen.getByTestId('step-probe').textContent).toBe('household');
+  });
+
+  it('edit links route to ?step=intent', () => {
+    renderAt();
+    const editBtns = screen.getAllByRole('button', { name: /edit/i });
+    fireEvent.click(editBtns[0]);
+    expect(screen.getByTestId('step-probe').textContent).toBe('intent');
+  });
+
+  it('has no axe-core a11y violations', async () => {
+    const { container } = renderAt();
+    const results = await axe.run(container);
+    expect(results.violations).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Ports GPMGLV `ReviewSelection` + `HouseholdComposition` wireframe screens to HF tokens as the 2nd pair of payment-wizard steps (`review → household → payment` per Contract 1).
- `StepReview.tsx` (119 lines) — boarding-pass recap card with property + photo, unit type, locked criteria pills (income band / household / move-in), expected waitlist position; in-line edit links → `?step=intent`; Continue → `?step=household`.
- `StepHousehold.tsx` (135 lines) — adults stepper (range 1–12), fee math `$35.95 × (adults+1)`, fee-calculator card, Continue → `?step=payment`.
- `ApplyContext.tsx` — **local stub** of Contract 2 until Lane W1 merges (canonical path `./ApplyContext`). Fields exactly per contract: `adults: number` (default 1), `paymentTotal: string` (computed `$35.95 × (adults+1)`), `paymentRef: string|null` (default null). Persisted to sessionStorage key `frank_apply_state`. Delete + replace when W1 lands.
- i18n: `review.*` and `household.*` namespaces in `client-tenant/src/i18n/{en,es}/apply.json` (ES copy verbatim from wireframe `lang === 'es'` branches).

## Contracts honored
- Contract 1 — step keys `… claim · review · household · payment · 2 · confirm`; advances `review→household→payment`.
- Contract 2 — see `ApplyContext.tsx` stub above (exact field names + defaults + sessionStorage key).
- Contract 3 — both step files <150 lines, HF tokens + Tailwind only, no `WF.*`, no Kalam/Caveat.
- Contract 6 — i18n keyspaces `review.*` / `household.*` under `client-tenant/src/i18n/{en,es}/apply.json`.

WF → HF token map is pasted at the top of each ported file.

## Test plan
- [x] `cd client-tenant && npm test -- StepReview StepHousehold` — **9/9 green**
- [x] Integration test walks `?step=review → household → payment`, asserts `state.adults === 3` and `state.paymentTotal === "$143.80"`
- [x] axe-core a11y clean on both steps
- [x] `npm run build` — green
- [x] Both files <150 lines
- [ ] Manual: `?lng=es` flips every visible string (verified i18n keys cover all copy; live check pending UI shell)

🤖 Generated with [Claude Code](https://claude.com/claude-code)