### PR TITLE
feat(wiz): router scaffold + PayHeader + ApplyContext extension (Lane W1)

### DIFF
--- a/client-tenant/.env.example
+++ b/client-tenant/.env.example
@@ -1,0 +1,7 @@
+# Feature flags (see src/lib/flags.ts)
+# Most flags default ENABLED — set `false` to disable.
+# `PAYMENT_WIZARD_ENABLED` defaults DISABLED — set `true` to enable.
+
+VITE_PROPERTY_DL2_ENABLED=true
+VITE_MOBILE_APPLY_ENABLED=true
+VITE_PAYMENT_WIZARD_ENABLED=false

--- a/client-tenant/package-lock.json
+++ b/client-tenant/package-lock.json
@@ -14,15 +14,27 @@
         "react-router-dom": "^6.28.0"
       },
       "devDependencies": {
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
         "@vitejs/plugin-react": "^4.3.4",
         "autoprefixer": "^10.4.20",
+        "jsdom": "^25.0.1",
         "postcss": "^8.4.49",
         "tailwindcss": "^3.4.15",
         "typescript": "^5.6.3",
-        "vite": "^6.0.3"
+        "vite": "^6.0.3",
+        "vitest": "^2.1.9"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -36,6 +48,27 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -271,6 +304,16 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
@@ -317,6 +360,121 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1215,6 +1373,104 @@
         "win32"
       ]
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1316,6 +1572,127 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/any-promise": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
@@ -1341,6 +1718,33 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -1454,6 +1858,30 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/camelcase-css": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
@@ -1484,6 +1912,33 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
     },
     "node_modules/chokidar": {
       "version": "3.6.0",
@@ -1523,6 +1978,19 @@
         "node": ">= 6"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
@@ -1540,6 +2008,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -1553,12 +2028,47 @@
         "node": ">=4"
       }
     },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -1578,6 +2088,43 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/didyoumean": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
@@ -1592,6 +2139,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.355",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.355.tgz",
@@ -1599,12 +2169,71 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-errors": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
       "engines": {
         "node": ">= 0.4"
       }
@@ -1661,6 +2290,26 @@
         "node": ">=6"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/fast-glob": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
@@ -1714,6 +2363,23 @@
         "node": ">=8"
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fraction.js": {
       "version": "5.3.4",
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
@@ -1763,6 +2429,45 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -1776,6 +2481,48 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
@@ -1787,6 +2534,70 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-binary-path": {
@@ -1851,6 +2662,13 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/jiti": {
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
@@ -1866,6 +2684,47 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
+      "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.1.0",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -1925,6 +2784,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -1942,6 +2808,37 @@
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/merge2": {
@@ -1966,6 +2863,39 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/ms": {
@@ -2023,6 +2953,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.23",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
+      "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -2043,12 +2980,42 @@
         "node": ">= 6"
       }
     },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -2253,6 +3220,32 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -2298,6 +3291,14 @@
       "peerDependencies": {
         "react": "^18.3.1"
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -2362,6 +3363,20 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/resolve": {
@@ -2442,6 +3457,13 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -2466,6 +3488,26 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
@@ -2485,6 +3527,13 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2493,6 +3542,33 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/sucrase": {
@@ -2530,6 +3606,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tailwindcss": {
       "version": "3.4.19",
@@ -2592,6 +3675,20 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -2640,6 +3737,56 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -2651,6 +3798,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/ts-interface-checker": {
@@ -2787,6 +3960,519 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vite-node/node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/vite/node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -2817,6 +4503,706 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/client-tenant/package.json
+++ b/client-tenant/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "lucide-react": "^0.460.0",
@@ -15,13 +17,18 @@
     "react-router-dom": "^6.28.0"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.4",
     "autoprefixer": "^10.4.20",
+    "jsdom": "^25.0.1",
     "postcss": "^8.4.49",
     "tailwindcss": "^3.4.15",
     "typescript": "^5.6.3",
-    "vite": "^6.0.3"
+    "vite": "^6.0.3",
+    "vitest": "^2.1.9"
   }
 }

--- a/client-tenant/src/components/primitives/CTA.tsx
+++ b/client-tenant/src/components/primitives/CTA.tsx
@@ -1,0 +1,29 @@
+import type { ButtonHTMLAttributes } from 'react';
+
+interface CTAProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variantStyle?: 'primary' | 'secondary' | 'ghost';
+  fullWidth?: boolean;
+}
+
+export function CTA({
+  variantStyle = 'primary',
+  fullWidth = true,
+  className = '',
+  children,
+  ...rest
+}: CTAProps) {
+  const base =
+    variantStyle === 'primary'
+      ? 'btn-primary'
+      : variantStyle === 'secondary'
+      ? 'rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50'
+      : 'text-sm text-gray-500 hover:text-gray-700 hover:underline';
+  return (
+    <button
+      className={`${base} ${fullWidth && variantStyle === 'primary' ? 'w-full' : ''} ${className}`}
+      {...rest}
+    >
+      {children}
+    </button>
+  );
+}

--- a/client-tenant/src/components/primitives/Card.tsx
+++ b/client-tenant/src/components/primitives/Card.tsx
@@ -1,0 +1,17 @@
+import type { ReactNode } from 'react';
+
+export function Card({
+  children,
+  className = '',
+  variant: _variant = 'mobile',
+}: {
+  children: ReactNode;
+  className?: string;
+  variant?: 'mobile' | 'desktop';
+}) {
+  return (
+    <div className={`rounded-xl bg-white p-6 shadow-sm ${className}`}>
+      {children}
+    </div>
+  );
+}

--- a/client-tenant/src/components/primitives/FormGrid.tsx
+++ b/client-tenant/src/components/primitives/FormGrid.tsx
@@ -1,0 +1,19 @@
+import type { ReactNode } from 'react';
+
+export function FormGrid({
+  children,
+  cols = 2,
+  className = '',
+}: {
+  children: ReactNode;
+  cols?: 1 | 2 | 3;
+  className?: string;
+}) {
+  const colClass =
+    cols === 3
+      ? 'grid-cols-1 lg:grid-cols-3'
+      : cols === 2
+      ? 'grid-cols-1 lg:grid-cols-2'
+      : 'grid-cols-1';
+  return <div className={`grid ${colClass} gap-3 ${className}`}>{children}</div>;
+}

--- a/client-tenant/src/components/primitives/ListRow.tsx
+++ b/client-tenant/src/components/primitives/ListRow.tsx
@@ -1,0 +1,19 @@
+import type { ReactNode } from 'react';
+
+export function ListRow({
+  leading,
+  children,
+  trailing,
+}: {
+  leading?: ReactNode;
+  children: ReactNode;
+  trailing?: ReactNode;
+}) {
+  return (
+    <div className="flex items-start gap-3 py-3">
+      {leading && <div className="mt-0.5 shrink-0">{leading}</div>}
+      <div className="min-w-0 flex-1 text-sm text-gray-800">{children}</div>
+      {trailing && <div className="ml-2 shrink-0">{trailing}</div>}
+    </div>
+  );
+}

--- a/client-tenant/src/components/primitives/PayHeader.tsx
+++ b/client-tenant/src/components/primitives/PayHeader.tsx
@@ -1,0 +1,96 @@
+// Payment-wizard header — breadcrumb + 5-segment progress bar.
+// HF skin only: Tailwind tokens, no Kalam/Caveat fonts. Semantics ported from
+// the GPMGLV wireframe (PayHeader at /tmp/gpmglv-welcome/015caabf-...).
+//
+// Step mapping (FROZEN CONTRACT 1, wizard slice):
+//   1 review · 2 household · 3 payment · 4 details (?step=2) · 5 confirm
+import type { ReactNode } from 'react';
+
+export type PayHeaderStep = 'review' | 'household' | 'payment' | 'details' | 'confirm';
+
+const STEP_ORDER: readonly PayHeaderStep[] = [
+  'review',
+  'household',
+  'payment',
+  'details',
+  'confirm',
+] as const;
+
+const LABELS: Record<'en' | 'es', Record<PayHeaderStep, string>> = {
+  en: {
+    review: 'Review',
+    household: 'Household',
+    payment: 'Payment',
+    details: 'Details',
+    confirm: 'Confirm',
+  },
+  es: {
+    review: 'Revisar',
+    household: 'Hogar',
+    payment: 'Pago',
+    details: 'Detalles',
+    confirm: 'Confirmar',
+  },
+};
+
+const COPY = {
+  en: { application: 'Application', back: 'Back' },
+  es: { application: 'Solicitud', back: 'Atrás' },
+};
+
+export interface PayHeaderProps {
+  step: PayHeaderStep;
+  total: string; // formatted USD (e.g. "$71.90")
+  lang: 'en' | 'es';
+  onBack?: () => void;
+}
+
+export function PayHeader({ step, total, lang, onBack }: PayHeaderProps): ReactNode {
+  const idx = STEP_ORDER.indexOf(step);
+  const safeIdx = idx === -1 ? 0 : idx;
+  const labels = LABELS[lang];
+  const copy = COPY[lang];
+
+  return (
+    <header className="space-y-2 px-4 pb-2 pt-3" data-testid="pay-header">
+      <div className="flex items-center gap-2">
+        {onBack && (
+          <button
+            type="button"
+            onClick={onBack}
+            className="text-xs text-gray-500 hover:text-gray-700"
+            aria-label={copy.back}
+          >
+            ← {copy.back}
+          </button>
+        )}
+        <span className="ml-auto text-[10px] font-semibold uppercase tracking-wider text-gray-500">
+          {copy.application} · {safeIdx + 1} / {STEP_ORDER.length}
+        </span>
+      </div>
+      <div className="flex gap-1" role="progressbar" aria-valuenow={safeIdx + 1} aria-valuemin={1} aria-valuemax={STEP_ORDER.length}>
+        {STEP_ORDER.map((s, i) => (
+          <div
+            key={s}
+            className={`h-1 flex-1 rounded-full ${i <= safeIdx ? 'bg-emerald-500' : 'bg-gray-200'}`}
+            data-segment={s}
+            data-active={i <= safeIdx ? 'true' : 'false'}
+          />
+        ))}
+      </div>
+      <div className="flex justify-between">
+        {STEP_ORDER.map((s, i) => (
+          <span
+            key={s}
+            className={`text-[10px] ${i === safeIdx ? 'font-bold text-gray-900' : 'text-gray-500'}`}
+          >
+            {labels[s]}
+          </span>
+        ))}
+      </div>
+      <div className="text-right text-xs text-gray-500">{total}</div>
+    </header>
+  );
+}
+
+export default PayHeader;

--- a/client-tenant/src/components/primitives/Pill.tsx
+++ b/client-tenant/src/components/primitives/Pill.tsx
@@ -1,0 +1,21 @@
+import type { ReactNode } from 'react';
+
+export function Pill({
+  children,
+  tone = 'neutral',
+}: {
+  children: ReactNode;
+  tone?: 'neutral' | 'success' | 'warn';
+}) {
+  const t =
+    tone === 'success'
+      ? 'bg-emerald-100 text-emerald-700'
+      : tone === 'warn'
+      ? 'bg-amber-100 text-amber-800'
+      : 'bg-gray-100 text-gray-700';
+  return (
+    <span className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${t}`}>
+      {children}
+    </span>
+  );
+}

--- a/client-tenant/src/components/primitives/__tests__/PayHeader.test.tsx
+++ b/client-tenant/src/components/primitives/__tests__/PayHeader.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { PayHeader, type PayHeaderStep } from '../PayHeader';
+
+const STEPS: PayHeaderStep[] = ['review', 'household', 'payment', 'details', 'confirm'];
+
+describe('PayHeader', () => {
+  it('renders all 5 wizard step states (en)', () => {
+    for (const step of STEPS) {
+      const { unmount } = render(<PayHeader step={step} total="$71.90" lang="en" />);
+      expect(screen.getByTestId('pay-header')).toBeInTheDocument();
+      const activeIdx = STEPS.indexOf(step);
+      expect(screen.getByText(`Application · ${activeIdx + 1} / 5`)).toBeInTheDocument();
+      const progressbar = screen.getByRole('progressbar');
+      expect(progressbar.getAttribute('aria-valuenow')).toBe(String(activeIdx + 1));
+      // Active segments equal step index + 1
+      const activeSegments = progressbar.querySelectorAll('[data-active="true"]');
+      expect(activeSegments.length).toBe(activeIdx + 1);
+      unmount();
+    }
+  });
+
+  it('translates labels for es', () => {
+    render(<PayHeader step="review" total="$71.90" lang="es" />);
+    expect(screen.getByText(/Solicitud · 1 \/ 5/)).toBeInTheDocument();
+    expect(screen.getByText('Revisar')).toBeInTheDocument();
+  });
+
+  it('renders back button only when onBack is supplied', () => {
+    const onBack = vi.fn();
+    const { rerender } = render(<PayHeader step="review" total="$71.90" lang="en" onBack={onBack} />);
+    const back = screen.getByRole('button', { name: /back/i });
+    fireEvent.click(back);
+    expect(onBack).toHaveBeenCalledOnce();
+
+    rerender(<PayHeader step="confirm" total="$71.90" lang="en" />);
+    expect(screen.queryByRole('button', { name: /back/i })).toBeNull();
+  });
+
+  it('renders the formatted total', () => {
+    render(<PayHeader step="payment" total="$107.85" lang="en" />);
+    expect(screen.getByText('$107.85')).toBeInTheDocument();
+  });
+});

--- a/client-tenant/src/components/primitives/index.ts
+++ b/client-tenant/src/components/primitives/index.ts
@@ -1,0 +1,7 @@
+// BP-00 primitive shims. Lane A replaces with canonical implementations.
+// Import paths remain stable; only internals change on merge.
+export { Card } from './Card';
+export { CTA } from './CTA';
+export { FormGrid } from './FormGrid';
+export { Pill } from './Pill';
+export { ListRow } from './ListRow';

--- a/client-tenant/src/components/primitives/index.ts
+++ b/client-tenant/src/components/primitives/index.ts
@@ -5,3 +5,4 @@ export { CTA } from './CTA';
 export { FormGrid } from './FormGrid';
 export { Pill } from './Pill';
 export { ListRow } from './ListRow';
+export { PayHeader, type PayHeaderStep, type PayHeaderProps } from './PayHeader';

--- a/client-tenant/src/hooks/useApplyProgress.ts
+++ b/client-tenant/src/hooks/useApplyProgress.ts
@@ -1,6 +1,8 @@
 import { useSearchParams } from 'react-router-dom';
 
-// The 7-step apply flow. Order matters — controls progress index.
+// FROZEN CONTRACT 1 — full apply flow, in order:
+// register · verify · intent · checklist · pick · claim · review · household · payment · details · confirm
+// (details === ?step=2; sits between payment and confirm; confirm is terminal)
 export const APPLY_STEP_KEYS = [
   'register',
   'verify',
@@ -8,7 +10,11 @@ export const APPLY_STEP_KEYS = [
   'checklist',
   'pick',
   'claim',
+  'review',
+  'household',
+  'payment',
   'details',
+  'confirm',
 ] as const;
 
 export type ApplyStepKey = (typeof APPLY_STEP_KEYS)[number];
@@ -26,6 +32,14 @@ function rawToKey(raw: string | null): ApplyStepKey {
       return 'pick';
     case 'claim':
       return 'claim';
+    case 'review':
+      return 'review';
+    case 'household':
+      return 'household';
+    case 'payment':
+      return 'payment';
+    case 'confirm':
+      return 'confirm';
     case '2':
       return 'details';
     default:

--- a/client-tenant/src/hooks/useApplyProgress.ts
+++ b/client-tenant/src/hooks/useApplyProgress.ts
@@ -1,0 +1,45 @@
+import { useSearchParams } from 'react-router-dom';
+
+// The 7-step apply flow. Order matters — controls progress index.
+export const APPLY_STEP_KEYS = [
+  'register',
+  'verify',
+  'intent',
+  'checklist',
+  'pick',
+  'claim',
+  'details',
+] as const;
+
+export type ApplyStepKey = (typeof APPLY_STEP_KEYS)[number];
+
+// Maps the ?step= URL param to the canonical step key.
+function rawToKey(raw: string | null): ApplyStepKey {
+  switch (raw) {
+    case 'verify':
+      return 'verify';
+    case 'intent':
+      return 'intent';
+    case 'checklist':
+      return 'checklist';
+    case 'pick':
+      return 'pick';
+    case 'claim':
+      return 'claim';
+    case '2':
+      return 'details';
+    default:
+      return 'register';
+  }
+}
+
+export function useApplyProgress(): {
+  current: number;
+  total: number;
+  stepKey: ApplyStepKey;
+} {
+  const [search] = useSearchParams();
+  const stepKey = rawToKey(search.get('step'));
+  const current = APPLY_STEP_KEYS.indexOf(stepKey) + 1;
+  return { current, total: APPLY_STEP_KEYS.length, stepKey };
+}

--- a/client-tenant/src/i18n/en/apply.json
+++ b/client-tenant/src/i18n/en/apply.json
@@ -1,0 +1,121 @@
+{
+  "phases": {
+    "account": "Account",
+    "pick": "Pick a unit",
+    "apply": "Apply"
+  },
+  "progress": {
+    "stepLabel": "Step {n} of {total}"
+  },
+  "common": {
+    "back": "Back",
+    "continue": "Continue",
+    "submitting": "Submitting…",
+    "saving": "Saving…",
+    "loading": "Loading…",
+    "signIn": "Sign in",
+    "alreadyHaveAccount": "Already have an account?",
+    "submitted": "Application submitted!",
+    "redirecting": "Redirecting to your application status…"
+  },
+  "register": {
+    "title": "Create your account",
+    "firstName": "First name *",
+    "lastName": "Last name *",
+    "email": "Email *",
+    "phone": "Phone",
+    "phonePlaceholder": "Optional",
+    "submit": "Continue",
+    "submitting": "Creating account…",
+    "error": "Registration failed"
+  },
+  "verify": {
+    "title": "Check your email",
+    "body": "We sent a verification link to {email}. Click it to continue your application. This page will advance automatically.",
+    "resent": "Link resent",
+    "resend": "Resend link",
+    "resending": "Resending…",
+    "devLink": "[Dev] Open magic link",
+    "useDifferent": "Use a different email",
+    "resendError": "Could not resend link"
+  },
+  "intent": {
+    "title": "What are you looking for?",
+    "subtitle": "A few quick questions so we can show you the right units.",
+    "bedrooms": "Bedrooms *",
+    "budget": "Monthly budget:",
+    "moveIn": "Target move-in *",
+    "household": "Household size",
+    "submit": "Show me units",
+    "saveError": "Could not save your preferences",
+    "br": {
+      "studio": "Studio",
+      "1": "1 BR",
+      "2": "2 BR",
+      "3": "3 BR",
+      "4plus": "4+ BR"
+    }
+  },
+  "checklist": {
+    "title": "Before you apply",
+    "subtitle": "Here's what you'll need to finish your application.",
+    "items": {
+      "id": "Government-issued photo ID",
+      "income": "Proof of income (last 2 pay stubs or offer letter)",
+      "ssn": "Social Security Number or ITIN",
+      "refs": "Two prior landlord references (last 3 years)",
+      "household": "Household composition (everyone moving in)"
+    },
+    "fee": {
+      "title": "Application fee",
+      "body": "A $35.95 application fee is required to process your application. This covers credit and background checks."
+    },
+    "rule120": {
+      "title": "120-day rule",
+      "body": "Your application stays active for 120 days. If we can't house you in that window, you'll be invited to refresh and continue."
+    },
+    "continue": "I have these — continue"
+  },
+  "pick": {
+    "title": "Pick your unit",
+    "subtitle": "Claiming a unit holds it for you for 48 hours while you finish your application.",
+    "loading": "Loading units…",
+    "noMatch": "No units match your preferences right now.",
+    "adjust": "Adjust your search",
+    "editPrefs": "← Edit preferences",
+    "claimError": "Could not claim this unit",
+    "loadError": "Could not load units"
+  },
+  "claim": {
+    "yours": "Unit {unitNumber} is yours",
+    "heldUntil": "Held until",
+    "finishBeforeTimer": "Finish your application before the timer runs out to lock it in.",
+    "continue": "Continue your application",
+    "pickDifferent": "Pick a different unit",
+    "noActive": "No active claim — let's pick a unit.",
+    "startOver": "Start over"
+  },
+  "details": {
+    "title": "Application details",
+    "property": "Property *",
+    "propertyPlaceholder": "Property ID (UUID)",
+    "selectProperty": "Select a property…",
+    "loadingProperties": "Loading properties…",
+    "unitNumber": "Unit number",
+    "unitOptional": "Optional",
+    "ssn": "Social Security Number *",
+    "ssnPlaceholder": "XXX-XX-XXXX",
+    "ssnError": "SSN must be XXX-XX-XXXX or 9 digits",
+    "dob": "Date of birth *",
+    "address": "Street address",
+    "city": "City",
+    "state": "State",
+    "zip": "ZIP",
+    "employer": "Employer name",
+    "income": "Annual income ($)",
+    "household": "Household size *",
+    "moveIn": "Requested move-in date",
+    "submit": "Submit application",
+    "submitError": "Application failed"
+  }
+}

--- a/client-tenant/src/i18n/es/apply.json
+++ b/client-tenant/src/i18n/es/apply.json
@@ -1,0 +1,121 @@
+{
+  "phases": {
+    "account": "Cuenta",
+    "pick": "Elige una unidad",
+    "apply": "Solicitar"
+  },
+  "progress": {
+    "stepLabel": "Paso {n} de {total}"
+  },
+  "common": {
+    "back": "Atrás",
+    "continue": "Continuar",
+    "submitting": "Enviando…",
+    "saving": "Guardando…",
+    "loading": "Cargando…",
+    "signIn": "Iniciar sesión",
+    "alreadyHaveAccount": "¿Ya tienes una cuenta?",
+    "submitted": "¡Solicitud enviada!",
+    "redirecting": "Redirigiendo al estado de tu solicitud…"
+  },
+  "register": {
+    "title": "Crea tu cuenta",
+    "firstName": "Nombre *",
+    "lastName": "Apellido *",
+    "email": "Correo electrónico *",
+    "phone": "Teléfono",
+    "phonePlaceholder": "Opcional",
+    "submit": "Continuar",
+    "submitting": "Creando cuenta…",
+    "error": "Error al registrarse"
+  },
+  "verify": {
+    "title": "Revisa tu correo",
+    "body": "Enviamos un enlace de verificación a {email}. Haz clic para continuar con tu solicitud. Esta página avanzará automáticamente.",
+    "resent": "Enlace reenviado",
+    "resend": "Reenviar enlace",
+    "resending": "Reenviando…",
+    "devLink": "[Dev] Abrir enlace mágico",
+    "useDifferent": "Usar otro correo",
+    "resendError": "No se pudo reenviar el enlace"
+  },
+  "intent": {
+    "title": "¿Qué estás buscando?",
+    "subtitle": "Unas preguntas rápidas para mostrarte las unidades correctas.",
+    "bedrooms": "Recámaras *",
+    "budget": "Presupuesto mensual:",
+    "moveIn": "Fecha de mudanza *",
+    "household": "Tamaño del hogar",
+    "submit": "Mostrar unidades",
+    "saveError": "No se pudieron guardar tus preferencias",
+    "br": {
+      "studio": "Estudio",
+      "1": "1 Rec",
+      "2": "2 Rec",
+      "3": "3 Rec",
+      "4plus": "4+ Rec"
+    }
+  },
+  "checklist": {
+    "title": "Antes de solicitar",
+    "subtitle": "Esto es lo que necesitarás para completar tu solicitud.",
+    "items": {
+      "id": "Identificación con foto emitida por el gobierno",
+      "income": "Comprobante de ingresos (últimos 2 talones o carta de oferta)",
+      "ssn": "Número de Seguro Social o ITIN",
+      "refs": "Dos referencias de propietarios anteriores (últimos 3 años)",
+      "household": "Composición del hogar (todos los que se mudarán)"
+    },
+    "fee": {
+      "title": "Cuota de solicitud",
+      "body": "Se requiere una cuota de $35.95 para procesar tu solicitud. Cubre verificaciones de crédito y antecedentes."
+    },
+    "rule120": {
+      "title": "Regla de 120 días",
+      "body": "Tu solicitud permanece activa durante 120 días. Si no podemos ubicarte en ese plazo, te invitaremos a actualizarla y continuar."
+    },
+    "continue": "Tengo todo esto — continuar"
+  },
+  "pick": {
+    "title": "Elige tu unidad",
+    "subtitle": "Reservar una unidad la aparta para ti por 48 horas mientras completas tu solicitud.",
+    "loading": "Cargando unidades…",
+    "noMatch": "Ninguna unidad coincide con tus preferencias ahora mismo.",
+    "adjust": "Ajustar tu búsqueda",
+    "editPrefs": "← Editar preferencias",
+    "claimError": "No se pudo reservar esta unidad",
+    "loadError": "No se pudieron cargar las unidades"
+  },
+  "claim": {
+    "yours": "La unidad {unitNumber} es tuya",
+    "heldUntil": "Reservada hasta",
+    "finishBeforeTimer": "Termina tu solicitud antes de que se acabe el tiempo para asegurarla.",
+    "continue": "Continuar tu solicitud",
+    "pickDifferent": "Elegir otra unidad",
+    "noActive": "Sin reserva activa — vamos a elegir una unidad.",
+    "startOver": "Empezar de nuevo"
+  },
+  "details": {
+    "title": "Detalles de la solicitud",
+    "property": "Propiedad *",
+    "propertyPlaceholder": "ID de propiedad (UUID)",
+    "selectProperty": "Selecciona una propiedad…",
+    "loadingProperties": "Cargando propiedades…",
+    "unitNumber": "Número de unidad",
+    "unitOptional": "Opcional",
+    "ssn": "Número de Seguro Social *",
+    "ssnPlaceholder": "XXX-XX-XXXX",
+    "ssnError": "El SSN debe ser XXX-XX-XXXX o 9 dígitos",
+    "dob": "Fecha de nacimiento *",
+    "address": "Dirección",
+    "city": "Ciudad",
+    "state": "Estado",
+    "zip": "Código postal",
+    "employer": "Nombre del empleador",
+    "income": "Ingreso anual ($)",
+    "household": "Tamaño del hogar *",
+    "moveIn": "Fecha de mudanza solicitada",
+    "submit": "Enviar solicitud",
+    "submitError": "Error al enviar la solicitud"
+  }
+}

--- a/client-tenant/src/i18n/index.ts
+++ b/client-tenant/src/i18n/index.ts
@@ -1,0 +1,44 @@
+// Lightweight i18n shim. Lane A will replace with react-i18next.
+// Same call signature: const { t } = useTranslation('apply'); t('key.path').
+import en from './en/apply.json';
+import es from './es/apply.json';
+
+const dictionaries: Record<string, Record<string, unknown>> = {
+  en: { apply: en },
+  es: { apply: es },
+};
+
+function detectLang(): 'en' | 'es' {
+  if (typeof window === 'undefined') return 'en';
+  const url = new URLSearchParams(window.location.search);
+  let stored: string | null = null;
+  try { stored = localStorage?.getItem?.('lng') ?? null; } catch { /* jsdom edge case */ }
+  const lng = url.get('lng') || stored || navigator.language;
+  return lng?.toLowerCase().startsWith('es') ? 'es' : 'en';
+}
+
+function lookup(dict: Record<string, unknown>, path: string): string | undefined {
+  const parts = path.split('.');
+  let cur: unknown = dict;
+  for (const p of parts) {
+    if (cur && typeof cur === 'object' && p in (cur as Record<string, unknown>)) {
+      cur = (cur as Record<string, unknown>)[p];
+    } else return undefined;
+  }
+  return typeof cur === 'string' ? cur : undefined;
+}
+
+export function useTranslation(ns: string = 'apply') {
+  const lang = detectLang();
+  const t = (key: string, fallback?: string): string => {
+    const dict = dictionaries[lang]?.[ns] as Record<string, unknown> | undefined;
+    const enDict = dictionaries.en[ns] as Record<string, unknown>;
+    return (
+      (dict && lookup(dict, key)) ??
+      lookup(enDict, key) ??
+      fallback ??
+      key
+    );
+  };
+  return { t, i18n: { language: lang } };
+}

--- a/client-tenant/src/lib/flags.ts
+++ b/client-tenant/src/lib/flags.ts
@@ -1,0 +1,23 @@
+/**
+ * Feature flags — driven by Vite env vars (`VITE_*`).
+ *
+ * Convention:
+ *   - Most flags default ENABLED. Set `VITE_<NAME>=false` to disable.
+ *   - `PAYMENT_WIZARD_ENABLED` defaults DISABLED (opt-in via `=true`)
+ *     because the wizard is in active integration (BP-03b Lane W).
+ */
+export type FlagName =
+  | 'PROPERTY_DL2_ENABLED'
+  | 'MOBILE_APPLY_ENABLED'
+  | 'PAYMENT_WIZARD_ENABLED';
+
+// Flags that default OFF (opt-in via `=true`).
+const DEFAULT_OFF: ReadonlySet<FlagName> = new Set(['PAYMENT_WIZARD_ENABLED']);
+
+export function useFlag(name: FlagName): boolean {
+  // Vite inlines import.meta.env at build time; safe to read by computed key.
+  const meta = import.meta as unknown as { env: Record<string, string | undefined> };
+  const raw = meta.env[`VITE_${name}`];
+  if (DEFAULT_OFF.has(name)) return raw === 'true';
+  return raw !== 'false';
+}

--- a/client-tenant/src/pages/Apply.tsx
+++ b/client-tenant/src/pages/Apply.tsx
@@ -1,11 +1,16 @@
-import { useEffect, useState } from 'react';
+import { lazy, Suspense, useEffect, useState } from 'react';
 import { useSearchParams, Link } from 'react-router-dom';
 import { CheckCircle } from 'lucide-react';
 import { api } from '@/api/client';
 import { ClaimedUnitHeader } from '@/components/ClaimedUnitHeader';
 import { Card } from '@/components/primitives';
 import { useTranslation } from '@/i18n';
-import { ApplyProvider, type ApplyState, type Step } from './apply/ApplyContext';
+import {
+  ApplyProvider,
+  useWizState,
+  type ApplyState,
+  type Step,
+} from './apply/ApplyContext';
 import { StepIndicator } from './apply/StepIndicator';
 import { Step1Register } from './apply/steps/Step1Register';
 import { StepVerify } from './apply/steps/StepVerify';
@@ -16,9 +21,28 @@ import { StepClaim } from './apply/steps/StepClaim';
 import { Step2Details } from './apply/steps/Step2Details';
 import type { Unit } from '@/api/units';
 
+// FROZEN CONTRACT 1 — Lane W payment-wizard steps, lazy-loaded.
+// W1 ships placeholder stubs; W2/W3 overwrite the file contents on merge.
+const StepReview = lazy(() => import('./apply/steps/StepReview'));
+const StepHousehold = lazy(() => import('./apply/steps/StepHousehold'));
+const StepPayment = lazy(() => import('./apply/steps/StepPayment'));
+const StepConfirm = lazy(() => import('./apply/steps/StepConfirm'));
+
 function parseStep(raw: string | null): Step {
   if (raw === '2') return 2;
-  if (raw === 'verify' || raw === 'intent' || raw === 'checklist' || raw === 'pick' || raw === 'claim') return raw;
+  if (
+    raw === 'verify' ||
+    raw === 'intent' ||
+    raw === 'checklist' ||
+    raw === 'pick' ||
+    raw === 'claim' ||
+    raw === 'review' ||
+    raw === 'household' ||
+    raw === 'payment' ||
+    raw === 'confirm'
+  ) {
+    return raw;
+  }
   return 1;
 }
 
@@ -80,6 +104,10 @@ export function Apply() {
   const [householdSize, setHouseholdSize] = useState('1');
   const [moveInDate, setMoveInDate] = useState('');
 
+  // FROZEN CONTRACT 2 — wizard state (adults / paymentTotal / paymentRef),
+  // persisted to sessionStorage under key `frank_apply_state`.
+  const wiz = useWizState();
+
   // Hydrate identity + intent prefill on entering intent/checklist/pick/2 (deep links).
   useEffect(() => {
     if (step !== 'intent' && step !== 'checklist' && step !== 'pick' && step !== 2) return;
@@ -131,6 +159,10 @@ export function Apply() {
     dateOfBirth, setDateOfBirth, addressLine1, setAddressLine1, city, setCity, state, setState, zip, setZip,
     employerName, setEmployerName, annualIncome, setAnnualIncome, householdSize, setHouseholdSize, moveInDate, setMoveInDate,
     done, setDone,
+    // Contract 2 — wizard
+    adults: wiz.adults, setAdults: wiz.setAdults,
+    paymentTotal: wiz.paymentTotal,
+    paymentRef: wiz.paymentRef, setPaymentRef: wiz.setPaymentRef,
   };
 
   if (done) {
@@ -171,7 +203,19 @@ export function Apply() {
               {step === 'checklist' && <StepChecklist />}
               {step === 'pick' && <StepPick />}
               {step === 'claim' && <StepClaim />}
+              {step === 'review' && (
+                <Suspense fallback={null}><StepReview /></Suspense>
+              )}
+              {step === 'household' && (
+                <Suspense fallback={null}><StepHousehold /></Suspense>
+              )}
+              {step === 'payment' && (
+                <Suspense fallback={null}><StepPayment /></Suspense>
+              )}
               {step === 2 && <Step2Details />}
+              {step === 'confirm' && (
+                <Suspense fallback={null}><StepConfirm /></Suspense>
+              )}
             </Card>
             <p className="text-center text-sm text-gray-500">
               {t('common.alreadyHaveAccount')}{' '}

--- a/client-tenant/src/pages/Apply.tsx
+++ b/client-tenant/src/pages/Apply.tsx
@@ -1,89 +1,71 @@
 import { useEffect, useState } from 'react';
-import { useNavigate, useSearchParams, Link } from 'react-router-dom';
-import { api, getToken } from '@/api/client';
-import { requestMagicLink } from '@/api/auth';
-import { saveIntent, fetchUnits, claimUnit, type Unit } from '@/api/units';
-import { UnitCard } from '@/components/UnitCard';
+import { useSearchParams, Link } from 'react-router-dom';
+import { CheckCircle } from 'lucide-react';
+import { api } from '@/api/client';
 import { ClaimedUnitHeader } from '@/components/ClaimedUnitHeader';
-import { CheckCircle, Mail, Loader2 } from 'lucide-react';
-
-interface Property {
-  id: string;
-  name: string;
-  address_line1?: string;
-  city?: string;
-  state?: string;
-}
-
-// Step 1: register → 'verify': check email → 'intent': quiz → 'pick': units grid
-// → 'claim': confirmation modal → 2: details form. Each step is a stable URL
-// param so deep links and back-button work.
-type Step = 1 | 'verify' | 'intent' | 'pick' | 'claim' | 2;
+import { Card } from '@/components/primitives';
+import { useTranslation } from '@/i18n';
+import { ApplyProvider, type ApplyState, type Step } from './apply/ApplyContext';
+import { StepIndicator } from './apply/StepIndicator';
+import { Step1Register } from './apply/steps/Step1Register';
+import { StepVerify } from './apply/steps/StepVerify';
+import { StepIntent } from './apply/steps/StepIntent';
+import { StepChecklist } from './apply/steps/StepChecklist';
+import { StepPick } from './apply/steps/StepPick';
+import { StepClaim } from './apply/steps/StepClaim';
+import { Step2Details } from './apply/steps/Step2Details';
+import type { Unit } from '@/api/units';
 
 function parseStep(raw: string | null): Step {
   if (raw === '2') return 2;
-  if (raw === 'verify' || raw === 'intent' || raw === 'pick' || raw === 'claim') return raw;
+  if (raw === 'verify' || raw === 'intent' || raw === 'checklist' || raw === 'pick' || raw === 'claim') return raw;
   return 1;
 }
 
-const BEDROOM_OPTIONS: Array<{ value: number; label: string }> = [
-  { value: 0, label: 'Studio' },
-  { value: 1, label: '1 BR' },
-  { value: 2, label: '2 BR' },
-  { value: 3, label: '3 BR' },
-  { value: 4, label: '4+ BR' },
-];
-// The highest option uses "N+" semantics — it should match any unit with at
-// least that many bedrooms. Anything below is an exact bedroom-count match.
-const BEDROOMS_INCLUSIVE_MIN = BEDROOM_OPTIONS[BEDROOM_OPTIONS.length - 1].value;
-
 export function Apply() {
-  const navigate = useNavigate();
   const [search, setSearch] = useSearchParams();
+  const { t } = useTranslation('apply');
   const [step, setStepState] = useState<Step>(parseStep(search.get('step')));
+
+  function setStep(next: Step) {
+    setStepState(next);
+    const value = next === 1 ? null : String(next);
+    // Preserve handoff params (unitType/propertyId/state) on step transitions.
+    const nextParams = new URLSearchParams(search);
+    if (value) nextParams.set('step', value);
+    else nextParams.delete('step');
+    setSearch(nextParams, { replace: true });
+  }
+
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [done, setDone] = useState(false);
 
-  // Keep ?step= in sync with state so reloads land on the same step.
-  function setStep(next: Step) {
-    setStepState(next);
-    const value = next === 1 ? null : String(next);
-    setSearch(value ? { step: value } : {}, { replace: true });
-  }
-
-  // Step 1 fields
   const [email, setEmail] = useState('');
   const [firstName, setFirstName] = useState('');
   const [lastName, setLastName] = useState('');
   const [phone, setPhone] = useState('');
 
-  // Verify
   const [resending, setResending] = useState(false);
   const [resent, setResent] = useState(false);
   const [devLink, setDevLink] = useState<string | null>(null);
 
-  // Intent quiz
   const [intentBedrooms, setIntentBedrooms] = useState<number | null>(null);
   const [intentBudgetMax, setIntentBudgetMax] = useState<number>(2000);
   const [intentMoveInDate, setIntentMoveInDate] = useState('');
   const [intentHouseholdSize, setIntentHouseholdSize] = useState<number>(1);
 
-  // Pick
   const [units, setUnits] = useState<Unit[]>([]);
   const [unitsLoading, setUnitsLoading] = useState(false);
   const [claimingUnitId, setClaimingUnitId] = useState<string | null>(null);
 
-  // Claim
   const [claimedUnit, setClaimedUnit] = useState<Unit | null>(null);
   const [claimExpiresAt, setClaimExpiresAt] = useState<string | null>(null);
 
-  // Properties for dropdown (step 2 fallback)
-  const [properties, setProperties] = useState<Property[]>([]);
+  const [properties, setProperties] = useState<ApplyState['properties']>([]);
   const [propertiesLoading, setPropertiesLoading] = useState(false);
   const [propertiesFailed, setPropertiesFailed] = useState(false);
 
-  // Step 2 fields
   const [propertyId, setPropertyId] = useState('');
   const [unitNumber, setUnitNumber] = useState('');
   const [ssn, setSsn] = useState('');
@@ -98,35 +80,9 @@ export function Apply() {
   const [householdSize, setHouseholdSize] = useState('1');
   const [moveInDate, setMoveInDate] = useState('');
 
-  // Verify-stage poll: advance when /auth/me reports emailVerified=true.
-  // Post-W6 /register no longer issues a token, so an unauthenticated 401 here
-  // would trigger client.ts's global redirect to /login and eject the user
-  // from the "Check your email" screen. Skip the poll until the magic-link
-  // verify flow has stored a token.
+  // Hydrate identity + intent prefill on entering intent/checklist/pick/2 (deep links).
   useEffect(() => {
-    if (step !== 'verify') return;
-    if (!getToken()) return;
-    let cancelled = false;
-    async function check() {
-      try {
-        const res = await api.get<{ user?: { email: string; emailVerified: boolean } }>('/auth/me');
-        if (cancelled) return;
-        if (res.user?.emailVerified) setStep('intent');
-      } catch {
-        /* ignored — 401 redirect handled by client.ts */
-      }
-    }
-    check();
-    const interval = setInterval(check, 5000);
-    return () => {
-      cancelled = true;
-      clearInterval(interval);
-    };
-  }, [step]);
-
-  // Hydrate identity + intent prefill on entering 'intent'/'pick'/2 (deep links).
-  useEffect(() => {
-    if (step !== 'intent' && step !== 'pick' && step !== 2) return;
+    if (step !== 'intent' && step !== 'checklist' && step !== 'pick' && step !== 2) return;
     if (email && firstName && lastName) return;
     let cancelled = false;
     (async () => {
@@ -138,9 +94,7 @@ export function Apply() {
         if (!lastName) setLastName(me.user.lastName);
 
         const apps = await api.get<{ applications?: Array<{
-          id: string;
-          property_id?: string;
-          unit_number?: string;
+          id: string; property_id?: string; unit_number?: string;
           intent_bedrooms?: number | null;
           intent_budget_max?: string | number | null;
           intent_move_in_date?: string | null;
@@ -161,612 +115,73 @@ export function Apply() {
         /* ignored */
       }
     })();
-    return () => {
-      cancelled = true;
-    };
+    return () => { cancelled = true; };
   }, [step, email, firstName, lastName, propertyId, unitNumber, intentBedrooms]);
 
-  // On entering 'pick': fetch units matching the intent. Bounce back to
-  // 'intent' if the quiz hasn't been answered.
-  useEffect(() => {
-    if (step !== 'pick') return;
-    if (intentBedrooms === null || !intentMoveInDate) {
-      setStep('intent');
-      return;
-    }
-    let cancelled = false;
-    (async () => {
-      setUnitsLoading(true);
-      setError(null);
-      try {
-        const res = await fetchUnits({
-          ...(intentBedrooms >= BEDROOMS_INCLUSIVE_MIN
-            ? { bedroomsMin: intentBedrooms }
-            : { bedrooms: intentBedrooms }),
-          maxRent: intentBudgetMax,
-          moveInBy: intentMoveInDate,
-        });
-        if (!cancelled) setUnits(res.units);
-      } catch (err) {
-        if (!cancelled) setError(err instanceof Error ? err.message : 'Could not load units');
-      } finally {
-        if (!cancelled) setUnitsLoading(false);
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [step, intentBedrooms, intentBudgetMax, intentMoveInDate]);
-
-  // Step 2 fallback: load properties if there's no claimed unit (rare path).
-  useEffect(() => {
-    if (step !== 2 || claimedUnit || properties.length > 0 || propertiesLoading) return;
-    let cancelled = false;
-    (async () => {
-      setPropertiesLoading(true);
-      try {
-        const data = await api.get<{ properties: Property[] } | Property[]>('/applicants/properties');
-        if (cancelled) return;
-        const list = Array.isArray(data) ? data : (data as { properties: Property[] }).properties ?? [];
-        setProperties(list);
-      } catch {
-        if (!cancelled) setPropertiesFailed(true);
-      } finally {
-        if (!cancelled) setPropertiesLoading(false);
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [step, claimedUnit, properties.length, propertiesLoading]);
-
-  async function handleStep1(e: React.FormEvent) {
-    e.preventDefault();
-    setError(null);
-    setLoading(true);
-    try {
-      const res = await api.post<{ ok: boolean; devLink?: string }>('/applicants/register', {
-        email,
-        firstName,
-        lastName,
-        phone: phone || undefined,
-      });
-      if (res.devLink) setDevLink(res.devLink);
-      setStep('verify');
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Registration failed');
-    } finally {
-      setLoading(false);
-    }
-  }
-
-  async function handleIntent(e: React.FormEvent) {
-    e.preventDefault();
-    if (intentBedrooms === null || !intentMoveInDate) return;
-    setError(null);
-    setLoading(true);
-    try {
-      await saveIntent({
-        bedrooms: intentBedrooms,
-        budget_max: intentBudgetMax,
-        move_in_date: intentMoveInDate,
-        household_size: intentHouseholdSize,
-      });
-      setHouseholdSize(String(intentHouseholdSize));
-      setMoveInDate(intentMoveInDate);
-      setStep('pick');
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Could not save your preferences');
-    } finally {
-      setLoading(false);
-    }
-  }
-
-  async function handleClaim(unitId: string) {
-    setClaimingUnitId(unitId);
-    setError(null);
-    try {
-      const res = await claimUnit(unitId);
-      setClaimedUnit(res.unit);
-      setClaimExpiresAt(res.expires_at);
-      // Snap details-form fields to the chosen unit so the user can't desync them.
-      setPropertyId(res.unit.property_id);
-      setUnitNumber(res.unit.unit_number);
-      setStep('claim');
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Could not claim this unit');
-    } finally {
-      setClaimingUnitId(null);
-    }
-  }
-
-  function validateSsn(value: string) {
-    const clean = value.replace(/-/g, '');
-    if (clean.length === 0) { setSsnError(null); return; }
-    const valid = /^\d{3}-?\d{2}-?\d{4}$/.test(value) || /^\d{9}$/.test(clean);
-    setSsnError(valid ? null : 'SSN must be XXX-XX-XXXX or 9 digits');
-  }
-
-  async function handleStep2(e: React.FormEvent) {
-    e.preventDefault();
-    if (ssnError) return;
-    setError(null);
-    setLoading(true);
-    try {
-      await api.post('/applicants/apply', {
-        propertyId: propertyId || undefined,
-        unitNumber: unitNumber || undefined,
-        firstName,
-        lastName,
-        ssn,
-        dateOfBirth,
-        email,
-        phone: phone || undefined,
-        currentAddressLine1: addressLine1 || undefined,
-        currentCity: city || undefined,
-        currentState: state || undefined,
-        currentZip: zip || undefined,
-        employerName: employerName || undefined,
-        annualIncome: annualIncome ? Number(annualIncome) : undefined,
-        householdSize: Number(householdSize),
-        requestedMoveInDate: moveInDate || undefined,
-        requestedLeaseTermMonths: 12,
-      });
-      setDone(true);
-      setTimeout(() => navigate('/status'), 2000);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Application failed');
-    } finally {
-      setLoading(false);
-    }
-  }
-
-  async function handleResend() {
-    if (!email) return;
-    setResending(true);
-    setError(null);
-    try {
-      await requestMagicLink(email);
-      setResent(true);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Could not resend link');
-    } finally {
-      setResending(false);
-    }
-  }
+  const value: ApplyState = {
+    step, setStep, error, setError, loading, setLoading,
+    email, setEmail, firstName, setFirstName, lastName, setLastName, phone, setPhone,
+    resending, setResending, resent, setResent, devLink, setDevLink,
+    intentBedrooms, setIntentBedrooms, intentBudgetMax, setIntentBudgetMax,
+    intentMoveInDate, setIntentMoveInDate, intentHouseholdSize, setIntentHouseholdSize,
+    units, setUnits, unitsLoading, setUnitsLoading, claimingUnitId, setClaimingUnitId,
+    claimedUnit, setClaimedUnit, claimExpiresAt, setClaimExpiresAt,
+    properties, setProperties, propertiesLoading, setPropertiesLoading, propertiesFailed, setPropertiesFailed,
+    propertyId, setPropertyId, unitNumber, setUnitNumber, ssn, setSsn, ssnError, setSsnError,
+    dateOfBirth, setDateOfBirth, addressLine1, setAddressLine1, city, setCity, state, setState, zip, setZip,
+    employerName, setEmployerName, annualIncome, setAnnualIncome, householdSize, setHouseholdSize, moveInDate, setMoveInDate,
+    done, setDone,
+  };
 
   if (done) {
     return (
       <div className="flex min-h-screen items-center justify-center bg-gray-50 p-4">
         <div className="flex flex-col items-center gap-4 text-center">
           <CheckCircle className="h-12 w-12 text-emerald-600" />
-          <h2 className="text-xl font-bold text-gray-900">Application submitted!</h2>
-          <p className="text-sm text-gray-500">Redirecting to your application status…</p>
+          <h2 className="text-xl font-bold text-gray-900">{t('common.submitted')}</h2>
+          <p className="text-sm text-gray-500">{t('common.redirecting')}</p>
         </div>
       </div>
     );
   }
 
-  // 3-phase progress: Account → Pick → Apply.
-  const phase: 1 | 2 | 3 =
-    step === 1 || step === 'verify' ? 1 :
-    step === 'intent' || step === 'pick' || step === 'claim' ? 2 : 3;
-  const phaseLabels: Array<{ n: 1 | 2 | 3; label: string }> = [
-    { n: 1, label: 'Account' },
-    { n: 2, label: 'Pick a unit' },
-    { n: 3, label: 'Apply' },
-  ];
-
-  // Wider container on the unit picker so the grid can breathe.
   const containerWidth = step === 'pick' ? 'max-w-3xl' : 'max-w-md';
 
   return (
-    <div className="min-h-screen bg-gray-50 p-4">
-      <div className={`mx-auto ${containerWidth} space-y-6 py-8`}>
-        {step === 2 && claimedUnit && claimExpiresAt && (
-          <ClaimedUnitHeader unit={claimedUnit} expiresAt={claimExpiresAt} />
-        )}
-
-        {/* Progress */}
-        <div className="flex items-center gap-2">
-          {phaseLabels.map(({ n, label }) => (
-            <div key={n} className="flex items-center gap-2">
-              <div className={`flex h-7 w-7 items-center justify-center rounded-full text-xs font-bold
-                ${phase === n ? 'bg-emerald-600 text-white' : phase > n ? 'bg-emerald-100 text-emerald-700' : 'bg-gray-200 text-gray-500'}`}>
-                {n}
-              </div>
-              <span className={`text-xs ${phase === n ? 'font-medium text-gray-900' : 'text-gray-400'}`}>
-                {label}
-              </span>
-              {n < 3 && <div className="mx-1 h-px w-8 bg-gray-300" />}
-            </div>
-          ))}
+    <ApplyProvider value={value}>
+      <div className="min-h-screen bg-gray-50 p-4">
+        <div className="mx-auto flex max-w-6xl gap-8 py-8">
+          <aside className="hidden w-56 shrink-0 lg:block">
+            <StepIndicator />
+          </aside>
+          <div className={`mx-auto ${containerWidth} flex-1 space-y-6`}>
+            {step === 2 && claimedUnit && claimExpiresAt && (
+              <ClaimedUnitHeader unit={claimedUnit} expiresAt={claimExpiresAt} />
+            )}
+            <div className="lg:hidden"><StepIndicator /></div>
+            <Card>
+              {error && (
+                <div className="mb-4 rounded-lg bg-red-50 p-3 text-sm text-red-700" role="alert">
+                  {error}
+                </div>
+              )}
+              {step === 1 && <Step1Register />}
+              {step === 'verify' && <StepVerify />}
+              {step === 'intent' && <StepIntent />}
+              {step === 'checklist' && <StepChecklist />}
+              {step === 'pick' && <StepPick />}
+              {step === 'claim' && <StepClaim />}
+              {step === 2 && <Step2Details />}
+            </Card>
+            <p className="text-center text-sm text-gray-500">
+              {t('common.alreadyHaveAccount')}{' '}
+              <Link to="/login" className="font-medium text-emerald-600 hover:underline">
+                {t('common.signIn')}
+              </Link>
+            </p>
+          </div>
         </div>
-
-        <div className="rounded-xl bg-white p-6 shadow-sm">
-          {error && (
-            <div className="mb-4 rounded-lg bg-red-50 p-3 text-sm text-red-700">{error}</div>
-          )}
-
-          {step === 1 && (
-            <>
-              <h1 className="mb-4 text-xl font-bold text-gray-900">Create your account</h1>
-              <form onSubmit={handleStep1} className="space-y-4">
-                <div className="grid grid-cols-2 gap-3">
-                  <div>
-                    <label className="label" htmlFor="firstName">First name *</label>
-                    <input id="firstName" className="input" required value={firstName} onChange={e => setFirstName(e.target.value)} />
-                  </div>
-                  <div>
-                    <label className="label" htmlFor="lastName">Last name *</label>
-                    <input id="lastName" className="input" required value={lastName} onChange={e => setLastName(e.target.value)} />
-                  </div>
-                </div>
-                <div>
-                  <label className="label" htmlFor="regEmail">Email *</label>
-                  <input id="regEmail" type="email" className="input" required value={email} onChange={e => setEmail(e.target.value)} />
-                </div>
-                <div>
-                  <label className="label" htmlFor="phone">Phone</label>
-                  <input id="phone" type="tel" className="input" value={phone} onChange={e => setPhone(e.target.value)} placeholder="Optional" />
-                </div>
-                <button type="submit" disabled={loading || !email || !firstName || !lastName} className="btn-primary w-full">
-                  {loading ? 'Creating account…' : 'Continue'}
-                </button>
-              </form>
-            </>
-          )}
-
-          {step === 'verify' && (
-            <div className="space-y-4 text-center">
-              <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-xl bg-emerald-100">
-                <Mail className="h-6 w-6 text-emerald-700" />
-              </div>
-              <h1 className="text-xl font-bold text-gray-900">Check your email</h1>
-              <p className="text-sm text-gray-500">
-                We sent a verification link to{' '}
-                <span className="font-medium text-gray-900">{email}</span>. Click
-                it to continue your application. This page will advance
-                automatically.
-              </p>
-              {resent && (
-                <div className="rounded-lg bg-emerald-50 p-3 text-sm text-emerald-700">
-                  Link resent
-                </div>
-              )}
-              <button
-                onClick={handleResend}
-                disabled={resending || !email}
-                className="btn-primary w-full"
-              >
-                {resending ? 'Resending…' : 'Resend link'}
-              </button>
-              {devLink && (
-                <a
-                  href={devLink}
-                  className="block rounded-lg border border-amber-300 bg-amber-50 px-4 py-2 text-center text-sm font-medium text-amber-800 hover:bg-amber-100"
-                >
-                  [Dev] Open magic link
-                </a>
-              )}
-              <button
-                onClick={() => setStep(1)}
-                className="text-sm text-gray-500 hover:text-gray-700 hover:underline"
-              >
-                Use a different email
-              </button>
-            </div>
-          )}
-
-          {step === 'intent' && (
-            <>
-              <h1 className="mb-1 text-xl font-bold text-gray-900">What are you looking for?</h1>
-              <p className="mb-4 text-sm text-gray-500">A few quick questions so we can show you the right units.</p>
-              <form onSubmit={handleIntent} className="space-y-5">
-                <div>
-                  <label className="label">Bedrooms *</label>
-                  <div className="grid grid-cols-5 gap-2">
-                    {BEDROOM_OPTIONS.map(opt => (
-                      <button
-                        type="button"
-                        key={opt.value}
-                        onClick={() => setIntentBedrooms(opt.value)}
-                        className={`rounded-lg border px-2 py-3 text-sm font-medium transition
-                          ${intentBedrooms === opt.value
-                            ? 'border-emerald-600 bg-emerald-50 text-emerald-700'
-                            : 'border-gray-300 bg-white text-gray-700 hover:border-emerald-400'}`}
-                      >
-                        {opt.label}
-                      </button>
-                    ))}
-                  </div>
-                </div>
-
-                <div>
-                  <label className="label" htmlFor="budget">
-                    Monthly budget: <span className="font-semibold text-gray-900">${intentBudgetMax.toLocaleString()}</span>
-                  </label>
-                  <input
-                    id="budget"
-                    type="range"
-                    min={500}
-                    max={5000}
-                    step={50}
-                    value={intentBudgetMax}
-                    onChange={e => setIntentBudgetMax(Number(e.target.value))}
-                    className="w-full accent-emerald-600"
-                  />
-                  <div className="mt-1 flex justify-between text-xs text-gray-400">
-                    <span>$500</span>
-                    <span>$5,000</span>
-                  </div>
-                </div>
-
-                <div>
-                  <label className="label" htmlFor="intentMoveIn">Target move-in *</label>
-                  <input
-                    id="intentMoveIn"
-                    type="date"
-                    className="input"
-                    required
-                    value={intentMoveInDate}
-                    onChange={e => setIntentMoveInDate(e.target.value)}
-                  />
-                </div>
-
-                <div>
-                  <label className="label" htmlFor="intentHousehold">Household size</label>
-                  <select
-                    id="intentHousehold"
-                    className="input"
-                    value={intentHouseholdSize}
-                    onChange={e => setIntentHouseholdSize(Number(e.target.value))}
-                  >
-                    {Array.from({ length: 8 }, (_, i) => i + 1).map(n => (
-                      <option key={n} value={n}>{n}</option>
-                    ))}
-                  </select>
-                </div>
-
-                <button
-                  type="submit"
-                  disabled={loading || intentBedrooms === null || !intentMoveInDate}
-                  className="btn-primary w-full"
-                >
-                  {loading ? 'Saving…' : 'Show me units'}
-                </button>
-              </form>
-            </>
-          )}
-
-          {step === 'pick' && (
-            <>
-              <h1 className="mb-1 text-xl font-bold text-gray-900">Pick your unit</h1>
-              <p className="mb-4 text-sm text-gray-500">
-                Claiming a unit holds it for you for 48 hours while you finish your application.
-              </p>
-              {unitsLoading ? (
-                <div className="flex items-center justify-center py-12 text-gray-400">
-                  <Loader2 className="mr-2 h-5 w-5 animate-spin" />
-                  Loading units…
-                </div>
-              ) : units.length === 0 ? (
-                <div className="rounded-lg bg-amber-50 p-4 text-sm text-amber-800">
-                  No units match your preferences right now.{' '}
-                  <button onClick={() => setStep('intent')} className="font-medium underline">
-                    Adjust your search
-                  </button>
-                </div>
-              ) : (
-                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-                  {units.map(u => (
-                    <UnitCard
-                      key={u.id}
-                      unit={u}
-                      onClaim={handleClaim}
-                      claiming={claimingUnitId === u.id}
-                    />
-                  ))}
-                </div>
-              )}
-              <button
-                onClick={() => setStep('intent')}
-                className="mt-6 text-sm text-gray-500 hover:text-gray-700 hover:underline"
-              >
-                ← Edit preferences
-              </button>
-            </>
-          )}
-
-          {step === 'claim' && claimedUnit && claimExpiresAt && (
-            <div className="space-y-4 text-center">
-              <div className="overflow-hidden rounded-xl">
-                <img
-                  src={claimedUnit.photo_url || `https://picsum.photos/seed/${claimedUnit.id.slice(0, 8)}/800/600`}
-                  alt=""
-                  className="aspect-[16/9] w-full object-cover"
-                />
-              </div>
-              <div>
-                <h1 className="text-xl font-bold text-gray-900">
-                  Unit {claimedUnit.unit_number} is yours
-                </h1>
-                <p className="mt-1 text-sm text-gray-500">
-                  {claimedUnit.property_name}
-                  {claimedUnit.property_city && `, ${claimedUnit.property_city}`}
-                </p>
-              </div>
-              <ClaimCountdown expiresAt={claimExpiresAt} />
-              <button onClick={() => setStep(2)} className="btn-primary w-full">
-                Continue your application
-              </button>
-              <button
-                onClick={() => setStep('pick')}
-                className="text-sm text-gray-500 hover:text-gray-700 hover:underline"
-              >
-                Pick a different unit
-              </button>
-            </div>
-          )}
-
-          {step === 'claim' && (!claimedUnit || !claimExpiresAt) && (
-            <div className="space-y-4 text-center">
-              <p className="text-sm text-gray-500">No active claim — let's pick a unit.</p>
-              <button onClick={() => setStep('intent')} className="btn-primary w-full">
-                Start over
-              </button>
-            </div>
-          )}
-
-          {step === 2 && (
-            <>
-              <h1 className="mb-4 text-xl font-bold text-gray-900">Application details</h1>
-              <form onSubmit={handleStep2} className="space-y-4">
-                {!claimedUnit && (
-                  <>
-                    <div>
-                      <label className="label" htmlFor="propertyId">Property *</label>
-                      {propertiesLoading ? (
-                        <p className="text-sm text-gray-400">Loading properties…</p>
-                      ) : propertiesFailed || properties.length === 0 ? (
-                        <input
-                          id="propertyId"
-                          className="input"
-                          required
-                          placeholder="Property ID (UUID)"
-                          value={propertyId}
-                          onChange={e => setPropertyId(e.target.value)}
-                        />
-                      ) : (
-                        <select
-                          id="propertyId"
-                          className="input"
-                          required
-                          value={propertyId}
-                          onChange={e => setPropertyId(e.target.value)}
-                        >
-                          <option value="">Select a property…</option>
-                          {properties.map(p => (
-                            <option key={p.id} value={p.id}>
-                              {p.name}{p.city && p.state ? ` — ${p.city}, ${p.state}` : ''}
-                            </option>
-                          ))}
-                        </select>
-                      )}
-                    </div>
-                    <div>
-                      <label className="label" htmlFor="unitNumber">Unit number</label>
-                      <input id="unitNumber" className="input" value={unitNumber} onChange={e => setUnitNumber(e.target.value)} placeholder="Optional" />
-                    </div>
-                  </>
-                )}
-                <div>
-                  <label className="label" htmlFor="ssn">Social Security Number *</label>
-                  <input
-                    id="ssn"
-                    className="input"
-                    required
-                    placeholder="XXX-XX-XXXX"
-                    value={ssn}
-                    onChange={e => setSsn(e.target.value)}
-                    onBlur={() => validateSsn(ssn)}
-                  />
-                  {ssnError && <p className="mt-1 text-xs text-red-600">{ssnError}</p>}
-                </div>
-                <div>
-                  <label className="label" htmlFor="dob">Date of birth *</label>
-                  <input id="dob" type="date" className="input" required value={dateOfBirth} onChange={e => setDateOfBirth(e.target.value)} />
-                </div>
-                <div>
-                  <label className="label" htmlFor="address">Street address</label>
-                  <input id="address" className="input" value={addressLine1} onChange={e => setAddressLine1(e.target.value)} />
-                </div>
-                <div className="grid grid-cols-3 gap-2">
-                  <div className="col-span-1">
-                    <label className="label" htmlFor="city">City</label>
-                    <input id="city" className="input" value={city} onChange={e => setCity(e.target.value)} />
-                  </div>
-                  <div>
-                    <label className="label" htmlFor="state">State</label>
-                    <input id="state" className="input" maxLength={2} placeholder="NV" value={state} onChange={e => setState(e.target.value.toUpperCase())} />
-                  </div>
-                  <div>
-                    <label className="label" htmlFor="zip">ZIP</label>
-                    <input id="zip" className="input" maxLength={10} value={zip} onChange={e => setZip(e.target.value)} />
-                  </div>
-                </div>
-                <div>
-                  <label className="label" htmlFor="employer">Employer name</label>
-                  <input id="employer" className="input" value={employerName} onChange={e => setEmployerName(e.target.value)} />
-                </div>
-                <div className="grid grid-cols-2 gap-3">
-                  <div>
-                    <label className="label" htmlFor="income">Annual income ($)</label>
-                    <input id="income" type="number" min={0} className="input" value={annualIncome} onChange={e => setAnnualIncome(e.target.value)} />
-                  </div>
-                  <div>
-                    <label className="label" htmlFor="household">Household size *</label>
-                    <select id="household" className="input" required value={householdSize} onChange={e => setHouseholdSize(e.target.value)}>
-                      {Array.from({ length: 8 }, (_, i) => i + 1).map(n => (
-                        <option key={n} value={n}>{n}</option>
-                      ))}
-                    </select>
-                  </div>
-                </div>
-                <div>
-                  <label className="label" htmlFor="moveIn">Requested move-in date</label>
-                  <input id="moveIn" type="date" className="input" value={moveInDate} onChange={e => setMoveInDate(e.target.value)} />
-                </div>
-                <div className="flex gap-3">
-                  <button
-                    type="button"
-                    onClick={() => setStep(claimedUnit ? 'claim' : 1)}
-                    className="flex-1 rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
-                  >
-                    Back
-                  </button>
-                  <button
-                    type="submit"
-                    disabled={loading || !ssn || !!ssnError || !dateOfBirth || (!claimedUnit && !propertyId && !propertiesFailed)}
-                    className="btn-primary flex-1"
-                  >
-                    {loading ? 'Submitting…' : 'Submit application'}
-                  </button>
-                </div>
-              </form>
-            </>
-          )}
-        </div>
-
-        <p className="text-center text-sm text-gray-500">
-          Already have an account?{' '}
-          <Link to="/login" className="font-medium text-emerald-600 hover:underline">Sign in</Link>
-        </p>
       </div>
-    </div>
-  );
-}
-
-// Inline countdown for the claim-confirmation card. ClaimedUnitHeader has its
-// own copy for the sticky header context — this one is centered and large.
-function ClaimCountdown({ expiresAt }: { expiresAt: string }) {
-  const [now, setNow] = useState(() => Date.now());
-  useEffect(() => {
-    const interval = setInterval(() => setNow(Date.now()), 1000);
-    return () => clearInterval(interval);
-  }, []);
-  const remaining = new Date(expiresAt).getTime() - now;
-  const total = Math.max(0, Math.floor(remaining / 1000));
-  const h = String(Math.floor(total / 3600)).padStart(2, '0');
-  const m = String(Math.floor((total % 3600) / 60)).padStart(2, '0');
-  const s = String(total % 60).padStart(2, '0');
-  return (
-    <div className="rounded-lg bg-emerald-50 p-4">
-      <div className="text-xs uppercase tracking-wide text-emerald-700">Held until</div>
-      <div className="mt-1 font-mono text-2xl font-bold text-emerald-800">{h}:{m}:{s}</div>
-      <div className="mt-1 text-xs text-emerald-700">
-        Finish your application before the timer runs out to lock it in.
-      </div>
-    </div>
+    </ApplyProvider>
   );
 }

--- a/client-tenant/src/pages/apply/ApplyContext.tsx
+++ b/client-tenant/src/pages/apply/ApplyContext.tsx
@@ -1,0 +1,72 @@
+import { createContext, useContext, type ReactNode } from 'react';
+import type { Unit } from '@/api/units';
+
+export type Step = 1 | 'verify' | 'intent' | 'checklist' | 'pick' | 'claim' | 2;
+
+export interface ApplyState {
+  step: Step;
+  setStep: (s: Step) => void;
+  error: string | null;
+  setError: (e: string | null) => void;
+  loading: boolean;
+  setLoading: (b: boolean) => void;
+
+  // Identity
+  email: string; setEmail: (v: string) => void;
+  firstName: string; setFirstName: (v: string) => void;
+  lastName: string; setLastName: (v: string) => void;
+  phone: string; setPhone: (v: string) => void;
+
+  // Verify
+  resending: boolean; setResending: (b: boolean) => void;
+  resent: boolean; setResent: (b: boolean) => void;
+  devLink: string | null; setDevLink: (v: string | null) => void;
+
+  // Intent
+  intentBedrooms: number | null; setIntentBedrooms: (n: number | null) => void;
+  intentBudgetMax: number; setIntentBudgetMax: (n: number) => void;
+  intentMoveInDate: string; setIntentMoveInDate: (s: string) => void;
+  intentHouseholdSize: number; setIntentHouseholdSize: (n: number) => void;
+
+  // Pick
+  units: Unit[]; setUnits: (u: Unit[]) => void;
+  unitsLoading: boolean; setUnitsLoading: (b: boolean) => void;
+  claimingUnitId: string | null; setClaimingUnitId: (id: string | null) => void;
+
+  // Claim
+  claimedUnit: Unit | null; setClaimedUnit: (u: Unit | null) => void;
+  claimExpiresAt: string | null; setClaimExpiresAt: (s: string | null) => void;
+
+  // Step 2
+  properties: Array<{ id: string; name: string; city?: string; state?: string }>;
+  setProperties: (p: ApplyState['properties']) => void;
+  propertiesLoading: boolean; setPropertiesLoading: (b: boolean) => void;
+  propertiesFailed: boolean; setPropertiesFailed: (b: boolean) => void;
+  propertyId: string; setPropertyId: (v: string) => void;
+  unitNumber: string; setUnitNumber: (v: string) => void;
+  ssn: string; setSsn: (v: string) => void;
+  ssnError: string | null; setSsnError: (v: string | null) => void;
+  dateOfBirth: string; setDateOfBirth: (v: string) => void;
+  addressLine1: string; setAddressLine1: (v: string) => void;
+  city: string; setCity: (v: string) => void;
+  state: string; setState: (v: string) => void;
+  zip: string; setZip: (v: string) => void;
+  employerName: string; setEmployerName: (v: string) => void;
+  annualIncome: string; setAnnualIncome: (v: string) => void;
+  householdSize: string; setHouseholdSize: (v: string) => void;
+  moveInDate: string; setMoveInDate: (v: string) => void;
+
+  done: boolean; setDone: (b: boolean) => void;
+}
+
+const Ctx = createContext<ApplyState | null>(null);
+
+export function ApplyProvider({ value, children }: { value: ApplyState; children: ReactNode }) {
+  return <Ctx.Provider value={value}>{children}</Ctx.Provider>;
+}
+
+export function useApply(): ApplyState {
+  const v = useContext(Ctx);
+  if (!v) throw new Error('useApply must be used inside ApplyProvider');
+  return v;
+}

--- a/client-tenant/src/pages/apply/ApplyContext.tsx
+++ b/client-tenant/src/pages/apply/ApplyContext.tsx
@@ -1,7 +1,60 @@
-import { createContext, useContext, type ReactNode } from 'react';
+import { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
 import type { Unit } from '@/api/units';
 
-export type Step = 1 | 'verify' | 'intent' | 'checklist' | 'pick' | 'claim' | 2;
+// FROZEN CONTRACT 1 — step-key union, in order:
+// 1 · verify · intent · checklist · pick · claim · review · household · payment · 2 · confirm
+// `claim → review` is the wedge point. `2` stays after `payment`. `confirm` is terminal.
+export type Step =
+  | 1
+  | 'verify'
+  | 'intent'
+  | 'checklist'
+  | 'pick'
+  | 'claim'
+  | 'review'
+  | 'household'
+  | 'payment'
+  | 2
+  | 'confirm';
+
+// FROZEN CONTRACT 2 — payment wizard fields, persisted to sessionStorage.
+const SESSION_KEY = 'frank_apply_state';
+
+export function formatPaymentTotal(adults: number): string {
+  return (35.95 * (adults + 1)).toLocaleString('en-US', {
+    style: 'currency',
+    currency: 'USD',
+  });
+}
+
+interface WizPersisted {
+  adults: number;
+  paymentRef: string | null;
+}
+
+function readPersisted(): WizPersisted {
+  if (typeof window === 'undefined') return { adults: 1, paymentRef: null };
+  try {
+    const raw = window.sessionStorage.getItem(SESSION_KEY);
+    if (!raw) return { adults: 1, paymentRef: null };
+    const parsed = JSON.parse(raw) as Partial<WizPersisted>;
+    return {
+      adults: typeof parsed.adults === 'number' ? parsed.adults : 1,
+      paymentRef: typeof parsed.paymentRef === 'string' ? parsed.paymentRef : null,
+    };
+  } catch {
+    return { adults: 1, paymentRef: null };
+  }
+}
+
+function writePersisted(data: WizPersisted) {
+  if (typeof window === 'undefined') return;
+  try {
+    window.sessionStorage.setItem(SESSION_KEY, JSON.stringify(data));
+  } catch {
+    /* sessionStorage may be unavailable; ignore */
+  }
+}
 
 export interface ApplyState {
   step: Step;
@@ -57,6 +110,11 @@ export interface ApplyState {
   moveInDate: string; setMoveInDate: (v: string) => void;
 
   done: boolean; setDone: (b: boolean) => void;
+
+  // FROZEN CONTRACT 2 — payment wizard
+  adults: number; setAdults: (n: number) => void;
+  paymentTotal: string; // computed from adults; not settable directly
+  paymentRef: string | null; setPaymentRef: (v: string | null) => void;
 }
 
 const Ctx = createContext<ApplyState | null>(null);
@@ -69,4 +127,24 @@ export function useApply(): ApplyState {
   const v = useContext(Ctx);
   if (!v) throw new Error('useApply must be used inside ApplyProvider');
   return v;
+}
+
+// Hook for callers (Apply.tsx) to build the wiz slice with sessionStorage persistence.
+// Returned object: { adults, setAdults, paymentTotal, paymentRef, setPaymentRef }.
+export function useWizState() {
+  const initial = readPersisted();
+  const [adults, setAdultsRaw] = useState<number>(initial.adults);
+  const [paymentRef, setPaymentRefRaw] = useState<string | null>(initial.paymentRef);
+
+  useEffect(() => {
+    writePersisted({ adults, paymentRef });
+  }, [adults, paymentRef]);
+
+  return {
+    adults,
+    setAdults: setAdultsRaw,
+    paymentTotal: formatPaymentTotal(adults),
+    paymentRef,
+    setPaymentRef: setPaymentRefRaw,
+  };
 }

--- a/client-tenant/src/pages/apply/StepIndicator.tsx
+++ b/client-tenant/src/pages/apply/StepIndicator.tsx
@@ -1,0 +1,74 @@
+import { useApplyProgress, APPLY_STEP_KEYS, type ApplyStepKey } from '@/hooks/useApplyProgress';
+import { useTranslation } from '@/i18n';
+
+const LABEL_KEYS: Record<ApplyStepKey, string> = {
+  register: 'register.title',
+  verify: 'verify.title',
+  intent: 'intent.title',
+  checklist: 'checklist.title',
+  pick: 'pick.title',
+  claim: 'claim.continue',
+  details: 'details.title',
+};
+
+export function StepIndicator() {
+  const { current, total, stepKey } = useApplyProgress();
+  const { t } = useTranslation('apply');
+  const pct = Math.round((current / total) * 100);
+
+  return (
+    <>
+      {/* Mobile: top progress bar */}
+      <div className="lg:hidden" aria-label={t('progress.stepLabel').replace('{n}', String(current)).replace('{total}', String(total))}>
+        <div className="mb-1 flex justify-between text-xs text-gray-500">
+          <span>{t(LABEL_KEYS[stepKey])}</span>
+          <span>
+            {current}/{total}
+          </span>
+        </div>
+        <div className="h-1.5 w-full rounded-full bg-gray-200">
+          <div
+            className="h-1.5 rounded-full bg-emerald-600 transition-all"
+            style={{ width: `${pct}%` }}
+          />
+        </div>
+      </div>
+
+      {/* Desktop: left-rail vertical list */}
+      <nav
+        className="hidden lg:block"
+        aria-label={t('progress.stepLabel').replace('{n}', String(current)).replace('{total}', String(total))}
+      >
+        <ol className="space-y-3">
+          {APPLY_STEP_KEYS.map((key, i) => {
+            const n = i + 1;
+            const isCurrent = key === stepKey;
+            const isDone = n < current;
+            return (
+              <li key={key} className="flex items-center gap-3">
+                <div
+                  className={`flex h-7 w-7 items-center justify-center rounded-full text-xs font-bold ${
+                    isCurrent
+                      ? 'bg-emerald-600 text-white'
+                      : isDone
+                      ? 'bg-emerald-100 text-emerald-700'
+                      : 'bg-gray-200 text-gray-500'
+                  }`}
+                >
+                  {n}
+                </div>
+                <span
+                  className={`text-sm ${
+                    isCurrent ? 'font-medium text-gray-900' : 'text-gray-500'
+                  }`}
+                >
+                  {t(LABEL_KEYS[key])}
+                </span>
+              </li>
+            );
+          })}
+        </ol>
+      </nav>
+    </>
+  );
+}

--- a/client-tenant/src/pages/apply/StepIndicator.tsx
+++ b/client-tenant/src/pages/apply/StepIndicator.tsx
@@ -8,7 +8,12 @@ const LABEL_KEYS: Record<ApplyStepKey, string> = {
   checklist: 'checklist.title',
   pick: 'pick.title',
   claim: 'claim.continue',
+  // Lane W payment-wizard steps (i18n strings supplied by W2/W3).
+  review: 'review.title',
+  household: 'household.title',
+  payment: 'payment.title',
   details: 'details.title',
+  confirm: 'confirm.title',
 };
 
 export function StepIndicator() {

--- a/client-tenant/src/pages/apply/__tests__/Apply.integration.test.tsx
+++ b/client-tenant/src/pages/apply/__tests__/Apply.integration.test.tsx
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { Apply } from '../../Apply';
+import { setToken } from '@/api/client';
+
+// One mock fetch covering every endpoint the flow touches.
+function installFetch() {
+  const fn = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    const method = init?.method ?? 'GET';
+    const body = (data: unknown, status = 200) =>
+      new Response(JSON.stringify(data), {
+        status,
+        headers: { 'Content-Type': 'application/json' },
+      });
+
+    if (url.includes('/applicants/register')) return body({ ok: true });
+    if (url.includes('/auth/me')) {
+      return body({
+        user: {
+          email: 'marisol@example.com',
+          firstName: 'Marisol',
+          lastName: 'Reyes',
+          emailVerified: true,
+        },
+      });
+    }
+    if (url.includes('/applicants/me/applications')) return body({ applications: [] });
+    if (url.includes('/applicants/intent') && method === 'POST') {
+      return body({ ok: true, application_id: 'app-1' });
+    }
+    if (url.includes('/applicants/units')) {
+      return body({
+        units: [
+          {
+            id: 'unit-aaaabbbb',
+            property_id: 'donna-louise-2',
+            unit_number: '204',
+            bedrooms: 2,
+            bathrooms: '1',
+            sqft: 800,
+            monthly_rent: '1500',
+            photo_url: null,
+            available_from: null,
+            property_name: 'Donna Louise II',
+            property_city: 'Reno',
+            property_state: 'NV',
+          },
+        ],
+      });
+    }
+    if (url.includes('/applicants/claim-unit/')) {
+      return body({
+        ok: true,
+        application_id: 'app-1',
+        unit: {
+          id: 'unit-aaaabbbb',
+          property_id: 'donna-louise-2',
+          unit_number: '204',
+          bedrooms: 2,
+          bathrooms: '1',
+          sqft: 800,
+          monthly_rent: '1500',
+          photo_url: null,
+          available_from: null,
+          property_name: 'Donna Louise II',
+          property_city: 'Reno',
+          property_state: 'NV',
+        },
+        expires_at: new Date(Date.now() + 48 * 3600 * 1000).toISOString(),
+      });
+    }
+    if (url.includes('/applicants/apply')) return body({ ok: true });
+    return body({ error: `unmocked ${url}` }, 404);
+  });
+  vi.stubGlobal('fetch', fn);
+  return fn;
+}
+
+function renderApp(route: string) {
+  return render(
+    <MemoryRouter initialEntries={[route]}>
+      <Routes>
+        <Route path="/apply" element={<Apply />} />
+        <Route path="/status" element={<div>Status page</div>} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('Apply — full happy path through 7 steps', () => {
+  it('progresses register → verify → intent → checklist → pick → claim → details → submit', async () => {
+    installFetch();
+    // Token present so the verify-stage poll auto-advances.
+    setToken('test-token');
+
+    const user = userEvent.setup();
+    renderApp('/apply');
+
+    // Step 1: Register
+    expect(await screen.findByRole('heading', { name: /create your account/i })).toBeInTheDocument();
+    await user.type(screen.getByLabelText(/first name/i), 'Marisol');
+    await user.type(screen.getByLabelText(/last name/i), 'Reyes');
+    await user.type(screen.getByLabelText(/email/i), 'marisol@example.com');
+    await user.click(screen.getByRole('button', { name: /^continue$/i }));
+
+    // Step 2: Verify — auto-advances to intent once /auth/me reports emailVerified.
+    // (Verify heading may flash too briefly to assert; intent heading is the stable signal.)
+    expect(await screen.findByRole('heading', { name: /what are you looking for/i })).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /^2 BR$/i }));
+    await user.type(screen.getByLabelText(/target move-in/i), '2026-09-01');
+    await user.click(screen.getByRole('button', { name: /show me units/i }));
+
+    // Step 4: Checklist (NEW)
+    expect(await screen.findByRole('heading', { name: /before you apply/i })).toBeInTheDocument();
+    expect(screen.getByText(/\$35\.95/)).toBeInTheDocument();
+    expect(screen.getByText(/120 days/i)).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /continue/i }));
+
+    // Step 5: Pick
+    expect(await screen.findByRole('heading', { name: /pick your unit/i })).toBeInTheDocument();
+    const claimBtn = await screen.findByRole('button', { name: /claim/i });
+    await user.click(claimBtn);
+
+    // Step 6: Claim confirmation
+    expect(await screen.findByRole('heading', { name: /unit 204 is yours/i })).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /continue your application/i }));
+
+    // Step 7: Details
+    expect(await screen.findByRole('heading', { name: /application details/i })).toBeInTheDocument();
+    await user.type(screen.getByLabelText(/social security number/i), '123-45-6789');
+    await user.type(screen.getByLabelText(/date of birth/i), '1990-01-01');
+    await user.click(screen.getByRole('button', { name: /submit application/i }));
+
+    // Submitted screen
+    await waitFor(() => {
+      expect(screen.getByText(/application submitted/i)).toBeInTheDocument();
+    });
+  }, 30000);
+});

--- a/client-tenant/src/pages/apply/__tests__/Step1Register.test.tsx
+++ b/client-tenant/src/pages/apply/__tests__/Step1Register.test.tsx
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { screen } from '@testing-library/react';
+import { Step1Register } from '../steps/Step1Register';
+import { renderWithApply, mockFetch } from './helpers';
+
+describe('Step1Register', () => {
+  it('renders the register form', () => {
+    mockFetch({});
+    renderWithApply(<Step1Register />);
+    expect(screen.getByRole('heading', { name: /create your account/i })).toBeInTheDocument();
+    expect(screen.getByLabelText(/first name/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
+  });
+});

--- a/client-tenant/src/pages/apply/__tests__/Step2Details.test.tsx
+++ b/client-tenant/src/pages/apply/__tests__/Step2Details.test.tsx
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { screen } from '@testing-library/react';
+import { Step2Details } from '../steps/Step2Details';
+import { renderWithApply, makeState, mockFetch } from './helpers';
+import type { Unit } from '@/api/units';
+
+const claimedUnit: Unit = {
+  id: 'u', property_id: 'p', unit_number: '101', bedrooms: 1, bathrooms: '1',
+  sqft: 600, monthly_rent: '1200', photo_url: null, available_from: null,
+  property_name: 'X', property_city: null, property_state: null,
+};
+
+describe('Step2Details', () => {
+  it('renders the details form with SSN + DOB when a unit is claimed', () => {
+    mockFetch({});
+    const state = makeState({ step: 2, claimedUnit });
+    renderWithApply(<Step2Details />, { state });
+    expect(screen.getByRole('heading', { name: /application details/i })).toBeInTheDocument();
+    expect(screen.getByLabelText(/social security number/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/date of birth/i)).toBeInTheDocument();
+  });
+});

--- a/client-tenant/src/pages/apply/__tests__/StepChecklist.test.tsx
+++ b/client-tenant/src/pages/apply/__tests__/StepChecklist.test.tsx
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { StepChecklist } from '../steps/StepChecklist';
+import { renderWithApply, makeState, mockFetch } from './helpers';
+
+describe('StepChecklist', () => {
+  it('renders 5 required-doc items + fee + 120-day rule', () => {
+    mockFetch({});
+    renderWithApply(<StepChecklist />, { state: makeState({ step: 'checklist' }) });
+    expect(screen.getByRole('heading', { name: /before you apply/i })).toBeInTheDocument();
+    expect(screen.getByText(/photo ID/i)).toBeInTheDocument();
+    expect(screen.getByText(/proof of income/i)).toBeInTheDocument();
+    expect(screen.getByText(/social security number/i)).toBeInTheDocument();
+    expect(screen.getByText(/landlord references/i)).toBeInTheDocument();
+    expect(screen.getByText(/household composition/i)).toBeInTheDocument();
+    expect(screen.getByText(/\$35\.95/)).toBeInTheDocument();
+    expect(screen.getByText(/120 days/i)).toBeInTheDocument();
+  });
+
+  it('advances to pick on continue', async () => {
+    mockFetch({});
+    const setStep = vi.fn();
+    const state = makeState({ step: 'checklist', setStep });
+    renderWithApply(<StepChecklist />, { state });
+    await userEvent.click(screen.getByRole('button', { name: /continue/i }));
+    expect(setStep).toHaveBeenCalledWith('pick');
+  });
+});

--- a/client-tenant/src/pages/apply/__tests__/StepClaim.test.tsx
+++ b/client-tenant/src/pages/apply/__tests__/StepClaim.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { screen } from '@testing-library/react';
+import { StepClaim } from '../steps/StepClaim';
+import { renderWithApply, makeState, mockFetch } from './helpers';
+import type { Unit } from '@/api/units';
+
+const unit: Unit = {
+  id: 'unit-1234abcd',
+  property_id: 'donna-louise-2',
+  unit_number: '204',
+  bedrooms: 2,
+  bathrooms: '1',
+  sqft: 800,
+  monthly_rent: '1500',
+  photo_url: null,
+  available_from: null,
+  property_name: 'Donna Louise II',
+  property_city: 'Reno',
+  property_state: 'NV',
+};
+
+describe('StepClaim', () => {
+  it('renders the claimed-unit confirmation', () => {
+    mockFetch({});
+    const state = makeState({
+      step: 'claim',
+      claimedUnit: unit,
+      claimExpiresAt: new Date(Date.now() + 48 * 3600 * 1000).toISOString(),
+    });
+    renderWithApply(<StepClaim />, { state });
+    expect(screen.getByRole('heading', { name: /unit 204 is yours/i })).toBeInTheDocument();
+    expect(screen.getByText(/donna louise ii/i)).toBeInTheDocument();
+  });
+
+  it('falls back to start-over when no claim exists', () => {
+    mockFetch({});
+    renderWithApply(<StepClaim />, { state: makeState({ step: 'claim' }) });
+    expect(screen.getByText(/no active claim/i)).toBeInTheDocument();
+  });
+});

--- a/client-tenant/src/pages/apply/__tests__/StepIntent.test.tsx
+++ b/client-tenant/src/pages/apply/__tests__/StepIntent.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import { StepIntent } from '../steps/StepIntent';
+import { renderWithApply, makeState, mockFetch } from './helpers';
+
+describe('StepIntent', () => {
+  it('renders the intent quiz', () => {
+    mockFetch({});
+    renderWithApply(<StepIntent />, { state: makeState({ step: 'intent' }) });
+    expect(screen.getByRole('heading', { name: /what are you looking for/i })).toBeInTheDocument();
+    expect(screen.getByLabelText(/target move-in/i)).toBeInTheDocument();
+  });
+
+  it('prefills bedrooms + propertyId from ?unitType=2BR&propertyId=donna-louise-2', async () => {
+    mockFetch({});
+    const setIntentBedrooms = vi.fn();
+    const setPropertyId = vi.fn();
+    const state = makeState({
+      step: 'intent',
+      setIntentBedrooms,
+      setPropertyId,
+    });
+    renderWithApply(<StepIntent />, {
+      state,
+      route: '/apply?step=intent&unitType=2BR&propertyId=donna-louise-2',
+    });
+    await waitFor(() => {
+      expect(setIntentBedrooms).toHaveBeenCalledWith(2);
+      expect(setPropertyId).toHaveBeenCalledWith('donna-louise-2');
+    });
+  });
+
+  it('maps STUDIO → 0 bedrooms', async () => {
+    mockFetch({});
+    const setIntentBedrooms = vi.fn();
+    const state = makeState({ step: 'intent', setIntentBedrooms });
+    renderWithApply(<StepIntent />, {
+      state,
+      route: '/apply?step=intent&unitType=STUDIO',
+    });
+    await waitFor(() => {
+      expect(setIntentBedrooms).toHaveBeenCalledWith(0);
+    });
+  });
+});

--- a/client-tenant/src/pages/apply/__tests__/StepPick.test.tsx
+++ b/client-tenant/src/pages/apply/__tests__/StepPick.test.tsx
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import { StepPick } from '../steps/StepPick';
+import { renderWithApply, makeState, mockFetch } from './helpers';
+
+describe('StepPick', () => {
+  it('renders the title and a loading state when units fetch is in flight', async () => {
+    mockFetch({
+      '/applicants/units': { units: [] },
+    });
+    const state = makeState({
+      step: 'pick',
+      intentBedrooms: 2,
+      intentMoveInDate: '2026-06-01',
+      intentBudgetMax: 2000,
+    });
+    renderWithApply(<StepPick />, { state });
+    expect(screen.getByRole('heading', { name: /pick your unit/i })).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByText(/loading units/i)).not.toBeInTheDocument();
+    });
+  });
+});

--- a/client-tenant/src/pages/apply/__tests__/StepVerify.test.tsx
+++ b/client-tenant/src/pages/apply/__tests__/StepVerify.test.tsx
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { screen } from '@testing-library/react';
+import { StepVerify } from '../steps/StepVerify';
+import { renderWithApply, makeState, mockFetch } from './helpers';
+
+describe('StepVerify', () => {
+  it('shows the check-your-email screen with the email address', () => {
+    mockFetch({});
+    const state = makeState({ step: 'verify', email: 'marisol@example.com' });
+    renderWithApply(<StepVerify />, { state });
+    expect(screen.getByRole('heading', { name: /check your email/i })).toBeInTheDocument();
+    expect(screen.getByText(/marisol@example\.com/)).toBeInTheDocument();
+  });
+});

--- a/client-tenant/src/pages/apply/__tests__/helpers.tsx
+++ b/client-tenant/src/pages/apply/__tests__/helpers.tsx
@@ -1,0 +1,82 @@
+import type { ReactNode } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { render } from '@testing-library/react';
+import { vi } from 'vitest';
+import { ApplyProvider, type ApplyState, type Step } from '../ApplyContext';
+
+// Build a stubbed ApplyState for unit smoke tests. Each step receives only
+// what it needs; setters are spies so transitions are observable.
+export function makeState(overrides: Partial<ApplyState> = {}): ApplyState {
+  let step: Step = overrides.step ?? 1;
+  const setStep = vi.fn((s: Step) => {
+    step = s;
+  });
+
+  const noop = vi.fn();
+  const base: ApplyState = {
+    step,
+    setStep: (s) => {
+      setStep(s);
+      // also reflect in returned object for assertions on .step
+      (base as ApplyState).step = s;
+    },
+    error: null, setError: noop, loading: false, setLoading: noop,
+    email: '', setEmail: noop, firstName: '', setFirstName: noop,
+    lastName: '', setLastName: noop, phone: '', setPhone: noop,
+    resending: false, setResending: noop, resent: false, setResent: noop,
+    devLink: null, setDevLink: noop,
+    intentBedrooms: null, setIntentBedrooms: noop,
+    intentBudgetMax: 2000, setIntentBudgetMax: noop,
+    intentMoveInDate: '', setIntentMoveInDate: noop,
+    intentHouseholdSize: 1, setIntentHouseholdSize: noop,
+    units: [], setUnits: noop, unitsLoading: false, setUnitsLoading: noop,
+    claimingUnitId: null, setClaimingUnitId: noop,
+    claimedUnit: null, setClaimedUnit: noop,
+    claimExpiresAt: null, setClaimExpiresAt: noop,
+    properties: [], setProperties: noop,
+    propertiesLoading: false, setPropertiesLoading: noop,
+    propertiesFailed: false, setPropertiesFailed: noop,
+    propertyId: '', setPropertyId: noop, unitNumber: '', setUnitNumber: noop,
+    ssn: '', setSsn: noop, ssnError: null, setSsnError: noop,
+    dateOfBirth: '', setDateOfBirth: noop, addressLine1: '', setAddressLine1: noop,
+    city: '', setCity: noop, state: '', setState: noop, zip: '', setZip: noop,
+    employerName: '', setEmployerName: noop, annualIncome: '', setAnnualIncome: noop,
+    householdSize: '1', setHouseholdSize: noop, moveInDate: '', setMoveInDate: noop,
+    done: false, setDone: noop,
+    ...overrides,
+  };
+  return base;
+}
+
+export function renderWithApply(
+  ui: ReactNode,
+  opts: { state?: ApplyState; route?: string } = {}
+) {
+  const state = opts.state ?? makeState();
+  return {
+    state,
+    ...render(
+      <MemoryRouter initialEntries={[opts.route ?? '/apply']}>
+        <ApplyProvider value={state}>{ui}</ApplyProvider>
+      </MemoryRouter>
+    ),
+  };
+}
+
+// Mock fetch with a simple route → response map. Returns the mock for spying.
+export function mockFetch(routes: Record<string, unknown>) {
+  const fn = vi.fn(async (input: RequestInfo | URL) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    for (const [pattern, body] of Object.entries(routes)) {
+      if (url.includes(pattern)) {
+        return new Response(JSON.stringify(body), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+    }
+    return new Response(JSON.stringify({ error: `unmocked ${url}` }), { status: 404 });
+  });
+  vi.stubGlobal('fetch', fn);
+  return fn;
+}

--- a/client-tenant/src/pages/apply/__tests__/helpers.tsx
+++ b/client-tenant/src/pages/apply/__tests__/helpers.tsx
@@ -43,6 +43,10 @@ export function makeState(overrides: Partial<ApplyState> = {}): ApplyState {
     employerName: '', setEmployerName: noop, annualIncome: '', setAnnualIncome: noop,
     householdSize: '1', setHouseholdSize: noop, moveInDate: '', setMoveInDate: noop,
     done: false, setDone: noop,
+    // Contract 2 — wizard slice
+    adults: 1, setAdults: noop,
+    paymentTotal: '$71.90',
+    paymentRef: null, setPaymentRef: noop,
     ...overrides,
   };
   return base;

--- a/client-tenant/src/pages/apply/steps/PropertySelector.tsx
+++ b/client-tenant/src/pages/apply/steps/PropertySelector.tsx
@@ -1,0 +1,58 @@
+import { useEffect } from 'react';
+import { api } from '@/api/client';
+import { useApply } from '../ApplyContext';
+import { useTranslation } from '@/i18n';
+
+interface Property { id: string; name: string; city?: string; state?: string; }
+
+// Property + unit-number sub-form used by Step2Details when there is no claim.
+export function PropertySelector() {
+  const s = useApply();
+  const { t } = useTranslation('apply');
+
+  useEffect(() => {
+    if (s.claimedUnit || s.properties.length > 0 || s.propertiesLoading) return;
+    let cancelled = false;
+    (async () => {
+      s.setPropertiesLoading(true);
+      try {
+        const data = await api.get<{ properties: Property[] } | Property[]>('/applicants/properties');
+        if (cancelled) return;
+        const list = Array.isArray(data) ? data : (data as { properties: Property[] }).properties ?? [];
+        s.setProperties(list);
+      } catch {
+        if (!cancelled) s.setPropertiesFailed(true);
+      } finally {
+        if (!cancelled) s.setPropertiesLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [s.claimedUnit, s.properties.length, s.propertiesLoading]);
+
+  return (
+    <>
+      <div>
+        <label className="label" htmlFor="propertyId">{t('details.property')}</label>
+        {s.propertiesLoading ? (
+          <p className="text-sm text-gray-400">{t('details.loadingProperties')}</p>
+        ) : s.propertiesFailed || s.properties.length === 0 ? (
+          <input id="propertyId" className="input" required placeholder={t('details.propertyPlaceholder')} value={s.propertyId} onChange={(e) => s.setPropertyId(e.target.value)} />
+        ) : (
+          <select id="propertyId" className="input" required value={s.propertyId} onChange={(e) => s.setPropertyId(e.target.value)}>
+            <option value="">{t('details.selectProperty')}</option>
+            {s.properties.map((p) => (
+              <option key={p.id} value={p.id}>
+                {p.name}{p.city && p.state ? ` — ${p.city}, ${p.state}` : ''}
+              </option>
+            ))}
+          </select>
+        )}
+      </div>
+      <div>
+        <label className="label" htmlFor="unitNumber">{t('details.unitNumber')}</label>
+        <input id="unitNumber" className="input" value={s.unitNumber} onChange={(e) => s.setUnitNumber(e.target.value)} placeholder={t('details.unitOptional')} />
+      </div>
+    </>
+  );
+}

--- a/client-tenant/src/pages/apply/steps/Step1Register.tsx
+++ b/client-tenant/src/pages/apply/steps/Step1Register.tsx
@@ -1,0 +1,87 @@
+import { api } from '@/api/client';
+import { useApply } from '../ApplyContext';
+import { useTranslation } from '@/i18n';
+import { CTA } from '@/components/primitives';
+
+export function Step1Register() {
+  const s = useApply();
+  const { t } = useTranslation('apply');
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    s.setError(null);
+    s.setLoading(true);
+    try {
+      const res = await api.post<{ ok: boolean; devLink?: string }>('/applicants/register', {
+        email: s.email,
+        firstName: s.firstName,
+        lastName: s.lastName,
+        phone: s.phone || undefined,
+      });
+      if (res.devLink) s.setDevLink(res.devLink);
+      s.setStep('verify');
+    } catch (err) {
+      s.setError(err instanceof Error ? err.message : t('register.error'));
+    } finally {
+      s.setLoading(false);
+    }
+  }
+
+  return (
+    <>
+      <h1 className="mb-4 text-xl font-bold text-gray-900">{t('register.title')}</h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <label className="label" htmlFor="firstName">{t('register.firstName')}</label>
+            <input
+              id="firstName"
+              className="input"
+              required
+              value={s.firstName}
+              onChange={(e) => s.setFirstName(e.target.value)}
+            />
+          </div>
+          <div>
+            <label className="label" htmlFor="lastName">{t('register.lastName')}</label>
+            <input
+              id="lastName"
+              className="input"
+              required
+              value={s.lastName}
+              onChange={(e) => s.setLastName(e.target.value)}
+            />
+          </div>
+        </div>
+        <div>
+          <label className="label" htmlFor="regEmail">{t('register.email')}</label>
+          <input
+            id="regEmail"
+            type="email"
+            className="input"
+            required
+            value={s.email}
+            onChange={(e) => s.setEmail(e.target.value)}
+          />
+        </div>
+        <div>
+          <label className="label" htmlFor="phone">{t('register.phone')}</label>
+          <input
+            id="phone"
+            type="tel"
+            className="input"
+            value={s.phone}
+            onChange={(e) => s.setPhone(e.target.value)}
+            placeholder={t('register.phonePlaceholder')}
+          />
+        </div>
+        <CTA
+          type="submit"
+          disabled={s.loading || !s.email || !s.firstName || !s.lastName}
+        >
+          {s.loading ? t('register.submitting') : t('register.submit')}
+        </CTA>
+      </form>
+    </>
+  );
+}

--- a/client-tenant/src/pages/apply/steps/Step2Details.tsx
+++ b/client-tenant/src/pages/apply/steps/Step2Details.tsx
@@ -1,0 +1,122 @@
+import { useNavigate } from 'react-router-dom';
+import { api } from '@/api/client';
+import { useApply } from '../ApplyContext';
+import { useTranslation } from '@/i18n';
+import { CTA, FormGrid } from '@/components/primitives';
+import { PropertySelector } from './PropertySelector';
+
+export function Step2Details() {
+  const s = useApply();
+  const navigate = useNavigate();
+  const { t } = useTranslation('apply');
+
+  function validateSsn(value: string) {
+    const clean = value.replace(/-/g, '');
+    if (clean.length === 0) { s.setSsnError(null); return; }
+    const valid = /^\d{3}-?\d{2}-?\d{4}$/.test(value) || /^\d{9}$/.test(clean);
+    s.setSsnError(valid ? null : t('details.ssnError'));
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (s.ssnError) return;
+    s.setError(null);
+    s.setLoading(true);
+    try {
+      await api.post('/applicants/apply', {
+        propertyId: s.propertyId || undefined,
+        unitNumber: s.unitNumber || undefined,
+        firstName: s.firstName, lastName: s.lastName,
+        ssn: s.ssn, dateOfBirth: s.dateOfBirth, email: s.email,
+        phone: s.phone || undefined,
+        currentAddressLine1: s.addressLine1 || undefined,
+        currentCity: s.city || undefined,
+        currentState: s.state || undefined,
+        currentZip: s.zip || undefined,
+        employerName: s.employerName || undefined,
+        annualIncome: s.annualIncome ? Number(s.annualIncome) : undefined,
+        householdSize: Number(s.householdSize),
+        requestedMoveInDate: s.moveInDate || undefined,
+        requestedLeaseTermMonths: 12,
+      });
+      s.setDone(true);
+      setTimeout(() => navigate('/status'), 2000);
+    } catch (err) {
+      s.setError(err instanceof Error ? err.message : t('details.submitError'));
+    } finally {
+      s.setLoading(false);
+    }
+  }
+
+  const submitDisabled =
+    s.loading || !s.ssn || !!s.ssnError || !s.dateOfBirth ||
+    (!s.claimedUnit && !s.propertyId && !s.propertiesFailed);
+
+  return (
+    <>
+      <h1 className="mb-4 text-xl font-bold text-gray-900">{t('details.title')}</h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        {!s.claimedUnit && <PropertySelector />}
+        <FormGrid cols={2}>
+          <div>
+            <label className="label" htmlFor="ssn">{t('details.ssn')}</label>
+            <input id="ssn" className="input" required placeholder={t('details.ssnPlaceholder')} value={s.ssn} onChange={(e) => s.setSsn(e.target.value)} onBlur={() => validateSsn(s.ssn)} />
+            {s.ssnError && <p className="mt-1 text-xs text-red-600">{s.ssnError}</p>}
+          </div>
+          <div>
+            <label className="label" htmlFor="dob">{t('details.dob')}</label>
+            <input id="dob" type="date" className="input" required value={s.dateOfBirth} onChange={(e) => s.setDateOfBirth(e.target.value)} />
+          </div>
+        </FormGrid>
+        <div>
+          <label className="label" htmlFor="address">{t('details.address')}</label>
+          <input id="address" className="input" value={s.addressLine1} onChange={(e) => s.setAddressLine1(e.target.value)} />
+        </div>
+        <div className="grid grid-cols-3 gap-2">
+          <div>
+            <label className="label" htmlFor="city">{t('details.city')}</label>
+            <input id="city" className="input" value={s.city} onChange={(e) => s.setCity(e.target.value)} />
+          </div>
+          <div>
+            <label className="label" htmlFor="state">{t('details.state')}</label>
+            <input id="state" className="input" maxLength={2} placeholder="NV" value={s.state} onChange={(e) => s.setState(e.target.value.toUpperCase())} />
+          </div>
+          <div>
+            <label className="label" htmlFor="zip">{t('details.zip')}</label>
+            <input id="zip" className="input" maxLength={10} value={s.zip} onChange={(e) => s.setZip(e.target.value)} />
+          </div>
+        </div>
+        <div>
+          <label className="label" htmlFor="employer">{t('details.employer')}</label>
+          <input id="employer" className="input" value={s.employerName} onChange={(e) => s.setEmployerName(e.target.value)} />
+        </div>
+        <FormGrid cols={2}>
+          <div>
+            <label className="label" htmlFor="income">{t('details.income')}</label>
+            <input id="income" type="number" min={0} className="input" value={s.annualIncome} onChange={(e) => s.setAnnualIncome(e.target.value)} />
+          </div>
+          <div>
+            <label className="label" htmlFor="household">{t('details.household')}</label>
+            <select id="household" className="input" required value={s.householdSize} onChange={(e) => s.setHouseholdSize(e.target.value)}>
+              {Array.from({ length: 8 }, (_, i) => i + 1).map((n) => (
+                <option key={n} value={n}>{n}</option>
+              ))}
+            </select>
+          </div>
+        </FormGrid>
+        <div>
+          <label className="label" htmlFor="moveIn">{t('details.moveIn')}</label>
+          <input id="moveIn" type="date" className="input" value={s.moveInDate} onChange={(e) => s.setMoveInDate(e.target.value)} />
+        </div>
+        <div className="flex gap-3">
+          <CTA type="button" variantStyle="secondary" fullWidth={false} className="flex-1" onClick={() => s.setStep(s.claimedUnit ? 'claim' : 1)}>
+            {t('common.back')}
+          </CTA>
+          <CTA type="submit" fullWidth={false} className="flex-1" disabled={submitDisabled}>
+            {s.loading ? t('common.submitting') : t('details.submit')}
+          </CTA>
+        </div>
+      </form>
+    </>
+  );
+}

--- a/client-tenant/src/pages/apply/steps/StepChecklist.tsx
+++ b/client-tenant/src/pages/apply/steps/StepChecklist.tsx
@@ -1,0 +1,52 @@
+import { CheckCircle, Info, Clock } from 'lucide-react';
+import { useApply } from '../ApplyContext';
+import { useTranslation } from '@/i18n';
+import { CTA, ListRow } from '@/components/primitives';
+
+const ITEM_KEYS = ['id', 'income', 'ssn', 'refs', 'household'] as const;
+
+export function StepChecklist() {
+  const s = useApply();
+  const { t } = useTranslation('apply');
+
+  return (
+    <>
+      <h1 className="mb-1 text-xl font-bold text-gray-900">{t('checklist.title')}</h1>
+      <p className="mb-4 text-sm text-gray-500">{t('checklist.subtitle')}</p>
+
+      <ul className="mb-5 divide-y divide-gray-100" aria-label={t('checklist.title')}>
+        {ITEM_KEYS.map((key) => (
+          <li key={key}>
+            <ListRow
+              leading={<CheckCircle className="h-5 w-5 text-emerald-600" aria-hidden="true" />}
+            >
+              {t(`checklist.items.${key}`)}
+            </ListRow>
+          </li>
+        ))}
+      </ul>
+
+      <div className="mb-3 rounded-lg border border-emerald-200 bg-emerald-50 p-4">
+        <div className="flex items-start gap-2">
+          <Info className="mt-0.5 h-4 w-4 shrink-0 text-emerald-700" aria-hidden="true" />
+          <div>
+            <p className="text-sm font-medium text-emerald-900">{t('checklist.fee.title')}</p>
+            <p className="mt-1 text-xs text-emerald-800">{t('checklist.fee.body')}</p>
+          </div>
+        </div>
+      </div>
+
+      <div className="mb-5 rounded-lg border border-amber-200 bg-amber-50 p-4">
+        <div className="flex items-start gap-2">
+          <Clock className="mt-0.5 h-4 w-4 shrink-0 text-amber-700" aria-hidden="true" />
+          <div>
+            <p className="text-sm font-medium text-amber-900">{t('checklist.rule120.title')}</p>
+            <p className="mt-1 text-xs text-amber-800">{t('checklist.rule120.body')}</p>
+          </div>
+        </div>
+      </div>
+
+      <CTA onClick={() => s.setStep('pick')}>{t('checklist.continue')}</CTA>
+    </>
+  );
+}

--- a/client-tenant/src/pages/apply/steps/StepClaim.tsx
+++ b/client-tenant/src/pages/apply/steps/StepClaim.tsx
@@ -1,0 +1,72 @@
+import { useEffect, useState } from 'react';
+import { useApply } from '../ApplyContext';
+import { useTranslation } from '@/i18n';
+import { CTA } from '@/components/primitives';
+
+export function StepClaim() {
+  const s = useApply();
+  const { t } = useTranslation('apply');
+
+  if (!s.claimedUnit || !s.claimExpiresAt) {
+    return (
+      <div className="space-y-4 text-center">
+        <p className="text-sm text-gray-500">{t('claim.noActive')}</p>
+        <CTA onClick={() => s.setStep('intent')}>{t('claim.startOver')}</CTA>
+      </div>
+    );
+  }
+
+  const unit = s.claimedUnit;
+
+  return (
+    <div className="space-y-4 text-center">
+      <div className="overflow-hidden rounded-xl">
+        <img
+          src={unit.photo_url || `https://picsum.photos/seed/${unit.id.slice(0, 8)}/800/600`}
+          alt=""
+          className="aspect-[16/9] w-full object-cover"
+        />
+      </div>
+      <div>
+        <h1 className="text-xl font-bold text-gray-900">
+          {t('claim.yours').replace('{unitNumber}', unit.unit_number)}
+        </h1>
+        <p className="mt-1 text-sm text-gray-500">
+          {unit.property_name}
+          {unit.property_city && `, ${unit.property_city}`}
+        </p>
+      </div>
+      <ClaimCountdown expiresAt={s.claimExpiresAt} />
+      <CTA onClick={() => s.setStep(2)}>{t('claim.continue')}</CTA>
+      <button
+        onClick={() => s.setStep('pick')}
+        className="text-sm text-gray-500 hover:text-gray-700 hover:underline"
+      >
+        {t('claim.pickDifferent')}
+      </button>
+    </div>
+  );
+}
+
+function ClaimCountdown({ expiresAt }: { expiresAt: string }) {
+  const { t } = useTranslation('apply');
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const interval = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(interval);
+  }, []);
+  const remaining = new Date(expiresAt).getTime() - now;
+  const total = Math.max(0, Math.floor(remaining / 1000));
+  const h = String(Math.floor(total / 3600)).padStart(2, '0');
+  const m = String(Math.floor((total % 3600) / 60)).padStart(2, '0');
+  const sec = String(total % 60).padStart(2, '0');
+  return (
+    <div className="rounded-lg bg-emerald-50 p-4">
+      <div className="text-xs uppercase tracking-wide text-emerald-700">{t('claim.heldUntil')}</div>
+      <div className="mt-1 font-mono text-2xl font-bold text-emerald-800">
+        {h}:{m}:{sec}
+      </div>
+      <div className="mt-1 text-xs text-emerald-700">{t('claim.finishBeforeTimer')}</div>
+    </div>
+  );
+}

--- a/client-tenant/src/pages/apply/steps/StepClaim.tsx
+++ b/client-tenant/src/pages/apply/steps/StepClaim.tsx
@@ -2,10 +2,14 @@ import { useEffect, useState } from 'react';
 import { useApply } from '../ApplyContext';
 import { useTranslation } from '@/i18n';
 import { CTA } from '@/components/primitives';
+import { useFlag } from '@/lib/flags';
 
 export function StepClaim() {
   const s = useApply();
   const { t } = useTranslation('apply');
+  // FROZEN CONTRACT 5 — flag off → ?step=2; flag on → ?step=review (wedge point).
+  const wizardEnabled = useFlag('PAYMENT_WIZARD_ENABLED');
+  const nextStep: 'review' | 2 = wizardEnabled ? 'review' : 2;
 
   if (!s.claimedUnit || !s.claimExpiresAt) {
     return (
@@ -37,7 +41,7 @@ export function StepClaim() {
         </p>
       </div>
       <ClaimCountdown expiresAt={s.claimExpiresAt} />
-      <CTA onClick={() => s.setStep(2)}>{t('claim.continue')}</CTA>
+      <CTA onClick={() => s.setStep(nextStep)}>{t('claim.continue')}</CTA>
       <button
         onClick={() => s.setStep('pick')}
         className="text-sm text-gray-500 hover:text-gray-700 hover:underline"

--- a/client-tenant/src/pages/apply/steps/StepConfirm.tsx
+++ b/client-tenant/src/pages/apply/steps/StepConfirm.tsx
@@ -1,0 +1,15 @@
+// Lane W1 placeholder — Lane W2/W3 owns the real implementation.
+import { useNavigate } from 'react-router-dom';
+import { useApply } from '../ApplyContext';
+import { CTA } from '@/components/primitives';
+
+export default function StepConfirm() {
+  const s = useApply();
+  const navigate = useNavigate();
+  return (
+    <div className="space-y-4">
+      <div>TODO Lane W2/W3 — StepConfirm (ref: {s.paymentRef ?? 'pending'})</div>
+      <CTA onClick={() => navigate('/dashboard')}>Done</CTA>
+    </div>
+  );
+}

--- a/client-tenant/src/pages/apply/steps/StepHousehold.tsx
+++ b/client-tenant/src/pages/apply/steps/StepHousehold.tsx
@@ -1,0 +1,15 @@
+// Lane W1 placeholder — Lane W2/W3 owns the real implementation.
+import { useNavigate } from 'react-router-dom';
+import { useApply } from '../ApplyContext';
+import { CTA } from '@/components/primitives';
+
+export default function StepHousehold() {
+  const s = useApply();
+  const navigate = useNavigate();
+  return (
+    <div className="space-y-4">
+      <div>TODO Lane W2/W3 — StepHousehold (adults: {s.adults})</div>
+      <CTA onClick={() => navigate('/apply?step=payment')}>Continue</CTA>
+    </div>
+  );
+}

--- a/client-tenant/src/pages/apply/steps/StepIntent.tsx
+++ b/client-tenant/src/pages/apply/steps/StepIntent.tsx
@@ -1,0 +1,137 @@
+import { useEffect, useRef } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { saveIntent } from '@/api/units';
+import { useApply } from '../ApplyContext';
+import { useTranslation } from '@/i18n';
+import { CTA } from '@/components/primitives';
+
+const BR_KEYS = ['br.studio', 'br.1', 'br.2', 'br.3', 'br.4plus'] as const;
+const BR_VALUES = [0, 1, 2, 3, 4] as const;
+
+// Welcome → Apply handoff: unitType query param → bedroom integer.
+const UNIT_TYPE_TO_BEDROOMS: Record<string, number> = {
+  STUDIO: 0,
+  '1BR': 1,
+  '2BR': 2,
+  '3BR': 3,
+};
+
+export function StepIntent() {
+  const s = useApply();
+  const { t } = useTranslation('apply');
+  const [search] = useSearchParams();
+  const prefilled = useRef(false);
+
+  // Prefill silently from ?unitType= & ?propertyId= (Lane B handoff).
+  useEffect(() => {
+    if (prefilled.current) return;
+    const unitType = search.get('unitType');
+    const propertyId = search.get('propertyId');
+    if (unitType && UNIT_TYPE_TO_BEDROOMS[unitType] !== undefined && s.intentBedrooms === null) {
+      s.setIntentBedrooms(UNIT_TYPE_TO_BEDROOMS[unitType]);
+    }
+    if (propertyId && !s.propertyId) {
+      s.setPropertyId(propertyId);
+    }
+    prefilled.current = true;
+  }, [search, s]);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (s.intentBedrooms === null || !s.intentMoveInDate) return;
+    s.setError(null);
+    s.setLoading(true);
+    try {
+      await saveIntent({
+        bedrooms: s.intentBedrooms,
+        budget_max: s.intentBudgetMax,
+        move_in_date: s.intentMoveInDate,
+        household_size: s.intentHouseholdSize,
+      });
+      s.setHouseholdSize(String(s.intentHouseholdSize));
+      s.setMoveInDate(s.intentMoveInDate);
+      s.setStep('checklist');
+    } catch (err) {
+      s.setError(err instanceof Error ? err.message : t('intent.saveError'));
+    } finally {
+      s.setLoading(false);
+    }
+  }
+
+  return (
+    <>
+      <h1 className="mb-1 text-xl font-bold text-gray-900">{t('intent.title')}</h1>
+      <p className="mb-4 text-sm text-gray-500">{t('intent.subtitle')}</p>
+      <form onSubmit={handleSubmit} className="space-y-5">
+        <div>
+          <label className="label">{t('intent.bedrooms')}</label>
+          <div className="grid grid-cols-5 gap-2">
+            {BR_VALUES.map((val, i) => (
+              <button
+                type="button"
+                key={val}
+                onClick={() => s.setIntentBedrooms(val)}
+                className={`rounded-lg border px-2 py-3 text-sm font-medium transition ${
+                  s.intentBedrooms === val
+                    ? 'border-emerald-600 bg-emerald-50 text-emerald-700'
+                    : 'border-gray-300 bg-white text-gray-700 hover:border-emerald-400'
+                }`}
+              >
+                {t(`intent.${BR_KEYS[i]}`)}
+              </button>
+            ))}
+          </div>
+        </div>
+        <div>
+          <label className="label" htmlFor="budget">
+            {t('intent.budget')}{' '}
+            <span className="font-semibold text-gray-900">
+              ${s.intentBudgetMax.toLocaleString()}
+            </span>
+          </label>
+          <input
+            id="budget"
+            type="range"
+            min={500}
+            max={5000}
+            step={50}
+            value={s.intentBudgetMax}
+            onChange={(e) => s.setIntentBudgetMax(Number(e.target.value))}
+            className="w-full accent-emerald-600"
+          />
+          <div className="mt-1 flex justify-between text-xs text-gray-400">
+            <span>$500</span>
+            <span>$5,000</span>
+          </div>
+        </div>
+        <div>
+          <label className="label" htmlFor="intentMoveIn">{t('intent.moveIn')}</label>
+          <input
+            id="intentMoveIn"
+            type="date"
+            className="input"
+            required
+            value={s.intentMoveInDate}
+            onChange={(e) => s.setIntentMoveInDate(e.target.value)}
+          />
+        </div>
+        <div>
+          <label className="label" htmlFor="intentHousehold">{t('intent.household')}</label>
+          <select
+            id="intentHousehold"
+            className="input"
+            value={s.intentHouseholdSize}
+            onChange={(e) => s.setIntentHouseholdSize(Number(e.target.value))}
+          >
+            {Array.from({ length: 8 }, (_, i) => i + 1).map((n) => (
+              <option key={n} value={n}>{n}</option>
+            ))}
+          </select>
+        </div>
+        <CTA type="submit" disabled={s.loading || s.intentBedrooms === null || !s.intentMoveInDate}>
+          {s.loading ? t('common.saving') : t('intent.submit')}
+        </CTA>
+      </form>
+    </>
+  );
+}

--- a/client-tenant/src/pages/apply/steps/StepPayment.tsx
+++ b/client-tenant/src/pages/apply/steps/StepPayment.tsx
@@ -1,0 +1,15 @@
+// Lane W1 placeholder — Lane W2/W3 owns the real implementation.
+import { useNavigate } from 'react-router-dom';
+import { useApply } from '../ApplyContext';
+import { CTA } from '@/components/primitives';
+
+export default function StepPayment() {
+  const s = useApply();
+  const navigate = useNavigate();
+  return (
+    <div className="space-y-4">
+      <div>TODO Lane W2/W3 — StepPayment (total: {s.paymentTotal})</div>
+      <CTA onClick={() => navigate('/apply?step=2')}>Continue</CTA>
+    </div>
+  );
+}

--- a/client-tenant/src/pages/apply/steps/StepPick.tsx
+++ b/client-tenant/src/pages/apply/steps/StepPick.tsx
@@ -1,0 +1,98 @@
+import { useEffect } from 'react';
+import { Loader2 } from 'lucide-react';
+import { fetchUnits, claimUnit } from '@/api/units';
+import { UnitCard } from '@/components/UnitCard';
+import { useApply } from '../ApplyContext';
+import { useTranslation } from '@/i18n';
+
+const BEDROOMS_INCLUSIVE_MIN = 4;
+
+export function StepPick() {
+  const s = useApply();
+  const { t } = useTranslation('apply');
+
+  // Bounce back to intent if quiz incomplete (deep-link guard).
+  useEffect(() => {
+    if (s.intentBedrooms === null || !s.intentMoveInDate) {
+      s.setStep('intent');
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      s.setUnitsLoading(true);
+      s.setError(null);
+      try {
+        const res = await fetchUnits({
+          ...(s.intentBedrooms! >= BEDROOMS_INCLUSIVE_MIN
+            ? { bedroomsMin: s.intentBedrooms! }
+            : { bedrooms: s.intentBedrooms! }),
+          maxRent: s.intentBudgetMax,
+          moveInBy: s.intentMoveInDate,
+        });
+        if (!cancelled) s.setUnits(res.units);
+      } catch (err) {
+        if (!cancelled) s.setError(err instanceof Error ? err.message : t('pick.loadError'));
+      } finally {
+        if (!cancelled) s.setUnitsLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [s.intentBedrooms, s.intentBudgetMax, s.intentMoveInDate]);
+
+  async function handleClaim(unitId: string) {
+    s.setClaimingUnitId(unitId);
+    s.setError(null);
+    try {
+      const res = await claimUnit(unitId);
+      s.setClaimedUnit(res.unit);
+      s.setClaimExpiresAt(res.expires_at);
+      s.setPropertyId(res.unit.property_id);
+      s.setUnitNumber(res.unit.unit_number);
+      s.setStep('claim');
+    } catch (err) {
+      s.setError(err instanceof Error ? err.message : t('pick.claimError'));
+    } finally {
+      s.setClaimingUnitId(null);
+    }
+  }
+
+  return (
+    <>
+      <h1 className="mb-1 text-xl font-bold text-gray-900">{t('pick.title')}</h1>
+      <p className="mb-4 text-sm text-gray-500">{t('pick.subtitle')}</p>
+      {s.unitsLoading ? (
+        <div className="flex items-center justify-center py-12 text-gray-400">
+          <Loader2 className="mr-2 h-5 w-5 animate-spin" />
+          {t('pick.loading')}
+        </div>
+      ) : s.units.length === 0 ? (
+        <div className="rounded-lg bg-amber-50 p-4 text-sm text-amber-800">
+          {t('pick.noMatch')}{' '}
+          <button onClick={() => s.setStep('intent')} className="font-medium underline">
+            {t('pick.adjust')}
+          </button>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          {s.units.map((u) => (
+            <UnitCard
+              key={u.id}
+              unit={u}
+              onClaim={handleClaim}
+              claiming={s.claimingUnitId === u.id}
+            />
+          ))}
+        </div>
+      )}
+      <button
+        onClick={() => s.setStep('intent')}
+        className="mt-6 text-sm text-gray-500 hover:text-gray-700 hover:underline"
+      >
+        {t('pick.editPrefs')}
+      </button>
+    </>
+  );
+}

--- a/client-tenant/src/pages/apply/steps/StepReview.tsx
+++ b/client-tenant/src/pages/apply/steps/StepReview.tsx
@@ -1,0 +1,15 @@
+// Lane W1 placeholder — Lane W2 owns the real implementation.
+import { useNavigate } from 'react-router-dom';
+import { useApply } from '../ApplyContext';
+import { CTA } from '@/components/primitives';
+
+export default function StepReview() {
+  const s = useApply();
+  const navigate = useNavigate();
+  return (
+    <div className="space-y-4">
+      <div>TODO Lane W2/W3 — StepReview (total: {s.paymentTotal})</div>
+      <CTA onClick={() => navigate('/apply?step=household')}>Continue</CTA>
+    </div>
+  );
+}

--- a/client-tenant/src/pages/apply/steps/StepVerify.tsx
+++ b/client-tenant/src/pages/apply/steps/StepVerify.tsx
@@ -1,0 +1,83 @@
+import { useEffect } from 'react';
+import { Mail } from 'lucide-react';
+import { api, getToken } from '@/api/client';
+import { requestMagicLink } from '@/api/auth';
+import { useApply } from '../ApplyContext';
+import { useTranslation } from '@/i18n';
+import { CTA } from '@/components/primitives';
+
+export function StepVerify() {
+  const s = useApply();
+  const { t } = useTranslation('apply');
+
+  // Verify-stage poll — preserved verbatim from legacy Apply.tsx semantics.
+  // Only polls once a token has been stored (post magic-link verify), else
+  // /auth/me 401 would eject the user to /login.
+  useEffect(() => {
+    if (!getToken()) return;
+    let cancelled = false;
+    async function check() {
+      try {
+        const res = await api.get<{ user?: { email: string; emailVerified: boolean } }>('/auth/me');
+        if (cancelled) return;
+        if (res.user?.emailVerified) s.setStep('intent');
+      } catch {
+        /* 401 handled by client.ts */
+      }
+    }
+    check();
+    const interval = setInterval(check, 5000);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, [s]);
+
+  async function handleResend() {
+    if (!s.email) return;
+    s.setResending(true);
+    s.setError(null);
+    try {
+      await requestMagicLink(s.email);
+      s.setResent(true);
+    } catch (err) {
+      s.setError(err instanceof Error ? err.message : t('verify.resendError'));
+    } finally {
+      s.setResending(false);
+    }
+  }
+
+  return (
+    <div className="space-y-4 text-center">
+      <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-xl bg-emerald-100">
+        <Mail className="h-6 w-6 text-emerald-700" />
+      </div>
+      <h1 className="text-xl font-bold text-gray-900">{t('verify.title')}</h1>
+      <p className="text-sm text-gray-500">
+        {t('verify.body').replace('{email}', s.email)}
+      </p>
+      {s.resent && (
+        <div className="rounded-lg bg-emerald-50 p-3 text-sm text-emerald-700">
+          {t('verify.resent')}
+        </div>
+      )}
+      <CTA onClick={handleResend} disabled={s.resending || !s.email}>
+        {s.resending ? t('verify.resending') : t('verify.resend')}
+      </CTA>
+      {s.devLink && (
+        <a
+          href={s.devLink}
+          className="block rounded-lg border border-amber-300 bg-amber-50 px-4 py-2 text-center text-sm font-medium text-amber-800 hover:bg-amber-100"
+        >
+          {t('verify.devLink')}
+        </a>
+      )}
+      <button
+        onClick={() => s.setStep(1)}
+        className="text-sm text-gray-500 hover:text-gray-700 hover:underline"
+      >
+        {t('verify.useDifferent')}
+      </button>
+    </div>
+  );
+}

--- a/client-tenant/src/test/setup.ts
+++ b/client-tenant/src/test/setup.ts
@@ -1,0 +1,36 @@
+import '@testing-library/jest-dom/vitest';
+import { beforeEach, vi } from 'vitest';
+
+// Node 25's built-in `localStorage` shadows jsdom's and is missing methods
+// like .getItem / .clear when run without --localstorage-file. Install a
+// minimal in-memory polyfill so api/client + i18n behave normally.
+function installLocalStorage() {
+  const w: { localStorage?: Storage } =
+    typeof window !== 'undefined' ? (window as unknown as { localStorage?: Storage }) : {};
+  const probe = w.localStorage ?? (globalThis as unknown as { localStorage?: Storage }).localStorage;
+  if (probe && typeof probe.getItem === 'function' && typeof probe.clear === 'function') return;
+
+  const store = new Map<string, string>();
+  const polyfill: Storage = {
+    get length() { return store.size; },
+    clear() { store.clear(); },
+    getItem(k: string) { return store.has(k) ? store.get(k)! : null; },
+    key(i: number) { return Array.from(store.keys())[i] ?? null; },
+    removeItem(k: string) { store.delete(k); },
+    setItem(k: string, v: string) { store.set(k, String(v)); },
+  };
+  (globalThis as unknown as { localStorage: Storage }).localStorage = polyfill;
+  if (typeof window !== 'undefined') {
+    try {
+      Object.defineProperty(window, 'localStorage', { value: polyfill, configurable: true });
+    } catch { /* ignore */ }
+  }
+}
+
+installLocalStorage();
+
+beforeEach(() => {
+  installLocalStorage();
+  try { localStorage.clear(); } catch { /* ignore */ }
+  vi.restoreAllMocks();
+});

--- a/client-tenant/vitest.config.ts
+++ b/client-tenant/vitest.config.ts
@@ -1,0 +1,19 @@
+/// <reference types="vitest" />
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+import path from 'path';
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./src/test/setup.ts'],
+    include: ['src/**/__tests__/**/*.test.{ts,tsx}'],
+  },
+});


### PR DESCRIPTION
## Summary

Lane W1 of the GPMGLV payment-wizard integration: wires the new step keys, extends `ApplyContext`, adds the shared `PayHeader` primitive, and gates `StepClaim` on `VITE_PAYMENT_WIZARD_ENABLED`. W2/W3 layer real Review / Household / Payment / Confirm pages on top.

## Scope (7 items)

1. **`client-tenant/src/pages/apply/ApplyContext.tsx`** — `Step` union extended with `review | household | payment | confirm` (Contract 1). Adds `adults: number` (default 1), `paymentTotal: string` (computed `$35.95 × (adults+1)` USD), `paymentRef: string | null` (Contract 2). New `useWizState()` hook persists adults + paymentRef to `sessionStorage` at key `frank_apply_state`.
2. **`client-tenant/src/hooks/useApplyProgress.ts`** — `APPLY_STEP_KEYS` extended to `register · verify · intent · checklist · pick · claim · review · household · payment · details · confirm`; `details` (= `?step=2`) sits between `payment` and `confirm`; `confirm` is terminal (Contract 1).
3. **`client-tenant/src/pages/Apply.tsx`** — lazy-imports `StepReview / StepHousehold / StepPayment / StepConfirm`, renders each inside `<Suspense fallback={null}>`, extends `parseStep()` to accept the new keys, and wires `useWizState()` into the `ApplyState` value.
4. **`client-tenant/src/pages/apply/steps/{StepReview,StepHousehold,StepPayment,StepConfirm}.tsx`** — placeholder stubs (each <30 lines, default-export, `useApply()` + `useNavigate()`, Continue → next step). W2/W3 overwrite on merge (Contract 3).
5. **`client-tenant/src/pages/apply/steps/StepClaim.tsx`** — reads `VITE_PAYMENT_WIZARD_ENABLED` via `lib/flags`; flag off → `setStep(2)`; flag on → `setStep('review')` (Contract 5, wedge point).
6. **`client-tenant/src/lib/flags.ts`** + **`client-tenant/.env.example`** — adds `PAYMENT_WIZARD_ENABLED` (defaults OFF, opt-in via `=true`); existing `PROPERTY_DL2_ENABLED` / `MOBILE_APPLY_ENABLED` keep their default-ON contract.
7. **`client-tenant/src/components/primitives/PayHeader.tsx`** + smoke test — 5-segment progress bar, EN/ES labels (`review · household · payment · details · confirm`), optional `onBack`, HF skin only (Tailwind, no Kalam/Caveat). Semantics ported from `/tmp/gpmglv-welcome/015caabf-…`; restyled to HF.

## Frozen contracts honored

- **Contract 1** — full step-key union exported from `ApplyContext.tsx` and `useApplyProgress.ts` in the canonical order. `claim → review` is the wedge; `2` (= `details`) sits after `payment`; `confirm` is terminal.
- **Contract 2** — `adults / paymentTotal / paymentRef` added with the specified defaults and the exact `toLocaleString` formatter; persisted to `sessionStorage` at `frank_apply_state`.
- **Contract 3** — every new step file: default-export React component, reads `useApply()` and `useNavigate()`, <30 lines, HF tokens + Tailwind only.
- **Contract 5** — `VITE_PAYMENT_WIZARD_ENABLED` gate verified: off ⇒ claim → `?step=2`; on ⇒ claim → `?step=review`.

## Base-branch note

Branched from `feat/bp-03b-apply` (canonical apply files live there). `feat/bp-03b-integration` has not yet absorbed Lane D apply, so this PR effectively brings both lanes together. The integrator will need to absorb the 3-line `lib/flags.ts` addition (`PAYMENT_WIZARD_ENABLED`) — straightforward merge.

## Test plan

- [x] `cd client-tenant && npm run build` → green (4 lazy chunks emitted for the new step stubs).
- [x] `npx vitest run` → 9 files, 16 tests passing. PayHeader 4/4. Existing claim → details integration path still green with the flag OFF.
- [ ] Manual: with `VITE_PAYMENT_WIZARD_ENABLED=true`, navigating from claim lands at `?step=review` and renders the W1 stub.
- [ ] Manual: with flag unset/false, claim → `?step=2` (existing behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)