### PR TITLE
fix(messaging): close 5 P0 follow-ups from PR #4

### DIFF
--- a/src/__tests__/messages-routes.test.ts
+++ b/src/__tests__/messages-routes.test.ts
@@ -1,0 +1,235 @@
+/**
+ * PR #4 follow-up P0 tests for the messaging endpoints.
+ *
+ * Covers:
+ *   - P0 #1 / #5 — markRead UPDATE scopes by application_id so an owner of
+ *     one application can no longer flip read_at on a message belonging to
+ *     a different application (IDOR closure).
+ *   - P0 #2 — POST /messages emits standard RateLimit-* headers.
+ *   - P0 #3 — Tenant POST /messages is gated by requireEmailVerified (the
+ *     same WARN #2 floor every other applicant mutating surface uses).
+ *
+ * Strategy: real JWTs decoded against the mocked users DB row, then a
+ * queue-mocked `query` chain matching the order of the route handlers
+ * (authenticate → scopeToOwnApplications → assertApplicationOwnership →
+ * service.markRead).
+ */
+import express from "express";
+import request from "supertest";
+import { generateToken, AuthUser } from "../middleware/auth";
+
+jest.mock("../config/database", () => ({
+  query: jest.fn(),
+  transaction: jest.fn(),
+}));
+jest.mock("../utils/logger", () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+import { query, transaction } from "../config/database";
+import tenantRouter from "../modules/tenant/routes";
+
+const mockQuery = query as jest.MockedFunction<typeof query>;
+const mockTransaction = transaction as jest.MockedFunction<typeof transaction>;
+
+const app = express();
+app.use(express.json());
+app.use("/tenant", tenantRouter);
+
+// Stub the users row that authenticate() reads.
+function mockUsersRow(user: AuthUser, emailVerifiedAt: Date | null) {
+  mockQuery.mockResolvedValueOnce({
+    rows: [
+      {
+        id: user.id,
+        email: user.email,
+        role: user.role,
+        first_name: user.firstName,
+        last_name: user.lastName,
+        property_ids: user.propertyIds ?? [],
+        is_active: true,
+        email_verified_at: emailVerifiedAt,
+      },
+    ],
+  } as any);
+}
+
+// scopeToOwnApplications → SELECT application_id FROM user_applications.
+function mockScopedApps(applicationIds: string[]) {
+  mockQuery.mockResolvedValueOnce({
+    rows: applicationIds.map((id) => ({ application_id: id })),
+  } as any);
+}
+
+// assertApplicationOwnership → SELECT 1 FROM user_applications.
+function mockOwnership(allow: boolean) {
+  mockQuery.mockResolvedValueOnce({
+    rows: allow ? [{ "?column?": 1 }] : [],
+  } as any);
+}
+
+const VERIFIED_AT = new Date("2026-05-14T00:00:00Z");
+
+const verifiedUser: AuthUser = {
+  id: "user-tenant-1",
+  email: "tenant@example.com",
+  role: "tenant",
+  firstName: "T",
+  lastName: "Enant",
+  propertyIds: [],
+  emailVerified: true,
+};
+
+const unverifiedApplicant: AuthUser = {
+  ...verifiedUser,
+  id: "user-applicant-unverified",
+  email: "unverified@example.com",
+  role: "applicant",
+  emailVerified: false,
+};
+
+describe("PR #4 P0 follow-ups — messaging routes", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  describe("P0 #1 / #5 — markRead IDOR scoped by application_id", () => {
+    it("scopes the UPDATE by application_id so a foreign message cannot be flipped", async () => {
+      const ownedAppId = "app-owned-by-user";
+      const foreignMsgId = "msg-belonging-to-another-app";
+      const token = generateToken(verifiedUser);
+
+      mockUsersRow(verifiedUser, VERIFIED_AT);
+      mockScopedApps([ownedAppId]);
+      mockOwnership(true);
+      // markRead UPDATE: 0 rows updated because application_id mismatch
+      // would prune the row in the production query — the test asserts the
+      // SQL/params shape that drives that pruning.
+      mockQuery.mockResolvedValueOnce({ rowCount: 0, rows: [] } as any);
+
+      const res = await request(app)
+        .post(`/tenant/applications/${ownedAppId}/messages/${foreignMsgId}/read`)
+        .set("Authorization", `Bearer ${token}`)
+        .send();
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ updated: false });
+
+      // Inspect the UPDATE call (4th mockQuery invocation: authenticate,
+      // scopeToOwnApplications, assertApplicationOwnership, then markRead).
+      const updateCall = mockQuery.mock.calls[3];
+      expect(updateCall).toBeDefined();
+      const [sql, params] = updateCall as [string, unknown[]];
+      // The scope predicate must be on the UPDATE.
+      expect(sql).toMatch(/application_id\s*=\s*\$2/);
+      expect(sql).toMatch(/UPDATE\s+application_messages/i);
+      // Param positions: [messageId, applicationId, readerUserId]
+      expect(params[0]).toBe(foreignMsgId);
+      expect(params[1]).toBe(ownedAppId);
+      expect(params[2]).toBe(verifiedUser.id);
+    });
+
+    it("returns updated:true when the message legitimately belongs to the owned application", async () => {
+      const ownedAppId = "app-owned-by-user";
+      const ownMsgId = "msg-on-owned-app";
+      const token = generateToken(verifiedUser);
+
+      mockUsersRow(verifiedUser, VERIFIED_AT);
+      mockScopedApps([ownedAppId]);
+      mockOwnership(true);
+      mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [{ id: ownMsgId }] } as any);
+
+      const res = await request(app)
+        .post(`/tenant/applications/${ownedAppId}/messages/${ownMsgId}/read`)
+        .set("Authorization", `Bearer ${token}`)
+        .send();
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ updated: true });
+    });
+  });
+
+  describe("P0 #3 — requireEmailVerified gates tenant message POST", () => {
+    it("rejects an unverified applicant with 403 EMAIL_UNVERIFIED on POST /messages", async () => {
+      const ownedAppId = "app-owned-by-unverified";
+      const token = generateToken(unverifiedApplicant, { emailVerified: false });
+
+      // authenticate users row — email_verified_at is null → emailVerified=false
+      mockUsersRow(unverifiedApplicant, null);
+      // scopeToOwnApplications still runs (it's on the router-level chain)
+      mockScopedApps([ownedAppId]);
+      // requireEmailVerified should short-circuit BEFORE any further DB call.
+
+      const res = await request(app)
+        .post(`/tenant/applications/${ownedAppId}/messages`)
+        .set("Authorization", `Bearer ${token}`)
+        .send({ body: "spam attempt" });
+
+      expect(res.status).toBe(403);
+      expect(res.body.code).toBe("EMAIL_UNVERIFIED");
+    });
+
+    it("rejects an unverified applicant on POST /:msgId/read as well", async () => {
+      const ownedAppId = "app-owned-by-unverified";
+      const someMsgId = "any-msg-id";
+      const token = generateToken(unverifiedApplicant, { emailVerified: false });
+
+      mockUsersRow(unverifiedApplicant, null);
+      mockScopedApps([ownedAppId]);
+
+      const res = await request(app)
+        .post(`/tenant/applications/${ownedAppId}/messages/${someMsgId}/read`)
+        .set("Authorization", `Bearer ${token}`)
+        .send();
+
+      expect(res.status).toBe(403);
+      expect(res.body.code).toBe("EMAIL_UNVERIFIED");
+    });
+  });
+
+  describe("P0 #2 — rate-limit headers present on POST /messages", () => {
+    it("emits RateLimit-* standard headers on a verified message POST", async () => {
+      const ownedAppId = "app-owned-by-user";
+      const token = generateToken(verifiedUser);
+
+      mockUsersRow(verifiedUser, VERIFIED_AT);
+      mockScopedApps([ownedAppId]);
+      mockOwnership(true);
+      // service.create runs in a transaction; stub it to return a hydrated row.
+      mockTransaction.mockImplementationOnce(async (fn: any) => {
+        const client = {
+          query: jest
+            .fn()
+            // INSERT … RETURNING id
+            .mockResolvedValueOnce({ rows: [{ id: "msg-new" }] })
+            // hydrate SELECT
+            .mockResolvedValueOnce({
+              rows: [
+                {
+                  id: "msg-new",
+                  application_id: ownedAppId,
+                  sender_user_id: verifiedUser.id,
+                  sender_role: "tenant",
+                  body: "hi",
+                  created_at: new Date(),
+                  read_at: null,
+                  first_name: "T",
+                  last_name: "Enant",
+                  email: verifiedUser.email,
+                },
+              ],
+            }),
+        };
+        return fn(client);
+      });
+
+      const res = await request(app)
+        .post(`/tenant/applications/${ownedAppId}/messages`)
+        .set("Authorization", `Bearer ${token}`)
+        .send({ body: "hi" });
+
+      expect(res.status).toBe(201);
+      // express-rate-limit with standardHeaders:true emits RateLimit-Limit + Remaining.
+      expect(res.headers["ratelimit-limit"]).toBeDefined();
+      expect(res.headers["ratelimit-remaining"]).toBeDefined();
+    });
+  });
+});

--- a/src/db/migrations/2026-05-21-application-messages-sender-index.sql
+++ b/src/db/migrations/2026-05-21-application-messages-sender-index.sql
@@ -1,0 +1,6 @@
+-- Add FK index on application_messages.sender_user_id (PR #4 follow-up P0 #4)
+-- Reverse-lookup queries (staff offboarding, user → messages, deletions)
+-- otherwise table-scan once message volume grows.
+
+CREATE INDEX IF NOT EXISTS idx_application_messages_sender
+  ON application_messages(sender_user_id);

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -758,6 +758,8 @@ CREATE TABLE application_messages (
 );
 CREATE INDEX idx_application_messages_app_created
   ON application_messages(application_id, created_at DESC);
+CREATE INDEX idx_application_messages_sender
+  ON application_messages(sender_user_id);
 
 -- Audit Log (immutable, append-only)
 CREATE TABLE audit_log (

--- a/src/modules/messages/routes.ts
+++ b/src/modules/messages/routes.ts
@@ -1,5 +1,6 @@
-import { Router, Response } from "express";
+import { Router, Request, Response } from "express";
 import { z } from "zod";
+import rateLimit from "express-rate-limit";
 import { authenticate, AuthRequest } from "../../middleware/auth";
 import { requirePermission } from "../../middleware/rbac";
 import { buildPropertyScope } from "../../middleware/scope";
@@ -13,6 +14,33 @@ const service = new MessagesService();
 
 const bodySchema = z.object({
   body: z.string().trim().min(1).max(4000),
+});
+
+// Per-user limiters for the authenticated messaging surface. Keyed on the
+// authenticated user id (populated by `authenticate`); falls back to a shared
+// "anon" bucket if the limiter ever runs before auth (defensive — the chain
+// below always runs authenticate first).
+const userKey = (req: Request): string => (req as AuthRequest).user?.id ?? "anon";
+
+// Posting a message — tighter cap to mitigate spam from a single account.
+const messageWriteLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 20,
+  keyGenerator: userKey,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: "Too many requests, slow down" },
+});
+
+// Marking a message read — looser, because the staff UI auto-fires this on
+// view of unread applicant/tenant messages.
+const messageReadLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 60,
+  keyGenerator: userKey,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: "Too many requests, slow down" },
 });
 
 /**
@@ -74,6 +102,7 @@ router.get(
 router.post(
   "/:id/messages",
   authenticate,
+  messageWriteLimiter,
   requirePermission("application:read"),
   async (req: AuthRequest, res: Response): Promise<void> => {
     try {
@@ -109,6 +138,7 @@ router.post(
 router.post(
   "/:id/messages/:msgId/read",
   authenticate,
+  messageReadLimiter,
   requirePermission("application:read"),
   async (req: AuthRequest, res: Response): Promise<void> => {
     try {
@@ -117,6 +147,7 @@ router.post(
       if (!(await assertStaffCanAccessApplication(req, res, applicationId))) return;
 
       const ok = await service.markRead({
+        applicationId,
         messageId,
         readerUserId: req.user!.id,
         readerRole: "staff",

--- a/src/modules/messages/service.ts
+++ b/src/modules/messages/service.ts
@@ -83,17 +83,23 @@ export class MessagesService {
    * Mark a message as read by the recipient. Senders may not mark their
    * own messages as read. Returns true if a row was updated.
    *
+   * The applicationId scope on the UPDATE closes the IDOR window where a
+   * route handler verifies ownership of the URL applicationId but the
+   * service-layer mutation only filtered on id — letting an attacker who
+   * owned any one application flip read_at on a foreign message by URL
+   * mismatch. See PR follow-up P0 #1.
+   *
    * Allowed pairings:
    *   - reader is 'staff' AND sender_role is 'applicant'|'tenant'
    *   - reader is 'applicant'|'tenant' AND sender_role is 'staff'
    */
   async markRead(input: {
+    applicationId: string;
     messageId: string;
     readerUserId: string;
     readerRole: SenderRole;
   }): Promise<boolean> {
     const isReaderStaff = input.readerRole === "staff";
-    // Recipient pairing predicate
     const senderRoleCondition = isReaderStaff
       ? "sender_role IN ('applicant','tenant')"
       : "sender_role = 'staff'";
@@ -102,11 +108,12 @@ export class MessagesService {
       `UPDATE application_messages
          SET read_at = NOW()
        WHERE id = $1
+         AND application_id = $2
          AND read_at IS NULL
-         AND sender_user_id <> $2
+         AND sender_user_id <> $3
          AND ${senderRoleCondition}
        RETURNING id`,
-      [input.messageId, input.readerUserId]
+      [input.messageId, input.applicationId, input.readerUserId]
     );
     return result.rowCount! > 0;
   }

--- a/src/modules/tenant/routes.ts
+++ b/src/modules/tenant/routes.ts
@@ -1,11 +1,13 @@
 import { Router, Response } from "express";
 import { z } from "zod";
+import rateLimit from "express-rate-limit";
 import { authenticate, AuthRequest } from "../../middleware/auth";
 import {
   requireTenantRole,
   scopeToOwnApplications,
   ScopedAuthRequest,
   assertApplicationOwnership,
+  requireEmailVerified,
 } from "../../middleware/scope";
 import { query } from "../../config/database";
 import { LedgerService } from "../ledger/service";
@@ -18,6 +20,26 @@ const router: Router = Router();
 const ledger = new LedgerService();
 const maintenance = new MaintenanceService();
 const messages = new MessagesService();
+
+// Per-user write limiter for tenant messaging. Keyed on the authenticated
+// user id (populated by `authenticate` on the router-level chain).
+const tenantUserKey = (req: any): string => req.user?.id ?? "anon";
+const messageWriteLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 20,
+  keyGenerator: tenantUserKey,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: "Too many requests, slow down" },
+});
+const messageReadLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 60,
+  keyGenerator: tenantUserKey,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: "Too many requests, slow down" },
+});
 
 // All tenant routes require auth + applicant/tenant role + scope
 router.use(authenticate, requireTenantRole, scopeToOwnApplications);
@@ -401,6 +423,8 @@ const messageBodySchema = z.object({
 
 router.post(
   "/applications/:applicationId/messages",
+  requireEmailVerified,
+  messageWriteLimiter,
   async (req: AuthRequest, res: Response) => {
     try {
       const applicationId = param(req.params.applicationId);
@@ -438,6 +462,8 @@ router.post(
 // ---------------------------------------------------------------
 router.post(
   "/applications/:applicationId/messages/:msgId/read",
+  requireEmailVerified,
+  messageReadLimiter,
   async (req: AuthRequest, res: Response) => {
     try {
       const applicationId = param(req.params.applicationId);
@@ -446,6 +472,7 @@ router.post(
 
       const readerRole = (req.user!.role === "tenant" ? "tenant" : "applicant") as SenderRole;
       const ok = await messages.markRead({
+        applicationId,
         messageId,
         readerUserId: req.user!.id,
         readerRole,


### PR DESCRIPTION
## Summary

Closes the 5 P0 caveats from the PR #4 messaging audit (deferred during W0).

- **P0 #1 / #5 — IDOR closure on `markRead`.** `service.markRead` UPDATE is now scoped by `application_id` in addition to `id`. Previously a user who owned any one application could flip `read_at` on a foreign message by URL mismatch (route verified URL appId but the mutation only filtered on `id`).
- **P0 #2 — Per-user rate limits on messaging.** `express-rate-limit` keyed off `req.user.id` on both staff (`src/modules/messages/routes.ts`) and tenant (`src/modules/tenant/routes.ts`) surfaces — 20/min write, 60/min read. Read is looser because the staff UI auto-fires mark-read on view.
- **P0 #3 — `requireEmailVerified` gate on tenant messaging.** Tenant POST `/messages` + mark-read now match the WARN #2 floor used by every other applicant mutating surface. Unverified accounts get 403 + `code: "EMAIL_UNVERIFIED"`.
- **P0 #4 — FK index on `application_messages.sender_user_id`.** Dated additive migration + `schema.ts` mirror. Closes the reverse-lookup hot path (staff offboarding, user-deletion sweeps, future "messages by sender" admin queries).

## Test plan

- [x] `src/__tests__/messages-routes.test.ts` — 5 new jest cases:
  - IDOR test: asserts the UPDATE SQL contains `application_id = $2` and that params bind `[messageId, applicationId, readerUserId]` in that order; `updated:false` returned when the foreign appId/msgId pairing would prune the row.
  - Happy path: `updated:true` returned when message legitimately belongs to the owned application.
  - `requireEmailVerified` 403 on POST /messages for unverified applicant.
  - `requireEmailVerified` 403 on POST /:msgId/read for unverified applicant.
  - `RateLimit-Limit` + `RateLimit-Remaining` headers present on a successful POST /messages.
- [x] Full server suite: 789 passed, 0 failed (38 suites, 1 pre-existing skipped).
- [x] `npx tsc --noEmit` clean.
- [ ] Apply migration on staging before merging (`2026-05-21-application-messages-sender-index.sql` — `CREATE INDEX IF NOT EXISTS`, safe to re-run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)