### PR TITLE
fix(applicants): redact /register INFO log payload (closes INFO-4)

### DIFF
--- a/src/modules/applicants/routes.ts
+++ b/src/modules/applicants/routes.ts
@@ -100,7 +100,12 @@ router.post("/register", registerLimiter, async (req: Request, res: Response): P
     const link = await createMagicLink(email);
     if (link) logMagicLink(email, link.link);
 
-    logger.info("Applicant registered", { userId, email, isNew, isStaffEmail });
+    // INFO-level payload is deliberately minimal: log-aggregation viewers
+    // (Railway, Datadog, etc.) cannot pivot on userId/isNew/isStaffEmail to
+    // distinguish which /register branch a given email took. Closes INFO-4
+    // fingerprinting from the W6 re-audit (2026-05-14). Per-path detail is
+    // still derivable via DB lookup on `email` for legitimate operator use.
+    logger.info("Register attempt", { email });
 
     // W6: uniform response for all paths — no token or user ever returned from
     // /register. The client must wait for the magic-link click; token+user are


### PR DESCRIPTION
## Summary
Closes INFO-4 from the W6 tenant-portal re-audit (2026-05-14).

The INFO-level \`Applicant registered\` log on \`POST /applicants/register\` included \`userId\`, \`isNew\`, and \`isStaffEmail\` — letting log-aggregation viewers (Railway, Datadog, etc.) pivot a single email across the new-user / existing-user / staff branches without DB access.

Reduce the INFO payload to \`{ email }\` only. Per-path detail is still derivable via DB lookup on the email for legitimate operator use; it just cannot be reconstructed from the log stream alone.

## Changes
- \`src/modules/applicants/routes.ts\` — single line: \`logger.info(\"Applicant registered\", { userId, email, isNew, isStaffEmail })\` → \`logger.info(\"Register attempt\", { email })\`, plus a comment explaining the constraint.

## Verification
- \`npx tsc --noEmit\` clean
- \`applicants-rate-limit.test.ts\` + \`applicants-routes-warn2.test.ts\` pass
- Full server suite: 789 tests passing
- Visible-from-logs delta confirmed by diff inspection

## Test plan
- [ ] Hit \`/applicants/register\` for a new email, an existing applicant email, and a staff email — confirm Railway logs show only \`{ email }\` for all three
- [ ] Confirm DB-side path reconstruction still works for operator queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)