### PR TITLE
refactor(apply): migrate 5 step bodies + UnitCard + PropertySelector to HF

### DIFF
--- a/client-tenant/src/components/UnitCard.tsx
+++ b/client-tenant/src/components/UnitCard.tsx
@@ -1,5 +1,7 @@
 import { Bed, Bath, Square } from 'lucide-react';
 import type { Unit } from '@/api/units';
+import { CTA } from '@/components/primitives';
+import { HF } from '@/styles/tokens';
 
 interface Props {
   unit: Unit;
@@ -12,13 +14,34 @@ function formatRent(rent: string | number): string {
   return `$${Math.round(n).toLocaleString()}/mo`;
 }
 
+const chipStyle = {
+  background: HF.cream,
+  color: HF.ink3,
+  border: `1px solid ${HF.border}`,
+  borderRadius: HF.r.pill,
+  padding: '4px 8px',
+  fontFamily: HF.body,
+} as const;
+
 export function UnitCard({ unit, onClaim, claiming }: Props) {
   const photo = unit.photo_url || `https://picsum.photos/seed/${unit.id.slice(0, 8)}/800/600`;
   const location = [unit.property_city, unit.property_state].filter(Boolean).join(', ');
 
   return (
-    <div className="overflow-hidden rounded-xl bg-white shadow-sm ring-1 ring-gray-200">
-      <div className="aspect-[16/9] w-full overflow-hidden bg-gray-100">
+    <div
+      className="overflow-hidden"
+      style={{
+        background: HF.paper,
+        border: `1px solid ${HF.border}`,
+        borderRadius: HF.r.lg,
+        boxShadow: HF.shadow.sm,
+        fontFamily: HF.body,
+      }}
+    >
+      <div
+        className="aspect-[16/9] w-full overflow-hidden"
+        style={{ background: HF.cream }}
+      >
         <img
           src={photo}
           alt={`Unit ${unit.unit_number}`}
@@ -28,39 +51,45 @@ export function UnitCard({ unit, onClaim, claiming }: Props) {
       </div>
       <div className="space-y-3 p-4">
         <div>
-          <h3 className="text-base font-semibold text-gray-900">
+          <h3
+            className="text-base font-semibold"
+            style={{ color: HF.ink, fontFamily: HF.display }}
+          >
             {unit.property_name} · Unit {unit.unit_number}
           </h3>
-          {location && <p className="text-xs text-gray-500">{location}</p>}
+          {location && (
+            <p className="text-xs" style={{ color: HF.ink3 }}>{location}</p>
+          )}
         </div>
 
-        <div className="text-lg font-bold text-emerald-700">{formatRent(unit.monthly_rent)}</div>
+        <div className="text-lg font-bold" style={{ color: HF.accent }}>
+          {formatRent(unit.monthly_rent)}
+        </div>
 
-        <div className="flex flex-wrap gap-2 text-xs text-gray-600">
-          <span className="inline-flex items-center gap-1 rounded-full bg-gray-100 px-2 py-1">
+        <div className="flex flex-wrap gap-2 text-xs">
+          <span className="inline-flex items-center gap-1" style={chipStyle}>
             <Bed className="h-3 w-3" />
             {unit.bedrooms === 0 ? 'Studio' : `${unit.bedrooms} bd`}
           </span>
-          <span className="inline-flex items-center gap-1 rounded-full bg-gray-100 px-2 py-1">
+          <span className="inline-flex items-center gap-1" style={chipStyle}>
             <Bath className="h-3 w-3" />
             {unit.bathrooms} ba
           </span>
           {unit.sqft != null && (
-            <span className="inline-flex items-center gap-1 rounded-full bg-gray-100 px-2 py-1">
+            <span className="inline-flex items-center gap-1" style={chipStyle}>
               <Square className="h-3 w-3" />
               {unit.sqft} sqft
             </span>
           )}
         </div>
 
-        <button
+        <CTA
           type="button"
           onClick={() => onClaim(unit.id)}
           disabled={claiming}
-          className="btn-primary w-full"
         >
           {claiming ? 'Claiming…' : 'Claim this unit'}
-        </button>
+        </CTA>
       </div>
     </div>
   );

--- a/client-tenant/src/pages/apply/steps/PropertySelector.tsx
+++ b/client-tenant/src/pages/apply/steps/PropertySelector.tsx
@@ -2,8 +2,30 @@ import { useEffect } from 'react';
 import { api } from '@/api/client';
 import { useApply } from '../ApplyContext';
 import { useTranslation } from 'react-i18next';
+import { HF } from '@/styles/tokens';
 
 interface Property { id: string; name: string; city?: string; state?: string; }
+
+const labelStyle = {
+  display: 'block',
+  marginBottom: 4,
+  fontSize: 13,
+  fontWeight: 500,
+  color: HF.ink,
+  fontFamily: HF.body,
+} as const;
+
+const inputStyle = {
+  width: '100%',
+  borderRadius: HF.r.sm,
+  border: `1px solid ${HF.border}`,
+  padding: '8px 12px',
+  fontSize: 14,
+  background: HF.paper,
+  color: HF.ink,
+  fontFamily: HF.body,
+  outline: 'none',
+} as const;
 
 // Property + unit-number sub-form used by Step2Details when there is no claim.
 export function PropertySelector() {
@@ -33,13 +55,13 @@ export function PropertySelector() {
   return (
     <>
       <div>
-        <label className="label" htmlFor="propertyId">{t('details.property')}</label>
+        <label style={labelStyle} htmlFor="propertyId">{t('details.property')}</label>
         {s.propertiesLoading ? (
-          <p className="text-sm text-gray-400">{t('details.loadingProperties')}</p>
+          <p className="text-sm" style={{ color: HF.ink3 }}>{t('details.loadingProperties')}</p>
         ) : s.propertiesFailed || s.properties.length === 0 ? (
-          <input id="propertyId" className="input" required placeholder={t('details.propertyPlaceholder')} value={s.propertyId} onChange={(e) => s.setPropertyId(e.target.value)} />
+          <input id="propertyId" style={inputStyle} required placeholder={t('details.propertyPlaceholder')} value={s.propertyId} onChange={(e) => s.setPropertyId(e.target.value)} />
         ) : (
-          <select id="propertyId" className="input" required value={s.propertyId} onChange={(e) => s.setPropertyId(e.target.value)}>
+          <select id="propertyId" style={inputStyle} required value={s.propertyId} onChange={(e) => s.setPropertyId(e.target.value)}>
             <option value="">{t('details.selectProperty')}</option>
             {s.properties.map((p) => (
               <option key={p.id} value={p.id}>
@@ -50,8 +72,8 @@ export function PropertySelector() {
         )}
       </div>
       <div>
-        <label className="label" htmlFor="unitNumber">{t('details.unitNumber')}</label>
-        <input id="unitNumber" className="input" value={s.unitNumber} onChange={(e) => s.setUnitNumber(e.target.value)} placeholder={t('details.unitOptional')} />
+        <label style={labelStyle} htmlFor="unitNumber">{t('details.unitNumber')}</label>
+        <input id="unitNumber" style={inputStyle} value={s.unitNumber} onChange={(e) => s.setUnitNumber(e.target.value)} placeholder={t('details.unitOptional')} />
       </div>
     </>
   );

--- a/client-tenant/src/pages/apply/steps/Step1Register.tsx
+++ b/client-tenant/src/pages/apply/steps/Step1Register.tsx
@@ -2,6 +2,28 @@ import { api } from '@/api/client';
 import { useApply } from '../ApplyContext';
 import { useTranslation } from 'react-i18next';
 import { CTA } from '@/components/primitives';
+import { HF } from '@/styles/tokens';
+
+const labelStyle = {
+  display: 'block',
+  marginBottom: 4,
+  fontSize: 13,
+  fontWeight: 500,
+  color: HF.ink,
+  fontFamily: HF.body,
+} as const;
+
+const inputStyle = {
+  width: '100%',
+  borderRadius: HF.r.sm,
+  border: `1px solid ${HF.border}`,
+  padding: '8px 12px',
+  fontSize: 14,
+  background: HF.paper,
+  color: HF.ink,
+  fontFamily: HF.body,
+  outline: 'none',
+} as const;
 
 export function Step1Register() {
   const s = useApply();
@@ -29,24 +51,29 @@ export function Step1Register() {
 
   return (
     <>
-      <h1 className="mb-4 text-xl font-bold text-gray-900">{t('register.title')}</h1>
+      <h1
+        className="mb-4 text-xl font-bold"
+        style={{ fontFamily: HF.display, color: HF.ink }}
+      >
+        {t('register.title')}
+      </h1>
       <form onSubmit={handleSubmit} className="space-y-4">
         <div className="grid grid-cols-2 gap-3">
           <div>
-            <label className="label" htmlFor="firstName">{t('register.firstName')}</label>
+            <label style={labelStyle} htmlFor="firstName">{t('register.firstName')}</label>
             <input
               id="firstName"
-              className="input"
+              style={inputStyle}
               required
               value={s.firstName}
               onChange={(e) => s.setFirstName(e.target.value)}
             />
           </div>
           <div>
-            <label className="label" htmlFor="lastName">{t('register.lastName')}</label>
+            <label style={labelStyle} htmlFor="lastName">{t('register.lastName')}</label>
             <input
               id="lastName"
-              className="input"
+              style={inputStyle}
               required
               value={s.lastName}
               onChange={(e) => s.setLastName(e.target.value)}
@@ -54,22 +81,22 @@ export function Step1Register() {
           </div>
         </div>
         <div>
-          <label className="label" htmlFor="regEmail">{t('register.email')}</label>
+          <label style={labelStyle} htmlFor="regEmail">{t('register.email')}</label>
           <input
             id="regEmail"
             type="email"
-            className="input"
+            style={inputStyle}
             required
             value={s.email}
             onChange={(e) => s.setEmail(e.target.value)}
           />
         </div>
         <div>
-          <label className="label" htmlFor="phone">{t('register.phone')}</label>
+          <label style={labelStyle} htmlFor="phone">{t('register.phone')}</label>
           <input
             id="phone"
             type="tel"
-            className="input"
+            style={inputStyle}
             value={s.phone}
             onChange={(e) => s.setPhone(e.target.value)}
             placeholder={t('register.phonePlaceholder')}

--- a/client-tenant/src/pages/apply/steps/Step2Details.tsx
+++ b/client-tenant/src/pages/apply/steps/Step2Details.tsx
@@ -3,7 +3,29 @@ import { api } from '@/api/client';
 import { useApply } from '../ApplyContext';
 import { useTranslation } from 'react-i18next';
 import { CTA, FormGrid } from '@/components/primitives';
+import { HF } from '@/styles/tokens';
 import { PropertySelector } from './PropertySelector';
+
+const labelStyle = {
+  display: 'block',
+  marginBottom: 4,
+  fontSize: 13,
+  fontWeight: 500,
+  color: HF.ink,
+  fontFamily: HF.body,
+} as const;
+
+const inputStyle = {
+  width: '100%',
+  borderRadius: HF.r.sm,
+  border: `1px solid ${HF.border}`,
+  padding: '8px 12px',
+  fontSize: 14,
+  background: HF.paper,
+  color: HF.ink,
+  fontFamily: HF.body,
+  outline: 'none',
+} as const;
 
 export function Step2Details() {
   const s = useApply();
@@ -54,50 +76,55 @@ export function Step2Details() {
 
   return (
     <>
-      <h1 className="mb-4 text-xl font-bold text-gray-900">{t('details.title')}</h1>
+      <h1
+        className="mb-4 text-xl font-bold"
+        style={{ fontFamily: HF.display, color: HF.ink }}
+      >
+        {t('details.title')}
+      </h1>
       <form onSubmit={handleSubmit} className="space-y-4">
         {!s.claimedUnit && <PropertySelector />}
         <FormGrid columns={2}>
           <div>
-            <label className="label" htmlFor="ssn">{t('details.ssn')}</label>
-            <input id="ssn" className="input" required placeholder={t('details.ssnPlaceholder')} value={s.ssn} onChange={(e) => s.setSsn(e.target.value)} onBlur={() => validateSsn(s.ssn)} />
-            {s.ssnError && <p className="mt-1 text-xs text-red-600">{s.ssnError}</p>}
+            <label style={labelStyle} htmlFor="ssn">{t('details.ssn')}</label>
+            <input id="ssn" style={inputStyle} required placeholder={t('details.ssnPlaceholder')} value={s.ssn} onChange={(e) => s.setSsn(e.target.value)} onBlur={() => validateSsn(s.ssn)} />
+            {s.ssnError && <p className="mt-1 text-xs" style={{ color: HF.err }}>{s.ssnError}</p>}
           </div>
           <div>
-            <label className="label" htmlFor="dob">{t('details.dob')}</label>
-            <input id="dob" type="date" className="input" required value={s.dateOfBirth} onChange={(e) => s.setDateOfBirth(e.target.value)} />
+            <label style={labelStyle} htmlFor="dob">{t('details.dob')}</label>
+            <input id="dob" type="date" style={inputStyle} required value={s.dateOfBirth} onChange={(e) => s.setDateOfBirth(e.target.value)} />
           </div>
         </FormGrid>
         <div>
-          <label className="label" htmlFor="address">{t('details.address')}</label>
-          <input id="address" className="input" value={s.addressLine1} onChange={(e) => s.setAddressLine1(e.target.value)} />
+          <label style={labelStyle} htmlFor="address">{t('details.address')}</label>
+          <input id="address" style={inputStyle} value={s.addressLine1} onChange={(e) => s.setAddressLine1(e.target.value)} />
         </div>
         <div className="grid grid-cols-3 gap-2">
           <div>
-            <label className="label" htmlFor="city">{t('details.city')}</label>
-            <input id="city" className="input" value={s.city} onChange={(e) => s.setCity(e.target.value)} />
+            <label style={labelStyle} htmlFor="city">{t('details.city')}</label>
+            <input id="city" style={inputStyle} value={s.city} onChange={(e) => s.setCity(e.target.value)} />
           </div>
           <div>
-            <label className="label" htmlFor="state">{t('details.state')}</label>
-            <input id="state" className="input" maxLength={2} placeholder="NV" value={s.state} onChange={(e) => s.setState(e.target.value.toUpperCase())} />
+            <label style={labelStyle} htmlFor="state">{t('details.state')}</label>
+            <input id="state" style={inputStyle} maxLength={2} placeholder="NV" value={s.state} onChange={(e) => s.setState(e.target.value.toUpperCase())} />
           </div>
           <div>
-            <label className="label" htmlFor="zip">{t('details.zip')}</label>
-            <input id="zip" className="input" maxLength={10} value={s.zip} onChange={(e) => s.setZip(e.target.value)} />
+            <label style={labelStyle} htmlFor="zip">{t('details.zip')}</label>
+            <input id="zip" style={inputStyle} maxLength={10} value={s.zip} onChange={(e) => s.setZip(e.target.value)} />
           </div>
         </div>
         <div>
-          <label className="label" htmlFor="employer">{t('details.employer')}</label>
-          <input id="employer" className="input" value={s.employerName} onChange={(e) => s.setEmployerName(e.target.value)} />
+          <label style={labelStyle} htmlFor="employer">{t('details.employer')}</label>
+          <input id="employer" style={inputStyle} value={s.employerName} onChange={(e) => s.setEmployerName(e.target.value)} />
         </div>
         <FormGrid columns={2}>
           <div>
-            <label className="label" htmlFor="income">{t('details.income')}</label>
-            <input id="income" type="number" min={0} className="input" value={s.annualIncome} onChange={(e) => s.setAnnualIncome(e.target.value)} />
+            <label style={labelStyle} htmlFor="income">{t('details.income')}</label>
+            <input id="income" type="number" min={0} style={inputStyle} value={s.annualIncome} onChange={(e) => s.setAnnualIncome(e.target.value)} />
           </div>
           <div>
-            <label className="label" htmlFor="household">{t('details.household')}</label>
-            <select id="household" className="input" required value={s.householdSize} onChange={(e) => s.setHouseholdSize(e.target.value)}>
+            <label style={labelStyle} htmlFor="household">{t('details.household')}</label>
+            <select id="household" style={inputStyle} required value={s.householdSize} onChange={(e) => s.setHouseholdSize(e.target.value)}>
               {Array.from({ length: 8 }, (_, i) => i + 1).map((n) => (
                 <option key={n} value={n}>{n}</option>
               ))}
@@ -105,8 +132,8 @@ export function Step2Details() {
           </div>
         </FormGrid>
         <div>
-          <label className="label" htmlFor="moveIn">{t('details.moveIn')}</label>
-          <input id="moveIn" type="date" className="input" value={s.moveInDate} onChange={(e) => s.setMoveInDate(e.target.value)} />
+          <label style={labelStyle} htmlFor="moveIn">{t('details.moveIn')}</label>
+          <input id="moveIn" type="date" style={inputStyle} value={s.moveInDate} onChange={(e) => s.setMoveInDate(e.target.value)} />
         </div>
         <div className="flex gap-3">
           <CTA type="button" tone="secondary" block={false} className="flex-1" onClick={() => s.setStep(s.claimedUnit ? 'claim' : 1)}>

--- a/client-tenant/src/pages/apply/steps/StepIntent.tsx
+++ b/client-tenant/src/pages/apply/steps/StepIntent.tsx
@@ -4,6 +4,7 @@ import { saveIntent } from '@/api/units';
 import { useApply } from '../ApplyContext';
 import { useTranslation } from 'react-i18next';
 import { CTA } from '@/components/primitives';
+import { HF } from '@/styles/tokens';
 import { formatAmiTier, qualifyAmiTier, type AmiTier } from '@/lib/ami';
 
 const BR_KEYS = ['br.studio', 'br.1', 'br.2', 'br.3', 'br.4plus'] as const;
@@ -19,6 +20,27 @@ const UNIT_TYPE_TO_BEDROOMS: Record<string, number> = {
   '2BR': 2,
   '3BR': 3,
 };
+
+const labelStyle = {
+  display: 'block',
+  marginBottom: 4,
+  fontSize: 13,
+  fontWeight: 500,
+  color: HF.ink,
+  fontFamily: HF.body,
+} as const;
+
+const inputStyle = {
+  width: '100%',
+  borderRadius: HF.r.sm,
+  border: `1px solid ${HF.border}`,
+  padding: '8px 12px',
+  fontSize: 14,
+  background: HF.paper,
+  color: HF.ink,
+  fontFamily: HF.body,
+  outline: 'none',
+} as const;
 
 export function StepIntent() {
   const s = useApply();
@@ -122,32 +144,45 @@ export function StepIntent() {
 
   return (
     <>
-      <h1 className="mb-1 text-xl font-bold text-gray-900">{t('intent.title')}</h1>
-      <p className="mb-4 text-sm text-gray-500">{t('intent.subtitle')}</p>
+      <h1
+        className="mb-1 text-xl font-bold"
+        style={{ fontFamily: HF.display, color: HF.ink }}
+      >
+        {t('intent.title')}
+      </h1>
+      <p className="mb-4 text-sm" style={{ color: HF.ink3 }}>{t('intent.subtitle')}</p>
       <form onSubmit={handleSubmit} className="space-y-5">
         <div>
-          <label className="label">{t('intent.bedrooms')}</label>
+          <label style={labelStyle}>{t('intent.bedrooms')}</label>
           <div className="grid grid-cols-5 gap-2">
-            {BR_VALUES.map((val, i) => (
-              <button
-                type="button"
-                key={val}
-                onClick={() => s.setIntentBedrooms(val)}
-                className={`rounded-lg border px-2 py-3 text-sm font-medium transition ${
-                  s.intentBedrooms === val
-                    ? 'border-emerald-600 bg-emerald-50 text-emerald-700'
-                    : 'border-gray-300 bg-white text-gray-700 hover:border-emerald-400'
-                }`}
-              >
-                {t(`intent.${BR_KEYS[i]}`)}
-              </button>
-            ))}
+            {BR_VALUES.map((val, i) => {
+              const active = s.intentBedrooms === val;
+              return (
+                <button
+                  type="button"
+                  key={val}
+                  onClick={() => s.setIntentBedrooms(val)}
+                  className="px-2 py-3 text-sm transition"
+                  style={{
+                    borderRadius: HF.r.sm,
+                    border: `1px solid ${active ? HF.accent : HF.border}`,
+                    background: active ? HF.accentLo : HF.paper,
+                    color: active ? HF.accentInk : HF.ink,
+                    fontWeight: active ? 600 : 500,
+                    fontFamily: HF.body,
+                    cursor: 'pointer',
+                  }}
+                >
+                  {t(`intent.${BR_KEYS[i]}`)}
+                </button>
+              );
+            })}
           </div>
         </div>
         <div>
-          <label className="label" htmlFor="budget">
+          <label style={labelStyle} htmlFor="budget">
             {t('intent.budget')}{' '}
-            <span className="font-semibold text-gray-900">
+            <span style={{ fontWeight: 700, color: HF.ink }}>
               ${s.intentBudgetMax.toLocaleString()}
             </span>
           </label>
@@ -159,29 +194,30 @@ export function StepIntent() {
             step={50}
             value={s.intentBudgetMax}
             onChange={(e) => s.setIntentBudgetMax(Number(e.target.value))}
-            className="w-full accent-emerald-600"
+            className="w-full"
+            style={{ accentColor: HF.accent }}
           />
-          <div className="mt-1 flex justify-between text-xs text-gray-400">
+          <div className="mt-1 flex justify-between text-xs" style={{ color: HF.ink3 }}>
             <span>$500</span>
             <span>$5,000</span>
           </div>
         </div>
         <div>
-          <label className="label" htmlFor="intentMoveIn">{t('intent.moveIn')}</label>
+          <label style={labelStyle} htmlFor="intentMoveIn">{t('intent.moveIn')}</label>
           <input
             id="intentMoveIn"
             type="date"
-            className="input"
+            style={inputStyle}
             required
             value={s.intentMoveInDate}
             onChange={(e) => s.setIntentMoveInDate(e.target.value)}
           />
         </div>
         <div>
-          <label className="label" htmlFor="intentHousehold">{t('intent.household')}</label>
+          <label style={labelStyle} htmlFor="intentHousehold">{t('intent.household')}</label>
           <select
             id="intentHousehold"
-            className="input"
+            style={inputStyle}
             value={s.intentHouseholdSize}
             onChange={(e) => s.setIntentHouseholdSize(Number(e.target.value))}
           >
@@ -191,9 +227,9 @@ export function StepIntent() {
           </select>
         </div>
         <div>
-          <label className="label" htmlFor="intentIncome">
+          <label style={labelStyle} htmlFor="intentIncome">
             Gross annual income (USD)
-            <span className="ml-2 text-xs font-normal text-gray-400">
+            <span className="ml-2 text-xs" style={{ fontWeight: 400, color: HF.ink3 }}>
               Optional — used to pre-qualify you for affordable units.
             </span>
           </label>
@@ -201,7 +237,7 @@ export function StepIntent() {
             id="intentIncome"
             type="text"
             inputMode="numeric"
-            className="input"
+            style={inputStyle}
             placeholder="e.g. 42000"
             value={incomeStr}
             onChange={(e) => setIncomeStr(e.target.value)}
@@ -214,11 +250,11 @@ export function StepIntent() {
             className="mt-2 min-h-[1.25rem] text-xs"
           >
             {incomeNum == null ? null : previewTier ? (
-              <span className="font-medium text-emerald-700">
+              <span style={{ fontWeight: 500, color: HF.sage }}>
                 You qualify for {formatAmiTier(previewTier)} units.
               </span>
             ) : (
-              <span className="font-medium text-amber-700">
+              <span style={{ fontWeight: 500, color: HF.warn }}>
                 Over income for affordable tiers. Market-rate units may still fit.
               </span>
             )}

--- a/client-tenant/src/pages/apply/steps/StepPick.tsx
+++ b/client-tenant/src/pages/apply/steps/StepPick.tsx
@@ -4,6 +4,7 @@ import { fetchUnits, claimUnit } from '@/api/units';
 import { UnitCard } from '@/components/UnitCard';
 import { useApply } from '../ApplyContext';
 import { useTranslation } from 'react-i18next';
+import { HF } from '@/styles/tokens';
 
 const BEDROOMS_INCLUSIVE_MIN = 4;
 
@@ -64,17 +65,37 @@ export function StepPick() {
 
   return (
     <>
-      <h1 className="mb-1 text-xl font-bold text-gray-900">{t('pick.title')}</h1>
-      <p className="mb-4 text-sm text-gray-500">{t('pick.subtitle')}</p>
+      <h1
+        className="mb-1 text-xl font-bold"
+        style={{ fontFamily: HF.display, color: HF.ink }}
+      >
+        {t('pick.title')}
+      </h1>
+      <p className="mb-4 text-sm" style={{ color: HF.ink3 }}>{t('pick.subtitle')}</p>
       {s.unitsLoading ? (
-        <div className="flex items-center justify-center py-12 text-gray-400">
+        <div
+          className="flex items-center justify-center py-12"
+          style={{ color: HF.ink3 }}
+        >
           <Loader2 className="mr-2 h-5 w-5 animate-spin" />
           {t('pick.loading')}
         </div>
       ) : s.units.length === 0 ? (
-        <div className="rounded-lg bg-amber-50 p-4 text-sm text-amber-800">
+        <div
+          className="p-4 text-sm"
+          style={{
+            background: `${HF.warn}14`,
+            color: HF.warn,
+            border: `1px solid ${HF.warn}33`,
+            borderRadius: HF.r.sm,
+          }}
+        >
           {t('pick.noMatch')}{' '}
-          <button onClick={() => s.setStep('intent')} className="font-medium underline">
+          <button
+            onClick={() => s.setStep('intent')}
+            className="font-medium underline"
+            style={{ color: HF.warn }}
+          >
             {t('pick.adjust')}
           </button>
         </div>
@@ -92,7 +113,8 @@ export function StepPick() {
       )}
       <button
         onClick={() => s.setStep('intent')}
-        className="mt-6 text-sm text-gray-500 hover:text-gray-700 hover:underline"
+        className="mt-6 text-sm hover:underline"
+        style={{ color: HF.ink3 }}
       >
         {t('pick.editPrefs')}
       </button>

--- a/client-tenant/src/pages/apply/steps/StepVerify.tsx
+++ b/client-tenant/src/pages/apply/steps/StepVerify.tsx
@@ -5,6 +5,7 @@ import { requestMagicLink } from '@/api/auth';
 import { useApply } from '../ApplyContext';
 import { useTranslation } from 'react-i18next';
 import { CTA } from '@/components/primitives';
+import { HF } from '@/styles/tokens';
 
 export function StepVerify() {
   const s = useApply();
@@ -49,15 +50,30 @@ export function StepVerify() {
 
   return (
     <div className="space-y-4 text-center">
-      <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-xl bg-emerald-100">
-        <Mail className="h-6 w-6 text-emerald-700" />
+      <div
+        className="mx-auto flex h-12 w-12 items-center justify-center"
+        style={{ background: HF.sageLo, borderRadius: HF.r.md }}
+      >
+        <Mail className="h-6 w-6" style={{ color: HF.sage }} />
       </div>
-      <h1 className="text-xl font-bold text-gray-900">{t('verify.title')}</h1>
-      <p className="text-sm text-gray-500">
+      <h1
+        className="text-xl font-bold"
+        style={{ fontFamily: HF.display, color: HF.ink }}
+      >
+        {t('verify.title')}
+      </h1>
+      <p className="text-sm" style={{ color: HF.ink3 }}>
         {t('verify.body').replace('{email}', s.email)}
       </p>
       {s.resent && (
-        <div className="rounded-lg bg-emerald-50 p-3 text-sm text-emerald-700">
+        <div
+          className="p-3 text-sm"
+          style={{
+            background: HF.sageLo,
+            color: HF.sage,
+            borderRadius: HF.r.sm,
+          }}
+        >
           {t('verify.resent')}
         </div>
       )}
@@ -67,14 +83,21 @@ export function StepVerify() {
       {s.devLink && (
         <a
           href={s.devLink}
-          className="block rounded-lg border border-amber-300 bg-amber-50 px-4 py-2 text-center text-sm font-medium text-amber-800 hover:bg-amber-100"
+          className="block px-4 py-2 text-center text-sm font-medium"
+          style={{
+            background: `${HF.warn}14`,
+            color: HF.warn,
+            border: `1px solid ${HF.warn}55`,
+            borderRadius: HF.r.sm,
+          }}
         >
           {t('verify.devLink')}
         </a>
       )}
       <button
         onClick={() => s.setStep(1)}
-        className="text-sm text-gray-500 hover:text-gray-700 hover:underline"
+        className="text-sm hover:underline"
+        style={{ color: HF.ink3 }}
       >
         {t('verify.useDifferent')}
       </button>


### PR DESCRIPTION
## Summary

Follow-up to **#35** (which shipped the apply shell + StepIndicator on HF). This PR migrates the 5 step bodies + 2 supporting components from emerald/gray/amber utility classes to inline HF token styles, so the full apply wizard now reads as one coherent HF surface end-to-end.

(Originally opened as **#37** stacked on #35; auto-closed when #35's base branch was deleted on merge. Rebased onto the updated bp-03b and re-opened here — same commit content.)

## Files migrated

- **Step1Register** — headings, inputs, labels → HF ink/border/paper
- **StepVerify** — mail icon emerald → sage; resent banner emerald → sage; dev-link amber → HF warn tint
- **StepIntent** — bedroom tiles emerald → HF.accent (active = accentLo fill + accentInk text); range slider → HF.accent; income status emerald/amber → sage/warn; inputs/labels → HF
- **StepPick** — headings → HF; no-match amber banner → HF warn tint; edit-prefs link → ink3
- **Step2Details + PropertySelector** — all `.input/.label` utility classes → inline HF; ssn error → HF.err
- **UnitCard** — `bg-white + ring-gray + emerald rent + gray chips + btn-primary` → `HF.paper/border/accent + cream pill chips + CTA` primitive

## Scope decision

Left the global `.input/.label/.btn-primary` CSS rules in `src/index.css` untouched. Those classes are used by ~8 non-apply pages (Login, Dashboard, Pay, Ledger, Application, Status, Maintenance, VerifyPending) that aren't on the HF migration path yet — flipping them globally would silently change visuals on pages outside this PR's review scope. When the rest of the non-apply pages land on HF, those rules can flip in one tight diff.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run src/pages/apply` — 29/30 pass; 1 pre-existing flake (`Apply.integration.test.tsx` Step 7 heading) confirmed identical on prior HEAD with no changes — not introduced here
- [x] Visual QA via Playwright at mobile (390×844) + desktop (1280×900) for all 5 step bodies — chrome is coherent w/ the #35 shell + stepper
- [ ] Reviewer: smoke the full register → verify → intent → pick → details flow on the dev server

🤖 Generated with [Claude Code](https://claude.com/claude-code)