### PR TITLE
fix(flags): static import.meta.env access so Vite can inline values

### DIFF
--- a/client-tenant/src/lib/__tests__/flags.test.ts
+++ b/client-tenant/src/lib/__tests__/flags.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Re-import the module fresh after stubbing env so the module-scoped ENV_RAW
+// object is rebuilt against the current import.meta.env snapshot.
+async function loadFlags() {
+  vi.resetModules();
+  return await import('../flags');
+}
+
+describe('useFlag — env override mechanism', () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  describe('default-on flags (PROPERTY_DL2_ENABLED, MOBILE_APPLY_ENABLED)', () => {
+    it('returns true when env var is unset (default-on)', async () => {
+      const { useFlag } = await loadFlags();
+      expect(useFlag('PROPERTY_DL2_ENABLED')).toBe(true);
+      expect(useFlag('MOBILE_APPLY_ENABLED')).toBe(true);
+    });
+
+    it('returns false when env var is explicitly "false"', async () => {
+      vi.stubEnv('VITE_PROPERTY_DL2_ENABLED', 'false');
+      const { useFlag } = await loadFlags();
+      expect(useFlag('PROPERTY_DL2_ENABLED')).toBe(false);
+    });
+
+    it('returns true for any non-"false" value (true, 1, garbage)', async () => {
+      vi.stubEnv('VITE_PROPERTY_DL2_ENABLED', 'true');
+      let mod = await loadFlags();
+      expect(mod.useFlag('PROPERTY_DL2_ENABLED')).toBe(true);
+
+      vi.stubEnv('VITE_PROPERTY_DL2_ENABLED', 'garbage');
+      mod = await loadFlags();
+      expect(mod.useFlag('PROPERTY_DL2_ENABLED')).toBe(true);
+    });
+  });
+
+  describe('default-off flags (PAYMENT_WIZARD_ENABLED)', () => {
+    it('returns false when env var is unset (default-off)', async () => {
+      const { useFlag } = await loadFlags();
+      expect(useFlag('PAYMENT_WIZARD_ENABLED')).toBe(false);
+    });
+
+    it('returns true ONLY when env var is exactly "true"', async () => {
+      vi.stubEnv('VITE_PAYMENT_WIZARD_ENABLED', 'true');
+      const { useFlag } = await loadFlags();
+      expect(useFlag('PAYMENT_WIZARD_ENABLED')).toBe(true);
+    });
+
+    it('returns false for "false" or any non-"true" value', async () => {
+      vi.stubEnv('VITE_PAYMENT_WIZARD_ENABLED', 'false');
+      let mod = await loadFlags();
+      expect(mod.useFlag('PAYMENT_WIZARD_ENABLED')).toBe(false);
+
+      vi.stubEnv('VITE_PAYMENT_WIZARD_ENABLED', '1');
+      mod = await loadFlags();
+      expect(mod.useFlag('PAYMENT_WIZARD_ENABLED')).toBe(false);
+    });
+  });
+});

--- a/client-tenant/src/lib/flags.ts
+++ b/client-tenant/src/lib/flags.ts
@@ -14,10 +14,19 @@ export type FlagName =
 // Flags that default OFF (opt-in via `=true`).
 const DEFAULT_OFF: ReadonlySet<FlagName> = new Set(['PAYMENT_WIZARD_ENABLED']);
 
+// Static lookup — Vite's `define` plugin can only substitute literal property
+// access on `import.meta.env.VITE_*`. Computed-key access (`env[`VITE_${name}`]`)
+// is left as a runtime expression, and the browser's native `import.meta.env`
+// is `undefined`, so every flag silently pinned to its default. See PR fixing
+// this for the empirical bundle-grep evidence.
+const ENV_RAW: Readonly<Record<FlagName, string | undefined>> = {
+  PROPERTY_DL2_ENABLED: import.meta.env.VITE_PROPERTY_DL2_ENABLED,
+  MOBILE_APPLY_ENABLED: import.meta.env.VITE_MOBILE_APPLY_ENABLED,
+  PAYMENT_WIZARD_ENABLED: import.meta.env.VITE_PAYMENT_WIZARD_ENABLED,
+};
+
 export function useFlag(name: FlagName): boolean {
-  // Vite inlines import.meta.env at build time; safe to read by computed key.
-  const meta = import.meta as unknown as { env: Record<string, string | undefined> };
-  const raw = meta.env[`VITE_${name}`];
+  const raw = ENV_RAW[name];
   if (DEFAULT_OFF.has(name)) return raw === 'true';
   return raw !== 'false';
 }


### PR DESCRIPTION
## Summary

The tenant client's feature-flag system silently fails: **every flag is pinned to its default regardless of any \`VITE_*\` env var on Vercel**. Discovered while verifying the bp-03b deploy checklist.

## Root cause

\`client-tenant/src/lib/flags.ts\` reads flags via computed-key access:

\`\`\`ts
const raw = meta.env[\`VITE_\${name}\`];
\`\`\`

Vite's \`define\` plugin can only statically substitute literal property access (\`import.meta.env.VITE_FOO\`). Dynamic keys are left as a runtime expression, and the browser's native \`import.meta.env\` is \`undefined\` — so the lookup returns \`undefined\` for every flag.

## Empirical evidence (pre-fix)

Grepped the deployed Preview bundle (\`frank-pilot-tenant-a0x7rx4z3.vercel.app/assets/index-BdXzz5uN.js\`):

- 1 \`import.meta.env\` reference — the broken dynamic one, unsubstituted
- 0 inlined \`VITE_*\` values across main bundle + 3 lazy chunks
- 0 env-shimming code in the bundle

Verified in a real browser (Playwright): \`typeof import.meta.env === 'undefined'\` in a runtime-injected module on the live page. The reason the app doesn't crash: \`useFlag\` is only called inside \`StepClaim\`, which is auth-gated and never reached on cold load.

## Fix

Replace dynamic lookup with a static \`ENV_RAW\` table populated via literal access at module load. Vite now substitutes each entry at build time. Confirmed by building with \`VITE_PAYMENT_WIZARD_ENABLED=true VITE_PROPERTY_DL2_ENABLED=false vite build\` and grepping output:

\`\`\`
PAYMENT_WIZARD_ENABLED:\"true\"
PROPERTY_DL2_ENABLED:\"false\"
MOBILE_APPLY_ENABLED:void 0
\`\`\`

Dynamic-key pattern is gone.

## Tests

Adds \`client-tenant/src/lib/__tests__/flags.test.ts\` — 6 cases covering:

- Default-on flag unset → \`true\`
- Default-on flag set to \`\"false\"\` → \`false\`
- Default-on flag set to garbage → \`true\`
- Default-off flag unset → \`false\`
- Default-off flag set to \`\"true\"\` → \`true\`
- Default-off flag set to \`\"1\"\` or \`\"false\"\` → \`false\`

Uses \`vi.stubEnv\` + \`vi.resetModules\` to rebuild the module-scoped lookup per case.

## Test plan
- [ ] CI green
- [ ] Set \`VITE_PAYMENT_WIZARD_ENABLED=true\` on a Preview branch, push, confirm payment-wizard step is reachable in \`/apply\` (was previously impossible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)