### PR TITLE
fix(apply): persist intent bedrooms + household across /auth/callback

### DIFF
--- a/client-tenant/src/pages/Apply.tsx
+++ b/client-tenant/src/pages/Apply.tsx
@@ -75,10 +75,8 @@ export function Apply() {
   const [resent, setResent] = useState(false);
   const [devLink, setDevLink] = useState<string | null>(null);
 
-  const [intentBedrooms, setIntentBedrooms] = useState<number | null>(null);
   const [intentBudgetMax, setIntentBudgetMax] = useState<number>(2000);
   const [intentMoveInDate, setIntentMoveInDate] = useState('');
-  const [intentHouseholdSize, setIntentHouseholdSize] = useState<number>(1);
 
   const [units, setUnits] = useState<Unit[]>([]);
   const [unitsLoading, setUnitsLoading] = useState(false);
@@ -133,11 +131,11 @@ export function Apply() {
         if (cancelled || !latest) return;
         if (latest.property_id && !propertyId) setPropertyId(latest.property_id);
         if (latest.unit_number && !unitNumber) setUnitNumber(latest.unit_number);
-        if (latest.intent_bedrooms != null && intentBedrooms === null) setIntentBedrooms(latest.intent_bedrooms);
+        if (latest.intent_bedrooms != null && wiz.intentBedrooms === null) wiz.setIntentBedrooms(latest.intent_bedrooms);
         if (latest.intent_budget_max != null) setIntentBudgetMax(Number(latest.intent_budget_max));
         if (latest.intent_move_in_date) setIntentMoveInDate(latest.intent_move_in_date.slice(0, 10));
         if (latest.intent_household_size != null) {
-          setIntentHouseholdSize(latest.intent_household_size);
+          wiz.setIntentHouseholdSize(latest.intent_household_size);
           setHouseholdSize(String(latest.intent_household_size));
         }
       } catch {
@@ -145,14 +143,16 @@ export function Apply() {
       }
     })();
     return () => { cancelled = true; };
-  }, [step, email, firstName, lastName, propertyId, unitNumber, intentBedrooms]);
+  }, [step, email, firstName, lastName, propertyId, unitNumber, wiz]);
 
   const value: ApplyState = {
     step, setStep, error, setError, loading, setLoading,
     email, setEmail, firstName, setFirstName, lastName, setLastName, phone, setPhone,
     resending, setResending, resent, setResent, devLink, setDevLink,
-    intentBedrooms, setIntentBedrooms, intentBudgetMax, setIntentBudgetMax,
-    intentMoveInDate, setIntentMoveInDate, intentHouseholdSize, setIntentHouseholdSize,
+    intentBedrooms: wiz.intentBedrooms, setIntentBedrooms: wiz.setIntentBedrooms,
+    intentBudgetMax, setIntentBudgetMax,
+    intentMoveInDate, setIntentMoveInDate,
+    intentHouseholdSize: wiz.intentHouseholdSize, setIntentHouseholdSize: wiz.setIntentHouseholdSize,
     grossAnnualIncome: wiz.grossAnnualIncome, setGrossAnnualIncome: wiz.setGrossAnnualIncome,
     qualifyingAmiTier: wiz.qualifyingAmiTier, setQualifyingAmiTier: wiz.setQualifyingAmiTier,
     qualifyingAmiCalculatedAt: wiz.qualifyingAmiCalculatedAt,

--- a/client-tenant/src/pages/apply/ApplyContext.tsx
+++ b/client-tenant/src/pages/apply/ApplyContext.tsx
@@ -39,6 +39,10 @@ interface WizPersisted {
   qualifyingAmiTier: AmiTier | null;
   qualifyingAmiCalculatedAt: string | null;
   qualifyingHouseholdSize: number | null;
+  // Welcome→apply handoff: bedroom + household size must survive the
+  // /auth/callback route hop (Apply unmounts during verify).
+  intentBedrooms: number | null;
+  intentHouseholdSize: number;
 }
 
 const DEFAULTS: WizPersisted = {
@@ -48,6 +52,8 @@ const DEFAULTS: WizPersisted = {
   qualifyingAmiTier: null,
   qualifyingAmiCalculatedAt: null,
   qualifyingHouseholdSize: null,
+  intentBedrooms: null,
+  intentHouseholdSize: 1,
 };
 
 const TIER_SET: ReadonlySet<AmiTier> = new Set(['30', '50', '60', '80']);
@@ -76,6 +82,12 @@ function readPersisted(): WizPersisted {
         typeof parsed.qualifyingHouseholdSize === 'number'
           ? parsed.qualifyingHouseholdSize
           : null,
+      intentBedrooms:
+        typeof parsed.intentBedrooms === 'number' ? parsed.intentBedrooms : null,
+      intentHouseholdSize:
+        typeof parsed.intentHouseholdSize === 'number' && parsed.intentHouseholdSize >= 1
+          ? parsed.intentHouseholdSize
+          : DEFAULTS.intentHouseholdSize,
     };
   } catch {
     return { ...DEFAULTS };
@@ -189,6 +201,10 @@ export function useWizState() {
   const [qualifyingHouseholdSize, setQualifyingHouseholdSizeRaw] = useState<number | null>(
     initial.qualifyingHouseholdSize,
   );
+  const [intentBedrooms, setIntentBedroomsRaw] = useState<number | null>(initial.intentBedrooms);
+  const [intentHouseholdSize, setIntentHouseholdSizeRaw] = useState<number>(
+    initial.intentHouseholdSize,
+  );
 
   useEffect(() => {
     writePersisted({
@@ -198,6 +214,8 @@ export function useWizState() {
       qualifyingAmiTier,
       qualifyingAmiCalculatedAt,
       qualifyingHouseholdSize,
+      intentBedrooms,
+      intentHouseholdSize,
     });
   }, [
     adults,
@@ -206,6 +224,8 @@ export function useWizState() {
     qualifyingAmiTier,
     qualifyingAmiCalculatedAt,
     qualifyingHouseholdSize,
+    intentBedrooms,
+    intentHouseholdSize,
   ]);
 
   return {
@@ -222,5 +242,9 @@ export function useWizState() {
     setQualifyingAmiCalculatedAt: setQualifyingAmiCalculatedAtRaw,
     qualifyingHouseholdSize,
     setQualifyingHouseholdSize: setQualifyingHouseholdSizeRaw,
+    intentBedrooms,
+    setIntentBedrooms: setIntentBedroomsRaw,
+    intentHouseholdSize,
+    setIntentHouseholdSize: setIntentHouseholdSizeRaw,
   };
 }


### PR DESCRIPTION
## Summary
- Welcome→apply handoff dropped bedroom tile + household-size dropdown after magic-link verify because `<Apply/>` unmounts during `/auth/callback`. Plain `useState` for `intentBedrooms` / `intentHouseholdSize` reset to defaults on remount; the AMI fields (already in FROZEN CONTRACT 2) survived because they ride sessionStorage.
- Extends FROZEN CONTRACT 2 with `intentBedrooms` + `intentHouseholdSize` so they persist alongside the W0 AMI fields. `Apply.tsx` sources both from `useWizState()` instead of local state.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] QA walks deep-link `/apply?step=intent&unitType=2BR&hh=2&income=42000&amiTier=80` → register → verify and asserts:
  - Step 1 (Register) rendered after gate (params preserved)
  - After verify: "2 BR" tile selected (terracotta border `rgb(201, 73, 42)`) and household-size select = `2`
  - Sage AMI verdict visible
- [ ] Manual smoke on a real Vercel preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)