### PR TITLE
fix(flags): trim whitespace from env values before comparison

### DIFF
--- a/client-tenant/src/lib/__tests__/flags.test.ts
+++ b/client-tenant/src/lib/__tests__/flags.test.ts
@@ -62,4 +62,25 @@ describe('useFlag — env override mechanism', () => {
       expect(mod.useFlag('PAYMENT_WIZARD_ENABLED')).toBe(false);
     });
   });
+
+  // Regression: `echo "true" | vercel env add` stores trailing newlines.
+  describe('whitespace handling (Vercel CLI artifact)', () => {
+    it('trims trailing newline before comparing — default-off flag', async () => {
+      vi.stubEnv('VITE_PAYMENT_WIZARD_ENABLED', 'true\n');
+      const { useFlag } = await loadFlags();
+      expect(useFlag('PAYMENT_WIZARD_ENABLED')).toBe(true);
+    });
+
+    it('trims trailing newline before comparing — default-on flag', async () => {
+      vi.stubEnv('VITE_PROPERTY_DL2_ENABLED', 'false\n');
+      const { useFlag } = await loadFlags();
+      expect(useFlag('PROPERTY_DL2_ENABLED')).toBe(false);
+    });
+
+    it('handles leading/trailing spaces and tabs', async () => {
+      vi.stubEnv('VITE_PAYMENT_WIZARD_ENABLED', '  true  ');
+      const { useFlag } = await loadFlags();
+      expect(useFlag('PAYMENT_WIZARD_ENABLED')).toBe(true);
+    });
+  });
 });

--- a/client-tenant/src/lib/flags.ts
+++ b/client-tenant/src/lib/flags.ts
@@ -26,7 +26,11 @@ const ENV_RAW: Readonly<Record<FlagName, string | undefined>> = {
 };
 
 export function useFlag(name: FlagName): boolean {
-  const raw = ENV_RAW[name];
+  // Trim whitespace — the Vercel CLI's `echo "true" | vercel env add` flow
+  // stores values with a trailing newline. Without `.trim()`, "true\n" !==
+  // "true" and a default-off flag would stay pinned OFF even when explicitly
+  // set to true in the dashboard.
+  const raw = ENV_RAW[name]?.trim();
   if (DEFAULT_OFF.has(name)) return raw === 'true';
   return raw !== 'false';
 }


### PR DESCRIPTION
## Summary

The Vercel CLI's `echo "true" | vercel env add` flow stores values with a trailing newline. Without `.trim()`, `"true\n" === "true"` is false, which would silently pin any default-OFF flag to OFF even when explicitly set to true in the Vercel dashboard.

Empirical: the current production bundle for frank-pilot-tenant inlines:
\`\`\`
PROPERTY_DL2_ENABLED: \`true\n\`,
MOBILE_APPLY_ENABLED: \`true\n\`,
PAYMENT_WIZARD_ENABLED: \`false\n\`,
\`\`\`
Today this is latent — the three flags currently provisioned all happen to produce the right answer by accident (default-on flags treat `"true\n"` as not-"false" → ON; default-off `PAYMENT_WIZARD` has `"false\n"` → not-"true" → OFF). The bug would surface the moment `PAYMENT_WIZARD_ENABLED` gets flipped to `true` before BP-08 Stripe lands.

## Changes

- `client-tenant/src/lib/flags.ts` — `.trim()` the raw env value before comparison
- `client-tenant/src/lib/__tests__/flags.test.ts` — 3 regression tests (trailing newline on default-off, trailing newline on default-on, leading/trailing whitespace)

## Test plan

- [x] `npx vitest run src/lib/__tests__/flags.test.ts` — all 3 new whitespace tests pass
- [ ] CI green
- [ ] After merge: redeploy not strictly required (bundle still works today), but next deploy will bake the safer code in

## Known unrelated test failure

`returns false when env var is unset (default-off)` fails locally for any dev whose `.env.local` has `VITE_PAYMENT_WIZARD_ENABLED=true` set — `vi.unstubAllEnvs()` doesn't clear values that Vite loaded from `.env.local` at startup. Pre-exists this PR (fails on `main` too). Out of scope; flagging for a future test-isolation cleanup.