### PR TITLE
fix(applicants): close INFO-1/-2/-3 from W6 re-audit

### DIFF
--- a/client-tenant/src/pages/apply/steps/StepVerify.tsx
+++ b/client-tenant/src/pages/apply/steps/StepVerify.tsx
@@ -80,7 +80,7 @@ export function StepVerify() {
       <CTA onClick={handleResend} disabled={s.resending || !s.email}>
         {s.resending ? t('verify.resending') : t('verify.resend')}
       </CTA>
-      {s.devLink && (
+      {import.meta.env.DEV && s.devLink && (
         <a
           href={s.devLink}
           className="block px-4 py-2 text-center text-sm font-medium"

--- a/src/__tests__/applicants-routes-info1.test.ts
+++ b/src/__tests__/applicants-routes-info1.test.ts
@@ -1,0 +1,103 @@
+/**
+ * INFO-1 (W6 re-audit) — /register wall-clock floor.
+ *
+ * The three /register branches do different amounts of DB work:
+ *   - staff           = 2 SELECT, 0 INSERT
+ *   - existing app    = 2 SELECT, 1 INSERT
+ *   - new applicant   = 2 SELECT, 2 INSERT
+ *
+ * The handler floors the response wall-clock at REGISTER_RESPONSE_FLOOR_MS
+ * (or NODE_ENV-default 250ms in non-test envs) so the three buckets aren't
+ * distinguishable downstream. These tests confirm the floor activates
+ * without locking the exact default value (which is environment-dependent).
+ */
+import express from "express";
+import request from "supertest";
+
+jest.mock("../config/database", () => ({ query: jest.fn(), transaction: jest.fn() }));
+jest.mock("../utils/logger", () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+const mockCreateMagicLink = jest.fn();
+const mockLogMagicLink = jest.fn();
+jest.mock("../modules/auth/magic-link-service", () => ({
+  createMagicLink: mockCreateMagicLink,
+  logMagicLink: mockLogMagicLink,
+}));
+
+import { query } from "../config/database";
+import applicantsRouter from "../modules/applicants/routes";
+
+const mockQuery = query as jest.MockedFunction<typeof query>;
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/applicants", applicantsRouter);
+  return app;
+}
+const app = buildApp();
+
+describe("POST /applicants/register — INFO-1 timing floor", () => {
+  const ORIGINAL_FLOOR = process.env.REGISTER_RESPONSE_FLOOR_MS;
+  beforeEach(() => jest.clearAllMocks());
+  afterEach(() => {
+    if (ORIGINAL_FLOOR === undefined) delete process.env.REGISTER_RESPONSE_FLOOR_MS;
+    else process.env.REGISTER_RESPONSE_FLOOR_MS = ORIGINAL_FLOOR;
+  });
+
+  it("floors response wall-clock at REGISTER_RESPONSE_FLOOR_MS for the fast (staff) path", async () => {
+    process.env.REGISTER_RESPONSE_FLOOR_MS = "150";
+    // Staff branch: SELECT users returns a staff role; createMagicLink
+    // short-circuits to null. Zero INSERTs — the otherwise-fastest path.
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: "staff-1", role: "leasing_agent", is_active: true }],
+    } as any);
+    mockCreateMagicLink.mockResolvedValueOnce(null);
+
+    const t0 = Date.now();
+    const res = await request(app)
+      .post("/applicants/register")
+      .send({ email: "staff@example.com", firstName: "S", lastName: "T" });
+    const elapsed = Date.now() - t0;
+
+    expect(res.status).toBe(202);
+    // Allow ~25ms negative fudge for timer granularity / event-loop scheduling.
+    expect(elapsed).toBeGreaterThanOrEqual(125);
+  });
+
+  it("does not stall meaningfully beyond the floor when the path is already slow", async () => {
+    process.env.REGISTER_RESPONSE_FLOOR_MS = "50";
+    mockQuery.mockResolvedValueOnce({ rows: [] } as any);
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: "n-1" }] } as any);
+    mockCreateMagicLink.mockResolvedValueOnce({ link: "http://x/auth/callback?token=raw", userId: "n-1" });
+
+    const t0 = Date.now();
+    const res = await request(app)
+      .post("/applicants/register")
+      .send({ email: "new@example.com", firstName: "N", lastName: "U" });
+    const elapsed = Date.now() - t0;
+
+    expect(res.status).toBe(202);
+    // Floor is small; the request should not add multi-second overhead.
+    expect(elapsed).toBeLessThan(2000);
+  });
+
+  it("floor=0 keeps fast paths fast", async () => {
+    process.env.REGISTER_RESPONSE_FLOOR_MS = "0";
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: "staff-1", role: "leasing_agent", is_active: true }],
+    } as any);
+    mockCreateMagicLink.mockResolvedValueOnce(null);
+
+    const t0 = Date.now();
+    const res = await request(app)
+      .post("/applicants/register")
+      .send({ email: "staff@example.com", firstName: "S", lastName: "T" });
+    const elapsed = Date.now() - t0;
+
+    expect(res.status).toBe(202);
+    expect(elapsed).toBeLessThan(150);
+  });
+});

--- a/src/__tests__/applicants-routes-warn2.test.ts
+++ b/src/__tests__/applicants-routes-warn2.test.ts
@@ -291,3 +291,60 @@ describe("GET /applicants/properties (public, ungated)", () => {
     expect(res.body.properties).toHaveLength(1);
   });
 });
+
+// INFO-2 / W6 re-audit: devLink must only leak when NODE_ENV is EXACTLY
+// "development". The gate is fail-closed today (`=== "development"`), and
+// these tests lock that behaviour so a future refactor to a looser predicate
+// (e.g. `!== "production"`) breaks CI instead of silently re-opening the
+// enumeration channel in staging/preview environments.
+describe("POST /applicants/register — INFO-2 devLink gate", () => {
+  const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
+  beforeEach(() => jest.clearAllMocks());
+  afterEach(() => { process.env.NODE_ENV = ORIGINAL_NODE_ENV; });
+
+  function stubNewApplicant() {
+    mockQuery.mockResolvedValueOnce({ rows: [] } as any);
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: "u-1" }] } as any);
+    mockCreateMagicLink.mockResolvedValueOnce({ link: "http://x/auth/callback?token=raw", userId: "u-1" });
+  }
+
+  it("omits devLink when NODE_ENV === 'production'", async () => {
+    process.env.NODE_ENV = "production";
+    stubNewApplicant();
+    const res = await request(app)
+      .post("/applicants/register")
+      .send({ email: "a@example.com", firstName: "A", lastName: "B" });
+    expect(res.status).toBe(202);
+    expect(res.body).not.toHaveProperty("devLink");
+  });
+
+  it("omits devLink when NODE_ENV === 'staging' (anything not 'development')", async () => {
+    process.env.NODE_ENV = "staging";
+    stubNewApplicant();
+    const res = await request(app)
+      .post("/applicants/register")
+      .send({ email: "a@example.com", firstName: "A", lastName: "B" });
+    expect(res.status).toBe(202);
+    expect(res.body).not.toHaveProperty("devLink");
+  });
+
+  it("omits devLink when NODE_ENV is unset", async () => {
+    delete process.env.NODE_ENV;
+    stubNewApplicant();
+    const res = await request(app)
+      .post("/applicants/register")
+      .send({ email: "a@example.com", firstName: "A", lastName: "B" });
+    expect(res.status).toBe(202);
+    expect(res.body).not.toHaveProperty("devLink");
+  });
+
+  it("includes devLink when NODE_ENV === 'development'", async () => {
+    process.env.NODE_ENV = "development";
+    stubNewApplicant();
+    const res = await request(app)
+      .post("/applicants/register")
+      .send({ email: "a@example.com", firstName: "A", lastName: "B" });
+    expect(res.status).toBe(202);
+    expect(res.body.devLink).toBe("http://x/auth/callback?token=raw");
+  });
+});

--- a/src/modules/applicants/routes.ts
+++ b/src/modules/applicants/routes.ts
@@ -29,6 +29,35 @@ const registerLimiter = rateLimit({
   message: { error: "Too many requests, try again in a minute" },
 });
 
+// INFO-1 (W6 re-audit): the three /register branches do measurably different
+// amounts of DB work (staff = 2 SELECT, existing applicant = 2 SELECT + 1
+// INSERT, new applicant = 2 SELECT + 2 INSERT), so an attacker with enough
+// timing probes can classify {staff, existing, new} for any given email. We
+// floor the wall-clock response time at a constant so all three buckets are
+// indistinguishable downstream. Default 250 ms is conservative for typical
+// Postgres INSERT variance; raise via env if observed branch deltas exceed it.
+// Tests opt in by setting REGISTER_RESPONSE_FLOOR_MS explicitly; default 0
+// under NODE_ENV=test keeps the existing suite fast.
+function getRegisterFloorMs(): number {
+  const explicit = process.env.REGISTER_RESPONSE_FLOOR_MS;
+  if (explicit !== undefined) return Math.max(0, Number(explicit) || 0);
+  return process.env.NODE_ENV === "test" ? 0 : 250;
+}
+
+async function respondAtFloor(
+  res: Response,
+  startedAt: number,
+  status: number,
+  body: unknown
+): Promise<void> {
+  const floor = getRegisterFloorMs();
+  const elapsed = Date.now() - startedAt;
+  if (elapsed < floor) {
+    await new Promise((resolve) => setTimeout(resolve, floor - elapsed));
+  }
+  res.status(status).json(body);
+}
+
 // Per-user limiters for the authenticated unit-claim flow (B3). Keyed by the
 // authenticated user id (populated by `authenticate`); falls back to a shared
 // "anon" bucket if the limiter ever runs before auth (should not happen given
@@ -59,9 +88,13 @@ const unitWriteLimiter = rateLimit({
 // Public: register as an applicant. Idempotent — if the email already exists as
 // an applicant, we reissue a magic link instead of erroring (no email enumeration).
 router.post("/register", registerLimiter, async (req: Request, res: Response): Promise<void> => {
+  const t0 = Date.now();
   try {
     const parsed = registerSchema.safeParse(req.body);
     if (!parsed.success) {
+      // Request-shape rejection (malformed payload) — no DB work yet, so the
+      // INFO-1 floor doesn't apply: this path doesn't disclose which branch
+      // the email would have taken.
       res.status(400).json({ error: "Validation failed", details: parsed.error.errors });
       return;
     }
@@ -95,8 +128,9 @@ router.post("/register", registerLimiter, async (req: Request, res: Response): P
     }
 
     // Always call createMagicLink. The service short-circuits for staff /
-    // inactive / missing emails (returns null) but still pays the SELECT cost,
-    // so all three /register paths take comparable wall-clock time.
+    // inactive / missing emails (returns null) but still pays the SELECT cost.
+    // This narrows the timing gap between branches; respondAtFloor() below
+    // closes the residual delta (INFO-1).
     const link = await createMagicLink(email);
     if (link) logMagicLink(email, link.link);
 
@@ -117,10 +151,13 @@ router.post("/register", registerLimiter, async (req: Request, res: Response): P
     if (link && process.env.NODE_ENV === "development") {
       payload.devLink = link.link;
     }
-    res.status(202).json(payload);
+    await respondAtFloor(res, t0, 202, payload);
   } catch (err) {
     logger.error("Applicant register failed", { error: (err as Error).message });
-    res.status(500).json({ error: "Registration failed" });
+    // Floor the 5xx path too: a branch-specific crash (e.g. INSERT-only
+    // failure on the new-applicant path) would otherwise give away which
+    // branch the email landed in.
+    await respondAtFloor(res, t0, 500, { error: "Registration failed" });
   }
 });
 


### PR DESCRIPTION
## Summary

Closes the W6 re-audit INFO backlog on `/applicants/register`. Three small hardenings, no observable behavior change for legitimate clients.

- **INFO-1 — Timing side-channel across /register branches**
  Wrap 202/500 paths in `respondAtFloor()` with a `REGISTER_RESPONSE_FLOOR_MS` env knob (default **250ms** in prod/dev, **0** in `NODE_ENV=test`). The three branch buckets (staff = 0 INSERT; existing = 1 INSERT; new = 2 INSERT) become indistinguishable downstream as long as the slowest branch < floor. 400 schema-validation early-return left unfloored (validation happens pre-DB so no probe signal).
- **INFO-2 — devLink fail-closed regression coverage**
  4 new tests in `applicants-routes-warn2.test.ts` lock the existing `NODE_ENV === "development"` gate against future relaxation to `!== "production"`. No production code change needed — gate has been fail-closed since W3 fix.
- **INFO-3 — Client defense-in-depth on devLink render**
  Wrap the `StepVerify` devLink anchor in `import.meta.env.DEV &&`. A misconfigured prod server emitting `devLink` would no longer render it. Vitest runs with `DEV=true` so the existing 18 wizard tests are unaffected.

## Files
- `src/modules/applicants/routes.ts` — INFO-1 helpers + wiring
- `src/__tests__/applicants-routes-info1.test.ts` — 3 timing-floor tests
- `src/__tests__/applicants-routes-warn2.test.ts` — INFO-2 describe block (+4 tests)
- `client-tenant/src/pages/apply/steps/StepVerify.tsx` — INFO-3 DEV gate

## Test plan
- [x] `npx jest src/__tests__/applicants-routes-info1.test.ts` — 3/3 pass
- [x] `npx jest src/__tests__/applicants-routes-warn2.test.ts` — 15/15 pass (4 new + 11 prior)
- [x] `cd client-tenant && npx vitest run src/pages/apply/steps` — 18/18 pass
- [x] `npx tsc --noEmit` clean (backend)
- [x] `cd client-tenant && npx tsc --noEmit` clean
- [ ] Manual smoke after merge: `/applicants/register` in dev, verify timing is uniform with `REGISTER_RESPONSE_FLOOR_MS=400`

## Notes
- Forge-Audit verdict on PR #5 was PASS-WITH-NOTES — these are hardening, not blockers. INFO-4 already closed via PR #36 (`6ad59ed`).
- Operational gate (`NODE_ENV=production` at Railway stand-up) is still required for INFO-2 to bind at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)