### PR TITLE
chore: ignore .vercel/ + fix flags test isolation against .env.local

### DIFF
--- a/client-tenant/.gitignore
+++ b/client-tenant/.gitignore
@@ -5,3 +5,4 @@ dist-ssr
 .vite
 .DS_Store
 tsconfig.tsbuildinfo
+.vercel

--- a/client-tenant/src/lib/__tests__/flags.test.ts
+++ b/client-tenant/src/lib/__tests__/flags.test.ts
@@ -18,6 +18,10 @@ describe('useFlag — env override mechanism', () => {
 
   describe('default-on flags (PROPERTY_DL2_ENABLED, MOBILE_APPLY_ENABLED)', () => {
     it('returns true when env var is unset (default-on)', async () => {
+      // Vite auto-loads .env.local; stub to undefined to simulate true absence
+      // regardless of developer setup.
+      vi.stubEnv('VITE_PROPERTY_DL2_ENABLED', undefined as unknown as string);
+      vi.stubEnv('VITE_MOBILE_APPLY_ENABLED', undefined as unknown as string);
       const { useFlag } = await loadFlags();
       expect(useFlag('PROPERTY_DL2_ENABLED')).toBe(true);
       expect(useFlag('MOBILE_APPLY_ENABLED')).toBe(true);
@@ -42,6 +46,7 @@ describe('useFlag — env override mechanism', () => {
 
   describe('default-off flags (PAYMENT_WIZARD_ENABLED)', () => {
     it('returns false when env var is unset (default-off)', async () => {
+      vi.stubEnv('VITE_PAYMENT_WIZARD_ENABLED', undefined as unknown as string);
       const { useFlag } = await loadFlags();
       expect(useFlag('PAYMENT_WIZARD_ENABLED')).toBe(false);
     });


### PR DESCRIPTION
## Summary

Two tiny post-BP-03b hygiene fixes bundled into one PR.

**1. `.vercel/` should be gitignored** — the Vercel CLI leaves an empty `.vercel/` directory in `client-tenant/` after `vercel --prod`. Without this it shows up as a dirty working tree on every checkout.

**2. Flags test isolation against `.env.local`** — two tests assert the "env var unset → default" path:
- `returns true when env var is unset (default-on)`
- `returns false when env var is unset (default-off)`

Vite auto-loads `.env.local` at test boot, and `vi.unstubAllEnvs()` doesn't clear values that were loaded that way. CI passes (no `.env.local`), but a developer with `VITE_PAYMENT_WIZARD_ENABLED=true` in their local file would see the default-off test fail. Stub the relevant vars to `undefined` to simulate true absence regardless of dev setup.

## Test plan

- [x] `client-tenant && npx vitest run src/lib/__tests__/flags.test.ts` — 9/9 pass locally
- [ ] CI green on all Node versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)