### PR TITLE
chore(tests): restore green baseline for client-tenant suite

### DIFF
--- a/client-tenant/src/pages/apply/__tests__/Apply.integration.test.tsx
+++ b/client-tenant/src/pages/apply/__tests__/Apply.integration.test.tsx
@@ -2,6 +2,20 @@ import { describe, it, expect, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
+
+// FROZEN CONTRACT 5: when PAYMENT_WIZARD_ENABLED is on, claim → review → household
+// → payment → 2 → confirm. This integration test asserts the legacy short-circuit
+// claim → 2 path; the wizard wedge is covered by per-step tests in steps/__tests__.
+// Mock at module-level so Apply imports the stubbed flag before the tree mounts.
+vi.mock('@/lib/flags', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/flags')>('@/lib/flags');
+  return {
+    ...actual,
+    useFlag: (name: string) =>
+      name === 'PAYMENT_WIZARD_ENABLED' ? false : true,
+  };
+});
+
 import { Apply } from '../../Apply';
 import { setToken } from '@/api/client';
 

--- a/client-tenant/src/pages/discover/__tests__/PropertyDetail.test.tsx
+++ b/client-tenant/src/pages/discover/__tests__/PropertyDetail.test.tsx
@@ -2,7 +2,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
-import { axe } from 'jest-axe';
+import axe from 'axe-core';
 import { PropertyDetail } from '../PropertyDetail';
 
 function renderAt(path: string) {
@@ -50,7 +50,7 @@ describe('PropertyDetail', () => {
     await waitFor(() => {
       expect(screen.getByText('Donna Louise 2')).toBeInTheDocument();
     });
-    const results = await axe(container);
+    const results = await axe.run(container);
     expect(results.violations).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
- **PropertyDetail**: swap missing `jest-axe` import for `axe-core`, matching the rest of the codebase's a11y test pattern (`axe.run(container)`).
- **Apply.integration**: mock `useFlag('PAYMENT_WIZARD_ENABLED')` to `false` so the legacy `claim → 2` short-circuit path is exercised deterministically — independent of whatever `.env.local` developers have set. The wizard wedge (`claim → review → household → payment → 2`) is already covered by per-step tests under `steps/__tests__`, and the end-to-end wizard walk belongs in Playwright (separate PR).

## Why
Local baseline run found 3 red items in client-tenant Vitest:
1. ✅ `flags.test.ts` (default-off when unset) — already fixed upstream in #44.
2. ✅ `PropertyDetail.test.tsx` — suite-level fail: unresolved `jest-axe` import (not in `package.json`; codebase uses `axe-core` everywhere else).
3. ✅ `Apply.integration.test.tsx` — `findByRole('heading', { name: /application details/i })` timing out because `.env.local` enables `PAYMENT_WIZARD_ENABLED`, so `StepClaim` now routes through `review → household → payment → 2` (FROZEN CONTRACT 5).

This PR closes 2 and 3. API Jest (39/40 suites, 796/811 tests) and Playwright (11/11 local, 9/9 prod) were already green.

## Test plan
- [x] `cd client-tenant && npm test` → **21/21 files, 106/106 tests pass**
- [x] `npm test` (root API) → unchanged, **796/811 pass** (15 intentional skips)
- [x] No app code touched; only `__tests__/*.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)