### PR TITLE
test(apply): regression net for welcome→apply prefill (PR #40)

### DIFF
--- a/client-tenant/src/pages/apply/__tests__/ApplyContext.prefill.test.tsx
+++ b/client-tenant/src/pages/apply/__tests__/ApplyContext.prefill.test.tsx
@@ -1,0 +1,139 @@
+// @vitest-environment jsdom
+//
+// Regression net for PR #40 — the welcome→apply handoff persists
+// intentBedrooms + intentHouseholdSize in sessionStorage so they survive
+// the Apply unmount that happens during /auth/callback. Without this,
+// Step 3 lost its prefill after magic-link verify.
+//
+// FROZEN CONTRACT 2 — sessionStorage key `frank_apply_state`, shape defined
+// by WizPersisted in ApplyContext.tsx.
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useWizState } from '../ApplyContext';
+
+const SESSION_KEY = 'frank_apply_state';
+
+describe('useWizState — intentBedrooms', () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+  });
+
+  it('defaults to null when sessionStorage is empty', () => {
+    const { result } = renderHook(() => useWizState());
+    expect(result.current.intentBedrooms).toBeNull();
+  });
+
+  it('hydrates from sessionStorage on mount', () => {
+    window.sessionStorage.setItem(
+      SESSION_KEY,
+      JSON.stringify({ intentBedrooms: 2 }),
+    );
+    const { result } = renderHook(() => useWizState());
+    expect(result.current.intentBedrooms).toBe(2);
+  });
+
+  it('ignores non-number values stored under intentBedrooms', () => {
+    window.sessionStorage.setItem(
+      SESSION_KEY,
+      JSON.stringify({ intentBedrooms: 'two' }),
+    );
+    const { result } = renderHook(() => useWizState());
+    expect(result.current.intentBedrooms).toBeNull();
+  });
+
+  it('persists setter changes back to sessionStorage', () => {
+    const { result } = renderHook(() => useWizState());
+    act(() => {
+      result.current.setIntentBedrooms(3);
+    });
+    const stored = JSON.parse(
+      window.sessionStorage.getItem(SESSION_KEY) ?? '{}',
+    );
+    expect(stored.intentBedrooms).toBe(3);
+  });
+});
+
+describe('useWizState — intentHouseholdSize', () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+  });
+
+  it('defaults to 1 when sessionStorage is empty', () => {
+    const { result } = renderHook(() => useWizState());
+    expect(result.current.intentHouseholdSize).toBe(1);
+  });
+
+  it('hydrates from sessionStorage on mount', () => {
+    window.sessionStorage.setItem(
+      SESSION_KEY,
+      JSON.stringify({ intentHouseholdSize: 4 }),
+    );
+    const { result } = renderHook(() => useWizState());
+    expect(result.current.intentHouseholdSize).toBe(4);
+  });
+
+  it('coerces values < 1 to the default (guards against 0/negative leaks)', () => {
+    window.sessionStorage.setItem(
+      SESSION_KEY,
+      JSON.stringify({ intentHouseholdSize: 0 }),
+    );
+    const { result } = renderHook(() => useWizState());
+    expect(result.current.intentHouseholdSize).toBe(1);
+  });
+
+  it('persists setter changes back to sessionStorage', () => {
+    const { result } = renderHook(() => useWizState());
+    act(() => {
+      result.current.setIntentHouseholdSize(5);
+    });
+    const stored = JSON.parse(
+      window.sessionStorage.getItem(SESSION_KEY) ?? '{}',
+    );
+    expect(stored.intentHouseholdSize).toBe(5);
+  });
+});
+
+describe('useWizState — round-trip across unmount/remount (the /auth/callback hop)', () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+  });
+
+  it('values set on mount A are visible on mount B (the actual PR #40 fix)', () => {
+    const a = renderHook(() => useWizState());
+    act(() => {
+      a.result.current.setIntentBedrooms(2);
+      a.result.current.setIntentHouseholdSize(3);
+    });
+    a.unmount();
+
+    const b = renderHook(() => useWizState());
+    expect(b.result.current.intentBedrooms).toBe(2);
+    expect(b.result.current.intentHouseholdSize).toBe(3);
+  });
+
+  it('does not clobber other persisted fields when updating intent fields', () => {
+    // Simulate a prior session that already wrote payment-wizard fields.
+    window.sessionStorage.setItem(
+      SESSION_KEY,
+      JSON.stringify({
+        adults: 2,
+        paymentRef: 'pay_pre_existing',
+        intentBedrooms: 1,
+        intentHouseholdSize: 1,
+      }),
+    );
+
+    const { result } = renderHook(() => useWizState());
+    act(() => {
+      result.current.setIntentBedrooms(3);
+    });
+
+    const stored = JSON.parse(
+      window.sessionStorage.getItem(SESSION_KEY) ?? '{}',
+    );
+    expect(stored.intentBedrooms).toBe(3);
+    expect(stored.adults).toBe(2);
+    expect(stored.paymentRef).toBe('pay_pre_existing');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds 10 Vitest unit tests around `useWizState`'s sessionStorage hydration for `intentBedrooms` + `intentHouseholdSize` — the two fields PR #40 added to FROZEN CONTRACT 2.
- Covers per field: default value, hydrate-from-storage on mount, type-validation (ignore non-numbers), range-validation (household size >= 1), and setter→storage persistence.
- Plus two round-trip cases: **mount-A → unmount → mount-B** (the actual `/auth/callback` Apply-remount that PR #40 fixed), and "don't clobber other persisted wiz fields" so future additions to the contract don't silently drop `adults` / `paymentRef` / etc.

## Why
PR #40 (welcome→apply prefill persistence) was validated by Playwright smoke (`scripts/qa-apply-handoff*.mjs`) — 9/9 prod assertions PASS. But there was no Vitest unit coverage on the core `useWizState` / `readPersisted` round-trip. That's the cheapest, fastest regression net for the FROZEN CONTRACT 2 shape — and the one most likely to catch a silent break when someone extends the contract in the future.

No app code touched. Pure `__tests__/*.tsx` addition.

## Test plan
- [x] `npx vitest run src/pages/apply/__tests__/ApplyContext.prefill.test.tsx` → **10/10 pass**
- [x] Full `npm test` — only pre-existing failures from main (covered by #45); no new regressions from this PR
- [x] Companion E2E (scripts/qa-apply-handoff-prod.mjs against `frank-pilot-tenant.vercel.app`) — **9/9 PASS**

🤖 Generated with [Claude Code](https://claude.com/claude-code)