### PR TITLE
chore(client-tenant): allow VITE_API_PROXY_TARGET to override dev proxy

### DIFF
--- a/client-tenant/vite.config.ts
+++ b/client-tenant/vite.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
     port: 5174,
     proxy: {
       '/api': {
-        target: 'http://localhost:3002',
+        target: process.env.VITE_API_PROXY_TARGET || 'http://localhost:3002',
         changeOrigin: true,
       },
     },


### PR DESCRIPTION
## Summary

`client-tenant/vite.config.ts` hard-codes the dev `/api` proxy to `http://localhost:3002`. When running an e2e smoke against a parallel backend on a different port (e.g. a second backend instance with a custom `TENANT_PORTAL_URL` to keep magic-link callbacks on the smoke origin), there's no way to redirect the proxy without editing the file.

Read `VITE_API_PROXY_TARGET` from `process.env`, fall back to the existing default.

Zero behavioral change for `npm run dev`. Unblocks multi-port smoke setups like:

```
PORT=3003 TENANT_PORTAL_URL=http://127.0.0.1:5180 npm run dev &
cd client-tenant && VITE_API_PROXY_TARGET=http://localhost:3003 \
  npx vite --port 5180 --strictPort
```

Used this to land a full Welcome→Apply walk with intent prefill all green (13/13 checks via `scripts/qa-apply-handoff.mjs`).

## Test plan

- [x] `npm run dev` in client-tenant — proxy still hits `:3002` (no env var set)
- [x] With `VITE_API_PROXY_TARGET=http://localhost:3003` — proxy redirects, full apply walk passes 13/13
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)