### PR TITLE
ci(smoke): wire qa-apply-handoff into CI as required check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,105 @@ jobs:
 
       - name: Run tests
         run: npx jest --passWithNoTests --ci --forceExit
+
+  smoke-apply:
+    name: smoke-apply (Welcome → Claim e2e)
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: frank_pilot_smoke
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/frank_pilot_smoke
+      NODE_ENV: development
+      PORT: '3002'
+      JWT_SECRET: ci-smoke-secret-do-not-reuse
+      TENANT_PORTAL_URL: http://127.0.0.1:5174
+      CORS_ORIGIN: http://127.0.0.1:5174
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'npm'
+
+      - name: Install root deps (backend + smoke script)
+        run: npm ci
+
+      - name: Install client-tenant deps
+        working-directory: client-tenant
+        run: npm install --no-audit --no-fund
+
+      - name: Install Playwright chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Migrate database
+        run: npm run migrate
+
+      - name: Seed database
+        run: npm run seed
+
+      - name: Start backend
+        run: |
+          mkdir -p /tmp/smoke-logs
+          nohup npm run dev > /tmp/smoke-logs/backend.log 2>&1 &
+          echo $! > /tmp/smoke-logs/backend.pid
+          for i in $(seq 1 40); do
+            if curl -fsS http://127.0.0.1:3002/health > /dev/null 2>&1; then
+              echo "backend ready after ${i}s"; exit 0
+            fi
+            sleep 1
+          done
+          echo "backend failed to come up"; tail -200 /tmp/smoke-logs/backend.log; exit 1
+
+      - name: Start Vite dev server
+        working-directory: client-tenant
+        run: |
+          nohup npx vite --host 127.0.0.1 --port 5174 > /tmp/smoke-logs/vite.log 2>&1 &
+          echo $! > /tmp/smoke-logs/vite.pid
+          for i in $(seq 1 30); do
+            if curl -fsS http://127.0.0.1:5174 > /dev/null 2>&1; then
+              echo "vite ready after ${i}s"; exit 0
+            fi
+            sleep 1
+          done
+          echo "vite failed to come up"; tail -200 /tmp/smoke-logs/vite.log; exit 1
+
+      - name: Run apply smoke
+        env:
+          BASE: http://127.0.0.1:5174
+          OUT: /tmp/qa-apply-handoff
+        run: node scripts/qa-apply-handoff.mjs | tee /tmp/smoke-logs/smoke.log
+
+      - name: Assert no FAIL in smoke output
+        run: |
+          if grep -E "^FAIL " /tmp/smoke-logs/smoke.log; then
+            echo "::error::Apply smoke produced FAIL lines"; exit 1
+          fi
+
+      - name: Upload smoke artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: apply-smoke-failure
+          path: |
+            /tmp/qa-apply-handoff
+            /tmp/smoke-logs
+          if-no-files-found: warn
+          retention-days: 7

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "@types/supertest": "^7.2.0",
         "@types/uuid": "^10.0.0",
         "jest": "^29.7.0",
+        "playwright": "^1.60.0",
         "supertest": "^7.2.2",
         "ts-jest": "^29.2.0",
         "ts-node": "^10.9.2",
@@ -5617,6 +5618,53 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/png-js": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@types/supertest": "^7.2.0",
     "@types/uuid": "^10.0.0",
     "jest": "^29.7.0",
+    "playwright": "^1.60.0",
     "supertest": "^7.2.2",
     "ts-jest": "^29.2.0",
     "ts-node": "^10.9.2",


### PR DESCRIPTION
## Summary
- New `smoke-apply` CI job spins up Postgres 16 + backend (`:3002`) + Vite (`:5174`) and walks the Marisol Welcome → register → magic-link → Intent → Checklist → Pick → Claim path end-to-end (21 checks via `scripts/qa-apply-handoff.mjs`).
- Runs in parallel with the existing `test` matrix on every push/PR to main.
- Pins `playwright ^1.60.0` as a devDep so `npm ci` picks it up (was installed locally but missing from `package.json`).

## Why
The Step 3 → Step 6 wedge is the FTU spine for the unit-claim flow (`[[project-ftu-unit-claim-carrot]]`) and was only covered by unit tests on individual wizard steps. A bad refactor to `StepIntent` / `Apply.tsx` / the magic-link verify path could break the applicant funnel without any red in CI. This adds the regression net we proved out locally yesterday (21/21 PASS on private `:5180`/`:3003` setup).

## What the smoke verifies in CI
- Deeplink gating (`/apply?step=intent&...` → Step 1 renders, Intent UI not shown)
- Handoff URL params survive the register redirect (`unitType`, `hh`, `income`, `amiTier`)
- Magic-link verify lands on Step 3 with intent prefill (household size, 2 BR tile, AMI verdict)
- URL transitions through `?step=checklist` → `?step=pick` → `?step=claim`
- Checklist content ($35.95 fee, 120-day rule, Application fee callout)
- Pick page shows ≥1 claim button (seed produces ~280 available 2BRs)
- Claim confirmation page ("Unit … is yours" + "Continue your application" CTA)

## Notes
- Backend boots with `NODE_ENV=development` so the dev magic-link banner surfaces (the smoke reads it via `page.locator('a[href*=\"token=\"]')`).
- `TENANT_PORTAL_URL=http://127.0.0.1:5174` is set on the backend so the magic-link callback origin matches the Vite origin — without this, the cross-origin redirect wipes `sessionStorage` and the intent prefill silently fails.
- `PORT=3002` because that's the default `vite.config.ts` proxy target (no env-driven override needed in CI).
- On failure, the job uploads `/tmp/qa-apply-handoff` (screenshots 01–06) + `/tmp/smoke-logs` (backend, vite, smoke stdout) as the `apply-smoke-failure` artifact, retained 7 days.

## To make this an actual blocking required check
Once this PR shows the `smoke-apply (Welcome → Claim e2e)` check green at least once, add it to the required status checks in **Settings → Branches → main branch protection rule**. The workflow file alone can't enforce required-check status.

## Test plan
- [ ] Both `test` matrix jobs (Node 18/20/22) stay green
- [ ] `smoke-apply` job goes green on this PR (it's testing itself)
- [ ] Artifact upload step doesn't fire on success (it's gated on `if: failure()`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)