### PR TITLE
deploy: Railway prep + /health DB ping + prod smoke POST + favicon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ logs/
 
 # BP-03b compliance tape stub ledger (runtime data; canonical BP-02 will replace this)
 server/tape/*.ndjson
+.env.production.local

--- a/client-tenant/index.html
+++ b/client-tenant/index.html
@@ -3,7 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Frank Pilot — Tenant Portal</title>
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <meta name="description" content="Affordable rental application portal for Community Development Programs Center of Nevada." />
+    <meta name="theme-color" content="#C9492A" />
+    <title>Apply — CDPC of Nevada</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/client-tenant/public/favicon.svg
+++ b/client-tenant/public/favicon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><circle cx="16" cy="16" r="15" fill="#C9492A"/><path d="M9 11l7-5 7 5v11a1 1 0 0 1-1 1h-4v-6h-4v6h-4a1 1 0 0 1-1-1z" fill="#fff"/></svg>

--- a/railway.json
+++ b/railway.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "NIXPACKS",
+    "buildCommand": "npm install && npm run build"
+  },
+  "deploy": {
+    "startCommand": "node dist/index.js",
+    "healthcheckPath": "/health",
+    "healthcheckTimeout": 30,
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 3
+  }
+}

--- a/scripts/qa-apply-handoff-prod.mjs
+++ b/scripts/qa-apply-handoff-prod.mjs
@@ -1,7 +1,9 @@
-// Prod smoke for the welcome→apply handoff. Two checks:
+// Prod smoke for the welcome→apply handoff. Three checks:
 //   1) Gate forces Step 1 + handoff URL params survive the redirect.
 //   2) intentBedrooms + intentHouseholdSize round-trip through sessionStorage
 //      under frank_apply_state (proves the persistence fix is in the shipped bundle).
+//   3) POST /api/applicants/register returns 202 — fails loudly on 405 so we
+//      catch "SPA shipped without backend" regressions in CI.
 //
 // We can't headlessly walk register → magic-link verify on prod (no dev banner),
 // so the post-verify prefill is proven via sessionStorage round-trip + bundle sniff.
@@ -10,6 +12,7 @@
 //   BASE=https://frank-pilot-tenant.vercel.app node scripts/qa-apply-handoff-prod.mjs
 //
 // Output: screenshots in $OUT (default /tmp/qa-apply-handoff-prod).
+// Exit code: 1 if any check fails (so CI can gate on it).
 
 import { chromium } from 'playwright';
 import { mkdir } from 'node:fs/promises';
@@ -26,7 +29,9 @@ async function shot(page, name) {
   console.log('SHOT', name, '←', page.url());
 }
 
+let anyFailed = false;
 function check(label, cond) {
+  if (!cond) anyFailed = true;
   console.log((cond ? 'PASS' : 'FAIL') + '  ' + label);
 }
 
@@ -94,6 +99,38 @@ try {
     }
   }
   check('Built bundle contains intentBedrooms identifier', foundIntentBedrooms);
+
+  // 06-register-post — POST the actual register endpoint. This is the gap the
+  // GET-only checks above can't see: a SPA shipped without a backend will return
+  // 405 here (Vercel's static handler rejects POST), and we want CI to FAIL
+  // loudly on that, not paper over it with a green "9/9 PASS".
+  const registerUrl = `${BASE}/api/applicants/register`;
+  const registerEmail = `qa+${Date.now()}@example.com`;
+  let registerStatus = 0;
+  let registerBody = '';
+  let registerJson = null;
+  try {
+    const res = await fetch(registerUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: registerEmail, firstName: 'QA', lastName: 'Prod' }),
+    });
+    registerStatus = res.status;
+    registerBody = await res.text();
+    try { registerJson = JSON.parse(registerBody); } catch { /* not JSON */ }
+  } catch (e) {
+    console.log('06-register-post fetch threw:', (e && e.message) || String(e));
+  }
+  console.log('06-register-post status:', registerStatus, 'body:', registerBody.slice(0, 200));
+  check('POST /api/applicants/register returns 202 (not 405 — backend is live)',
+    registerStatus === 202);
+  check('Register response body has ok === true',
+    !!(registerJson && registerJson.ok === true));
+
+  if (anyFailed) {
+    console.error('PROD SMOKE FAILED');
+    process.exitCode = 1;
+  }
 } finally {
   await ctx.close();
   await browser.close();

--- a/src/config/database.ts
+++ b/src/config/database.ts
@@ -3,18 +3,29 @@ import dotenv from "dotenv";
 
 dotenv.config();
 
-const poolConfig: PoolConfig = {
-  connectionString: process.env.DATABASE_URL,
-  host: process.env.DB_HOST || "localhost",
-  port: parseInt(process.env.DB_PORT || "5432"),
-  database: process.env.DB_NAME || "frank_pilot",
-  user: process.env.DB_USER || "postgres",
-  password: process.env.DB_PASSWORD,
-  max: 20,
-  idleTimeoutMillis: 30000,
-  connectionTimeoutMillis: 2000,
-  ssl: process.env.NODE_ENV === "production" ? { rejectUnauthorized: true } : false,
-};
+// When DATABASE_URL is set (Railway, Heroku, etc.), use it exclusively — mixing
+// it with host/port/user fields produces undefined behavior in `pg`.
+// Railway's managed Postgres uses self-signed certs, so rejectUnauthorized must
+// be false when connecting over its public proxy.
+const poolConfig: PoolConfig = process.env.DATABASE_URL
+  ? {
+      connectionString: process.env.DATABASE_URL,
+      max: 20,
+      idleTimeoutMillis: 30000,
+      connectionTimeoutMillis: 5000,
+      ssl: process.env.NODE_ENV === "production" ? { rejectUnauthorized: false } : false,
+    }
+  : {
+      host: process.env.DB_HOST || "localhost",
+      port: parseInt(process.env.DB_PORT || "5432"),
+      database: process.env.DB_NAME || "frank_pilot",
+      user: process.env.DB_USER || "postgres",
+      password: process.env.DB_PASSWORD,
+      max: 20,
+      idleTimeoutMillis: 30000,
+      connectionTimeoutMillis: 5000,
+      ssl: process.env.NODE_ENV === "production" ? { rejectUnauthorized: false } : false,
+    };
 
 export const pool = new Pool(poolConfig);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,19 @@ import messagesRoutes from "./modules/messages/routes";
 import tapeRoutes from "./modules/tape/routes";
 import { startScheduler } from "./scheduler";
 
+// Boot-time guardrails: in production, refuse to start without the secrets that
+// gate auth + at-rest crypto. Crashing here is preferable to silently booting
+// with a misconfigured server that issues unverifiable JWTs or leaves PII
+// unencryptable.
+if (process.env.NODE_ENV === "production") {
+  const required = ["JWT_SECRET", "ENCRYPTION_KEY"] as const;
+  const missing = required.filter((k) => !process.env[k]);
+  if (missing.length > 0) {
+    console.error(`Missing required env vars in production: ${missing.join(", ")}`);
+    process.exit(1);
+  }
+}
+
 const app = express();
 app.set("trust proxy", 1);
 const PORT = parseInt(process.env.PORT || "3000");
@@ -57,9 +70,30 @@ app.use((req, _res, next) => {
 // Public routes
 // ============================================================
 
-// Health check
-app.get("/health", (_req, res) => {
-  res.json({ status: "ok", service: "frank-pilot", timestamp: new Date().toISOString() });
+// Health check — pings the DB so silent outages don't look healthy.
+app.get("/health", async (_req, res) => {
+  let dbStatus = "unknown";
+  try {
+    const { query } = await import("./config/database");
+    const r = await query("SELECT 1 AS ok");
+    dbStatus = r.rows[0]?.ok === 1 ? "ok" : "unexpected";
+  } catch (err) {
+    dbStatus = "error";
+    res.status(503).json({
+      status: "degraded",
+      service: "frank-pilot",
+      db: dbStatus,
+      error: (err as Error).message,
+      timestamp: new Date().toISOString(),
+    });
+    return;
+  }
+  res.json({
+    status: "ok",
+    service: "frank-pilot",
+    db: dbStatus,
+    timestamp: new Date().toISOString(),
+  });
 });
 
 // Magic-link auth (tenants + applicants)

--- a/src/modules/applicants/routes.ts
+++ b/src/modules/applicants/routes.ts
@@ -148,7 +148,16 @@ router.post("/register", registerLimiter, async (req: Request, res: Response): P
       ok: true,
       message: "If this email is registered, a verification link has been sent.",
     };
-    if (link && process.env.NODE_ENV === "development") {
+    // In dev we always return the magic link so the post-register "check your
+    // email" banner can surface it. In prod we keep that gate closed (INFO-3:
+    // prevent devLink from leaking in production) UNLESS the operator has
+    // explicitly opted-in via DEMO_LINK_IN_RESPONSE=true. The demo-mode flag
+    // exists to let us walk a stakeholder through the funnel before real
+    // email/SMS delivery is wired; never set it on a tenant-facing deploy.
+    const includeDevLink =
+      process.env.NODE_ENV === "development" ||
+      process.env.DEMO_LINK_IN_RESPONSE === "true";
+    if (link && includeDevLink) {
       payload.devLink = link.link;
     }
     await respondAtFloor(res, t0, 202, payload);


### PR DESCRIPTION
## Summary
- Hardens API for Railway deploy: DATABASE_URL+SSL split (Railway managed Postgres self-signed certs work), boot-time JWT/ENCRYPTION_KEY assert, /health now pings DB (503 on failure)
- Gated DEMO_LINK_IN_RESPONSE=true flag so we can walk Frank through the funnel before real email/SMS delivery is wired; INFO-3 protection stays in place when flag is off
- Prod smoke now POSTs /api/applicants/register and sets process.exitCode=1 on failure — would have caught the SPA-without-backend regression
- Favicon + title polish: "Apply — CDPC of Nevada", terracotta house glyph, theme-color meta
- railway.json: Nixpacks build, /health probe, 3-retry on-failure policy

## Test plan
- [ ] tsc passes
- [ ] Once Railway is provisioned, curl /health returns `{status:'ok',db:'ok'}`
- [ ] node scripts/qa-apply-handoff-prod.mjs returns 0 against live API + Vercel SPA
- [ ] Manual: register → see magic-link banner → click → arrive Step 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)