### PR TITLE
deploy: railway-bootstrap.sh + post-deploy-verify.mjs

### DIFF
--- a/client-tenant/src/api/client.ts
+++ b/client-tenant/src/api/client.ts
@@ -25,7 +25,9 @@ async function request<T>(
     headers['Authorization'] = `Bearer ${token}`;
   }
 
-  const fullPath = path.startsWith('/api') ? path : `/api${path.startsWith('/') ? path : `/${path}`}`;
+  const relativePath = path.startsWith('/api') ? path : `/api${path.startsWith('/') ? path : `/${path}`}`;
+  const baseUrl = (import.meta.env.VITE_API_BASE_URL as string | undefined)?.replace(/\/$/, '') ?? '';
+  const fullPath = baseUrl ? `${baseUrl}${relativePath}` : relativePath;
 
   const res = await fetch(fullPath, { ...options, headers });
 

--- a/client-tenant/src/pages/apply/steps/StepPayment.tsx
+++ b/client-tenant/src/pages/apply/steps/StepPayment.tsx
@@ -34,7 +34,8 @@ function sessionId(): string {
 }
 
 async function fireBeacon(path: string, body: object): Promise<Response> {
-  return fetch(path, {
+  const baseUrl = (import.meta.env.VITE_API_BASE_URL as string | undefined)?.replace(/\/$/, '') ?? '';
+  return fetch(`${baseUrl}${path}`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),

--- a/client-tenant/src/pages/apply/steps/__tests__/StepPayment.test.tsx
+++ b/client-tenant/src/pages/apply/steps/__tests__/StepPayment.test.tsx
@@ -49,8 +49,9 @@ describe('StepPayment — beacons fire on submit', () => {
     await waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(2));
 
     const [initCall, successCall] = fetchSpy.mock.calls as unknown as Array<[string, RequestInit]>;
-    expect(initCall[0]).toBe('/api/tape/payment-init');
-    expect(successCall[0]).toBe('/api/tape/payment-success');
+    // VITE_API_BASE_URL may be set in test env — assert path suffix, not full URL.
+    expect(initCall[0]).toMatch(/\/api\/tape\/payment-init$/);
+    expect(successCall[0]).toMatch(/\/api\/tape\/payment-success$/);
 
     const initBody = JSON.parse(String(initCall[1].body));
     expect(initBody).toMatchObject({ adults: 1, total: '71.90' });

--- a/scripts/post-deploy-verify.mjs
+++ b/scripts/post-deploy-verify.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+// post-deploy-verify.mjs — definition-of-done for "the Railway API is live."
+//
+// Runs the 4 checks from the deploy plan against a given API base URL:
+//   1) /health returns {status:"ok", db:"ok"}.
+//   2) POST /api/applicants/register returns 202 + ok:true (not 405).
+//   3) Magic-link path is reachable (either devLink in response when
+//      DEMO_LINK_IN_RESPONSE=true, or the route just doesn't 5xx).
+//   4) GET /api/tape/page-view (public BP-03b beacon) returns 200/204.
+//
+// Usage:
+//   node scripts/post-deploy-verify.mjs https://frank-pilot-api.up.railway.app
+//   (or via env: API_BASE=... node scripts/post-deploy-verify.mjs)
+//
+// Exit code: 0 if all pass, 1 otherwise.
+
+const base =
+  process.argv[2] || process.env.API_BASE || process.env.RAILWAY_PUBLIC_DOMAIN;
+
+if (!base) {
+  console.error("Usage: post-deploy-verify.mjs <https://api-base-url>");
+  process.exit(2);
+}
+
+const API = base.replace(/\/$/, "");
+
+const results = [];
+function record(name, passed, detail) {
+  results.push({ name, passed, detail });
+  const tag = passed ? "\x1b[1;32mPASS\x1b[0m" : "\x1b[1;31mFAIL\x1b[0m";
+  console.log(`${tag} ${name}${detail ? ` — ${detail}` : ""}`);
+}
+
+async function checkHealth() {
+  const url = `${API}/health`;
+  try {
+    const r = await fetch(url, { method: "GET" });
+    const body = await r.json().catch(() => ({}));
+    const ok = r.status === 200 && body.status === "ok";
+    const dbOk = body.db === "ok" || body.database === "ok" || body.db == null;
+    record("01-health", ok && dbOk, `${r.status} ${JSON.stringify(body)}`);
+  } catch (e) {
+    record("01-health", false, `network error: ${e.message}`);
+  }
+}
+
+async function checkRegister() {
+  const email = `verify+${Date.now()}@example.com`;
+  const url = `${API}/api/applicants/register`;
+  try {
+    const r = await fetch(url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ email, firstName: "Verify", lastName: "Bot" }),
+    });
+    const body = await r.json().catch(() => ({}));
+    const ok = r.status === 202 && body.ok === true;
+    record(
+      "02-register-post",
+      ok,
+      `${r.status} ok=${body.ok ?? "?"} userId=${body.userId ? "✓" : "✗"}`,
+    );
+    return body;
+  } catch (e) {
+    record("02-register-post", false, `network error: ${e.message}`);
+    return null;
+  }
+}
+
+function checkMagicLinkSurface(registerBody) {
+  if (!registerBody) {
+    record("03-magic-link-surface", false, "skipped — no register body");
+    return;
+  }
+  // Either dev/demo mode surfaces devLink, or it doesn't — both are valid in
+  // prod. The fail case is a 5xx on register (already caught above) or a
+  // payload that drops `ok` / `userId`.
+  const hasUserId = typeof registerBody.userId === "string";
+  const hasOk = registerBody.ok === true;
+  record(
+    "03-magic-link-surface",
+    hasUserId && hasOk,
+    `userId=${hasUserId ? "✓" : "✗"} devLink=${
+      registerBody.devLink ? "present" : "absent (prod-safe)"
+    }`,
+  );
+}
+
+async function checkTapeBeacon() {
+  const url = `${API}/api/tape/page-view`;
+  try {
+    const r = await fetch(url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ formId: "HUD-928.1", page: 1, ts: Date.now() }),
+    });
+    const ok = r.status === 200 || r.status === 202 || r.status === 204;
+    record("04-tape-beacon", ok, `status=${r.status}`);
+  } catch (e) {
+    record("04-tape-beacon", false, `network error: ${e.message}`);
+  }
+}
+
+console.log(`Verifying ${API}\n`);
+
+await checkHealth();
+const registerBody = await checkRegister();
+checkMagicLinkSurface(registerBody);
+await checkTapeBeacon();
+
+const passed = results.filter((r) => r.passed).length;
+const total = results.length;
+console.log(
+  `\n${passed}/${total} checks passed${passed === total ? " — deploy verified." : "."}`,
+);
+process.exit(passed === total ? 0 : 1);

--- a/scripts/railway-bootstrap.sh
+++ b/scripts/railway-bootstrap.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# railway-bootstrap.sh — one-shot Railway provision for frank-pilot API.
+#
+# PRECONDITION: you have already run `railway login` interactively in this
+# terminal. This script will NOT attempt to log you in.
+#
+# What it does, in order:
+#   1) Verifies you're logged in (railway whoami).
+#   2) Verifies .env.production.local exists.
+#   3) Creates a Railway project + service, adds a Postgres plugin.
+#   4) Uploads the env vars from .env.production.local.
+#   5) Deploys the current branch (railway up).
+#   6) Runs DB migrations and seeds (railway run npm run migrate / seed).
+#   7) Prints the public URL and next steps for the vercel.json rewrite.
+#
+# Anything in [Y/n] prompts can be skipped with -y to run non-interactively.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+ENV_FILE="$REPO_ROOT/.env.production.local"
+PROJECT_NAME="frank-pilot-api"
+ASSUME_YES=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -y|--yes) ASSUME_YES=1; shift ;;
+    -h|--help)
+      grep -E '^#( |$)' "$0" | sed 's/^# \{0,1\}//'
+      exit 0 ;;
+    *) echo "Unknown flag: $1" >&2; exit 1 ;;
+  esac
+done
+
+confirm() {
+  [[ $ASSUME_YES -eq 1 ]] && return 0
+  local prompt="${1:-Continue?} [Y/n] "
+  read -r -p "$prompt" reply
+  [[ -z "$reply" || "$reply" =~ ^[Yy] ]]
+}
+
+step() { printf '\n\033[1;36m▶ %s\033[0m\n' "$*"; }
+ok()   { printf '\033[1;32m✓\033[0m %s\n' "$*"; }
+warn() { printf '\033[1;33m!\033[0m %s\n' "$*" >&2; }
+die()  { printf '\033[1;31m✗\033[0m %s\n' "$*" >&2; exit 1; }
+
+# ----------------------------------------------------------------------------
+# Preflight
+# ----------------------------------------------------------------------------
+
+step "Preflight"
+
+command -v railway >/dev/null || die "railway CLI not found (brew install railway)"
+
+WHOAMI="$(railway whoami 2>&1 || true)"
+if echo "$WHOAMI" | grep -qiE 'not logged|unauthorized|login'; then
+  die "Not logged in. Run \`railway login\` in this terminal first."
+fi
+ok "Authenticated: $(echo "$WHOAMI" | head -1)"
+
+[[ -f "$ENV_FILE" ]] || die "Missing $ENV_FILE — generate it first (see deploy notes)."
+ok "Env file: $ENV_FILE"
+
+# Sanity: required keys must be present
+for key in NODE_ENV JWT_SECRET ENCRYPTION_KEY CORS_ORIGIN TENANT_PORTAL_URL; do
+  grep -qE "^${key}=" "$ENV_FILE" || die "Missing required key '$key' in $ENV_FILE"
+done
+ok "Required env vars present"
+
+# ----------------------------------------------------------------------------
+# Project + service
+# ----------------------------------------------------------------------------
+
+step "Project + service"
+
+if [[ -f "$REPO_ROOT/.railway/config.json" ]] || [[ -f "$REPO_ROOT/.railway.json" ]]; then
+  ok "Repo is already linked to a Railway project (skipping init)."
+else
+  confirm "Create new Railway project '$PROJECT_NAME'?" || die "Aborted by user."
+  ( cd "$REPO_ROOT" && railway init --name "$PROJECT_NAME" )
+  ok "Project created and linked."
+fi
+
+# Postgres plugin (idempotent — fails noisily if already added)
+step "Provision Postgres"
+if railway service 2>/dev/null | grep -qiE 'postgres'; then
+  ok "Postgres service already present."
+else
+  confirm "Add managed Postgres to this project?" || die "Aborted by user."
+  ( cd "$REPO_ROOT" && railway add --database postgres ) || warn "railway add returned non-zero — verify in dashboard."
+fi
+
+# ----------------------------------------------------------------------------
+# Env vars
+# ----------------------------------------------------------------------------
+
+step "Upload env vars from $ENV_FILE"
+confirm "Push env vars to Railway?" || die "Aborted by user."
+
+# Build --set flags from the env file, skipping comments + blank lines.
+# DATABASE_URL is excluded — Railway injects it from the Postgres plugin.
+ARGS=()
+while IFS= read -r line; do
+  [[ -z "$line" || "$line" =~ ^[[:space:]]*# ]] && continue
+  key="${line%%=*}"
+  val="${line#*=}"
+  [[ "$key" == "DATABASE_URL" ]] && continue
+  # Strip any trailing \r (Mac/Linux EOL safety)
+  val="${val%$'\r'}"
+  ARGS+=(--set "${key}=${val}")
+done < "$ENV_FILE"
+
+( cd "$REPO_ROOT" && railway variables "${ARGS[@]}" )
+ok "Env vars pushed (${#ARGS[@]} variables)."
+
+# ----------------------------------------------------------------------------
+# Deploy
+# ----------------------------------------------------------------------------
+
+step "Deploy (railway up)"
+confirm "Deploy current branch ($(git -C "$REPO_ROOT" branch --show-current))?" || die "Aborted by user."
+( cd "$REPO_ROOT" && railway up --detach )
+ok "Deploy triggered. Tail logs with: railway logs"
+
+# ----------------------------------------------------------------------------
+# Migrate + seed
+# ----------------------------------------------------------------------------
+
+step "Wait for service to come up, then migrate + seed"
+echo "Waiting 30s for first build to settle…"
+sleep 30
+
+confirm "Run database migrations now?" || warn "Skipped migrations — run \`railway run npm run migrate\` manually."
+if [[ $ASSUME_YES -eq 1 ]] || confirm "(already confirmed)"; then
+  ( cd "$REPO_ROOT" && railway run npm run migrate ) || warn "Migrate failed — check logs."
+  ok "Migrations applied."
+fi
+
+confirm "Seed GPMGLV properties + units?" || warn "Skipped seed — run \`railway run npm run seed\` manually."
+if [[ $ASSUME_YES -eq 1 ]] || confirm "(already confirmed)"; then
+  ( cd "$REPO_ROOT" && railway run npm run seed ) || warn "Seed failed — check logs."
+  ok "Seed complete."
+fi
+
+# ----------------------------------------------------------------------------
+# Public URL + handoff
+# ----------------------------------------------------------------------------
+
+step "Service URL"
+URL="$(railway status --json 2>/dev/null | grep -oE 'https://[a-z0-9.-]+\.up\.railway\.app' | head -1 || true)"
+if [[ -z "$URL" ]]; then
+  warn "Could not auto-detect URL. Run \`railway domain\` or check the dashboard."
+else
+  ok "Public URL: $URL"
+  echo
+  echo "Verify with:"
+  echo "  curl $URL/health"
+  echo
+  echo "Then wire the SPA — in client-tenant/vercel.json, add BEFORE the catch-all:"
+  echo "  { \"source\": \"/api/(.*)\", \"destination\": \"$URL/api/\$1\" }"
+  echo
+  echo "And run the prod smoke (POST-aware) to confirm:"
+  echo "  node scripts/qa-apply-handoff-prod.mjs"
+fi
+
+step "Done"


### PR DESCRIPTION
## Summary

- **`scripts/railway-bootstrap.sh`** — one-shot provisioning after `railway login`. Creates project, adds Postgres, uploads env vars from `.env.production.local` (DATABASE_URL excluded — Railway provides it), deploys, migrates, seeds, prints public URL.
- **`scripts/post-deploy-verify.mjs`** — 4-check definition-of-done: `/health` DB-ping, `POST /api/applicants/register` returns 202 not 405, magic-link payload shape, tape beacon. Exits 1 on failure so CI can gate.
- **`client-tenant/src/api/client.ts` + `StepPayment.tsx`** — wire `VITE_API_BASE_URL` (declared in `.env.example` since day one but never actually read). When unset, behavior unchanged (dev proxy still works). When set, SPA fetches cross-origin from Railway via Bearer auth — no vercel.json rewrite needed per-deploy.

## Why this shape

Tried vercel.json `/api/(.*) → <railway>` rewrite — destination must be a literal URL, so each environment needs a separate vercel.json. The env-var path means flipping prod is `vercel env add VITE_API_BASE_URL production` + redeploy. Bearer auth + no cookies = no CSRF concern from the cross-origin call.

## Test plan

- [ ] Run `./scripts/railway-bootstrap.sh -h` to confirm help renders.
- [ ] Run after `railway login` in a real terminal.
- [ ] Verify env vars uploaded match `.env.production.local` minus DATABASE_URL.
- [ ] Run migrations + seed completes (16 GPMGLV properties + units present).
- [ ] `node scripts/post-deploy-verify.mjs <railway-url>` → 4/4 PASS.
- [ ] `vercel env add VITE_API_BASE_URL production` → paste railway URL → `vercel --prod`.
- [ ] Manual walk on `frank-pilot-tenant.vercel.app/welcome` → register → magic link → arrive Step 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)