### PR TITLE
fix(schema): add units FK + 5 indexes to bootstrap SQL (closes #16)

### DIFF
--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -433,6 +433,21 @@ CREATE TABLE units (
   UNIQUE (property_id, unit_number)
 );
 
+-- Units indexes (mirrors 2026-05-14-units-and-intent.sql migration)
+CREATE INDEX idx_units_property_status ON units(property_id, status);
+CREATE INDEX idx_units_available ON units(status) WHERE status = 'available';
+CREATE INDEX idx_units_bedrooms_rent ON units(bedrooms, monthly_rent);
+-- Stale-hold scan support for the lazy-expire path in GET /applicants/units.
+CREATE INDEX idx_units_held_expires ON units(claim_expires_at) WHERE status = 'held';
+
+-- FK from applications.claimed_unit_id → units(id). Declared post-units because
+-- the applications table is created earlier in this bootstrap SQL.
+ALTER TABLE applications
+  ADD CONSTRAINT applications_claimed_unit_id_fkey
+  FOREIGN KEY (claimed_unit_id) REFERENCES units(id) ON DELETE SET NULL;
+
+CREATE INDEX idx_applications_claimed_unit ON applications(claimed_unit_id);
+
 -- Tenant/applicant join to applications (multiple users per application: primary, co-applicant, household member)
 CREATE TABLE user_applications (
   id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),


### PR DESCRIPTION
## Summary

`src/db/schema.ts` (bootstrap SQL used for fresh installs + CI/test) had drifted from the `2026-05-14-units-and-intent.sql` migration. Mirrors the migration exactly:

- Adds `applications.claimed_unit_id` → `units(id) ON DELETE SET NULL` FK (via `ALTER TABLE` post-`units` block, since `applications` is declared first in `SCHEMA_SQL`).
- Adds 5 missing indexes:
  - `idx_units_property_status` on `units(property_id, status)`
  - `idx_units_available` on `units(status) WHERE status = 'available'`
  - `idx_units_bedrooms_rent` on `units(bedrooms, monthly_rent)`
  - `idx_units_held_expires` on `units(claim_expires_at) WHERE status = 'held'`
  - `idx_applications_claimed_unit` on `applications(claimed_unit_id)`

## Impact

- Fresh-install CI/dev DBs now match prod: orphan `claimed_unit_id` rows are prevented after unit DELETE (cascades to NULL).
- Lazy-expire scan in `GET /applicants/units` no longer seq-scans on fresh DBs.
- Integration tests can now detect FK behavior because the bootstrap matches the migrated schema.

## Test plan

- [x] `npm run build` (tsc clean)
- [x] Fresh DB bootstrap: `dropdb frank_pilot_test; createdb frank_pilot_test && DATABASE_URL=postgresql://localhost/frank_pilot_test npm run migrate`
- [x] `psql frank_pilot_test -c "\d+ applications"` confirms `applications_claimed_unit_id_fkey ... ON DELETE SET NULL`
- [x] `psql frank_pilot_test -c "\di"` shows all 5 new indexes
- [ ] CI smoke + test matrix pass

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)