### PR TITLE
fix(units): replace picsum placeholders with local asset (closes #11)

### DIFF
--- a/client-tenant/public/unit-placeholder.svg
+++ b/client-tenant/public/unit-placeholder.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 600" fill="none">
+  <!-- Warm terracotta background -->
+  <rect width="800" height="600" fill="#F5EDE6"/>
+  <!-- Subtle grain overlay circles (decorative texture) -->
+  <circle cx="120" cy="80" r="60" fill="#EDD9CB" opacity="0.5"/>
+  <circle cx="680" cy="520" r="80" fill="#EDD9CB" opacity="0.5"/>
+  <!-- House body -->
+  <rect x="270" y="290" width="260" height="190" rx="6" fill="#C8785A"/>
+  <!-- Roof -->
+  <polygon points="240,295 400,165 560,295" fill="#A85A40"/>
+  <!-- Door -->
+  <rect x="358" y="380" width="84" height="100" rx="4" fill="#8C3D25"/>
+  <!-- Door knob -->
+  <circle cx="428" cy="434" r="6" fill="#F5EDE6"/>
+  <!-- Left window -->
+  <rect x="290" y="320" width="64" height="48" rx="3" fill="#F5EDE6" opacity="0.85"/>
+  <line x1="322" y1="320" x2="322" y2="368" stroke="#C8785A" stroke-width="2"/>
+  <line x1="290" y1="344" x2="354" y2="344" stroke="#C8785A" stroke-width="2"/>
+  <!-- Right window -->
+  <rect x="446" y="320" width="64" height="48" rx="3" fill="#F5EDE6" opacity="0.85"/>
+  <line x1="478" y1="320" x2="478" y2="368" stroke="#C8785A" stroke-width="2"/>
+  <line x1="446" y1="344" x2="510" y2="344" stroke="#C8785A" stroke-width="2"/>
+  <!-- Chimney -->
+  <rect x="470" y="190" width="30" height="70" rx="3" fill="#A85A40"/>
+  <!-- Ground line -->
+  <rect x="200" y="478" width="400" height="6" rx="3" fill="#C8785A" opacity="0.4"/>
+</svg>

--- a/client-tenant/src/api/properties.ts
+++ b/client-tenant/src/api/properties.ts
@@ -1,4 +1,5 @@
 import { api } from './client';
+import { UNIT_PLACEHOLDER } from '@/utils/unitPlaceholder';
 
 export interface PropertyDetail {
   slug: string;
@@ -43,11 +44,11 @@ export const DL2_FIXTURE: PropertyDetail = {
   description:
     'Family-oriented community in East Las Vegas, walking distance to Garcia Elementary and Sunrise Hospital. Three-story building with elevator, on-site laundry, gated parking, and a courtyard with playground equipment. Section 8 vouchers welcome.',
   photos: [
-    'https://picsum.photos/seed/dl2-1/1200/900',
-    'https://picsum.photos/seed/dl2-2/1200/900',
-    'https://picsum.photos/seed/dl2-3/1200/900',
-    'https://picsum.photos/seed/dl2-4/1200/900',
-    'https://picsum.photos/seed/dl2-5/1200/900',
+    UNIT_PLACEHOLDER,
+    UNIT_PLACEHOLDER,
+    UNIT_PLACEHOLDER,
+    UNIT_PLACEHOLDER,
+    UNIT_PLACEHOLDER,
   ],
   amenities: [
     'Pool',

--- a/client-tenant/src/components/ClaimedUnitHeader.tsx
+++ b/client-tenant/src/components/ClaimedUnitHeader.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { Clock } from 'lucide-react';
 import type { Unit } from '@/api/units';
+import { getUnitPhoto } from '@/utils/unitPlaceholder';
 
 interface Props {
   unit: Unit;
@@ -30,7 +31,7 @@ export function ClaimedUnitHeader({ unit, expiresAt }: Props) {
   }, []);
 
   const remaining = new Date(expiresAt).getTime() - now;
-  const photo = unit.photo_url || `https://picsum.photos/seed/${unit.id.slice(0, 8)}/200/200`;
+  const photo = getUnitPhoto(unit.photo_url);
 
   return (
     <div className="sticky top-0 z-20 -mx-4 mb-4 border-b border-emerald-200 bg-emerald-50/95 px-4 py-3 backdrop-blur">

--- a/client-tenant/src/components/UnitCard.tsx
+++ b/client-tenant/src/components/UnitCard.tsx
@@ -2,6 +2,7 @@ import { Bed, Bath, Square } from 'lucide-react';
 import type { Unit } from '@/api/units';
 import { CTA } from '@/components/primitives';
 import { HF } from '@/styles/tokens';
+import { getUnitPhoto } from '@/utils/unitPlaceholder';
 
 interface Props {
   unit: Unit;
@@ -24,7 +25,7 @@ const chipStyle = {
 } as const;
 
 export function UnitCard({ unit, onClaim, claiming }: Props) {
-  const photo = unit.photo_url || `https://picsum.photos/seed/${unit.id.slice(0, 8)}/800/600`;
+  const photo = getUnitPhoto(unit.photo_url);
   const location = [unit.property_city, unit.property_state].filter(Boolean).join(', ');
 
   return (

--- a/client-tenant/src/pages/Application.tsx
+++ b/client-tenant/src/pages/Application.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState, useCallback } from 'react';
 import { Link } from 'react-router-dom';
 import { api } from '@/api/client';
 import { releaseClaim } from '@/api/units';
+import { getUnitPhoto } from '@/utils/unitPlaceholder';
 import {
   FileText,
   AlertCircle,
@@ -286,7 +287,7 @@ function ClaimedUnitCard({
 
   const remaining = new Date(expiresAt).getTime() - now;
   const photo =
-    unit.photo_url || `https://picsum.photos/seed/${unit.id.slice(0, 8)}/800/600`;
+    getUnitPhoto(unit.photo_url);
 
   async function handleRelease() {
     const ok = window.confirm(

--- a/client-tenant/src/pages/apply/steps/StepClaim.tsx
+++ b/client-tenant/src/pages/apply/steps/StepClaim.tsx
@@ -3,6 +3,7 @@ import { useApply } from '../ApplyContext';
 import { useTranslation } from 'react-i18next';
 import { CTA } from '@/components/primitives';
 import { useFlag } from '@/lib/flags';
+import { getUnitPhoto } from '@/utils/unitPlaceholder';
 
 export function StepClaim() {
   const s = useApply();
@@ -26,7 +27,7 @@ export function StepClaim() {
     <div className="space-y-4 text-center">
       <div className="overflow-hidden rounded-xl">
         <img
-          src={unit.photo_url || `https://picsum.photos/seed/${unit.id.slice(0, 8)}/800/600`}
+          src={getUnitPhoto(unit.photo_url)}
           alt=""
           className="aspect-[16/9] w-full object-cover"
         />

--- a/client-tenant/src/pages/discover/PropertyList.tsx
+++ b/client-tenant/src/pages/discover/PropertyList.tsx
@@ -6,6 +6,7 @@ import { fetchUnits, type Unit } from '@/api/units';
 import { getToken } from '@/api/client';
 import { DL2_FIXTURE } from '@/api/properties';
 import { Card, CTA } from '@/components/primitives';
+import { getUnitPhoto } from '@/utils/unitPlaceholder';
 
 interface PropertyTile {
   slug: string;
@@ -39,9 +40,7 @@ function unitsToProperties(units: Unit[]): PropertyTile[] {
       name: first.property_name,
       city: first.property_city,
       state: first.property_state,
-      photo:
-        first.photo_url ||
-        `https://picsum.photos/seed/${first.property_id.slice(0, 8)}/800/600`,
+      photo: getUnitPhoto(first.photo_url),
       rentMin: Math.min(...rents),
       rentMax: Math.max(...rents),
       hasAvailable: list.some((u) => !!u.available_from),

--- a/client-tenant/src/utils/unitPlaceholder.ts
+++ b/client-tenant/src/utils/unitPlaceholder.ts
@@ -1,0 +1,10 @@
+/**
+ * Returns a photo URL for a unit, falling back to a self-hosted SVG placeholder
+ * when no photo has been uploaded. Using a local asset avoids the flakiness and
+ * rate-limiting of third-party placeholder services (e.g. picsum.photos).
+ */
+export const UNIT_PLACEHOLDER = '/unit-placeholder.svg';
+
+export function getUnitPhoto(photoUrl: string | null | undefined): string {
+  return photoUrl || UNIT_PLACEHOLDER;
+}


### PR DESCRIPTION
## Summary

- Adds `client-tenant/public/unit-placeholder.svg` — a self-hosted terracotta house glyph SVG that matches the Frank warm palette, no external network required
- Adds `client-tenant/src/utils/unitPlaceholder.ts` exporting `getUnitPhoto(url)` and `UNIT_PLACEHOLDER` constant
- Replaces all 7 picsum.photos references across `client-tenant/src/`: UnitCard, ClaimedUnitHeader, Application.tsx, StepClaim, PropertyList, and the 5-entry gallery array in api/properties.ts

Zero picsum.photos URLs remain in `client-tenant/src/` or `client-tenant/public/` (grep-verified).

Build TS errors (`@testing-library/jest-dom` / `vitest/globals` not found) are pre-existing on main — not introduced by this PR.

## Test plan

- [ ] `grep -rn "picsum" client-tenant/src client-tenant/public` returns no code references (only comment in unitPlaceholder.ts)
- [ ] Unit cards, property list, and application header all display the warm house SVG when `photo_url` is null
- [ ] No network request to picsum.photos is made during offline dev or when `photo_url` is populated

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)