### PR TITLE
fix(applicants): guard claim-unit release with holder+expiry predicate (closes #15)

### DIFF
--- a/src/__tests__/unit-claim.test.ts
+++ b/src/__tests__/unit-claim.test.ts
@@ -410,6 +410,105 @@ describe("POST /applicants/claim-unit/:id", () => {
     expect(forUpdateIdx).toBeGreaterThan(advisoryIdx);
   });
 
+  // Regression for issue #15 Bug 1 (cross-user clobber). Setup: User A's
+  // draft still points at PRIOR_UNIT with the original 48h expiry, but that
+  // hold has lapsed and User B has since re-claimed PRIOR_UNIT with a NEW
+  // expiry. When A now claims VALID_UNIT, the prior-unit release UPDATE must
+  // be gated on the (status='held', claim_expires_at = $priorExpiresAt)
+  // predicate so it cannot touch B's active hold. We assert the actual SQL
+  // shape since this is the only deterministic way to verify the gate
+  // without spinning up Postgres.
+  it("guards prior-unit release with holder+expiry predicate (issue #15 Bug 1)", async () => {
+    mockUsersRow(applicant, VERIFIED_AT);
+    const PRIOR_UNIT = "550e8400-e29b-41d4-a716-446655440099";
+    const ORIGINAL_EXPIRY = new Date("2026-05-19T00:00:00Z").toISOString();
+    const calls: Array<[string, any[] | undefined]> = [];
+    mockTransaction.mockImplementationOnce(async (fn: any) => {
+      const queue: Array<{ rows: any[] }> = [
+        { rows: [] },                                                                          // advisory lock
+        { rows: [{ id: VALID_UNIT, property_id: PROPERTY_ID, status: "available", claim_expires_at: null }] },
+        { rows: [{ id: "app-001", claimed_unit_id: PRIOR_UNIT, claim_expires_at: ORIGINAL_EXPIRY }] },
+        { rows: [] }, // guarded UPDATE on PRIOR_UNIT — assumed no-op in real DB if B now holds it
+        { rows: [] }, // UPDATE units (new claim → held)
+        { rows: [] }, // UPDATE applications
+        { rows: [{ id: VALID_UNIT, unit_number: "A-101" }] },
+      ];
+      const client = {
+        query: jest.fn().mockImplementation((sql: string, params?: any[]) => {
+          calls.push([sql, params]);
+          return Promise.resolve(queue.shift()!);
+        }),
+      };
+      return fn(client);
+    });
+    const token = generateToken(applicant);
+    const res = await request(app)
+      .post(`/applicants/claim-unit/${VALID_UNIT}`)
+      .set("Authorization", `Bearer ${token}`);
+    expect(res.status).toBe(200);
+
+    // The prior-unit release UPDATE must include status + expiry predicates,
+    // and must pass the expected priorExpiresAt as $2. An unguarded UPDATE
+    // (the pre-fix code) would have neither.
+    const releaseCall = calls.find(([sql]) =>
+      /UPDATE units\s+SET status = 'available'/.test(sql) &&
+      /WHERE id = \$1/.test(sql)
+    );
+    expect(releaseCall).toBeDefined();
+    const [releaseSql, releaseParams] = releaseCall!;
+    expect(releaseSql).toMatch(/AND\s+status\s*=\s*'held'/);
+    expect(releaseSql).toMatch(/AND\s+claim_expires_at\s+IS\s+NOT\s+DISTINCT\s+FROM\s+\$2/i);
+    expect(releaseParams).toEqual([PRIOR_UNIT, ORIGINAL_EXPIRY]);
+
+    // And the draft SELECT must surface claim_expires_at (so the route has
+    // the value to bind) and lock the row with FOR UPDATE.
+    const draftSelect = calls.find(([sql]) =>
+      /FROM user_applications/.test(sql) && /JOIN applications/.test(sql)
+    );
+    expect(draftSelect![0]).toMatch(/a\.claim_expires_at/);
+    expect(draftSelect![0]).toMatch(/FOR UPDATE OF a/);
+  });
+
+  // Issue #15 Bug 2 (concurrent same-user leak): even with the per-user
+  // advisory lock, the draft SELECT must also FOR UPDATE the application
+  // row so the prior-unit pointer we read at the top of the txn is the same
+  // row we write at the bottom. (Tested via SQL shape — true parallel-tab
+  // races would need two pool connections.) See the test "acquires per-user
+  // advisory lock before locking the unit row" above for the lock-ordering
+  // half of Bug 2's defense.
+  it("locks the draft application row with FOR UPDATE (issue #15 Bug 2)", async () => {
+    mockUsersRow(applicant, VERIFIED_AT);
+    const calls: Array<[string, any[] | undefined]> = [];
+    mockTransaction.mockImplementationOnce(async (fn: any) => {
+      const queue: Array<{ rows: any[] }> = [
+        { rows: [] }, // advisory lock
+        { rows: [{ id: VALID_UNIT, property_id: PROPERTY_ID, status: "available", claim_expires_at: null }] },
+        { rows: [{ id: "app-001", claimed_unit_id: null, claim_expires_at: null }] },
+        { rows: [] },
+        { rows: [] },
+        { rows: [{ id: VALID_UNIT, unit_number: "A-101" }] },
+      ];
+      const client = {
+        query: jest.fn().mockImplementation((sql: string, params?: any[]) => {
+          calls.push([sql, params]);
+          return Promise.resolve(queue.shift()!);
+        }),
+      };
+      return fn(client);
+    });
+    const token = generateToken(applicant);
+    const res = await request(app)
+      .post(`/applicants/claim-unit/${VALID_UNIT}`)
+      .set("Authorization", `Bearer ${token}`);
+    expect(res.status).toBe(200);
+
+    const draftSelect = calls.find(([sql]) =>
+      /FROM user_applications/.test(sql) && /JOIN applications/.test(sql)
+    );
+    expect(draftSelect).toBeDefined();
+    expect(draftSelect![0]).toMatch(/FOR UPDATE OF a/);
+  });
+
   it("creates a draft when claiming with none yet", async () => {
     mockUsersRow(applicant, VERIFIED_AT);
     mockTxnWithQueue([
@@ -490,6 +589,49 @@ describe("DELETE /applicants/claim-unit", () => {
     expect(res.status).toBe(200);
     expect(calls[0][0]).toMatch(/pg_advisory_xact_lock\(hashtext\(\$1\)\)/);
     expect(calls[0][1]).toEqual([`claim-unit:${applicant.id}`]);
+  });
+
+  // Issue #15 Bug 1 companion: DELETE must use the same holder+expiry guard
+  // so an explicit release can't clobber a different user's hold that took
+  // over after the original lazy-expired.
+  it("guards release with holder+expiry predicate (issue #15 Bug 1)", async () => {
+    mockUsersRow(applicant, VERIFIED_AT);
+    const ORIGINAL_EXPIRY = new Date("2026-05-19T00:00:00Z").toISOString();
+    const calls: Array<[string, any[] | undefined]> = [];
+    mockTransaction.mockImplementationOnce(async (fn: any) => {
+      const queue: Array<{ rows: any[] }> = [
+        { rows: [] }, // advisory lock
+        { rows: [{ id: "app-001", claimed_unit_id: "unit-XYZ", claim_expires_at: ORIGINAL_EXPIRY }] },
+        { rows: [] }, // UPDATE units
+        { rows: [] }, // UPDATE applications
+      ];
+      const client = {
+        query: jest.fn().mockImplementation((sql: string, params?: any[]) => {
+          calls.push([sql, params]);
+          return Promise.resolve(queue.shift()!);
+        }),
+      };
+      return fn(client);
+    });
+    const token = generateToken(applicant);
+    const res = await request(app)
+      .delete("/applicants/claim-unit")
+      .set("Authorization", `Bearer ${token}`);
+    expect(res.status).toBe(200);
+
+    const releaseCall = calls.find(([sql]) =>
+      /UPDATE units\s+SET status = 'available'/.test(sql)
+    );
+    const [releaseSql, releaseParams] = releaseCall!;
+    expect(releaseSql).toMatch(/AND\s+status\s*=\s*'held'/);
+    expect(releaseSql).toMatch(/AND\s+claim_expires_at\s+IS\s+NOT\s+DISTINCT\s+FROM\s+\$2/i);
+    expect(releaseParams).toEqual(["unit-XYZ", ORIGINAL_EXPIRY]);
+
+    const draftSelect = calls.find(([sql]) =>
+      /FROM user_applications/.test(sql) && /JOIN applications/.test(sql)
+    );
+    expect(draftSelect![0]).toMatch(/a\.claim_expires_at/);
+    expect(draftSelect![0]).toMatch(/FOR UPDATE OF a/);
   });
 
   it("ok=true even when user has no active claim (idempotent)", async () => {

--- a/src/modules/applicants/routes.ts
+++ b/src/modules/applicants/routes.ts
@@ -587,21 +587,30 @@ router.post(
           return { error: "UNIT_UNAVAILABLE" as const };
         }
 
+        // Issue #15 Bug 2 (concurrent same-user leak): the per-user advisory
+        // lock above serializes claims from the same user, but we still need
+        // FOR UPDATE on the draft row itself so the prior-unit pointer we
+        // read is the one we'll mutate at the end of the txn. Without it, a
+        // sibling txn that already advanced past the lock could have rewritten
+        // claimed_unit_id between our read and our write.
         const draft = await client.query(
-          `SELECT a.id, a.claimed_unit_id
+          `SELECT a.id, a.claimed_unit_id, a.claim_expires_at
              FROM user_applications ua
              JOIN applications a ON a.id = ua.application_id
             WHERE ua.user_id = $1 AND a.status = 'draft'
             ORDER BY a.created_at DESC
-            LIMIT 1`,
+            LIMIT 1
+            FOR UPDATE OF a`,
           [req.user!.id]
         );
 
         let applicationId: string;
         let priorUnitId: string | null = null;
+        let priorExpiresAt: Date | string | null = null;
         if (draft.rows.length > 0) {
           applicationId = draft.rows[0].id;
           priorUnitId = draft.rows[0].claimed_unit_id;
+          priorExpiresAt = draft.rows[0].claim_expires_at;
         } else {
           const created = await client.query(
             `INSERT INTO applications (property_id, first_name, last_name, email, status)
@@ -624,13 +633,22 @@ router.post(
         }
 
         if (priorUnitId && priorUnitId !== unitId) {
+          // Issue #15 Bug 1 (cross-user clobber): the prior-unit release used
+          // to be an unconditional UPDATE on the unit row, so if the user's
+          // own hold had already expired and a different applicant had since
+          // re-claimed that unit, this UPDATE would silently destroy the new
+          // holder's claim. Gate the UPDATE on the expected (holder, expiry)
+          // predicate — if the row no longer matches what we held, the UPDATE
+          // is a no-op and the new holder is safe.
           await client.query(
             `UPDATE units
                 SET status = 'available',
                     claim_expires_at = NULL,
                     updated_at = NOW()
-              WHERE id = $1`,
-            [priorUnitId]
+              WHERE id = $1
+                AND status = 'held'
+                AND claim_expires_at IS NOT DISTINCT FROM $2`,
+            [priorUnitId, priorExpiresAt]
           );
         }
 
@@ -721,25 +739,36 @@ router.delete(
           `claim-unit:${req.user!.id}`,
         ]);
 
+        // Issue #15: lock the draft row so we read the (claimed_unit_id,
+        // claim_expires_at) pair that we'll guard the release UPDATE with.
         const draft = await client.query(
-          `SELECT a.id, a.claimed_unit_id
+          `SELECT a.id, a.claimed_unit_id, a.claim_expires_at
              FROM user_applications ua
              JOIN applications a ON a.id = ua.application_id
             WHERE ua.user_id = $1 AND a.status = 'draft' AND a.claimed_unit_id IS NOT NULL
             ORDER BY a.created_at DESC
-            LIMIT 1`,
+            LIMIT 1
+            FOR UPDATE OF a`,
           [req.user!.id]
         );
         if (draft.rows.length === 0) return;
-        const { id: applicationId, claimed_unit_id: unitId } = draft.rows[0];
+        const {
+          id: applicationId,
+          claimed_unit_id: unitId,
+          claim_expires_at: priorExpiresAt,
+        } = draft.rows[0];
 
+        // Issue #15 Bug 1: guard the release with holder+expiry so we can't
+        // clobber a unit that has lazy-expired into a different user's hold.
         await client.query(
           `UPDATE units
               SET status = 'available',
                   claim_expires_at = NULL,
                   updated_at = NOW()
-            WHERE id = $1`,
-          [unitId]
+            WHERE id = $1
+              AND status = 'held'
+              AND claim_expires_at IS NOT DISTINCT FROM $2`,
+          [unitId, priorExpiresAt]
         );
         await client.query(
           `UPDATE applications


### PR DESCRIPTION
## Summary

Closes #15, closes #7.

Two race-condition bugs in `src/modules/applicants/routes.ts` (`POST /applicants/claim-unit/:id` and `DELETE /applicants/claim-unit`).

### Bug 1 — cross-user clobber
1. User A claims unit U at T=0, hold expires at T+48h.
2. T=49h+: lazy-expiry treats U as available; User B claims U with a NEW `claim_expires_at`.
3. T=51h: A returns, claims a different unit V. The route reads A's stale `claimed_unit_id=U` from the draft and runs unconditional `UPDATE units WHERE id=U SET status='available'`. **B's active hold is silently destroyed.**

### Bug 2 — concurrent same-user leak
Two rage-clicks on different unit cards take `FOR UPDATE` on disjoint unit rows. Both txns read the draft (`claimed_unit_id=null`) and both succeed. Final state: 2 units held, draft pointer back to only one. The other leaks for 48h until lazy expiry.

## Fix

- **Bug 2 — serialize the user's own concurrent requests.** Per-user `pg_advisory_xact_lock(hashtext('claim-unit:' || user_id))` was already in place at the top of both txns. Added `FOR UPDATE OF a` on the draft `SELECT` so the `(claimed_unit_id, claim_expires_at)` pair read at the top of the txn is the same row we write at the bottom — closing the read/write gap inside each txn.
- **Bug 1 — gate the prior-unit release with holder+expiry predicate.** The release UPDATE now reads:
  ```sql
  UPDATE units
     SET status = 'available', claim_expires_at = NULL, updated_at = NOW()
   WHERE id = $1
     AND status = 'held'
     AND claim_expires_at IS NOT DISTINCT FROM $2
  ```
  passing the expected expiry the draft was holding. If the row no longer matches (because another user now holds it, or status changed), the UPDATE is a no-op and the new holder is safe.
- Applied identically to both `POST /applicants/claim-unit/:id` (prior-unit release on a switching claim) and `DELETE /applicants/claim-unit` (release of the current unit).
- Both routes were already wrapped in `transaction(...)` — no transaction boundary changes needed.

## Closing #7

Issue #7 asks for `SELECT … FOR UPDATE` on the prior unit row before the release UPDATE. The holder+expiry predicate is a stronger guarantee than that lock (the UPDATE is provably a no-op if the row state has changed since we read the draft), so this PR closes both issues. If the reviewer prefers an explicit row lock on top, happy to add it in a follow-up — but it would be belt-and-suspenders on the predicate guard.

## Test plan

`src/__tests__/unit-claim.test.ts` — 24/24 pass (3 new tests added).

- [x] **Bug 1 regression (POST):** asserts release SQL carries `status = 'held'` and `claim_expires_at IS NOT DISTINCT FROM $2` predicates, asserts draft SELECT carries `a.claim_expires_at` and `FOR UPDATE OF a`, asserts bind params are `[priorUnitId, originalExpiry]`. Setup: User A's draft points at PRIOR_UNIT with the original 48h expiry; A claims a different unit V.
- [x] **Bug 1 regression (DELETE):** same shape assertions on the release path.
- [x] **Bug 2 lock coverage:** asserts the draft SELECT carries `FOR UPDATE OF a`. Combined with the existing `acquires per-user advisory lock before locking the unit row` test, both halves of Bug 2's defense are SQL-shape covered.
- [x] **Bug 2 deterministic gap noted:** a true-parallel race test would need two pool connections + a live Postgres; SQL-shape coverage is the best we can do at the jest layer without dragging Postgres into CI.
- [x] **Full backend suite:** `npx jest --forceExit` → 802/802 pass. One unrelated suite-level failure in `email-service.test.ts` (`Cannot find module 'resend'`) is a pre-existing environment issue, not from this PR.
- [x] **TypeScript:** `npm run build` clean (`tsc`, no errors).
- [ ] **e2e smoke (`scripts/qa-apply-handoff.mjs`)** — not run from this worktree (no local Postgres + dev server stack); CI's required `smoke-apply` check will cover it.

## Files touched
- `src/modules/applicants/routes.ts` — POST handler (around L590, L630), DELETE handler (around L725, L745)
- `src/__tests__/unit-claim.test.ts` — 3 new tests

No other files touched. No changes to schema, migrations, package.json, env, or any other module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)