### PR TITLE
fix(apply): hydrate before render on deep-link + merge searchParams (closes #8, closes #9)

### DIFF
--- a/client-tenant/src/pages/Apply.tsx
+++ b/client-tenant/src/pages/Apply.tsx
@@ -29,6 +29,57 @@ const StepHousehold = lazy(() => import('./apply/steps/StepHousehold'));
 const StepPayment = lazy(() => import('./apply/steps/StepPayment'));
 const StepConfirm = lazy(() => import('./apply/steps/StepConfirm'));
 
+// Issue #8 — placeholder painted while the intent-step hydration fetch is in
+// flight on a fresh deep link (`?step=intent`). Mirrors the StepIntent layout
+// (title, bedroom row, slider, date, household, income, CTA) so swapping in
+// the real form doesn't shift layout. Reads as "loading" via aria-busy.
+function IntentSkeleton() {
+  const bar = (h: number, w: string) => (
+    <div
+      style={{
+        height: h,
+        width: w,
+        background: HF.border,
+        borderRadius: HF.r.sm,
+        opacity: 0.5,
+      }}
+    />
+  );
+  return (
+    <div aria-busy="true" aria-live="polite" data-testid="intent-skeleton" className="space-y-5">
+      <div className="space-y-2">
+        {bar(20, '60%')}
+        {bar(14, '80%')}
+      </div>
+      <div className="space-y-2">
+        {bar(12, '30%')}
+        <div className="grid grid-cols-5 gap-2">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <div key={i}>{bar(40, '100%')}</div>
+          ))}
+        </div>
+      </div>
+      <div className="space-y-2">
+        {bar(12, '40%')}
+        {bar(16, '100%')}
+      </div>
+      <div className="space-y-2">
+        {bar(12, '35%')}
+        {bar(36, '100%')}
+      </div>
+      <div className="space-y-2">
+        {bar(12, '35%')}
+        {bar(36, '100%')}
+      </div>
+      <div className="space-y-2">
+        {bar(12, '55%')}
+        {bar(36, '100%')}
+      </div>
+      {bar(44, '100%')}
+    </div>
+  );
+}
+
 function parseStep(raw: string | null): Step {
   if (raw === '2') return 2;
   if (
@@ -55,11 +106,19 @@ export function Apply() {
   function setStep(next: Step) {
     setStepState(next);
     const value = next === 1 ? null : String(next);
-    // Preserve handoff params (unitType/propertyId/state) on step transitions.
-    const nextParams = new URLSearchParams(search);
-    if (value) nextParams.set('step', value);
-    else nextParams.delete('step');
-    setSearch(nextParams, { replace: true });
+    // Issue #9 — merge with the LATEST URLSearchParams snapshot rather than
+    // the closure-captured `search`. The functional form guarantees we don't
+    // clobber utm_* / unitType / propertyId / state / any inbound params that
+    // were added between renders or in a sibling effect.
+    setSearch(
+      (prev) => {
+        const nextParams = new URLSearchParams(prev);
+        if (value) nextParams.set('step', value);
+        else nextParams.delete('step');
+        return nextParams;
+      },
+      { replace: true },
+    );
   }
 
   const [error, setError] = useState<string | null>(null);
@@ -107,18 +166,37 @@ export function Apply() {
   // persisted to sessionStorage under key `frank_apply_state`.
   const wiz = useWizState();
 
+  // Issue #8 — gate render on intent-step deep links until hydration completes.
+  // Without this, landing on `?step=intent` paints the empty quiz form for a
+  // tick before /auth/me + /applicants/me/applications resolve and backfill
+  // bedrooms / budget / move-in / household size. We flip `hydrated` true in
+  // the same effect that does the fetch — including the early-out paths — so
+  // any code path that "doesn't need hydration" still unlocks render.
+  const [hydrated, setHydrated] = useState(false);
+
   // Hydrate identity + intent prefill on entering intent/checklist/pick/2 (deep links).
   useEffect(() => {
-    if (step !== 'intent' && step !== 'checklist' && step !== 'pick' && step !== 2) return;
-    if (email && firstName && lastName) return;
+    if (step !== 'intent' && step !== 'checklist' && step !== 'pick' && step !== 2) {
+      // Non-hydrating step (1 / verify / claim / review / household / payment /
+      // confirm): nothing to wait on, render immediately.
+      setHydrated(true);
+      return;
+    }
+    if (email && firstName && lastName) {
+      // Identity already in memory — no fetch needed, unblock render.
+      setHydrated(true);
+      return;
+    }
     let cancelled = false;
     (async () => {
       try {
         const me = await api.get<{ user?: { email: string; firstName: string; lastName: string } }>('/auth/me');
-        if (cancelled || !me.user) return;
-        if (!email) setEmail(me.user.email);
-        if (!firstName) setFirstName(me.user.firstName);
-        if (!lastName) setLastName(me.user.lastName);
+        if (cancelled) return;
+        if (me.user) {
+          if (!email) setEmail(me.user.email);
+          if (!firstName) setFirstName(me.user.firstName);
+          if (!lastName) setLastName(me.user.lastName);
+        }
 
         const apps = await api.get<{ applications?: Array<{
           id: string; property_id?: string; unit_number?: string;
@@ -127,19 +205,23 @@ export function Apply() {
           intent_move_in_date?: string | null;
           intent_household_size?: number | null;
         }> }>('/applicants/me/applications');
+        if (cancelled) return;
         const latest = apps.applications?.[0];
-        if (cancelled || !latest) return;
-        if (latest.property_id && !propertyId) setPropertyId(latest.property_id);
-        if (latest.unit_number && !unitNumber) setUnitNumber(latest.unit_number);
-        if (latest.intent_bedrooms != null && wiz.intentBedrooms === null) wiz.setIntentBedrooms(latest.intent_bedrooms);
-        if (latest.intent_budget_max != null) setIntentBudgetMax(Number(latest.intent_budget_max));
-        if (latest.intent_move_in_date) setIntentMoveInDate(latest.intent_move_in_date.slice(0, 10));
-        if (latest.intent_household_size != null) {
-          wiz.setIntentHouseholdSize(latest.intent_household_size);
-          setHouseholdSize(String(latest.intent_household_size));
+        if (latest) {
+          if (latest.property_id && !propertyId) setPropertyId(latest.property_id);
+          if (latest.unit_number && !unitNumber) setUnitNumber(latest.unit_number);
+          if (latest.intent_bedrooms != null && wiz.intentBedrooms === null) wiz.setIntentBedrooms(latest.intent_bedrooms);
+          if (latest.intent_budget_max != null) setIntentBudgetMax(Number(latest.intent_budget_max));
+          if (latest.intent_move_in_date) setIntentMoveInDate(latest.intent_move_in_date.slice(0, 10));
+          if (latest.intent_household_size != null) {
+            wiz.setIntentHouseholdSize(latest.intent_household_size);
+            setHouseholdSize(String(latest.intent_household_size));
+          }
         }
       } catch {
-        /* ignored */
+        /* ignored — hydration is best-effort, unblock render on failure too */
+      } finally {
+        if (!cancelled) setHydrated(true);
       }
     })();
     return () => { cancelled = true; };
@@ -223,7 +305,7 @@ export function Apply() {
               )}
               {step === 1 && <Step1Register />}
               {step === 'verify' && <StepVerify />}
-              {step === 'intent' && <StepIntent />}
+              {step === 'intent' && (hydrated ? <StepIntent /> : <IntentSkeleton />)}
               {step === 'checklist' && <StepChecklist />}
               {step === 'pick' && <StepPick />}
               {step === 'claim' && <StepClaim />}

--- a/client-tenant/src/pages/apply/__tests__/Apply.integration.test.tsx
+++ b/client-tenant/src/pages/apply/__tests__/Apply.integration.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom';
 import { Apply } from '../../Apply';
 import { setToken } from '@/api/client';
 
@@ -139,4 +139,137 @@ describe('Apply — full happy path through 7 steps', () => {
       expect(screen.getByText(/application submitted/i)).toBeInTheDocument();
     });
   }, 30000);
+});
+
+// Issue #8 regression — deep-linking to ?step=intent must not paint the empty
+// quiz before the hydration fetch resolves. We assert the skeleton renders
+// first (heading absent), then the quiz heading appears.
+describe('Apply — issue #8 deep-link hydration', () => {
+  it('renders skeleton on ?step=intent until hydration completes', async () => {
+    let resolveMe!: (v: unknown) => void;
+    const mePromise = new Promise((res) => {
+      resolveMe = res;
+    });
+    const fn = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      const method = init?.method ?? 'GET';
+      const body = (data: unknown, status = 200) =>
+        new Response(JSON.stringify(data), {
+          status,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      if (url.includes('/auth/me')) {
+        await mePromise;
+        return body({
+          user: {
+            email: 'm@example.com',
+            firstName: 'M',
+            lastName: 'R',
+            emailVerified: true,
+          },
+        });
+      }
+      if (url.includes('/applicants/me/applications')) {
+        return body({ applications: [] });
+      }
+      if (url.includes('/applicants/intent') && method === 'POST') {
+        return body({ ok: true });
+      }
+      return body({ error: `unmocked ${url}` }, 404);
+    });
+    vi.stubGlobal('fetch', fn);
+    setToken('test-token');
+
+    render(
+      <MemoryRouter initialEntries={['/apply?step=intent']}>
+        <Routes>
+          <Route path="/apply" element={<Apply />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    // Skeleton first; quiz heading must NOT be present while hydration pends.
+    expect(await screen.findByTestId('intent-skeleton')).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: /what are you looking for/i })).toBeNull();
+
+    // Resolve hydration → real form swaps in.
+    resolveMe(undefined);
+    expect(
+      await screen.findByRole('heading', { name: /what are you looking for/i }),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId('intent-skeleton')).toBeNull();
+  }, 15000);
+});
+
+// Issue #9 regression — advancing steps must merge with existing query params
+// rather than overwriting them. We seed utm_source/unitType, advance the
+// wizard, and assert both survive alongside the new step param.
+describe('Apply — issue #9 query param merge', () => {
+  function LocationProbe() {
+    const loc = useLocation();
+    return <div data-testid="loc-search">{loc.search}</div>;
+  }
+
+  it('preserves utm_* and inbound handoff params across setStep transitions', async () => {
+    const fn = vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      const body = (data: unknown, status = 200) =>
+        new Response(JSON.stringify(data), {
+          status,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      if (url.includes('/auth/me')) {
+        return body({
+          user: {
+            email: 'm@example.com',
+            firstName: 'M',
+            lastName: 'R',
+            emailVerified: true,
+          },
+        });
+      }
+      if (url.includes('/applicants/me/applications')) return body({ applications: [] });
+      if (url.includes('/applicants/intent')) return body({ ok: true, application_id: 'a' });
+      return body({ error: `unmocked ${url}` }, 404);
+    });
+    vi.stubGlobal('fetch', fn);
+    setToken('test-token');
+
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter
+        initialEntries={[
+          '/apply?step=intent&utm_source=newsletter&utm_campaign=launch&unitType=2BR',
+        ]}
+      >
+        <Routes>
+          <Route
+            path="/apply"
+            element={
+              <>
+                <Apply />
+                <LocationProbe />
+              </>
+            }
+          />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    // Wait for hydration → real form.
+    await screen.findByRole('heading', { name: /what are you looking for/i });
+    await user.click(screen.getByRole('button', { name: /^2 BR$/i }));
+    await user.type(screen.getByLabelText(/target move-in/i), '2026-09-01');
+    await user.click(screen.getByRole('button', { name: /show me units/i }));
+
+    // Advanced to checklist — utm_* + unitType must survive alongside the new step.
+    const probe = await screen.findByTestId('loc-search');
+    await waitFor(() => {
+      expect(probe.textContent ?? '').toMatch(/step=checklist/);
+    });
+    const search = probe.textContent ?? '';
+    expect(search).toMatch(/utm_source=newsletter/);
+    expect(search).toMatch(/utm_campaign=launch/);
+    expect(search).toMatch(/unitType=2BR/);
+  }, 15000);
 });


### PR DESCRIPTION
## Summary

Two related bugs in `client-tenant/src/pages/Apply.tsx` — bundled so they don't conflict back-to-back on the same file.

### Issue #8 — `?step=intent` deep-link hydration race
Landing on `?step=intent` rendered `StepIntent` before `/auth/me` + `/applicants/me/applications` resolved, flashing an empty quiz before bedrooms / budget / move-in / household-size backfilled.

**Fix:** added a `hydrated` state, flipped to `true` in the hydration effect (success, error, and early-out paths), and gated `<StepIntent />` behind it with an `<IntentSkeleton />` that mirrors the form layout — no CLS on the swap.

### Issue #9 — `setSearchParams` overwrites query string
`setStep` cloned a closure-captured `search` snapshot which could go stale between batched updates and clobber `utm_*` / `unitType` / `propertyId` / `state`.

**Fix:** moved to the functional form so we always merge against the latest `URLSearchParams` snapshot. `replace: true` semantics preserved.

## Files touched

- `client-tenant/src/pages/Apply.tsx` — `IntentSkeleton` component (file-local), `hydrated` state + effect updates, functional `setSearch`
- `client-tenant/src/pages/apply/__tests__/Apply.integration.test.tsx` — 2 regression tests (one per issue)

## Test plan

- [x] `cd client-tenant && npm run build` — clean
- [x] `cd client-tenant && npx vitest run src/pages/apply` — 30/30 pass (12 files)
- [x] `cd client-tenant && npx vitest run` — 105/105 pass (+2 new). 1 unrelated pre-existing failing suite (`PropertyDetail.test.tsx` missing `jest-axe` import; no diff vs main on that file)
- [x] Issue #8 regression — `?step=intent` renders `data-testid="intent-skeleton"` while `/auth/me` is pending; quiz heading only appears post-resolve
- [x] Issue #9 regression — seeded `utm_source=newsletter`, `utm_campaign=launch`, `unitType=2BR`; advanced intent → checklist; all three params survive alongside the new `step=checklist`

## Architecture note (no action this PR)

There are two more `setSearch({ step: ... })` call sites that overwrite query params — `client-tenant/src/pages/apply/steps/StepHousehold.tsx:99` and `StepReview.tsx:69,90,106`. Out of scope per the constraint of only editing `Apply.tsx`, but worth a follow-up issue if `utm_*` survival matters all the way through the wizard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)