### PR TITLE
fix(apply): merge searchParams in StepHousehold + StepReview (follow-up to #58)

### DIFF
--- a/client-tenant/src/pages/apply/steps/StepHousehold.tsx
+++ b/client-tenant/src/pages/apply/steps/StepHousehold.tsx
@@ -96,7 +96,7 @@ export function StepHousehold() {
           <div style={{ fontSize: 10, color: HF.ink3, marginTop: 4 }}>{t('household.disclaimer')}</div>
         </Card>
 
-        <CTA variant="mobile" onClick={() => setSearch({ step: 'payment' }, { replace: true })}>
+        <CTA variant="mobile" onClick={() => setSearch(prev => { const next = new URLSearchParams(prev); next.set('step', 'payment'); return next; }, { replace: true })}>
           {t('household.cta', { total })}
         </CTA>
       </div>

--- a/client-tenant/src/pages/apply/steps/StepReview.tsx
+++ b/client-tenant/src/pages/apply/steps/StepReview.tsx
@@ -66,7 +66,7 @@ export function StepReview() {
                 <div style={{ fontFamily: HF.display, fontSize: 18, fontWeight: 700, color: HF.ink, marginTop: 2 }}>{propName}</div>
                 <div style={{ fontSize: 12, color: HF.ink3 }}>{propAddress}</div>
               </div>
-              <button onClick={() => setSearch({ step: 'intent' }, { replace: true })}
+              <button onClick={() => setSearch(prev => { const next = new URLSearchParams(prev); next.set('step', 'intent'); return next; }, { replace: true })}
                       style={{ background: 'transparent', border: 'none', color: HF.accent, fontSize: 11, textDecoration: 'underline', cursor: 'pointer' }}>
                 {t('review.edit')}
               </button>
@@ -87,7 +87,7 @@ export function StepReview() {
                 {incomeBand && <Pill>{incomeBand}</Pill>}
                 <Pill>{t('review.household', { count: householdSize })}</Pill>
                 <Pill>{moveIn}</Pill>
-                <button onClick={() => setSearch({ step: 'intent' }, { replace: true })}
+                <button onClick={() => setSearch(prev => { const next = new URLSearchParams(prev); next.set('step', 'intent'); return next; }, { replace: true })}
                         style={{ background: 'transparent', border: 'none', color: HF.accent, fontSize: 11, textDecoration: 'underline', cursor: 'pointer', marginLeft: 'auto' }}>
                   {t('review.edit')}
                 </button>
@@ -103,7 +103,7 @@ export function StepReview() {
           <div style={{ fontSize: 11, color: HF.ink3, marginTop: 2 }}>{t('review.confirmBody')}</div>
         </Card>
 
-        <CTA variant="mobile" onClick={() => setSearch({ step: 'household' }, { replace: true })}>
+        <CTA variant="mobile" onClick={() => setSearch(prev => { const next = new URLSearchParams(prev); next.set('step', 'household'); return next; }, { replace: true })}>
           {t('review.cta')}
         </CTA>
       </div>


### PR DESCRIPTION
## Summary

Follow-up to PR #58 (closes issue #9). PR #58 fixed the `setSearch` overwrite bug in `Apply.tsx` but the same pattern existed in two payment-wizard step components. This PR closes that gap.

**4 call sites fixed** — all used `setSearch({ step: '...' })` which replaced the entire query string, dropping `utm_*`, `unitType`, `propertyId`, and any other inbound params:

| File | Line | Was navigating to |
|------|------|-------------------|
| `StepHousehold.tsx` | 99 | `step=payment` CTA |
| `StepReview.tsx` | 69 | `step=intent` (property card edit button) |
| `StepReview.tsx` | 90 | `step=intent` (locked criteria edit button) |
| `StepReview.tsx` | 106 | `step=household` CTA |

**Fix pattern** (matches PR #58's Apply.tsx canonical form):
```ts
setSearch(prev => {
  const next = new URLSearchParams(prev);
  next.set('step', '...');
  return next;
}, { replace: true });
```

All 4 call sites preserved `{ replace: true }` — the replace/push semantics at each site were unchanged.

**No other files affected** — `grep -rn "setSearch({" client-tenant/src` confirmed exactly these 4 sites and no others.

## Test plan

- [x] `grep -rn "setSearch({" client-tenant/src` — returns 0 results (all overwrite forms eliminated)
- [x] TypeScript: only pre-existing TS2688 errors (missing test type defs) — no new errors
- [x] Test suite: 102/103 passed; 2 pre-existing failures (PropertyDetail.test.tsx jest-axe + Apply integration Step 2 heading) — not related to this change
- [ ] Manual: navigate to `/apply?utm_source=email&utm_campaign=may`, proceed through review → household steps, verify `utm_*` params survive transitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)