### PR TITLE
fix(railway): always-restart policy + 90s healthcheck for PG cold-start

### DIFF
--- a/railway.json
+++ b/railway.json
@@ -7,8 +7,7 @@
   "deploy": {
     "startCommand": "node dist/index.js",
     "healthcheckPath": "/health",
-    "healthcheckTimeout": 30,
-    "restartPolicyType": "ON_FAILURE",
-    "restartPolicyMaxRetries": 3
+    "healthcheckTimeout": 90,
+    "restartPolicyType": "ALWAYS"
   }
 }


### PR DESCRIPTION
## What

Follow-up to PR #50 (Railway deploy prep), addressing two issues flagged in the post-merge code review.

## Changes

**`restartPolicyType`: `ON_FAILURE` → `ALWAYS`**
The previous config capped retries at 3. After 3 crashes Railway stops trying, leaving the API permanently down for applicants. `ALWAYS` tells Railway to keep restarting indefinitely — the correct policy for a public-facing service.

`restartPolicyMaxRetries` is removed: it's a no-op for `ALWAYS` and leaving stale config keys invites future confusion.

**`healthcheckTimeout`: `30` → `90`**
`/health` now round-trips the database. On a cold Railway container + cold Postgres, that first request can exceed 30 s. 90 s covers the cold-start window without being so generous that genuine hangs go unnoticed by the deploy probe.

## Schema check
`https://railway.com/railway.schema.json` did not resolve at time of edit. `"ALWAYS"` is used per Railway's official documentation (the same constant appears in Railway's UI and CLI tooling).

## Files changed
- `railway.json` only — no application code touched.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>