### PR TITLE
feat(waitlist): real position math per (property, bedroom tier)

### DIFF
--- a/client-tenant/src/api/properties.ts
+++ b/client-tenant/src/api/properties.ts
@@ -26,9 +26,15 @@ export interface PropertyDetail {
 }
 
 export interface WaitlistSummary {
-  position: number;
+  // Server returns "estimatedWindow"; we expose it under the legacy
+  // property name `expectedNotificationWindow` too via the fetcher below so
+  // existing call sites keep working. New code should read `estimatedWindow`.
+  position?: number;
   totalQueue: number;
+  movement?: { spotsThisMonth: number; direction: 'up' | 'down' | 'flat' } | null;
+  estimatedWindow: string;
   expectedNotificationWindow: string;
+  enrolled?: boolean;
 }
 
 // Donna Louise 2 — MVP fixture. Mirrors the DL2 data the prototype implies.
@@ -87,10 +93,62 @@ export async function fetchProperty(slug: string): Promise<PropertyDetail> {
   }
 }
 
-export async function fetchWaitlistSummary(slug: string): Promise<WaitlistSummary> {
+// Wedge #5: the summary endpoint requires ?bedrooms now that it returns a real
+// per-tier position. Callers without a tier (the discover banner) pass a
+// sensible default; the Position page wires through the applicant's intent.
+export async function fetchWaitlistSummary(
+  slug: string,
+  bedrooms = 2,
+): Promise<WaitlistSummary> {
   try {
-    return await api.get<WaitlistSummary>(`/applicants/properties/${slug}/waitlist-summary`);
+    const raw = await api.get<{
+      position?: number;
+      totalQueue: number;
+      movement?: { spotsThisMonth: number; direction: 'up' | 'down' | 'flat' } | null;
+      estimatedWindow: string;
+      enrolled?: boolean;
+    }>(`/applicants/properties/${slug}/waitlist-summary?bedrooms=${bedrooms}`);
+    return {
+      position: raw.position,
+      totalQueue: raw.totalQueue,
+      movement: raw.movement,
+      estimatedWindow: raw.estimatedWindow,
+      // Back-compat alias: a few legacy spots still read this field name.
+      expectedNotificationWindow: raw.estimatedWindow,
+      enrolled: raw.enrolled,
+    };
   } catch {
-    return { position: 38, totalQueue: 38, expectedNotificationWindow: '3–6 months' };
+    return {
+      totalQueue: 38,
+      estimatedWindow: '3–6 months',
+      expectedNotificationWindow: '3–6 months',
+    };
   }
+}
+
+export async function joinWaitlist(
+  slug: string,
+  bedrooms: number,
+): Promise<WaitlistSummary> {
+  const raw = await api.post<{
+    position?: number;
+    totalQueue: number;
+    movement?: { spotsThisMonth: number; direction: 'up' | 'down' | 'flat' } | null;
+    estimatedWindow: string;
+    enrolled?: boolean;
+  }>(`/applicants/properties/${slug}/waitlist-join`, { bedrooms });
+  return {
+    position: raw.position,
+    totalQueue: raw.totalQueue,
+    movement: raw.movement,
+    estimatedWindow: raw.estimatedWindow,
+    expectedNotificationWindow: raw.estimatedWindow,
+    enrolled: raw.enrolled,
+  };
+}
+
+export async function leaveWaitlist(slug: string, bedrooms: number): Promise<void> {
+  await api.del<{ ok: true }>(
+    `/applicants/properties/${slug}/waitlist-leave?bedrooms=${bedrooms}`,
+  );
 }

--- a/client-tenant/src/pages/discover/WaitlistBanner.tsx
+++ b/client-tenant/src/pages/discover/WaitlistBanner.tsx
@@ -1,13 +1,17 @@
 import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { fetchWaitlistSummary, type WaitlistSummary } from '@/api/properties';
 import { Pill } from '@/components/primitives';
 
 interface Props {
   slug: string;
+  // Wedge #5: position is per-bedroom-tier per property. Callers (PropertyDetail)
+  // pass the tier they're showing; default 2BR matches the most common request.
+  bedrooms?: number;
 }
 
-export function WaitlistBanner({ slug }: Props) {
+export function WaitlistBanner({ slug, bedrooms = 2 }: Props) {
   const { t } = useTranslation('discover');
   const [summary, setSummary] = useState<WaitlistSummary | null>(null);
   const [loading, setLoading] = useState(true);
@@ -15,7 +19,7 @@ export function WaitlistBanner({ slug }: Props) {
   useEffect(() => {
     let alive = true;
     setLoading(true);
-    fetchWaitlistSummary(slug)
+    fetchWaitlistSummary(slug, bedrooms)
       .then((s) => {
         if (alive) setSummary(s);
       })
@@ -25,7 +29,7 @@ export function WaitlistBanner({ slug }: Props) {
     return () => {
       alive = false;
     };
-  }, [slug]);
+  }, [slug, bedrooms]);
 
   if (loading) {
     return (
@@ -41,22 +45,40 @@ export function WaitlistBanner({ slug }: Props) {
 
   if (!summary) return null;
 
+  // Position is only present for enrolled (authenticated + on-list) users.
+  // For everyone else the banner shows queue depth so the wedge always reads
+  // as a real number, not gpmglv's silent black hole.
+  const showPosition = summary.position != null;
+
+  const inner = (
+    <div className="flex flex-wrap items-center gap-2">
+      <Pill tone="warn">● {t('waitlist.title')}</Pill>
+      {showPosition ? (
+        <span className="text-sm font-semibold text-amber-900">
+          {t('waitlist.position', { position: summary.position })}
+        </span>
+      ) : (
+        <span className="text-sm font-semibold text-amber-900">
+          {summary.totalQueue} on list
+        </span>
+      )}
+      <span className="text-sm text-amber-900/80">
+        · {t('waitlist.estimate', { window: summary.expectedNotificationWindow })}
+      </span>
+    </div>
+  );
+
+  // Link to the position screen with the bedrooms tier preserved so the
+  // detail view doesn't drop back to the 2BR default.
   return (
-    <div
-      className="rounded-xl border border-amber-200 bg-amber-50 px-4 py-3"
+    <Link
+      to={`/waitlist/position/${slug}?bedrooms=${bedrooms}`}
+      className="block rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 hover:bg-amber-100"
       role="status"
       aria-live="polite"
       data-testid="waitlist-banner"
     >
-      <div className="flex flex-wrap items-center gap-2">
-        <Pill tone="warn">● {t('waitlist.title')}</Pill>
-        <span className="text-sm font-semibold text-amber-900">
-          {t('waitlist.position', { position: summary.position })}
-        </span>
-        <span className="text-sm text-amber-900/80">
-          · {t('waitlist.estimate', { window: summary.expectedNotificationWindow })}
-        </span>
-      </div>
-    </div>
+      {inner}
+    </Link>
   );
 }

--- a/client-tenant/src/pages/waitlist/Position.tsx
+++ b/client-tenant/src/pages/waitlist/Position.tsx
@@ -1,21 +1,23 @@
-import { useEffect, useState } from "react";
-import { useParams, Link } from "react-router-dom";
+import { useEffect, useMemo, useState } from "react";
+import { useParams, useSearchParams, Link } from "react-router-dom";
 import { api } from "@/api/client";
 import { useTranslation } from "react-i18next";
 import { HF } from "@/styles/tokens";
 
 /**
- * BP-03b — Waitlist position screen ("#12 of 38").
+ * Wedge #5 — Waitlist position screen ("#12 of 38").
  *
- * Reads GET /api/applicants/properties/:slug/waitlist-summary. Falls back to
- * a placeholder shape if the endpoint is unreachable (which keeps the demo
- * working in offline mode).
+ * Reads GET /api/applicants/properties/:slug/waitlist-summary?bedrooms=N.
+ * The server now requires ?bedrooms since position is per-tier-per-property.
+ * Falls back to a placeholder shape if the endpoint is unreachable (keeps
+ * the offline demo working).
  */
 interface WaitlistSummary {
-  position: number;
+  position?: number;
   totalQueue: number;
-  movement?: { spotsThisMonth: number; direction: "up" | "down" | "flat" };
+  movement?: { spotsThisMonth: number; direction: "up" | "down" | "flat" } | null;
   estimatedWindow: string;
+  enrolled?: boolean;
   placeholder?: boolean;
 }
 
@@ -28,8 +30,18 @@ const FALLBACK: WaitlistSummary = {
 
 export function WaitlistPosition() {
   const params = useParams<{ slug?: string }>();
+  const [searchParams] = useSearchParams();
   const slug = params.slug ?? "donna-louise-2";
   const { t } = useTranslation("waitlist");
+
+  // Bedrooms tier comes from the URL (?bedrooms=N), set by WaitlistBanner or
+  // the apply funnel. Default to 2BR as the most common tier when missing —
+  // the server still returns a meaningful answer either way.
+  const bedrooms = useMemo(() => {
+    const raw = searchParams.get("bedrooms");
+    const n = raw ? Number.parseInt(raw, 10) : NaN;
+    return Number.isFinite(n) && n >= 0 && n <= 6 ? n : 2;
+  }, [searchParams]);
 
   const [summary, setSummary] = useState<WaitlistSummary | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -37,7 +49,9 @@ export function WaitlistPosition() {
   useEffect(() => {
     let cancelled = false;
     api
-      .get<WaitlistSummary>(`/applicants/properties/${slug}/waitlist-summary`)
+      .get<WaitlistSummary>(
+        `/applicants/properties/${slug}/waitlist-summary?bedrooms=${bedrooms}`
+      )
       .then((data) => {
         if (!cancelled) setSummary(data);
       })
@@ -50,7 +64,7 @@ export function WaitlistPosition() {
     return () => {
       cancelled = true;
     };
-  }, [slug, t]);
+  }, [slug, bedrooms, t]);
 
   if (!summary) {
     return (
@@ -90,12 +104,36 @@ export function WaitlistPosition() {
         </h1>
 
         <div className="my-8">
-          <p className="text-5xl font-bold" style={{ color: HF.accent, fontFamily: HF.display }}>
-            #{summary.position}
-          </p>
-          <p className="mt-2 text-sm" style={{ color: HF.ink2 }}>
-            {t("position.rank", { position: summary.position, total: summary.totalQueue })}
-          </p>
+          {summary.position != null ? (
+            <>
+              <p
+                className="text-5xl font-bold"
+                style={{ color: HF.accent, fontFamily: HF.display }}
+              >
+                #{summary.position}
+              </p>
+              <p className="mt-2 text-sm" style={{ color: HF.ink2 }}>
+                {t("position.rank", {
+                  position: summary.position,
+                  total: summary.totalQueue,
+                })}
+              </p>
+            </>
+          ) : (
+            // Not-yet-enrolled callers still get a useful number — the queue
+            // depth — so the screen never renders "#undefined".
+            <>
+              <p
+                className="text-5xl font-bold"
+                style={{ color: HF.accent, fontFamily: HF.display }}
+              >
+                {summary.totalQueue}
+              </p>
+              <p className="mt-2 text-sm" style={{ color: HF.ink2 }}>
+                {t("position.queue_depth", { total: summary.totalQueue, defaultValue: "{{total}} on the waitlist" })}
+              </p>
+            </>
+          )}
         </div>
 
         {summary.movement && (

--- a/src/__tests__/waitlist-routes.test.ts
+++ b/src/__tests__/waitlist-routes.test.ts
@@ -1,0 +1,355 @@
+/**
+ * Wedge #5 — Position-aware waitlist route tests.
+ *
+ * Covers:
+ *   GET    /applicants/properties/:slug/waitlist-summary
+ *   POST   /applicants/properties/:slug/waitlist-join
+ *   DELETE /applicants/properties/:slug/waitlist-leave
+ *
+ * Strategy mirrors src/__tests__/unit-claim.test.ts: query() is mocked and
+ * each test scripts the rows the handler will SELECT/INSERT/DELETE.
+ *
+ * Note on query ordering: `authenticate` issues a SELECT against users before
+ * the handler runs, so authenticated tests must mockUsersRow() first.
+ */
+import express from "express";
+import request from "supertest";
+import { generateToken, AuthUser } from "../middleware/auth";
+
+jest.mock("../config/database", () => ({
+  query: jest.fn(),
+  transaction: jest.fn(),
+}));
+jest.mock("../utils/logger", () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+jest.mock("../modules/auth/magic-link-service", () => ({
+  createMagicLink: jest.fn(),
+  logMagicLink: jest.fn(),
+  sendMagicLink: jest.fn(),
+}));
+jest.mock("../modules/application/service", () => ({
+  ApplicationService: jest.fn().mockImplementation(() => ({ create: jest.fn() })),
+}));
+
+import { query } from "../config/database";
+import applicantsRouter from "../modules/applicants/routes";
+
+const mockQuery = query as jest.MockedFunction<typeof query>;
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/applicants", applicantsRouter);
+  return app;
+}
+const app = buildApp();
+
+function mockUsersRow(user: AuthUser, emailVerifiedAt: Date | null) {
+  mockQuery.mockResolvedValueOnce({
+    rows: [
+      {
+        id: user.id,
+        email: user.email,
+        role: user.role,
+        first_name: user.firstName,
+        last_name: user.lastName,
+        property_ids: user.propertyIds ?? [],
+        is_active: true,
+        email_verified_at: emailVerifiedAt,
+      },
+    ],
+  } as any);
+}
+
+// Per-test unique user id so the per-user rate limiter on POST/DELETE
+// (20/min, shared across the write bucket) doesn't bleed between tests.
+let __testSeq = 0;
+function makeApplicant(): AuthUser {
+  __testSeq += 1;
+  return {
+    id: `waitlist-test-${Date.now()}-${__testSeq}`,
+    email: `wl${__testSeq}@x.com`,
+    role: "applicant",
+    firstName: "Ann",
+    lastName: "App",
+    propertyIds: [],
+    emailVerified: true,
+  };
+}
+
+const VERIFIED_AT = new Date("2026-05-13T00:00:00Z");
+const SLUG = "donna-louise-2";
+const PROPERTY_ID = "550e8400-e29b-41d4-a716-446655440099";
+
+describe("GET /applicants/properties/:slug/waitlist-summary", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("400 when ?bedrooms is missing", async () => {
+    const res = await request(app).get(`/applicants/properties/${SLUG}/waitlist-summary`);
+    expect(res.status).toBe(400);
+  });
+
+  it("404 when slug resolves to no property", async () => {
+    // resolvePropertyIdBySlug → no match
+    mockQuery.mockResolvedValueOnce({ rows: [] } as any);
+    const res = await request(app)
+      .get(`/applicants/properties/${SLUG}/waitlist-summary?bedrooms=2`);
+    expect(res.status).toBe(404);
+  });
+
+  it("unauth: returns totalQueue with no position (enrolled=false)", async () => {
+    // Query order without auth: resolve slug → total queue.
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: PROPERTY_ID }] } as any); // resolve slug
+    mockQuery.mockResolvedValueOnce({ rows: [{ n: 7 }] } as any);            // total queue
+
+    const res = await request(app)
+      .get(`/applicants/properties/${SLUG}/waitlist-summary?bedrooms=2`);
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      slug: SLUG,
+      totalQueue: 7,
+      enrolled: false,
+      movement: null,
+    });
+    expect(res.body.position).toBeUndefined();
+    expect(typeof res.body.estimatedWindow).toBe("string");
+  });
+
+  it("auth + enrolled: returns position computed from rows ahead + 1", async () => {
+    // Query order with auth: resolve slug → user lookup (optional auth) →
+    // total queue → SELECT mine → COUNT ahead.
+    const applicant = makeApplicant();
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: PROPERTY_ID }] } as any); // resolve slug
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: applicant.id }] } as any); // user lookup
+    mockQuery.mockResolvedValueOnce({ rows: [{ n: 3 }] } as any);            // total queue
+    mockQuery.mockResolvedValueOnce({                                          // SELECT mine
+      rows: [
+        {
+          created_at: new Date("2026-05-20T12:00:00Z"),
+          notified_position_at: null,
+          last_notified_position: null,
+        },
+      ],
+    } as any);
+    mockQuery.mockResolvedValueOnce({ rows: [{ n: 1 }] } as any);            // COUNT ahead
+
+    const token = generateToken(applicant);
+    const res = await request(app)
+      .get(`/applicants/properties/${SLUG}/waitlist-summary?bedrooms=2`)
+      .set("Authorization", `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      slug: SLUG,
+      position: 2,           // 1 ahead + 1
+      totalQueue: 3,
+      enrolled: true,
+      movement: null,        // null when no notification snapshot exists
+    });
+  });
+
+  it("auth + enrolled + prior snapshot: returns movement direction=up", async () => {
+    const applicant = makeApplicant();
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: PROPERTY_ID }] } as any);  // resolve slug
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: applicant.id }] } as any); // user lookup
+    mockQuery.mockResolvedValueOnce({ rows: [{ n: 10 }] } as any);            // total
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        {
+          created_at: new Date("2026-05-20T12:00:00Z"),
+          notified_position_at: new Date("2026-04-20T12:00:00Z"),
+          last_notified_position: 8,
+        },
+      ],
+    } as any);
+    mockQuery.mockResolvedValueOnce({ rows: [{ n: 4 }] } as any); // 4 ahead → position 5
+
+    const token = generateToken(applicant);
+    const res = await request(app)
+      .get(`/applicants/properties/${SLUG}/waitlist-summary?bedrooms=2`)
+      .set("Authorization", `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(res.body.position).toBe(5);
+    expect(res.body.movement).toEqual({ spotsThisMonth: 3, direction: "up" });
+  });
+
+  it("auth but not enrolled: enrolled=false, no position", async () => {
+    const applicant = makeApplicant();
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: PROPERTY_ID }] } as any);  // resolve slug
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: applicant.id }] } as any); // user lookup
+    mockQuery.mockResolvedValueOnce({ rows: [{ n: 5 }] } as any);             // total queue
+    mockQuery.mockResolvedValueOnce({ rows: [] } as any);                      // SELECT mine → none
+
+    const token = generateToken(applicant);
+    const res = await request(app)
+      .get(`/applicants/properties/${SLUG}/waitlist-summary?bedrooms=2`)
+      .set("Authorization", `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      enrolled: false,
+      totalQueue: 5,
+      movement: null,
+    });
+    expect(res.body.position).toBeUndefined();
+  });
+
+  it("estimatedWindow shifts with queue depth", async () => {
+    // unauth path → resolve slug + total queue only.
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: PROPERTY_ID }] } as any); // resolve
+    mockQuery.mockResolvedValueOnce({ rows: [{ n: 50 }] } as any);
+
+    const res = await request(app)
+      .get(`/applicants/properties/${SLUG}/waitlist-summary?bedrooms=2`);
+    expect(res.status).toBe(200);
+    expect(res.body.estimatedWindow).toBe("6+ months");
+  });
+});
+
+describe("POST /applicants/properties/:slug/waitlist-join", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("401 unauthenticated", async () => {
+    const res = await request(app)
+      .post(`/applicants/properties/${SLUG}/waitlist-join`)
+      .send({ bedrooms: 2 });
+    expect(res.status).toBe(401);
+  });
+
+  it("400 on bad body (bedrooms missing)", async () => {
+    const applicant = makeApplicant();
+    mockUsersRow(applicant, VERIFIED_AT);
+    const token = generateToken(applicant);
+    const res = await request(app)
+      .post(`/applicants/properties/${SLUG}/waitlist-join`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({});
+    expect(res.status).toBe(400);
+  });
+
+  it("404 when slug resolves to nothing", async () => {
+    const applicant = makeApplicant();
+    mockUsersRow(applicant, VERIFIED_AT);
+    mockQuery.mockResolvedValueOnce({ rows: [] } as any); // resolve slug → none
+    const token = generateToken(applicant);
+    const res = await request(app)
+      .post(`/applicants/properties/${SLUG}/waitlist-join`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ bedrooms: 2 });
+    expect(res.status).toBe(404);
+  });
+
+  it("first-to-join gets position 1, totalQueue 1", async () => {
+    const applicant = makeApplicant();
+    mockUsersRow(applicant, VERIFIED_AT);
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: PROPERTY_ID }] } as any); // resolve slug
+    mockQuery.mockResolvedValueOnce({ rows: [] } as any);                     // INSERT
+    // buildWaitlistSummary follow-up:
+    mockQuery.mockResolvedValueOnce({ rows: [{ n: 1 }] } as any);             // total
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        {
+          created_at: new Date("2026-05-23T00:00:00Z"),
+          notified_position_at: null,
+          last_notified_position: null,
+        },
+      ],
+    } as any);
+    mockQuery.mockResolvedValueOnce({ rows: [{ n: 0 }] } as any);             // 0 ahead
+
+    const token = generateToken(applicant);
+    const res = await request(app)
+      .post(`/applicants/properties/${SLUG}/waitlist-join`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ bedrooms: 2 });
+    expect(res.status).toBe(201);
+    expect(res.body).toMatchObject({
+      position: 1,
+      totalQueue: 1,
+      enrolled: true,
+    });
+  });
+
+  it("re-join is idempotent (ON CONFLICT DO NOTHING) — same position returned", async () => {
+    const applicant = makeApplicant();
+    mockUsersRow(applicant, VERIFIED_AT);
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: PROPERTY_ID }] } as any);
+    mockQuery.mockResolvedValueOnce({ rows: [] } as any);                     // INSERT (no rows = conflict)
+    mockQuery.mockResolvedValueOnce({ rows: [{ n: 3 }] } as any);             // total = same as before
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        {
+          created_at: new Date("2026-05-21T00:00:00Z"),
+          notified_position_at: null,
+          last_notified_position: null,
+        },
+      ],
+    } as any);
+    mockQuery.mockResolvedValueOnce({ rows: [{ n: 1 }] } as any);             // still 1 ahead
+
+    const token = generateToken(applicant);
+    const res = await request(app)
+      .post(`/applicants/properties/${SLUG}/waitlist-join`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ bedrooms: 2 });
+    expect(res.status).toBe(201);
+    expect(res.body.position).toBe(2);
+    expect(res.body.totalQueue).toBe(3);
+
+    // The INSERT must use ON CONFLICT DO NOTHING.
+    const insertSql = mockQuery.mock.calls.find(
+      (c) => typeof c[0] === "string" && (c[0] as string).includes("INSERT INTO waitlist_entries")
+    )?.[0] as string;
+    expect(insertSql).toContain("ON CONFLICT");
+    expect(insertSql).toContain("DO NOTHING");
+  });
+});
+
+describe("DELETE /applicants/properties/:slug/waitlist-leave", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("401 unauthenticated", async () => {
+    const res = await request(app)
+      .delete(`/applicants/properties/${SLUG}/waitlist-leave?bedrooms=2`);
+    expect(res.status).toBe(401);
+  });
+
+  it("400 when bedrooms missing", async () => {
+    const applicant = makeApplicant();
+    mockUsersRow(applicant, VERIFIED_AT);
+    const token = generateToken(applicant);
+    const res = await request(app)
+      .delete(`/applicants/properties/${SLUG}/waitlist-leave`)
+      .set("Authorization", `Bearer ${token}`);
+    expect(res.status).toBe(400);
+  });
+
+  it("idempotent: ok=true even when no row to delete", async () => {
+    const applicant = makeApplicant();
+    mockUsersRow(applicant, VERIFIED_AT);
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: PROPERTY_ID }] } as any); // resolve slug
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 } as any);        // DELETE → 0
+    const token = generateToken(applicant);
+    const res = await request(app)
+      .delete(`/applicants/properties/${SLUG}/waitlist-leave?bedrooms=2`)
+      .set("Authorization", `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true });
+  });
+
+  it("issues a DELETE keyed on (property, bedrooms, user)", async () => {
+    const applicant = makeApplicant();
+    mockUsersRow(applicant, VERIFIED_AT);
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: PROPERTY_ID }] } as any);
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 } as any);
+    const token = generateToken(applicant);
+    const res = await request(app)
+      .delete(`/applicants/properties/${SLUG}/waitlist-leave?bedrooms=2`)
+      .set("Authorization", `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    const deleteCall = mockQuery.mock.calls.find(
+      (c) => typeof c[0] === "string" && (c[0] as string).includes("DELETE FROM waitlist_entries")
+    );
+    expect(deleteCall).toBeDefined();
+    expect(deleteCall![1]).toEqual([PROPERTY_ID, 2, applicant.id]);
+  });
+});

--- a/src/db/migrations/2026-05-23-waitlist-entries.sql
+++ b/src/db/migrations/2026-05-23-waitlist-entries.sql
@@ -1,0 +1,23 @@
+-- Position-aware waitlist (gpmglv-gap wedge #5) — 2026-05-23
+-- One row per (property, bedroom_count, user). Position is derived from
+-- created_at ordering at query time. `notified_position_at` /
+-- `last_notified_position` snapshot what we last told the applicant so the
+-- API can compute monthly "moved up N spots" movement without storing a
+-- per-day position history.
+
+CREATE TABLE IF NOT EXISTS waitlist_entries (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  property_id UUID NOT NULL REFERENCES properties(id) ON DELETE CASCADE,
+  bedroom_count SMALLINT NOT NULL,
+  applicant_user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  notified_position_at TIMESTAMPTZ,
+  last_notified_position SMALLINT,
+  UNIQUE (property_id, bedroom_count, applicant_user_id)
+);
+
+-- Hot query path: rank by created_at within a (property, bedroom_count) lane.
+CREATE INDEX IF NOT EXISTS idx_waitlist_entries_lane_created
+  ON waitlist_entries(property_id, bedroom_count, created_at);
+CREATE INDEX IF NOT EXISTS idx_waitlist_entries_user
+  ON waitlist_entries(applicant_user_id);

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -448,6 +448,28 @@ ALTER TABLE applications
 
 CREATE INDEX idx_applications_claimed_unit ON applications(claimed_unit_id);
 
+-- Position-aware waitlist (gpmglv-gap wedge #5).
+-- One row per (property, bedroom_count, user). Position is derived from
+-- created_at ordering at query time. notified_position_at /
+-- last_notified_position snapshot what we last told the applicant so the
+-- API can compute monthly "moved up N spots" movement without storing a
+-- per-day position history.
+CREATE TABLE waitlist_entries (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  property_id UUID NOT NULL REFERENCES properties(id) ON DELETE CASCADE,
+  bedroom_count SMALLINT NOT NULL,
+  applicant_user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  notified_position_at TIMESTAMPTZ,
+  last_notified_position SMALLINT,
+  UNIQUE (property_id, bedroom_count, applicant_user_id)
+);
+-- Hot query path: rank by created_at within a (property, bedroom_count) lane.
+CREATE INDEX idx_waitlist_entries_lane_created
+  ON waitlist_entries(property_id, bedroom_count, created_at);
+CREATE INDEX idx_waitlist_entries_user
+  ON waitlist_entries(applicant_user_id);
+
 -- Tenant/applicant join to applications (multiple users per application: primary, co-applicant, household member)
 CREATE TABLE user_applications (
   id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
@@ -948,6 +970,7 @@ DROP TABLE IF EXISTS adverse_action_notices CASCADE;
 DROP TABLE IF EXISTS audit_log CASCADE;
 DROP TABLE IF EXISTS lease_modifications CASCADE;
 DROP TABLE IF EXISTS fraud_flags CASCADE;
+DROP TABLE IF EXISTS waitlist_entries CASCADE;
 DROP TABLE IF EXISTS known_problem_addresses CASCADE;
 DROP TABLE IF EXISTS ami_limits CASCADE;
 DROP TABLE IF EXISTS applications CASCADE;

--- a/src/db/seed.ts
+++ b/src/db/seed.ts
@@ -263,6 +263,54 @@ async function seed() {
     }
     console.log("  Known problem addresses seeded");
 
+    // ── Waitlist entries (wedge #5) ───────────────────────────────────
+    // Seed a realistic queue for the two senior properties that have
+    // waitingListEnabled=true and the demo-favorite Donna Louise 2 family
+    // property. Uses the existing 5 staff users as stand-in applicants
+    // (the seed doesn't create dedicated applicant users), each enrolled in
+    // a few (property, bedroom_count) lanes so a freshly-seeded dev DB
+    // shows "#3 of 5" rather than "#1 of 1". One synthetic notification
+    // snapshot per (property, bedroom) drives the "moved up N spots"
+    // chip on the position screen.
+    const waitlistProps = [
+      "Louise Shell Senior Apartments",
+      "Frank Hawkins Senior Apartments",
+      "Cambridge Apartments",
+    ];
+    const userIdsRes = await query(
+      `SELECT id FROM users WHERE email = ANY($1) ORDER BY email ASC`,
+      [users.map((u) => u.email)]
+    );
+    const userIds: string[] = userIdsRes.rows.map((r: { id: string }) => r.id);
+
+    let waitlistInserted = 0;
+    for (const propName of waitlistProps) {
+      const propRow = await query("SELECT id FROM properties WHERE name = $1", [propName]);
+      if (propRow.rows.length === 0) continue;
+      const propertyId = propRow.rows[0].id;
+
+      for (const bedrooms of [1, 2]) {
+        // Insert each user with a staggered created_at so positions are
+        // stable and visibly different across the queue. -i hours so the
+        // earliest user is "first in line".
+        for (let i = 0; i < userIds.length; i++) {
+          const userId = userIds[i];
+          const hoursAgo = (userIds.length - i) * 24;
+          const ins = await query(
+            `INSERT INTO waitlist_entries
+               (property_id, bedroom_count, applicant_user_id, created_at,
+                notified_position_at, last_notified_position)
+             VALUES ($1, $2, $3, NOW() - ($4 || ' hours')::interval, NOW() - INTERVAL '30 days', $5)
+             ON CONFLICT (property_id, bedroom_count, applicant_user_id) DO NOTHING
+             RETURNING id`,
+            [propertyId, bedrooms, userId, String(hoursAgo), i + 3]
+          );
+          if (ins.rows.length > 0) waitlistInserted++;
+        }
+      }
+    }
+    console.log(`  Waitlist entries: ${waitlistInserted} seeded across ${waitlistProps.length} properties`);
+
     console.log(`\nSeed complete! ${properties.length} properties seeded.`);
     console.log("\nTest credentials (all passwords: password123):");
     for (const user of users) {

--- a/src/modules/applicants/routes.ts
+++ b/src/modules/applicants/routes.ts
@@ -243,27 +243,299 @@ router.post("/apply", authenticate, requireEmailVerified, async (req: AuthReques
   }
 });
 
-// Public-ish: BP-03b waitlist position summary for a property slug.
-// DL2 MVP: hardcoded placeholder shape until the waitlist service lands.
-// `:slug` is currently ignored beyond echoing it back; the picker UI just
-// needs *some* shape to render the "#12 of 38" screen.
+// ────────────────────────────────────────────────────────────────────────────
+// Wedge #5 — position-aware waitlist.
+// gpmglv's /join-waitlist is submit-and-disappear. We expose real position
+// math per (property, bedroom tier) so the applicant always knows where they
+// stand: "#7 of 23, moved up 3 spots, est. 3–6 months". The position screen
+// (client-tenant/src/pages/waitlist/Position.tsx) reads the GET summary; the
+// banner and Apply funnel POST/DELETE to manage membership.
+
+// Slug ↔ property lookup. The properties table has no slug column; seed
+// derives the slug from `name` via lowercase + non-alnum-to-dash + trim. We
+// reverse the mapping by normalizing both sides in SQL. Cheap on a 16-row
+// table; if the catalog ever grows we can add a stored slug column.
+async function resolvePropertyIdBySlug(slug: string): Promise<string | null> {
+  // regex_replace mirrors the seed slugify: collapse runs of non-alnum to "-"
+  // and strip leading/trailing dashes, all lowercase. The trim_both replaces
+  // ltrim+rtrim to keep the SQL portable.
+  const result = await query(
+    `SELECT id
+       FROM properties
+      WHERE regexp_replace(
+              trim(BOTH '-' FROM regexp_replace(LOWER(name), '[^a-z0-9]+', '-', 'g')),
+              '^$', NULL
+            ) = $1
+      LIMIT 1`,
+    [slug]
+  );
+  return result.rows[0]?.id ?? null;
+}
+
+// estimatedWindow heuristic: assumes ~12 moves/year (one open unit per
+// bedroom-tier per month, very rough). Replace with property-level historical
+// throughput when that signal is available.
+function estimateWindow(totalQueue: number, positionAhead: number): string {
+  // For unauth/non-enrolled callers we estimate by total queue depth; for
+  // enrolled callers we estimate by spots ahead (positionAhead = position - 1).
+  const ahead = positionAhead > 0 ? positionAhead : totalQueue;
+  if (ahead < 3) return "1–3 months";
+  if (ahead < 6) return "3–6 months";
+  return "6+ months";
+}
+
+interface WaitlistSummaryPayload {
+  slug: string;
+  position?: number;
+  totalQueue: number;
+  movement: { spotsThisMonth: number; direction: "up" | "down" | "flat" } | null;
+  estimatedWindow: string;
+  enrolled: boolean;
+}
+
+async function buildWaitlistSummary(
+  slug: string,
+  propertyId: string,
+  bedrooms: number,
+  userId: string | null
+): Promise<WaitlistSummaryPayload> {
+  const totalRes = await query(
+    `SELECT COUNT(*)::int AS n
+       FROM waitlist_entries
+      WHERE property_id = $1 AND bedroom_count = $2`,
+    [propertyId, bedrooms]
+  );
+  const totalQueue: number = totalRes.rows[0]?.n ?? 0;
+
+  if (!userId) {
+    return {
+      slug,
+      totalQueue,
+      movement: null,
+      estimatedWindow: estimateWindow(totalQueue, 0),
+      enrolled: false,
+    };
+  }
+
+  // Position is 1 + the count of entries created strictly before this user's
+  // entry in the same lane. Ties on created_at are vanishingly rare (uuid PK
+  // insert is sub-millisecond) and harmless — they'd just share rank.
+  const mineRes = await query(
+    `SELECT created_at, notified_position_at, last_notified_position
+       FROM waitlist_entries
+      WHERE property_id = $1 AND bedroom_count = $2 AND applicant_user_id = $3
+      LIMIT 1`,
+    [propertyId, bedrooms, userId]
+  );
+  if (mineRes.rows.length === 0) {
+    return {
+      slug,
+      totalQueue,
+      movement: null,
+      estimatedWindow: estimateWindow(totalQueue, 0),
+      enrolled: false,
+    };
+  }
+  const mine = mineRes.rows[0];
+
+  const aheadRes = await query(
+    `SELECT COUNT(*)::int AS n
+       FROM waitlist_entries
+      WHERE property_id = $1
+        AND bedroom_count = $2
+        AND created_at < $3`,
+    [propertyId, bedrooms, mine.created_at]
+  );
+  const position: number = (aheadRes.rows[0]?.n ?? 0) + 1;
+
+  // Movement requires a prior snapshot. If we haven't notified the applicant
+  // about their position yet, return null (the UI hides the chip cleanly).
+  let movement: WaitlistSummaryPayload["movement"] = null;
+  if (mine.last_notified_position != null && mine.notified_position_at != null) {
+    const delta = mine.last_notified_position - position;
+    const direction: "up" | "down" | "flat" =
+      delta > 0 ? "up" : delta < 0 ? "down" : "flat";
+    movement = { spotsThisMonth: Math.abs(delta), direction };
+  }
+
+  return {
+    slug,
+    position,
+    totalQueue,
+    movement,
+    estimatedWindow: estimateWindow(totalQueue, position - 1),
+    enrolled: true,
+  };
+}
+
+// GET /properties/:slug/waitlist-summary?bedrooms=N
+// - Requires ?bedrooms (the queue is per bedroom-tier per property).
+// - Unauthenticated callers get the public shape (totalQueue + window, no
+//   position). Authenticated but not-enrolled callers get the same shape with
+//   `enrolled: false`. Enrolled callers get position + movement.
+const waitlistBedroomsSchema = z.object({
+  bedrooms: z.coerce.number().int().min(0).max(6),
+});
+
 router.get(
   "/properties/:slug/waitlist-summary",
   async (req: Request, res: Response): Promise<void> => {
     try {
-      const slug = String(req.params.slug ?? "");
-      // Placeholder values — real math arrives with BP-04 waitlist scoring.
-      res.json({
-        slug,
-        position: 12,
-        totalQueue: 38,
-        movement: { spotsThisMonth: 3, direction: "up" as const },
-        estimatedWindow: "3–6 months",
-        placeholder: true,
-      });
+      const slug = String(req.params.slug ?? "").trim();
+      if (!slug) {
+        res.status(400).json({ error: "Property slug required" });
+        return;
+      }
+
+      const parsed = waitlistBedroomsSchema.safeParse(req.query);
+      if (!parsed.success) {
+        res.status(400).json({
+          error: "bedrooms query param is required (0–6)",
+          details: parsed.error.errors,
+        });
+        return;
+      }
+      const bedrooms = parsed.data.bedrooms;
+
+      const propertyId = await resolvePropertyIdBySlug(slug);
+      if (!propertyId) {
+        res.status(404).json({ error: "Property not found" });
+        return;
+      }
+
+      // Resolve the caller — optional. If a Bearer token is present and valid,
+      // attribute the position to that user; otherwise fall back to the
+      // public shape (no position, just queue depth + window).
+      let userId: string | null = null;
+      const authHeader = req.headers.authorization;
+      if (authHeader?.startsWith("Bearer ")) {
+        try {
+          const jwt = await import("jsonwebtoken");
+          const decoded = jwt.verify(
+            authHeader.substring(7),
+            // Must match middleware/auth.ts default — mismatch would silently
+            // make every token "invalid" in dev/test and break enrolled GETs.
+            process.env.JWT_SECRET || "dev-secret-change-me"
+          ) as { id?: string };
+          if (decoded?.id) {
+            // Quick role + active check; not paying the full authenticate()
+            // tax (which 401s on miss — we want graceful unauth fallback).
+            const u = await query(
+              "SELECT id FROM users WHERE id = $1 AND is_active = TRUE",
+              [decoded.id]
+            );
+            if (u.rows.length > 0) userId = u.rows[0].id;
+          }
+        } catch {
+          // Invalid/expired token → treat as anonymous. No 401: the summary
+          // is informational and the unauth shape is intentional.
+        }
+      }
+
+      const summary = await buildWaitlistSummary(slug, propertyId, bedrooms, userId);
+      res.json(summary);
     } catch (err) {
       logger.error("Failed to fetch waitlist summary", { error: (err as Error).message });
       res.status(500).json({ error: "Failed to fetch waitlist summary" });
+    }
+  }
+);
+
+const waitlistJoinSchema = z.object({
+  bedrooms: z.number().int().min(0).max(6),
+});
+
+// POST /properties/:slug/waitlist-join — body { bedrooms }
+// Idempotent: re-joining the same (property, bedroom_count) is a no-op and
+// returns the existing position (does NOT shuffle the applicant to the back).
+router.post(
+  "/properties/:slug/waitlist-join",
+  authenticate,
+  requireEmailVerified,
+  unitWriteLimiter,
+  async (req: AuthRequest, res: Response): Promise<void> => {
+    try {
+      if (!req.user || !["applicant", "tenant"].includes(req.user.role)) {
+        res.status(403).json({ error: "Applicant role required" });
+        return;
+      }
+      const slug = String(req.params.slug ?? "").trim();
+      if (!slug) {
+        res.status(400).json({ error: "Property slug required" });
+        return;
+      }
+      const parsed = waitlistJoinSchema.safeParse(req.body);
+      if (!parsed.success) {
+        res.status(400).json({ error: "Validation failed", details: parsed.error.errors });
+        return;
+      }
+      const propertyId = await resolvePropertyIdBySlug(slug);
+      if (!propertyId) {
+        res.status(404).json({ error: "Property not found" });
+        return;
+      }
+      // ON CONFLICT DO NOTHING: re-clicking "Join" preserves the original
+      // created_at (and thus the original position).
+      await query(
+        `INSERT INTO waitlist_entries (property_id, bedroom_count, applicant_user_id)
+         VALUES ($1, $2, $3)
+         ON CONFLICT (property_id, bedroom_count, applicant_user_id) DO NOTHING`,
+        [propertyId, parsed.data.bedrooms, req.user.id]
+      );
+
+      const summary = await buildWaitlistSummary(
+        slug,
+        propertyId,
+        parsed.data.bedrooms,
+        req.user.id
+      );
+      res.status(201).json(summary);
+    } catch (err) {
+      logger.error("Failed to join waitlist", { error: (err as Error).message });
+      res.status(500).json({ error: "Failed to join waitlist" });
+    }
+  }
+);
+
+// DELETE /properties/:slug/waitlist-leave?bedrooms=N — idempotent
+router.delete(
+  "/properties/:slug/waitlist-leave",
+  authenticate,
+  requireEmailVerified,
+  unitWriteLimiter,
+  async (req: AuthRequest, res: Response): Promise<void> => {
+    try {
+      if (!req.user || !["applicant", "tenant"].includes(req.user.role)) {
+        res.status(403).json({ error: "Applicant role required" });
+        return;
+      }
+      const slug = String(req.params.slug ?? "").trim();
+      if (!slug) {
+        res.status(400).json({ error: "Property slug required" });
+        return;
+      }
+      const parsed = waitlistBedroomsSchema.safeParse(req.query);
+      if (!parsed.success) {
+        res.status(400).json({
+          error: "bedrooms query param is required (0–6)",
+          details: parsed.error.errors,
+        });
+        return;
+      }
+      const propertyId = await resolvePropertyIdBySlug(slug);
+      if (!propertyId) {
+        res.status(404).json({ error: "Property not found" });
+        return;
+      }
+      await query(
+        `DELETE FROM waitlist_entries
+          WHERE property_id = $1 AND bedroom_count = $2 AND applicant_user_id = $3`,
+        [propertyId, parsed.data.bedrooms, req.user.id]
+      );
+      res.json({ ok: true });
+    } catch (err) {
+      logger.error("Failed to leave waitlist", { error: (err as Error).message });
+      res.status(500).json({ error: "Failed to leave waitlist" });
     }
   }
 );


### PR DESCRIPTION
## Summary

Wedge #5 from `docs/intel/gpmglv-gap-backlog.md` — turns the placeholder waitlist into real position math. Replaces hardcoded `GET /properties/:slug/waitlist-summary` with per-(property, bedroom-tier) position queries, idempotent join/leave, and a graceful unauth fallback so the screen never renders dead air.

- **Backend**: new `waitlist_entries` table (FK to properties + users, UNIQUE per `(property, bedroom_count, user)`), three routes — `GET` (optional-auth, returns `position` only when enrolled; queue depth + window for everyone else), `POST .../waitlist-join` (auth + email-verified + rate-limited, `ON CONFLICT DO NOTHING`), `DELETE .../waitlist-leave` (idempotent `ok: true`).
- **Frontend (banner + position screen only — apply funnel untouched)**: `WaitlistBanner` takes a `bedrooms` prop (default 2) and links into the position page with the tier preserved; `Position.tsx` reads `?bedrooms=N` and renders queue depth instead of `#undefined` for unauth callers.
- **Seed**: 5 staff users x [1BR, 2BR] x 3 properties with staggered `created_at` so position ordering is deterministic and seeded notification snapshots make "moved up N spots" badges render real data immediately after `npm run seed`.
- **Tests**: 16 new (full Jest suite 824 pass / 0 fail).

## Response-shape compatibility

The legacy `{ position, totalQueue, movement: {spotsThisMonth, direction}, estimatedWindow }` shape is preserved as a **superset**:
- `position` is now **optional** (only present for enrolled authenticated callers)
- `movement: null` returned when there's no notification snapshot history yet (instead of fabricating a number)
- `enrolled: boolean` added so the UI can branch without inspecting `position`
- `expectedNotificationWindow` kept as a string alias for `estimatedWindow` so the existing 137-line `Position.tsx` UI keeps rendering with no breaking changes for any non-updated consumer

## `estimatedWindow` heuristic

Intentionally coarse — we don't have enough real notification history yet to do anything smarter, and the UI just needs a stable bucket:

| Ahead of me | Window |
|---|---|
| `< 3` | `"1–3 months"` |
| `< 6` | `"3–6 months"` |
| `≥ 6` | `"6+ months"` |

Trivially swappable later when notification cadence stabilizes.

## Schema/migration drift discipline

`src/db/migrate.ts` only runs `SCHEMA_SQL`, not the `migrations/` folder, so changes land in both:
- `src/db/schema.ts` → fresh dev/CI databases
- `src/db/migrations/2026-05-23-waitlist-entries.sql` → prod via `npm run migrate`

Closes the same drift class as #54.

## Test plan
- [x] `npx jest src/__tests__/waitlist-routes.test.ts` → 16/16 pass
- [x] `npx jest --forceExit` → 824 pass, 0 fail (1 pre-existing skip — unrelated `email-service` test that needs `resend` installed; passes after `npm install`)
- [x] `npx tsc --noEmit` (backend) clean
- [x] `cd client-tenant && npx tsc --noEmit` clean
- [ ] CI: `smoke-apply (Welcome → Claim e2e)` green
- [ ] CI: `test (18)` / `test (20)` / `test (22)` green
- [ ] Manual: hit `GET /api/applicants/properties/donna-louise-2/waitlist-summary?bedrooms=2` post-deploy and confirm real queue counts

## Files NOT touched (per coordination)
`client-tenant/src/pages/apply/**`, `Apply.tsx`, `StepPick.tsx`, `UnitCard.tsx`, `i18n/{en,es}/apply.json`, `src/modules/tape/routes.ts` — left alone for the in-flight session working that area. No textual collisions in `seed.ts` (appended a bottom block instead of weaving into existing loops). No changes to the `properties` table schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)