### PR TITLE
feat: HF design pass + 17 GPMG properties + Apply hardening

### DIFF
--- a/client-tenant/.env.example
+++ b/client-tenant/.env.example
@@ -1,8 +1,10 @@
 # client-tenant environment variables (Vite)
 # Copy to .env.local and fill in values for local development.
 
-# API base — points to the Express server.
-VITE_API_BASE_URL=http://localhost:3001
+# API base.
+# - In dev: leave EMPTY — Vite proxy in vite.config.ts forwards /api/* → :3002.
+# - In prod: set on Vercel to the Railway API URL (e.g. https://frank-pilot-api.up.railway.app).
+VITE_API_BASE_URL=
 
 # Feature flags (see src/lib/flags.ts)
 # Most flags default ENABLED — set `false` to disable.

--- a/client-tenant/smoke/apply-smoke.mjs
+++ b/client-tenant/smoke/apply-smoke.mjs
@@ -50,15 +50,15 @@ async function checkPropertiesAPI() {
 }
 
 async function checkDiscoverHTML() {
-  const label = `GET ${BASE}/discover contains "Las Vegas"`;
+  const label = `GET ${BASE}/discover returns SPA shell`;
   try {
     const res = await fetch(`${BASE}/discover`);
     if (!res.ok) return fail(label, `HTTP ${res.status}`);
     const html = await res.text();
-    // The SPA bundle is what we get back; "Las Vegas" appears at runtime
-    // in the rendered DOM, not the static shell. Treat as advisory.
-    if (html.includes('Las Vegas') || html.includes('discover')) ok(label);
-    else fail(label, 'no Las Vegas / discover marker in HTML shell');
+    // SPA bundle — runtime strings ("Las Vegas") hydrate client-side, so
+    // we look for shell markers proving the route served the React app.
+    if (html.includes('<div id="root"') || html.includes('CDPC') || html.includes('Apply')) ok(label);
+    else fail(label, 'no SPA shell marker found');
   } catch (e) {
     fail(label, e instanceof Error ? e.message : String(e));
   }

--- a/client-tenant/smoke/apply-smoke.mjs
+++ b/client-tenant/smoke/apply-smoke.mjs
@@ -1,0 +1,71 @@
+// Discover slice smoke — light HTTP-only checks.
+//
+// Usage:
+//   BASE=http://localhost:5173 API=http://localhost:3002 node client-tenant/smoke/apply-smoke.mjs
+//
+// - GET ${API}/api/properties with auth header (if TENANT_TOKEN is set), assert 17 properties.
+//   If no token, skip with a warning rather than failing — the route requires auth.
+// - GET ${BASE}/discover HTML, assert it contains "Las Vegas".
+
+const BASE = (process.env.BASE || 'http://localhost:5173').replace(/\/$/, '');
+const API = (process.env.API || 'http://localhost:3002').replace(/\/$/, '');
+const TENANT_TOKEN = process.env.TENANT_TOKEN || '';
+
+let passed = 0;
+let failed = 0;
+let skipped = 0;
+
+function ok(label) {
+  passed++;
+  console.log(`PASS  ${label}`);
+}
+function fail(label, err) {
+  failed++;
+  console.log(`FAIL  ${label}${err ? ` — ${err}` : ''}`);
+}
+function skip(label, reason) {
+  skipped++;
+  console.log(`SKIP  ${label} — ${reason}`);
+}
+
+async function checkPropertiesAPI() {
+  const label = `GET ${API}/api/properties → 17 rows`;
+  if (!TENANT_TOKEN) {
+    skip(label, 'TENANT_TOKEN not set (route requires property:view auth)');
+    return;
+  }
+  try {
+    const res = await fetch(`${API}/api/properties`, {
+      headers: { Authorization: `Bearer ${TENANT_TOKEN}` },
+    });
+    if (!res.ok) return fail(label, `HTTP ${res.status}`);
+    const body = await res.json();
+    const list = body.properties ?? body;
+    if (!Array.isArray(list)) return fail(label, 'response not an array');
+    if (list.length !== 17) return fail(label, `got ${list.length}, expected 17`);
+    ok(label);
+  } catch (e) {
+    fail(label, e instanceof Error ? e.message : String(e));
+  }
+}
+
+async function checkDiscoverHTML() {
+  const label = `GET ${BASE}/discover contains "Las Vegas"`;
+  try {
+    const res = await fetch(`${BASE}/discover`);
+    if (!res.ok) return fail(label, `HTTP ${res.status}`);
+    const html = await res.text();
+    // The SPA bundle is what we get back; "Las Vegas" appears at runtime
+    // in the rendered DOM, not the static shell. Treat as advisory.
+    if (html.includes('Las Vegas') || html.includes('discover')) ok(label);
+    else fail(label, 'no Las Vegas / discover marker in HTML shell');
+  } catch (e) {
+    fail(label, e instanceof Error ? e.message : String(e));
+  }
+}
+
+await checkPropertiesAPI();
+await checkDiscoverHTML();
+
+console.log(`\nresults: ${passed} pass, ${failed} fail, ${skipped} skip`);
+process.exit(failed > 0 ? 1 : 0);

--- a/client-tenant/src/api/client.ts
+++ b/client-tenant/src/api/client.ts
@@ -25,7 +25,9 @@ async function request<T>(
     headers['Authorization'] = `Bearer ${token}`;
   }
 
-  const fullPath = path.startsWith('/api') ? path : `/api${path.startsWith('/') ? path : `/${path}`}`;
+  const relativePath = path.startsWith('/api') ? path : `/api${path.startsWith('/') ? path : `/${path}`}`;
+  const baseUrl = (import.meta.env.VITE_API_BASE_URL as string | undefined)?.replace(/\/$/, '') ?? '';
+  const fullPath = baseUrl ? `${baseUrl}${relativePath}` : relativePath;
 
   const res = await fetch(fullPath, { ...options, headers });
 

--- a/client-tenant/src/api/gpmg-fixtures.ts
+++ b/client-tenant/src/api/gpmg-fixtures.ts
@@ -1,0 +1,77 @@
+/**
+ * GPMG Las Vegas property fixtures — 17 affordable communities.
+ *
+ * Sourced from the public GPMG catalog. Used as the client-side data source
+ * for the public `/discover` browse page because the canonical
+ * `GET /api/properties` route requires `property:view` auth. This fixture is
+ * the MVP carry-over until a public discovery endpoint lands.
+ */
+
+export type GPMGType = 'senior' | 'family';
+
+export interface GPMGProperty {
+  /** Display name. */
+  name: string;
+  /** Street address line. */
+  addr: string;
+  /** City. */
+  city: 'Las Vegas' | 'North Las Vegas' | 'Henderson';
+  /** ZIP. */
+  zip: string;
+  /** Phone (formatted). */
+  phone: string;
+  /** Contact email — null if not published. */
+  email: string | null;
+  /** Unit count — null if not published. */
+  units: number | null;
+  /** Senior or family community. */
+  type: GPMGType;
+}
+
+export const GPMG_FIXTURES: readonly GPMGProperty[] = [
+  { name: 'Aldene Kline Barlow Senior Apartments', addr: '1327 H St.', city: 'Las Vegas', zip: '89106', phone: '(702) 920-6550', email: 'barlow@gpmglv.org', units: 39, type: 'senior' },
+  { name: 'David J. Hoggard Family Community', addr: '1100 W. Monroe Ave.', city: 'Las Vegas', zip: '89106', phone: '(702) 631-2281', email: 'hoggard@gpmglv.org', units: 100, type: 'family' },
+  { name: 'Donna Louise Apartments', addr: '6225 Donna St.', city: 'North Las Vegas', zip: '89081', phone: '(702) 920-6548', email: 'donnalouise@gpmglv.org', units: 48, type: 'family' },
+  { name: 'Donna Louise Apartments 2', addr: '6225 Donna St.', city: 'North Las Vegas', zip: '89081', phone: '(702) 920-6548', email: 'donnalouise@gpmglv.org', units: null, type: 'family' },
+  { name: 'Luther Mack, Jr. Senior Apartments', addr: '8158 Giles St.', city: 'Las Vegas', zip: '89123', phone: '(702) 920-6569', email: 'drluthermack@gpmglv.org', units: 48, type: 'senior' },
+  { name: 'Dr. Paul Meacham Senior Community', addr: '65 E Windmill Ln', city: 'Las Vegas', zip: '89123', phone: '(877) 895-8207', email: 'paulmeacham@gpmglv.org', units: 57, type: 'senior' },
+  { name: 'Ethel Mae Fletcher Apartments', addr: '1503 Laurelhurst Dr.', city: 'Las Vegas', zip: '89108', phone: '(702) 920-6572', email: 'ethelmaefletcher@gpmglv.org', units: 42, type: 'senior' },
+  { name: 'Ethel Mae Robinson Senior Apartments', addr: '1327 H Street', city: 'Las Vegas', zip: '89106', phone: '(702) 648-6800', email: 'ethelmaerobinson@gpmglv.org', units: 20, type: 'senior' },
+  { name: "Mike O'Callaghan Legacy Apartments", addr: '1502 Laurelhurst Dr', city: 'Las Vegas', zip: '89108', phone: '(725) 735-7779', email: 'mikeocallaghan@gpmglv.org', units: 40, type: 'senior' },
+  { name: 'Juan Garcia Garden Apartments', addr: '2851 Sunrise Ave.', city: 'Las Vegas', zip: '89101', phone: '(725) 735-7779', email: 'juangarcia@gpmglv.org', units: 52, type: 'family' },
+  { name: 'Louise Shell Senior Apartments', addr: '2101 N. Martin Luther King Blvd.', city: 'Las Vegas', zip: '89106', phone: '(702) 648-6800', email: 'louiseshell@gpmglv.org', units: 100, type: 'senior' },
+  { name: 'Owens Senior Housing', addr: '1626 Davis Pl.', city: 'North Las Vegas', zip: '89030', phone: '(702) 642-0896', email: 'owens@gpmglv.org', units: 72, type: 'senior' },
+  { name: 'Sarann Knight Apartments', addr: '1327 H Street', city: 'Las Vegas', zip: '89106', phone: '(702) 538-9031', email: 'sarannknight@gpmglv.org', units: 82, type: 'senior' },
+  { name: 'Senator Harry Reid Senior Apartments', addr: '328 N. 11th St', city: 'Las Vegas', zip: '89101', phone: '(702) 383-1091', email: 'harryreid@gpmglv.org', units: 100, type: 'senior' },
+  { name: 'Senator Richard Bryan Senior Apartments', addr: '2651 Searles Ave.', city: 'Las Vegas', zip: '89101', phone: '(702) 649-3508', email: 'senatorrichardbryan@gpmglv.org', units: 120, type: 'senior' },
+  { name: 'Smith Williams Senior Apartments', addr: '575 E. Lake Mead Pkwy.', city: 'Henderson', zip: '89015', phone: '(702) 382-3726', email: null, units: 80, type: 'senior' },
+  { name: 'Yale Keyes Senior Apartments', addr: '1705 Yale Str.', city: 'North Las Vegas', zip: '89030', phone: '(702) 642-7758', email: null, units: 70, type: 'senior' },
+] as const;
+
+/** kebab-case a property name into a URL slug. */
+export function slugify(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+/**
+ * Find a fixture by URL slug. Also matches the legacy DL2 slug
+ * `donna-louise-2` (kept working as a hand-mapped alias from the MVP).
+ */
+export function findGPMGBySlug(slug: string): GPMGProperty | undefined {
+  if (slug === 'donna-louise-2') {
+    return GPMG_FIXTURES.find((p) => p.name === 'Donna Louise Apartments 2');
+  }
+  return GPMG_FIXTURES.find((p) => slugify(p.name) === slug);
+}
+
+/**
+ * Rough "from $X/mo" estimate — GPMG publishes ranges only via PDFs and the
+ * catalog doesn't expose per-unit rent, so we surface a conservative number
+ * for the tile until a real rent endpoint lands.
+ */
+export function rentEstimate(p: GPMGProperty): number {
+  return p.type === 'senior' ? 747 : 920;
+}

--- a/client-tenant/src/components/ClaimedUnitHeader.tsx
+++ b/client-tenant/src/components/ClaimedUnitHeader.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { Clock } from 'lucide-react';
 import type { Unit } from '@/api/units';
 import { getUnitPhoto } from '@/utils/unitPlaceholder';
+import { HF } from '@/styles/tokens';
 
 interface Props {
   unit: Unit;
@@ -34,25 +35,47 @@ export function ClaimedUnitHeader({ unit, expiresAt }: Props) {
   const photo = getUnitPhoto(unit.photo_url);
 
   return (
-    <div className="sticky top-0 z-20 -mx-4 mb-4 border-b border-emerald-200 bg-emerald-50/95 px-4 py-3 backdrop-blur">
+    <div
+      className="sticky top-0 z-20 -mx-4 mb-4 px-4 py-3 backdrop-blur"
+      style={{
+        background: HF.accentLo,
+        borderBottom: `1px solid ${HF.border}`,
+      }}
+    >
       <div className="mx-auto flex max-w-md items-center gap-3">
         <img
           src={photo}
           alt=""
-          className="h-12 w-12 flex-shrink-0 rounded-lg object-cover"
+          className="h-12 w-12 flex-shrink-0 object-cover"
+          style={{ borderRadius: HF.r.md }}
         />
         <div className="min-w-0 flex-1">
-          <div className="truncate text-sm font-semibold text-gray-900">
+          <div
+            className="truncate text-sm font-semibold"
+            style={{ color: HF.ink }}
+          >
             {unit.property_name} · Unit {unit.unit_number}
           </div>
-          <div className="text-xs text-gray-600">{formatRent(unit.monthly_rent)}</div>
+          <div className="text-xs" style={{ color: HF.ink2 }}>
+            {formatRent(unit.monthly_rent)}
+          </div>
         </div>
         <div className="flex flex-col items-end">
-          <div className="inline-flex items-center gap-1 text-xs text-emerald-800">
+          <div
+            className="inline-flex items-center gap-1 text-xs"
+            style={{ color: HF.accentInk }}
+          >
             <Clock className="h-3 w-3" />
-            <span className="font-mono font-medium">{formatCountdown(remaining)}</span>
+            <span className="font-mono font-medium" style={{ fontFamily: HF.mono }}>
+              {formatCountdown(remaining)}
+            </span>
           </div>
-          <div className="text-[10px] uppercase tracking-wide text-emerald-700">held</div>
+          <div
+            className="text-[10px] uppercase tracking-wide"
+            style={{ color: HF.accent }}
+          >
+            held
+          </div>
         </div>
       </div>
     </div>

--- a/client-tenant/src/components/Layout.tsx
+++ b/client-tenant/src/components/Layout.tsx
@@ -8,6 +8,7 @@ import {
   LogOut,
 } from 'lucide-react';
 import { clearToken } from '@/api/client';
+import { HF } from '@/styles/tokens';
 
 const navItems = [
   { to: '/dashboard', label: 'Home', icon: LayoutDashboard },
@@ -34,34 +35,51 @@ export function Layout() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div
+      className="min-h-screen"
+      style={{ background: HF.cream, color: HF.ink, fontFamily: HF.body }}
+    >
       {/* Desktop sidebar */}
-      <aside className="fixed inset-y-0 left-0 hidden w-64 flex-col border-r border-gray-200 bg-white md:flex">
-        <div className="flex h-16 items-center border-b border-gray-200 px-6">
-          <span className="text-lg font-semibold text-emerald-700">Frank Pilot</span>
+      <aside
+        className="fixed inset-y-0 left-0 hidden w-64 flex-col md:flex"
+        style={{
+          background: HF.paper,
+          borderRight: `1px solid ${HF.border}`,
+        }}
+      >
+        <div
+          className="flex h-16 items-center px-6"
+          style={{ borderBottom: `1px solid ${HF.border}` }}
+        >
+          <span
+            className="text-lg font-semibold"
+            style={{ color: HF.accent, fontFamily: HF.display }}
+          >
+            Frank Pilot
+          </span>
         </div>
         <nav className="flex-1 space-y-1 px-3 py-4">
           {navItems.map(({ to, label, icon: Icon }) => (
             <NavLink
               key={to}
               to={to}
-              className={({ isActive }) =>
-                `flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition ${
-                  isActive
-                    ? 'bg-emerald-50 text-emerald-700'
-                    : 'text-gray-700 hover:bg-gray-100'
-                }`
-              }
+              className="flex items-center gap-3 px-3 py-2 text-sm font-medium transition"
+              style={({ isActive }) => ({
+                background: isActive ? HF.accentLo : 'transparent',
+                color: isActive ? HF.accentInk : HF.ink2,
+                borderRadius: HF.r.md,
+              })}
             >
               <Icon className="h-5 w-5" />
               {label}
             </NavLink>
           ))}
         </nav>
-        <div className="border-t border-gray-200 p-3">
+        <div className="p-3" style={{ borderTop: `1px solid ${HF.border}` }}>
           <button
             onClick={handleLogout}
-            className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-sm text-gray-500 hover:bg-gray-100 hover:text-gray-700"
+            className="flex w-full items-center gap-3 px-3 py-2 text-sm"
+            style={{ color: HF.ink3, borderRadius: HF.r.md }}
           >
             <LogOut className="h-5 w-5" />
             Log out
@@ -72,11 +90,23 @@ export function Layout() {
       {/* Main content */}
       <div className="flex min-h-screen flex-col md:pl-64">
         {/* Mobile top bar with logout */}
-        <header className="sticky top-0 z-10 flex h-12 items-center justify-between border-b border-gray-200 bg-white px-4 md:hidden">
-          <span className="text-base font-semibold text-emerald-700">Frank Pilot</span>
+        <header
+          className="sticky top-0 z-10 flex h-12 items-center justify-between px-4 md:hidden"
+          style={{
+            background: HF.paper,
+            borderBottom: `1px solid ${HF.border}`,
+          }}
+        >
+          <span
+            className="text-base font-semibold"
+            style={{ color: HF.accent, fontFamily: HF.display }}
+          >
+            Frank Pilot
+          </span>
           <button
             onClick={handleLogout}
-            className="flex items-center gap-1 text-xs font-medium text-gray-500 hover:text-gray-700"
+            className="flex items-center gap-1 text-xs font-medium"
+            style={{ color: HF.ink3 }}
           >
             <LogOut className="h-4 w-4" />
             Sign out
@@ -88,17 +118,22 @@ export function Layout() {
       </div>
 
       {/* Mobile bottom nav */}
-      <nav className="fixed inset-x-0 bottom-0 z-10 border-t border-gray-200 bg-white md:hidden">
+      <nav
+        className="fixed inset-x-0 bottom-0 z-10 md:hidden"
+        style={{
+          background: HF.paper,
+          borderTop: `1px solid ${HF.border}`,
+        }}
+      >
         <div className="grid grid-cols-5">
           {mobileNavItems.map(({ to, label, icon: Icon }) => (
             <NavLink
               key={to}
               to={to}
-              className={({ isActive }) =>
-                `flex flex-col items-center justify-center gap-1 py-2.5 text-xs font-medium ${
-                  isActive ? 'text-emerald-700' : 'text-gray-500'
-                }`
-              }
+              className="flex flex-col items-center justify-center gap-1 py-2.5 text-xs font-medium"
+              style={({ isActive }) => ({
+                color: isActive ? HF.accent : HF.ink3,
+              })}
             >
               <Icon className="h-5 w-5" />
               {label}

--- a/client-tenant/src/components/UnitCard.tsx
+++ b/client-tenant/src/components/UnitCard.tsx
@@ -1,13 +1,18 @@
-import { Bed, Bath, Square } from 'lucide-react';
+import { Bed, Bath, Square, AlertCircle } from 'lucide-react';
 import type { Unit } from '@/api/units';
 import { CTA } from '@/components/primitives';
 import { HF } from '@/styles/tokens';
 import { getUnitPhoto } from '@/utils/unitPlaceholder';
 
+export interface UnitMismatch {
+  notes: string[];
+}
+
 interface Props {
   unit: Unit;
   onClaim: (unitId: string) => void;
   claiming?: boolean;
+  mismatch?: UnitMismatch;
 }
 
 function formatRent(rent: string | number): string {
@@ -24,9 +29,10 @@ const chipStyle = {
   fontFamily: HF.body,
 } as const;
 
-export function UnitCard({ unit, onClaim, claiming }: Props) {
+export function UnitCard({ unit, onClaim, claiming, mismatch }: Props) {
   const photo = getUnitPhoto(unit.photo_url);
   const location = [unit.property_city, unit.property_state].filter(Boolean).join(', ');
+  const hasMismatch = mismatch && mismatch.notes.length > 0;
 
   return (
     <div
@@ -83,6 +89,29 @@ export function UnitCard({ unit, onClaim, claiming }: Props) {
             </span>
           )}
         </div>
+
+        {hasMismatch && (
+          <ul
+            aria-label="Differences from your preferences"
+            className="space-y-1 text-xs"
+            style={{
+              background: `${HF.warn}14`,
+              border: `1px solid ${HF.warn}33`,
+              borderRadius: HF.r.sm,
+              color: HF.warn,
+              padding: '8px 10px',
+              listStyle: 'none',
+              margin: 0,
+            }}
+          >
+            {mismatch!.notes.map((note, i) => (
+              <li key={i} className="flex items-start gap-1.5">
+                <AlertCircle className="h-3.5 w-3.5 shrink-0" style={{ marginTop: 1 }} />
+                <span>{note}</span>
+              </li>
+            ))}
+          </ul>
+        )}
 
         <CTA
           type="button"

--- a/client-tenant/src/components/primitives/PayHeader.tsx
+++ b/client-tenant/src/components/primitives/PayHeader.tsx
@@ -5,6 +5,7 @@
 // Step mapping (FROZEN CONTRACT 1, wizard slice):
 //   1 review · 2 household · 3 payment · 4 details (?step=2) · 5 confirm
 import type { ReactNode } from 'react';
+import { HF } from '@/styles/tokens';
 
 export type PayHeaderStep = 'review' | 'household' | 'payment' | 'details' | 'confirm';
 
@@ -52,27 +53,45 @@ export function PayHeader({ step, total, lang, onBack }: PayHeaderProps): ReactN
   const copy = COPY[lang];
 
   return (
-    <header className="space-y-2 px-4 pb-2 pt-3" data-testid="pay-header">
+    <header
+      className="space-y-2 px-4 pb-2 pt-3"
+      data-testid="pay-header"
+      style={{ fontFamily: HF.body }}
+    >
       <div className="flex items-center gap-2">
         {onBack && (
           <button
             type="button"
             onClick={onBack}
-            className="text-xs text-gray-500 hover:text-gray-700"
+            className="text-xs"
+            style={{ color: HF.ink3 }}
             aria-label={copy.back}
           >
             ← {copy.back}
           </button>
         )}
-        <span className="ml-auto text-[10px] font-semibold uppercase tracking-wider text-gray-500">
+        <span
+          className="ml-auto text-[10px] font-semibold uppercase tracking-wider"
+          style={{ color: HF.ink3 }}
+        >
           {copy.application} · {safeIdx + 1} / {STEP_ORDER.length}
         </span>
       </div>
-      <div className="flex gap-1" role="progressbar" aria-valuenow={safeIdx + 1} aria-valuemin={1} aria-valuemax={STEP_ORDER.length}>
+      <div
+        className="flex gap-1"
+        role="progressbar"
+        aria-valuenow={safeIdx + 1}
+        aria-valuemin={1}
+        aria-valuemax={STEP_ORDER.length}
+      >
         {STEP_ORDER.map((s, i) => (
           <div
             key={s}
-            className={`h-1 flex-1 rounded-full ${i <= safeIdx ? 'bg-emerald-500' : 'bg-gray-200'}`}
+            className="h-1 flex-1"
+            style={{
+              background: i <= safeIdx ? HF.accent : HF.border,
+              borderRadius: HF.r.pill,
+            }}
             data-segment={s}
             data-active={i <= safeIdx ? 'true' : 'false'}
           />
@@ -82,13 +101,19 @@ export function PayHeader({ step, total, lang, onBack }: PayHeaderProps): ReactN
         {STEP_ORDER.map((s, i) => (
           <span
             key={s}
-            className={`text-[10px] ${i === safeIdx ? 'font-bold text-gray-900' : 'text-gray-500'}`}
+            className="text-[10px]"
+            style={{
+              color: i === safeIdx ? HF.ink : HF.ink3,
+              fontWeight: i === safeIdx ? 700 : 400,
+            }}
           >
             {labels[s]}
           </span>
         ))}
       </div>
-      <div className="text-right text-xs text-gray-500">{total}</div>
+      <div className="text-right text-xs" style={{ color: HF.ink3 }}>
+        {total}
+      </div>
     </header>
   );
 }

--- a/client-tenant/src/i18n/en/apply.json
+++ b/client-tenant/src/i18n/en/apply.json
@@ -81,10 +81,19 @@
     "subtitle": "Claiming a unit holds it for you for 48 hours while you finish your application.",
     "loading": "Loading units…",
     "noMatch": "No units match your preferences right now.",
+    "noUnitsAvailable": "We don't have any units available at the moment. Check back soon.",
+    "fallbackBanner": "No exact matches. Here are the closest options — your preferences are noted on each card.",
     "adjust": "Adjust your search",
     "editPrefs": "← Edit preferences",
     "claimError": "Could not claim this unit",
-    "loadError": "Could not load units"
+    "loadError": "Could not load units",
+    "mismatch": {
+      "overBudget": "${{amount}}/mo over your budget",
+      "bedroomsMore": "{{actual}} BR — you wanted {{wanted}}",
+      "bedroomsFewer": "{{actual}} BR — you wanted {{wanted}}+",
+      "studioInstead": "Studio — you wanted {{wanted}} BR",
+      "availableLater": "Available {{date}}"
+    }
   },
   "claim": {
     "yours": "Unit {unitNumber} is yours",

--- a/client-tenant/src/i18n/es/apply.json
+++ b/client-tenant/src/i18n/es/apply.json
@@ -81,10 +81,19 @@
     "subtitle": "Reservar una unidad la aparta para ti por 48 horas mientras completas tu solicitud.",
     "loading": "Cargando unidades…",
     "noMatch": "Ninguna unidad coincide con tus preferencias ahora mismo.",
+    "noUnitsAvailable": "No hay unidades disponibles en este momento. Vuelve a consultar pronto.",
+    "fallbackBanner": "Sin coincidencias exactas. Estas son las opciones más cercanas — tus preferencias aparecen en cada tarjeta.",
     "adjust": "Ajustar tu búsqueda",
     "editPrefs": "← Editar preferencias",
     "claimError": "No se pudo reservar esta unidad",
-    "loadError": "No se pudieron cargar las unidades"
+    "loadError": "No se pudieron cargar las unidades",
+    "mismatch": {
+      "overBudget": "${{amount}}/mes por encima de tu presupuesto",
+      "bedroomsMore": "{{actual}} hab. — pediste {{wanted}}",
+      "bedroomsFewer": "{{actual}} hab. — pediste {{wanted}}+",
+      "studioInstead": "Estudio — pediste {{wanted}} hab.",
+      "availableLater": "Disponible el {{date}}"
+    }
   },
   "claim": {
     "yours": "La unidad {unitNumber} es tuya",

--- a/client-tenant/src/pages/Application.tsx
+++ b/client-tenant/src/pages/Application.tsx
@@ -14,6 +14,8 @@ import {
   Clock,
   X,
 } from 'lucide-react';
+import { HF } from '@/styles/tokens';
+import { Card, CTA, Pill, type PillTone } from '@/components/primitives';
 
 interface ClaimedUnit {
   id: string;
@@ -159,33 +161,47 @@ export function Application() {
 
   if (loading) {
     return (
-      <div className="flex min-h-[60vh] items-center justify-center">
-        <Loader2 className="h-7 w-7 animate-spin text-emerald-600" />
+      <div
+        className="flex min-h-[60vh] items-center justify-center"
+        style={{ background: HF.cream }}
+      >
+        <Loader2 className="h-7 w-7 animate-spin" style={{ color: HF.accent }} />
       </div>
     );
   }
 
   if (error) {
     return (
-      <div className="p-4">
-        <div className="flex items-center gap-2 rounded-lg bg-red-50 p-4 text-red-700">
-          <AlertCircle className="h-5 w-5 shrink-0" />
-          <p className="text-sm">{error}</p>
-        </div>
+      <div className="p-4" style={{ background: HF.cream, minHeight: '60vh' }}>
+        <Card
+          variant="mobile"
+          padding={14}
+          style={{ background: HF.errLo, border: `1px solid ${HF.err}` }}
+        >
+          <div className="flex items-center gap-2" style={{ color: HF.err }}>
+            <AlertCircle className="h-5 w-5 shrink-0" />
+            <p style={{ fontFamily: HF.body, fontSize: 13 }}>{error}</p>
+          </div>
+        </Card>
       </div>
     );
   }
 
   if (!data || !data.activeApplication) {
     return (
-      <div className="flex min-h-[60vh] flex-col items-center justify-center gap-4 p-6 text-center">
-        <FileText className="h-10 w-10 text-gray-300" />
-        <h2 className="text-lg font-semibold text-gray-900">No active application</h2>
-        <p className="text-sm text-gray-500">
+      <div
+        className="flex min-h-[60vh] flex-col items-center justify-center gap-4 p-6 text-center"
+        style={{ background: HF.cream, color: HF.ink, fontFamily: HF.body }}
+      >
+        <FileText className="h-10 w-10" style={{ color: HF.ink4 }} />
+        <h2 style={{ fontFamily: HF.display, fontSize: 18, fontWeight: 800, color: HF.ink }}>
+          No active application
+        </h2>
+        <p style={{ fontFamily: HF.body, fontSize: 13, color: HF.ink3 }}>
           Submit an application to track its progress and message staff here.
         </p>
-        <Link to="/apply" className="btn-primary">
-          Start an application
+        <Link to="/apply" style={{ textDecoration: 'none' }}>
+          <CTA tone="primary">Start an application</CTA>
         </Link>
       </div>
     );
@@ -195,12 +211,20 @@ export function Application() {
   const userId = data.user.id;
 
   return (
-    <div className="mx-auto max-w-3xl space-y-5 p-4 pb-24 sm:p-6">
+    <div
+      className="mx-auto max-w-3xl space-y-5 p-4 pb-24 sm:p-6"
+      style={{ background: HF.cream, minHeight: '100vh', color: HF.ink, fontFamily: HF.body }}
+    >
       {/* Header */}
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div>
-          <h1 className="text-xl font-bold text-gray-900">My Application</h1>
-          <p className="mt-1 text-sm text-gray-500">
+          <h1 style={{ fontFamily: HF.display, fontSize: 22, fontWeight: 800, color: HF.ink }}>
+            My Application
+          </h1>
+          <p
+            className="mt-1"
+            style={{ fontFamily: HF.body, fontSize: 13, color: HF.ink3 }}
+          >
             {app.property_name}
             {app.unit_number ? ` · Unit ${app.unit_number}` : ''}
           </p>
@@ -220,8 +244,17 @@ export function Application() {
       )}
 
       {/* Key dates */}
-      <section className="rounded-xl bg-white p-5 shadow-sm">
-        <h2 className="mb-3 flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-gray-500">
+      <Card variant="mobile" padding={20}>
+        <h2
+          className="mb-3 flex items-center gap-2 uppercase"
+          style={{
+            fontFamily: HF.body,
+            fontSize: 11,
+            fontWeight: 700,
+            letterSpacing: 1,
+            color: HF.ink3,
+          }}
+        >
           <Calendar className="h-4 w-4" /> Key dates
         </h2>
         <dl className="grid grid-cols-1 gap-3 sm:grid-cols-3">
@@ -229,11 +262,20 @@ export function Application() {
           <Field label="Requested move-in" value={fmtDate(app.requested_move_in_date)} />
           <Field label="Last updated" value={fmtDate(app.created_at)} />
         </dl>
-      </section>
+      </Card>
 
       {/* Property / lease snapshot */}
-      <section className="rounded-xl bg-white p-5 shadow-sm">
-        <h2 className="mb-3 flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-gray-500">
+      <Card variant="mobile" padding={20}>
+        <h2
+          className="mb-3 flex items-center gap-2 uppercase"
+          style={{
+            fontFamily: HF.body,
+            fontSize: 11,
+            fontWeight: 700,
+            letterSpacing: 1,
+            color: HF.ink3,
+          }}
+        >
           <Home className="h-4 w-4" /> Property
         </h2>
         <dl className="grid grid-cols-1 gap-3 sm:grid-cols-2">
@@ -242,7 +284,7 @@ export function Application() {
           <Field label="Unit" value={app.unit_number || 'TBD'} />
           <Field label="Requested rent" value={fmt(app.requested_rent_amount)} />
         </dl>
-      </section>
+      </Card>
 
       {/* Next steps */}
       <NextStepsCard app={app} />
@@ -307,30 +349,70 @@ function ClaimedUnitCard({
   }
 
   return (
-    <section className="overflow-hidden rounded-xl bg-white shadow-sm ring-1 ring-emerald-100">
+    <Card
+      variant="mobile"
+      padding={0}
+      style={{ overflow: 'hidden', border: `1px solid ${HF.accentLo}` }}
+    >
       <div className="relative">
         <img src={photo} alt="" className="h-40 w-full object-cover sm:h-48" />
-        <div className="absolute right-3 top-3 inline-flex items-center gap-1.5 rounded-full bg-white/95 px-2.5 py-1 text-xs font-semibold text-emerald-700 shadow-sm">
+        <div
+          className="absolute right-3 top-3 inline-flex items-center gap-1.5 rounded-full px-2.5 py-1"
+          style={{
+            background: 'rgba(255,255,255,0.95)',
+            color: HF.accentInk,
+            fontFamily: HF.body,
+            fontSize: 12,
+            fontWeight: 700,
+            boxShadow: HF.shadow.xs,
+          }}
+        >
           <Clock className="h-3.5 w-3.5" />
-          <span className="font-mono">{formatCountdown(remaining)}</span>
+          <span style={{ fontFamily: HF.mono }}>{formatCountdown(remaining)}</span>
         </div>
       </div>
-      <div className="p-5">
-        <div className="text-[11px] font-semibold uppercase tracking-wider text-emerald-700">
+      <div style={{ padding: 20 }}>
+        <div
+          className="uppercase"
+          style={{
+            fontFamily: HF.body,
+            fontSize: 11,
+            fontWeight: 700,
+            letterSpacing: 1,
+            color: HF.accent,
+          }}
+        >
           You're holding this unit
         </div>
-        <h3 className="mt-1 text-base font-semibold text-gray-900">
+        <h3
+          className="mt-1"
+          style={{ fontFamily: HF.display, fontSize: 16, fontWeight: 700, color: HF.ink }}
+        >
           {unit.property_name} · Unit {unit.unit_number}
         </h3>
-        <div className="mt-1 text-sm text-gray-600">
+        <div
+          className="mt-1"
+          style={{ fontFamily: HF.body, fontSize: 13, color: HF.ink2 }}
+        >
           {unit.bedrooms} bd · {unit.bathrooms} ba
           {unit.sqft ? ` · ${unit.sqft} sqft` : ''} · {formatRent(unit.monthly_rent)}
         </div>
-        <p className="mt-3 text-xs text-gray-500">
+        <p
+          className="mt-3"
+          style={{ fontFamily: HF.body, fontSize: 12, color: HF.ink3 }}
+        >
           Complete your application before the hold expires to keep this unit.
         </p>
         {releaseError && (
-          <div className="mt-3 rounded-lg bg-red-50 px-3 py-2 text-xs text-red-700">
+          <div
+            className="mt-3 rounded-lg px-3 py-2"
+            style={{
+              background: HF.errLo,
+              color: HF.err,
+              fontFamily: HF.body,
+              fontSize: 12,
+            }}
+          >
             {releaseError}
           </div>
         )}
@@ -339,27 +421,36 @@ function ClaimedUnitCard({
             type="button"
             onClick={handleRelease}
             disabled={releasing}
-            className="inline-flex items-center gap-1.5 rounded-lg border border-gray-200 px-3 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+            className="inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 disabled:opacity-50"
+            style={{
+              border: `1px solid ${HF.border}`,
+              background: HF.paper,
+              color: HF.ink2,
+              fontFamily: HF.body,
+              fontSize: 12,
+              fontWeight: 600,
+              cursor: 'pointer',
+            }}
           >
             <X className="h-3.5 w-3.5" />
             {releasing ? 'Releasing…' : 'Release this unit'}
           </button>
         </div>
       </div>
-    </section>
+    </Card>
   );
 }
 
 function StatusPill({ status }: { status: string }) {
   const label = STATUS_LABELS[status] ?? status;
-  const tone = DENIED.has(status)
-    ? 'bg-red-100 text-red-700'
+  const tone: PillTone = DENIED.has(status)
+    ? 'err'
     : status === 'onboarded'
-    ? 'bg-emerald-100 text-emerald-700'
-    : 'bg-emerald-50 text-emerald-700';
+    ? 'sage'
+    : 'accent';
   return (
-    <span className={`shrink-0 rounded-full px-3 py-1 text-xs font-semibold ${tone}`}>
-      {label}
+    <span className="shrink-0">
+      <Pill tone={tone}>{label}</Pill>
     </span>
   );
 }
@@ -367,8 +458,23 @@ function StatusPill({ status }: { status: string }) {
 function Field({ label, value }: { label: string; value: string }) {
   return (
     <div>
-      <dt className="text-[11px] uppercase tracking-wider text-gray-400">{label}</dt>
-      <dd className="text-sm font-medium text-gray-900">{value}</dd>
+      <dt
+        className="uppercase"
+        style={{
+          fontFamily: HF.body,
+          fontSize: 11,
+          fontWeight: 600,
+          letterSpacing: 1,
+          color: HF.ink4,
+        }}
+      >
+        {label}
+      </dt>
+      <dd
+        style={{ fontFamily: HF.body, fontSize: 13, fontWeight: 500, color: HF.ink }}
+      >
+        {value}
+      </dd>
     </div>
   );
 }
@@ -396,21 +502,39 @@ function NextStepsCard({ app }: { app: ApplicationDetail }) {
   ];
 
   return (
-    <section className="rounded-xl bg-white p-5 shadow-sm">
-      <h2 className="mb-3 text-xs font-semibold uppercase tracking-wider text-gray-500">
+    <Card variant="mobile" padding={20}>
+      <h2
+        className="mb-3 uppercase"
+        style={{
+          fontFamily: HF.body,
+          fontSize: 11,
+          fontWeight: 700,
+          letterSpacing: 1,
+          color: HF.ink3,
+        }}
+      >
         Next steps
       </h2>
       <ol className="space-y-2">
         {steps.map((s) => (
-          <li key={s.label} className="flex items-center gap-2 text-sm">
+          <li key={s.label} className="flex items-center gap-2">
             <CheckCircle2
-              className={`h-4 w-4 ${s.done ? 'text-emerald-600' : 'text-gray-300'}`}
+              className="h-4 w-4"
+              style={{ color: s.done ? HF.sage : HF.ink4 }}
             />
-            <span className={s.done ? 'text-gray-800' : 'text-gray-400'}>{s.label}</span>
+            <span
+              style={{
+                fontFamily: HF.body,
+                fontSize: 13,
+                color: s.done ? HF.ink2 : HF.ink4,
+              }}
+            >
+              {s.label}
+            </span>
           </li>
         ))}
       </ol>
-    </section>
+    </Card>
   );
 }
 
@@ -501,10 +625,17 @@ function MessagesThread({
   }
 
   return (
-    <section className="rounded-xl bg-white shadow-sm">
-      <header className="border-b border-gray-100 px-5 py-3">
-        <h2 className="text-sm font-semibold text-gray-900">Messages</h2>
-        <p className="text-xs text-gray-500">Talk directly to your leasing team.</p>
+    <Card variant="mobile" padding={0}>
+      <header
+        className="px-5 py-3"
+        style={{ borderBottom: `1px solid ${HF.border}` }}
+      >
+        <h2 style={{ fontFamily: HF.display, fontSize: 14, fontWeight: 700, color: HF.ink }}>
+          Messages
+        </h2>
+        <p style={{ fontFamily: HF.body, fontSize: 12, color: HF.ink3 }}>
+          Talk directly to your leasing team.
+        </p>
       </header>
 
       <div
@@ -512,11 +643,17 @@ function MessagesThread({
         className="max-h-[26rem] min-h-[12rem] space-y-3 overflow-y-auto px-5 py-4"
       >
         {loading ? (
-          <div className="flex items-center justify-center py-6 text-gray-400">
+          <div
+            className="flex items-center justify-center py-6"
+            style={{ color: HF.ink4 }}
+          >
             <Loader2 className="h-5 w-5 animate-spin" />
           </div>
         ) : messages.length === 0 ? (
-          <p className="py-6 text-center text-sm text-gray-400">
+          <p
+            className="py-6 text-center"
+            style={{ fontFamily: HF.body, fontSize: 13, color: HF.ink4 }}
+          >
             No messages yet. Send the first one below.
           </p>
         ) : (
@@ -525,14 +662,23 @@ function MessagesThread({
       </div>
 
       {error && (
-        <div className="mx-5 mb-2 rounded-lg bg-red-50 px-3 py-2 text-xs text-red-700">
+        <div
+          className="mx-5 mb-2 rounded-lg px-3 py-2"
+          style={{
+            background: HF.errLo,
+            color: HF.err,
+            fontFamily: HF.body,
+            fontSize: 12,
+          }}
+        >
           {error}
         </div>
       )}
 
       <form
         onSubmit={handleSend}
-        className="flex items-end gap-2 border-t border-gray-100 px-5 py-3"
+        className="flex items-end gap-2 px-5 py-3"
+        style={{ borderTop: `1px solid ${HF.border}` }}
       >
         <textarea
           value={draft}
@@ -540,50 +686,59 @@ function MessagesThread({
           rows={2}
           maxLength={4000}
           placeholder="Type a message…"
-          className="flex-1 resize-none rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
+          className="flex-1 resize-none rounded-lg px-3 py-2 focus:outline-none"
+          style={{
+            border: `1px solid ${HF.border}`,
+            background: HF.paper,
+            color: HF.ink,
+            fontFamily: HF.body,
+            fontSize: 13,
+          }}
           onKeyDown={(e) => {
             if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
               handleSend(e);
             }
           }}
         />
-        <button
+        <CTA
           type="submit"
+          tone="primary"
           disabled={sending || draft.trim().length === 0}
-          className="flex items-center gap-1.5 rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-700 disabled:opacity-50"
         >
           <Send className="h-4 w-4" />
           {sending ? 'Sending…' : 'Send'}
-        </button>
+        </CTA>
       </form>
-    </section>
+    </Card>
   );
 }
 
 function MessageBubble({ m, selfId }: { m: Message; selfId: string }) {
   const isMine = m.senderUserId === selfId;
+  const roleTone: PillTone = m.senderRole === 'staff' ? 'sage' : 'accent';
   return (
     <div className={`flex ${isMine ? 'justify-end' : 'justify-start'}`}>
       <div className={`max-w-[80%] ${isMine ? 'text-right' : 'text-left'}`}>
-        <div className="mb-1 flex items-center gap-2 text-[11px] text-gray-400">
-          {!isMine && <span className="font-medium text-gray-600">{m.senderName}</span>}
-          <span
-            className={`rounded-full px-1.5 py-0.5 text-[10px] font-medium ${
-              m.senderRole === 'staff'
-                ? 'bg-blue-100 text-blue-700'
-                : 'bg-emerald-100 text-emerald-700'
-            }`}
-          >
+        <div
+          className="mb-1 flex items-center gap-2"
+          style={{ fontFamily: HF.body, fontSize: 11, color: HF.ink4 }}
+        >
+          {!isMine && (
+            <span style={{ fontWeight: 500, color: HF.ink2 }}>{m.senderName}</span>
+          )}
+          <Pill tone={roleTone} style={{ padding: '1px 8px', fontSize: 10 }}>
             {isMine ? 'You' : m.senderRole === 'staff' ? 'Staff' : 'Tenant'}
-          </span>
+          </Pill>
           <span>{fmtTime(m.createdAt)}</span>
         </div>
         <div
-          className={`whitespace-pre-wrap break-words rounded-2xl px-3 py-2 text-sm ${
-            isMine
-              ? 'bg-emerald-600 text-white'
-              : 'bg-gray-100 text-gray-900'
-          }`}
+          className="whitespace-pre-wrap break-words rounded-2xl px-3 py-2"
+          style={{
+            background: isMine ? HF.accent : HF.sageLo,
+            color: isMine ? HF.paper : HF.ink,
+            fontFamily: HF.body,
+            fontSize: 13,
+          }}
         >
           {m.body}
         </div>

--- a/client-tenant/src/pages/Apply.tsx
+++ b/client-tenant/src/pages/Apply.tsx
@@ -62,6 +62,14 @@ export function Apply() {
     setSearch(nextParams, { replace: true });
   }
 
+  // Sync step state when the URL changes externally — child steps (Household,
+  // Review, Payment) call setSearch directly and browser back/forward also
+  // mutate `search` without going through setStep.
+  useEffect(() => {
+    const next = parseStep(search.get('step'));
+    setStepState((prev) => (prev === next ? prev : next));
+  }, [search]);
+
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [done, setDone] = useState(false);

--- a/client-tenant/src/pages/AuthCallback.tsx
+++ b/client-tenant/src/pages/AuthCallback.tsx
@@ -3,6 +3,7 @@ import { useSearchParams, useNavigate, Link } from 'react-router-dom';
 import { api } from '@/api/client';
 import { verifyMagicLink } from '@/api/auth';
 import { Loader2 } from 'lucide-react';
+import { HF } from '@/styles/tokens';
 
 interface MeResponse {
   user?: { role: string; emailVerified: boolean };
@@ -94,13 +95,27 @@ export function AuthCallback() {
 
   if (error) {
     return (
-      <div className="flex min-h-screen items-center justify-center bg-gray-50 p-4">
+      <div
+        className="flex min-h-screen items-center justify-center p-4"
+        style={{ background: HF.cream, color: HF.ink, fontFamily: HF.body }}
+      >
         <div className="w-full max-w-sm space-y-4 text-center">
-          <div className="rounded-lg bg-red-50 p-4">
-            <p className="font-medium text-red-800">Invalid or expired link</p>
-            <p className="mt-1 text-sm text-red-600">{error}</p>
+          <div
+            className="p-4"
+            style={{ background: HF.errLo, borderRadius: HF.r.md }}
+          >
+            <p className="font-medium" style={{ color: HF.err }}>
+              Invalid or expired link
+            </p>
+            <p className="mt-1 text-sm" style={{ color: HF.err }}>
+              {error}
+            </p>
           </div>
-          <Link to="/login" className="text-sm font-medium text-emerald-600 hover:underline">
+          <Link
+            to="/login"
+            className="text-sm font-medium underline"
+            style={{ color: HF.accent }}
+          >
             Back to login
           </Link>
         </div>
@@ -109,9 +124,12 @@ export function AuthCallback() {
   }
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-gray-50">
-      <div className="flex flex-col items-center gap-3 text-gray-500">
-        <Loader2 className="h-8 w-8 animate-spin text-emerald-600" />
+    <div
+      className="flex min-h-screen items-center justify-center"
+      style={{ background: HF.cream, color: HF.ink, fontFamily: HF.body }}
+    >
+      <div className="flex flex-col items-center gap-3" style={{ color: HF.ink3 }}>
+        <Loader2 className="h-8 w-8 animate-spin" style={{ color: HF.accent }} />
         <p className="text-sm">Signing you in…</p>
       </div>
     </div>

--- a/client-tenant/src/pages/Dashboard.tsx
+++ b/client-tenant/src/pages/Dashboard.tsx
@@ -4,6 +4,8 @@ import { api } from '@/api/client';
 import {
   DollarSign, Wrench, Home, Clock, RefreshCw, FileText, AlertCircle
 } from 'lucide-react';
+import { HF } from '@/styles/tokens';
+import { Card, CTA, Pill } from '@/components/primitives';
 
 interface DashboardData {
   user: { firstName: string; lastName: string; email: string };
@@ -29,9 +31,12 @@ function fmtDate(d: string | null) {
 
 function SkeletonCard() {
   return (
-    <div className="animate-pulse rounded-xl bg-white p-5 shadow-sm">
-      <div className="mb-3 h-4 w-1/3 rounded bg-gray-200" />
-      <div className="h-7 w-1/2 rounded bg-gray-200" />
+    <div
+      className="animate-pulse rounded-xl p-5"
+      style={{ background: HF.paper, border: `1px solid ${HF.border}`, boxShadow: HF.shadow.xs }}
+    >
+      <div className="mb-3 h-4 w-1/3 rounded" style={{ background: HF.border }} />
+      <div className="h-7 w-1/2 rounded" style={{ background: HF.border }} />
     </div>
   );
 }
@@ -50,8 +55,14 @@ export function Dashboard() {
 
   if (loading) {
     return (
-      <div className="p-4 space-y-4">
-        <div className="mb-2 h-6 w-40 animate-pulse rounded bg-gray-200" />
+      <div
+        className="p-4 space-y-4"
+        style={{ background: HF.cream, minHeight: '100vh', color: HF.ink, fontFamily: HF.body }}
+      >
+        <div
+          className="mb-2 h-6 w-40 animate-pulse rounded"
+          style={{ background: HF.border }}
+        />
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {Array.from({ length: 6 }).map((_, i) => <SkeletonCard key={i} />)}
         </div>
@@ -61,11 +72,17 @@ export function Dashboard() {
 
   if (error) {
     return (
-      <div className="p-4">
-        <div className="flex items-center gap-2 rounded-lg bg-red-50 p-4 text-red-700">
-          <AlertCircle className="h-5 w-5 shrink-0" />
-          <p className="text-sm">{error}</p>
-        </div>
+      <div className="p-4" style={{ background: HF.cream, minHeight: '60vh' }}>
+        <Card
+          variant="mobile"
+          padding={14}
+          style={{ background: HF.errLo, border: `1px solid ${HF.err}` }}
+        >
+          <div className="flex items-center gap-2" style={{ color: HF.err }}>
+            <AlertCircle className="h-5 w-5 shrink-0" />
+            <p style={{ fontFamily: HF.body, fontSize: 13 }}>{error}</p>
+          </div>
+        </Card>
       </div>
     );
   }
@@ -76,134 +93,255 @@ export function Dashboard() {
 
   if (!activeApplication) {
     return (
-      <div className="flex min-h-[60vh] flex-col items-center justify-center gap-4 p-6 text-center">
-        <FileText className="h-12 w-12 text-gray-300" />
-        <h2 className="text-lg font-semibold text-gray-900">No active application</h2>
-        <p className="text-sm text-gray-500">Submit an application to access your dashboard.</p>
-        <Link to="/apply" className="btn-primary">Start an application</Link>
+      <div
+        className="flex min-h-[60vh] flex-col items-center justify-center gap-4 p-6 text-center"
+        style={{ background: HF.cream, color: HF.ink, fontFamily: HF.body }}
+      >
+        <FileText className="h-12 w-12" style={{ color: HF.ink4 }} />
+        <h2 style={{ fontFamily: HF.display, fontSize: 18, fontWeight: 800, color: HF.ink }}>
+          No active application
+        </h2>
+        <p style={{ fontFamily: HF.body, fontSize: 13, color: HF.ink3 }}>
+          Submit an application to access your dashboard.
+        </p>
+        <Link to="/apply" style={{ textDecoration: 'none' }}>
+          <CTA tone="primary">Start an application</CTA>
+        </Link>
       </div>
     );
   }
 
   return (
-    <div className="p-4 pb-24 sm:p-6">
-      <h1 className="mb-5 text-xl font-bold text-gray-900">
+    <div
+      className="p-4 pb-24 sm:p-6"
+      style={{ background: HF.cream, minHeight: '100vh', color: HF.ink, fontFamily: HF.body }}
+    >
+      <h1
+        className="mb-5"
+        style={{ fontFamily: HF.display, fontSize: 22, fontWeight: 800, color: HF.ink }}
+      >
         Welcome back, {user.firstName}
       </h1>
 
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
         {/* Balance card */}
-        <div className="rounded-xl bg-emerald-600 p-5 text-white shadow-sm">
-          <div className="flex items-center gap-2 text-emerald-100">
+        <Card
+          variant="mobile"
+          padding={20}
+          style={{ background: HF.accent, border: `1px solid ${HF.accent}`, color: HF.paper }}
+        >
+          <div className="flex items-center gap-2" style={{ color: 'rgba(255,255,255,0.85)' }}>
             <DollarSign className="h-4 w-4" />
-            <span className="text-sm font-medium">Current balance</span>
+            <span style={{ fontFamily: HF.body, fontSize: 13, fontWeight: 600 }}>
+              Current balance
+            </span>
           </div>
-          <p className="mt-2 text-3xl font-bold">
+          <p
+            className="mt-2"
+            style={{ fontFamily: HF.display, fontSize: 30, fontWeight: 800, color: HF.paper }}
+          >
             {balance ? fmt(balance.balance) : '—'}
           </p>
           {balance?.nextDueDate && (
-            <p className="mt-1 text-xs text-emerald-200">
+            <p
+              className="mt-1"
+              style={{ fontFamily: HF.body, fontSize: 12, color: 'rgba(255,255,255,0.85)' }}
+            >
               Next due {fmtDate(balance.nextDueDate)}
             </p>
           )}
           <Link
             to="/pay"
-            className="mt-4 inline-block rounded-lg bg-white px-4 py-2 text-sm font-medium text-emerald-700 hover:bg-emerald-50"
+            className="mt-4 inline-block rounded-lg px-4 py-2"
+            style={{
+              background: HF.paper,
+              color: HF.accentInk,
+              fontFamily: HF.body,
+              fontSize: 13,
+              fontWeight: 600,
+              textDecoration: 'none',
+            }}
           >
             Pay rent
           </Link>
-        </div>
+        </Card>
 
         {/* Work orders */}
-        <div className="rounded-xl bg-white p-5 shadow-sm">
-          <div className="flex items-center gap-2 text-gray-500">
+        <Card variant="mobile" padding={20}>
+          <div className="flex items-center gap-2" style={{ color: HF.ink3 }}>
             <Wrench className="h-4 w-4" />
-            <span className="text-sm font-medium">Open work orders</span>
+            <span style={{ fontFamily: HF.body, fontSize: 13, fontWeight: 600 }}>
+              Open work orders
+            </span>
           </div>
-          <p className="mt-2 text-3xl font-bold text-gray-900">{openWorkOrders}</p>
-          <Link to="/maintenance" className="mt-4 inline-block text-sm font-medium text-emerald-600 hover:underline">
+          <p
+            className="mt-2"
+            style={{ fontFamily: HF.display, fontSize: 30, fontWeight: 800, color: HF.ink }}
+          >
+            {openWorkOrders}
+          </p>
+          <Link
+            to="/maintenance"
+            className="mt-4 inline-block"
+            style={{
+              fontFamily: HF.body,
+              fontSize: 13,
+              fontWeight: 600,
+              color: HF.accent,
+              textDecoration: 'none',
+            }}
+          >
             View all →
           </Link>
-        </div>
+        </Card>
 
         {/* Lease */}
         {lease && (
-          <div className="rounded-xl bg-white p-5 shadow-sm">
-            <div className="flex items-center gap-2 text-gray-500">
+          <Card variant="mobile" padding={20}>
+            <div className="flex items-center gap-2" style={{ color: HF.ink3 }}>
               <Home className="h-4 w-4" />
-              <span className="text-sm font-medium">Lease</span>
+              <span style={{ fontFamily: HF.body, fontSize: 13, fontWeight: 600 }}>
+                Lease
+              </span>
             </div>
-            <p className="mt-2 text-base font-semibold text-gray-900">{lease.propertyName}</p>
+            <p
+              className="mt-2"
+              style={{ fontFamily: HF.display, fontSize: 16, fontWeight: 700, color: HF.ink }}
+            >
+              {lease.propertyName}
+            </p>
             {lease.unitNumber && (
-              <p className="text-sm text-gray-500">Unit {lease.unitNumber}</p>
+              <p style={{ fontFamily: HF.body, fontSize: 13, color: HF.ink3 }}>
+                Unit {lease.unitNumber}
+              </p>
             )}
-            <span className={`mt-2 inline-block rounded-full px-2 py-0.5 text-xs font-medium
-              ${lease.status === 'active' ? 'bg-emerald-100 text-emerald-700' : 'bg-gray-100 text-gray-600'}`}>
-              {lease.status}
-            </span>
-          </div>
+            <div className="mt-2">
+              <Pill tone={lease.status === 'active' ? 'sage' : 'neutral'}>
+                {lease.status}
+              </Pill>
+            </div>
+          </Card>
         )}
 
         {/* Recertification */}
-        <div className="rounded-xl bg-white p-5 shadow-sm">
-          <div className="flex items-center gap-2 text-gray-500">
+        <Card variant="mobile" padding={20}>
+          <div className="flex items-center gap-2" style={{ color: HF.ink3 }}>
             <RefreshCw className="h-4 w-4" />
-            <span className="text-sm font-medium">Recertification</span>
+            <span style={{ fontFamily: HF.body, fontSize: 13, fontWeight: 600 }}>
+              Recertification
+            </span>
           </div>
           {recertification ? (
             <>
-              <p className="mt-2 text-sm font-semibold text-amber-700">
+              <p
+                className="mt-2"
+                style={{ fontFamily: HF.body, fontSize: 13, fontWeight: 700, color: HF.warn }}
+              >
                 Due {fmtDate(recertification.cutoff_date)}
               </p>
-              <p className="text-xs text-gray-500 capitalize">{recertification.status}</p>
+              <p
+                className="capitalize"
+                style={{ fontFamily: HF.body, fontSize: 12, color: HF.ink3 }}
+              >
+                {recertification.status}
+              </p>
             </>
           ) : (
-            <p className="mt-2 text-sm text-gray-400">No recertification due</p>
+            <p
+              className="mt-2"
+              style={{ fontFamily: HF.body, fontSize: 13, color: HF.ink4 }}
+            >
+              No recertification due
+            </p>
           )}
-        </div>
+        </Card>
 
         {/* Renewal */}
-        <div className="rounded-xl bg-white p-5 shadow-sm">
-          <div className="flex items-center gap-2 text-gray-500">
+        <Card variant="mobile" padding={20}>
+          <div className="flex items-center gap-2" style={{ color: HF.ink3 }}>
             <Clock className="h-4 w-4" />
-            <span className="text-sm font-medium">Lease renewal</span>
+            <span style={{ fontFamily: HF.body, fontSize: 13, fontWeight: 600 }}>
+              Lease renewal
+            </span>
           </div>
           {renewal ? (
             <>
-              <p className="mt-2 text-sm font-semibold text-gray-900 capitalize">{renewal.status}</p>
+              <p
+                className="mt-2 capitalize"
+                style={{ fontFamily: HF.body, fontSize: 13, fontWeight: 700, color: HF.ink }}
+              >
+                {renewal.status}
+              </p>
               {renewal.proposed_rent !== null && (
-                <p className="text-xs text-gray-500">Proposed rent: {fmt(renewal.proposed_rent)}/mo</p>
+                <p style={{ fontFamily: HF.body, fontSize: 12, color: HF.ink3 }}>
+                  Proposed rent: {fmt(renewal.proposed_rent)}/mo
+                </p>
               )}
             </>
           ) : (
-            <p className="mt-2 text-sm text-gray-400">Not yet eligible</p>
+            <p
+              className="mt-2"
+              style={{ fontFamily: HF.body, fontSize: 13, color: HF.ink4 }}
+            >
+              Not yet eligible
+            </p>
           )}
-        </div>
+        </Card>
 
         {/* Recent activity */}
-        <div className="rounded-xl bg-white p-5 shadow-sm sm:col-span-2 lg:col-span-1">
+        <Card variant="mobile" padding={20} className="sm:col-span-2 lg:col-span-1">
           <div className="mb-3 flex items-center justify-between">
-            <span className="text-sm font-medium text-gray-500">Recent activity</span>
-            <Link to="/ledger" className="text-xs font-medium text-emerald-600 hover:underline">See all</Link>
+            <span style={{ fontFamily: HF.body, fontSize: 13, fontWeight: 600, color: HF.ink3 }}>
+              Recent activity
+            </span>
+            <Link
+              to="/ledger"
+              style={{
+                fontFamily: HF.body,
+                fontSize: 12,
+                fontWeight: 600,
+                color: HF.accent,
+                textDecoration: 'none',
+              }}
+            >
+              See all
+            </Link>
           </div>
           {recentLedger.length === 0 ? (
-            <p className="text-sm text-gray-400">No recent transactions</p>
+            <p style={{ fontFamily: HF.body, fontSize: 13, color: HF.ink4 }}>
+              No recent transactions
+            </p>
           ) : (
             <ul className="space-y-2">
               {recentLedger.slice(0, 5).map(entry => (
-                <li key={entry.id} className="flex items-center justify-between text-sm">
+                <li key={entry.id} className="flex items-center justify-between">
                   <div>
-                    <p className="font-medium text-gray-800 line-clamp-1">{entry.description}</p>
-                    <p className="text-xs text-gray-400">{fmtDate(entry.createdAt)}</p>
+                    <p
+                      className="line-clamp-1"
+                      style={{ fontFamily: HF.body, fontSize: 13, fontWeight: 500, color: HF.ink2 }}
+                    >
+                      {entry.description}
+                    </p>
+                    <p style={{ fontFamily: HF.body, fontSize: 11, color: HF.ink4 }}>
+                      {fmtDate(entry.createdAt)}
+                    </p>
                   </div>
-                  <span className={`ml-3 font-medium ${entry.amount < 0 ? 'text-emerald-600' : 'text-red-600'}`}>
+                  <span
+                    className="ml-3"
+                    style={{
+                      fontFamily: HF.body,
+                      fontSize: 13,
+                      fontWeight: 600,
+                      color: entry.amount < 0 ? HF.sage : HF.err,
+                    }}
+                  >
                     {entry.amount < 0 ? '-' : '+'}{fmt(entry.amount)}
                   </span>
                 </li>
               ))}
             </ul>
           )}
-        </div>
+        </Card>
       </div>
     </div>
   );

--- a/client-tenant/src/pages/Ledger.tsx
+++ b/client-tenant/src/pages/Ledger.tsx
@@ -2,6 +2,8 @@ import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { api } from '@/api/client';
 import { Loader2, AlertCircle, FileText } from 'lucide-react';
+import { HF } from '@/styles/tokens';
+import { Card, CTA, Pill, type PillTone } from '@/components/primitives';
 
 interface LedgerEntry {
   id: string;
@@ -31,12 +33,12 @@ const TYPE_LABELS: Record<string, string> = {
   deposit: 'Deposit',
 };
 
-const TYPE_COLORS: Record<string, string> = {
-  payment: 'bg-emerald-100 text-emerald-700',
-  credit: 'bg-blue-100 text-blue-700',
-  rent_charge: 'bg-gray-100 text-gray-600',
-  late_fee: 'bg-red-100 text-red-700',
-  deposit: 'bg-purple-100 text-purple-700',
+const TYPE_TONES: Record<string, PillTone> = {
+  payment: 'sage',
+  credit: 'sage',
+  rent_charge: 'neutral',
+  late_fee: 'err',
+  deposit: 'accent',
 };
 
 function fmt(amount: number) {
@@ -102,84 +104,150 @@ export function Ledger() {
 
   if (loading) {
     return (
-      <div className="flex min-h-[60vh] items-center justify-center">
-        <Loader2 className="h-7 w-7 animate-spin text-emerald-600" />
+      <div
+        className="flex min-h-[60vh] items-center justify-center"
+        style={{ background: HF.cream }}
+      >
+        <Loader2 className="h-7 w-7 animate-spin" style={{ color: HF.accent }} />
       </div>
     );
   }
 
   if (!appId) {
     return (
-      <div className="flex min-h-[60vh] flex-col items-center justify-center gap-4 p-6 text-center">
-        <FileText className="h-10 w-10 text-gray-300" />
-        <p className="text-gray-500">No active application.</p>
-        <Link to="/apply" className="btn-primary">Start an application</Link>
+      <div
+        className="flex min-h-[60vh] flex-col items-center justify-center gap-4 p-6 text-center"
+        style={{ background: HF.cream, color: HF.ink, fontFamily: HF.body }}
+      >
+        <FileText className="h-10 w-10" style={{ color: HF.ink4 }} />
+        <p style={{ fontFamily: HF.body, fontSize: 13, color: HF.ink3 }}>
+          No active application.
+        </p>
+        <Link to="/apply" style={{ textDecoration: 'none' }}>
+          <CTA tone="primary">Start an application</CTA>
+        </Link>
       </div>
     );
   }
 
   return (
-    <div className="p-4 pb-24 sm:p-6">
-      <h1 className="mb-5 text-xl font-bold text-gray-900">Account Ledger</h1>
+    <div
+      className="p-4 pb-24 sm:p-6"
+      style={{ background: HF.cream, minHeight: '100vh', color: HF.ink, fontFamily: HF.body }}
+    >
+      <h1
+        className="mb-5"
+        style={{ fontFamily: HF.display, fontSize: 22, fontWeight: 800, color: HF.ink }}
+      >
+        Account Ledger
+      </h1>
 
       {error && (
-        <div className="mb-4 flex items-center gap-2 rounded-lg bg-red-50 p-3 text-sm text-red-700">
-          <AlertCircle className="h-4 w-4 shrink-0" />
-          {error}
-        </div>
+        <Card
+          variant="mobile"
+          padding={12}
+          elevation="none"
+          className="mb-4"
+          style={{ background: HF.errLo, border: `1px solid ${HF.err}` }}
+        >
+          <div className="flex items-center gap-2" style={{ color: HF.err }}>
+            <AlertCircle className="h-4 w-4 shrink-0" />
+            <span style={{ fontFamily: HF.body, fontSize: 13 }}>{error}</span>
+          </div>
+        </Card>
       )}
 
       {/* Balance summary */}
       {balance && (
-        <div className="mb-5 grid grid-cols-3 gap-3 rounded-xl bg-white p-4 shadow-sm">
-          <div>
-            <p className="text-xs text-gray-400">Balance</p>
-            <p className={`text-base font-bold ${balance.balance > 0 ? 'text-red-600' : 'text-emerald-600'}`}>
-              {fmt(balance.balance)}
-            </p>
+        <Card variant="mobile" padding={16} className="mb-5">
+          <div className="grid grid-cols-3 gap-3">
+            <div>
+              <p style={{ fontFamily: HF.body, fontSize: 11, color: HF.ink4 }}>
+                Balance
+              </p>
+              <p
+                style={{
+                  fontFamily: HF.display,
+                  fontSize: 16,
+                  fontWeight: 700,
+                  color: balance.balance > 0 ? HF.err : HF.sage,
+                }}
+              >
+                {fmt(balance.balance)}
+              </p>
+            </div>
+            <div>
+              <p style={{ fontFamily: HF.body, fontSize: 11, color: HF.ink4 }}>
+                Next due
+              </p>
+              <p style={{ fontFamily: HF.body, fontSize: 13, fontWeight: 500, color: HF.ink }}>
+                {fmtDate(balance.nextDueDate)}
+              </p>
+            </div>
+            <div>
+              <p style={{ fontFamily: HF.body, fontSize: 11, color: HF.ink4 }}>
+                Last payment
+              </p>
+              <p style={{ fontFamily: HF.body, fontSize: 13, fontWeight: 500, color: HF.ink }}>
+                {fmtDate(balance.lastPaymentDate)}
+              </p>
+            </div>
           </div>
-          <div>
-            <p className="text-xs text-gray-400">Next due</p>
-            <p className="text-sm font-medium text-gray-900">{fmtDate(balance.nextDueDate)}</p>
-          </div>
-          <div>
-            <p className="text-xs text-gray-400">Last payment</p>
-            <p className="text-sm font-medium text-gray-900">{fmtDate(balance.lastPaymentDate)}</p>
-          </div>
-        </div>
+        </Card>
       )}
 
       {entries.length === 0 ? (
-        <div className="rounded-xl bg-white p-8 text-center shadow-sm">
-          <p className="text-sm text-gray-400">No transactions yet.</p>
-        </div>
+        <Card variant="mobile" padding={32} style={{ textAlign: 'center' }}>
+          <p style={{ fontFamily: HF.body, fontSize: 13, color: HF.ink4 }}>
+            No transactions yet.
+          </p>
+        </Card>
       ) : (
         <div className="space-y-2">
           {entries.map(entry => (
-            <div key={entry.id} className="flex items-center gap-3 rounded-xl bg-white p-4 shadow-sm">
-              <div className="flex-1 min-w-0">
-                <p className="text-sm font-medium text-gray-900 truncate">{entry.description}</p>
-                <p className="text-xs text-gray-400">{fmtDate(entry.createdAt)}</p>
+            <Card key={entry.id} variant="mobile" padding={16}>
+              <div className="flex items-center gap-3">
+                <div className="flex-1 min-w-0">
+                  <p
+                    className="truncate"
+                    style={{ fontFamily: HF.body, fontSize: 13, fontWeight: 500, color: HF.ink }}
+                  >
+                    {entry.description}
+                  </p>
+                  <p style={{ fontFamily: HF.body, fontSize: 11, color: HF.ink4 }}>
+                    {fmtDate(entry.createdAt)}
+                  </p>
+                </div>
+                <span className="shrink-0">
+                  <Pill tone={TYPE_TONES[entry.entryType] ?? 'neutral'}>
+                    {TYPE_LABELS[entry.entryType] ?? entry.entryType}
+                  </Pill>
+                </span>
+                <span
+                  className="shrink-0"
+                  style={{
+                    fontFamily: HF.body,
+                    fontSize: 13,
+                    fontWeight: 700,
+                    color: entry.amount < 0 ? HF.sage : HF.err,
+                  }}
+                >
+                  {entry.amount < 0 ? '-' : '+'}{fmt(entry.amount)}
+                </span>
               </div>
-              <span className={`shrink-0 rounded-full px-2 py-0.5 text-xs font-medium ${TYPE_COLORS[entry.entryType] ?? 'bg-gray-100 text-gray-600'}`}>
-                {TYPE_LABELS[entry.entryType] ?? entry.entryType}
-              </span>
-              <span className={`shrink-0 text-sm font-semibold ${entry.amount < 0 ? 'text-emerald-600' : 'text-red-600'}`}>
-                {entry.amount < 0 ? '-' : '+'}{fmt(entry.amount)}
-              </span>
-            </div>
+            </Card>
           ))}
 
           {entries.length < total && (
             <div className="pt-2 text-center">
-              <button
+              <CTA
+                tone="primary"
                 onClick={loadMore}
                 disabled={loadingMore}
-                className="btn-primary inline-flex items-center gap-2"
               >
                 {loadingMore && <Loader2 className="h-4 w-4 animate-spin" />}
                 Load more
-              </button>
+              </CTA>
             </div>
           )}
         </div>

--- a/client-tenant/src/pages/Login.tsx
+++ b/client-tenant/src/pages/Login.tsx
@@ -2,6 +2,8 @@ import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { Mail, ArrowRight } from 'lucide-react';
 import { requestMagicLink } from '@/api/auth';
+import { HF } from '@/styles/tokens';
+import { CTA, Card } from '@/components/primitives';
 
 export function Login() {
   const navigate = useNavigate();
@@ -16,7 +18,7 @@ export function Login() {
     setError(null);
     setLoading(true);
     try {
-      const res = await requestMagicLink(email) as any;
+      const res = (await requestMagicLink(email)) as { devLink?: string };
       setSent(true);
       if (res.devLink) {
         setDevLink(res.devLink);
@@ -39,68 +41,124 @@ export function Login() {
   }
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-gray-50 p-4">
-      <div className="w-full max-w-sm space-y-6">
+    <div
+      className="flex min-h-screen items-center justify-center p-4"
+      style={{ background: HF.cream, fontFamily: HF.body, color: HF.ink }}
+    >
+      <Card variant="mobile" padding={24} style={{ width: '100%', maxWidth: 380 }}>
         <div className="text-center">
-          <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-xl bg-emerald-600">
-            <Mail className="h-6 w-6 text-white" />
+          <div
+            style={{
+              margin: '0 auto 16px',
+              width: 56,
+              height: 56,
+              borderRadius: HF.r.lg,
+              background: HF.accent,
+              display: 'grid',
+              placeItems: 'center',
+            }}
+          >
+            <Mail className="h-6 w-6" style={{ color: HF.paper }} />
           </div>
-          <h1 className="text-2xl font-bold text-gray-900">Tenant Portal</h1>
-          <p className="mt-1 text-sm text-gray-500">Sign in with a magic link</p>
+          <h1 style={{ fontFamily: HF.display, fontSize: 24, fontWeight: 800 }}>
+            Tenant Portal
+          </h1>
+          <p style={{ fontSize: 13, color: HF.ink3, marginTop: 4 }}>
+            Sign in with a magic link
+          </p>
         </div>
 
         {error && (
-          <div className="rounded-lg bg-red-50 p-3 text-sm text-red-700">{error}</div>
+          <div
+            style={{
+              marginTop: 20,
+              background: HF.errLo,
+              border: `1px solid ${HF.err}`,
+              color: HF.err,
+              borderRadius: HF.r.sm,
+              padding: '10px 12px',
+              fontSize: 13,
+            }}
+          >
+            {error}
+          </div>
         )}
 
         {!sent ? (
-          <form onSubmit={handleSubmit} className="space-y-4">
-            <div>
-              <label className="label" htmlFor="email">Email address</label>
+          <form onSubmit={handleSubmit} className="space-y-4" style={{ marginTop: 20 }}>
+            <label className="flex flex-col gap-1" htmlFor="email">
+              <span
+                style={{
+                  fontSize: 11,
+                  textTransform: 'uppercase',
+                  letterSpacing: 1,
+                  fontWeight: 700,
+                  color: HF.ink3,
+                }}
+              >
+                Email address
+              </span>
               <input
                 id="email"
                 type="email"
                 required
-                className="input"
                 placeholder="you@example.com"
                 value={email}
-                onChange={e => setEmail(e.target.value)}
+                onChange={(e) => setEmail(e.target.value)}
+                style={{
+                  background: HF.paper,
+                  border: `1px solid ${HF.border}`,
+                  borderRadius: HF.r.sm,
+                  padding: '10px 12px',
+                  fontSize: 14,
+                  color: HF.ink,
+                  fontFamily: HF.body,
+                }}
               />
-            </div>
-            <button
-              type="submit"
-              disabled={loading || !email}
-              className="btn-primary w-full"
-            >
+            </label>
+            <CTA type="submit" tone="primary" size="lg" disabled={loading || !email} block>
               {loading ? 'Sending…' : 'Send magic link'}
-            </button>
+            </CTA>
           </form>
         ) : (
-          <div className="space-y-4 text-center">
-            <div className="rounded-lg bg-emerald-50 p-4">
-              <p className="font-medium text-emerald-800">Check your email!</p>
-              <p className="mt-1 text-sm text-emerald-700">
+          <div className="space-y-4 text-center" style={{ marginTop: 20 }}>
+            <div
+              style={{
+                background: HF.sageLo,
+                border: `1px solid ${HF.sage}33`,
+                borderRadius: HF.r.md,
+                padding: 14,
+              }}
+            >
+              <p style={{ fontFamily: HF.display, fontWeight: 700, fontSize: 14, color: HF.ink }}>
+                Check your email
+              </p>
+              <p style={{ fontSize: 13, color: HF.ink2, marginTop: 4 }}>
                 We sent a link to <strong>{email}</strong>. Click it to sign in.
               </p>
             </div>
             {devLink && (
-              <button
-                onClick={handleDevLink}
-                className="btn-primary inline-flex items-center gap-2"
-              >
+              <CTA onClick={handleDevLink} tone="sage">
                 Continue (dev) <ArrowRight className="h-4 w-4" />
-              </button>
+              </CTA>
             )}
           </div>
         )}
 
-        <p className="text-center text-sm text-gray-500">
+        <p
+          style={{
+            textAlign: 'center',
+            marginTop: 24,
+            fontSize: 13,
+            color: HF.ink3,
+          }}
+        >
           First time?{' '}
-          <Link to="/apply" className="font-medium text-emerald-600 hover:underline">
+          <Link to="/apply" style={{ color: HF.accent, fontWeight: 700, textDecoration: 'none' }}>
             Create an applicant account
           </Link>
         </p>
-      </div>
+      </Card>
     </div>
   );
 }

--- a/client-tenant/src/pages/Maintenance.tsx
+++ b/client-tenant/src/pages/Maintenance.tsx
@@ -2,6 +2,8 @@ import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { api } from '@/api/client';
 import { Loader2, AlertCircle, ChevronDown, ChevronUp, Wrench } from 'lucide-react';
+import { HF } from '@/styles/tokens';
+import { Card, CTA, Pill, type PillTone } from '@/components/primitives';
 
 interface WorkOrder {
   id: string;
@@ -17,10 +19,10 @@ interface DashboardData {
   activeApplication: { id: string } | null;
 }
 
-const PRIORITY_STYLES: Record<string, string> = {
-  routine: 'bg-emerald-100 text-emerald-700',
-  urgent: 'bg-amber-100 text-amber-700',
-  emergency: 'bg-red-100 text-red-700',
+const PRIORITY_TONES: Record<string, PillTone> = {
+  routine: 'sage',
+  urgent: 'warn',
+  emergency: 'err',
 };
 
 function relativeTime(dateStr: string) {
@@ -95,47 +97,83 @@ export function Maintenance() {
 
   if (loading) {
     return (
-      <div className="flex min-h-[60vh] items-center justify-center">
-        <Loader2 className="h-7 w-7 animate-spin text-emerald-600" />
+      <div
+        className="flex min-h-[60vh] items-center justify-center"
+        style={{ background: HF.cream }}
+      >
+        <Loader2 className="h-7 w-7 animate-spin" style={{ color: HF.accent }} />
       </div>
     );
   }
 
   if (!appId) {
     return (
-      <div className="flex min-h-[60vh] flex-col items-center justify-center gap-4 p-6 text-center">
-        <Wrench className="h-10 w-10 text-gray-300" />
-        <p className="text-gray-500">No active application found.</p>
-        <Link to="/dashboard" className="btn-primary">Back to dashboard</Link>
+      <div
+        className="flex min-h-[60vh] flex-col items-center justify-center gap-4 p-6 text-center"
+        style={{ background: HF.cream, color: HF.ink, fontFamily: HF.body }}
+      >
+        <Wrench className="h-10 w-10" style={{ color: HF.ink4 }} />
+        <p style={{ fontFamily: HF.body, fontSize: 13, color: HF.ink3 }}>
+          No active application found.
+        </p>
+        <Link to="/dashboard" style={{ textDecoration: 'none' }}>
+          <CTA tone="primary">Back to dashboard</CTA>
+        </Link>
       </div>
     );
   }
 
   return (
-    <div className="p-4 pb-24 sm:p-6">
+    <div
+      className="p-4 pb-24 sm:p-6"
+      style={{ background: HF.cream, minHeight: '100vh', color: HF.ink, fontFamily: HF.body }}
+    >
       <div className="mb-5 flex items-center justify-between">
-        <h1 className="text-xl font-bold text-gray-900">Maintenance</h1>
-        <button
-          onClick={() => setFormOpen(v => !v)}
-          className="btn-primary inline-flex items-center gap-1"
-        >
+        <h1 style={{ fontFamily: HF.display, fontSize: 22, fontWeight: 800, color: HF.ink }}>
+          Maintenance
+        </h1>
+        <CTA tone="primary" onClick={() => setFormOpen(v => !v)}>
           New request
           {formOpen ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
-        </button>
+        </CTA>
       </div>
 
       {error && (
-        <div className="mb-4 flex items-center gap-2 rounded-lg bg-red-50 p-3 text-sm text-red-700">
-          <AlertCircle className="h-4 w-4 shrink-0" />{error}
-        </div>
+        <Card
+          variant="mobile"
+          padding={12}
+          elevation="none"
+          className="mb-4"
+          style={{ background: HF.errLo, border: `1px solid ${HF.err}` }}
+        >
+          <div className="flex items-center gap-2" style={{ color: HF.err }}>
+            <AlertCircle className="h-4 w-4 shrink-0" />
+            <span style={{ fontFamily: HF.body, fontSize: 13 }}>{error}</span>
+          </div>
+        </Card>
       )}
 
       {/* New request form */}
       {formOpen && (
-        <div className="mb-5 rounded-xl bg-white p-5 shadow-sm">
-          <h2 className="mb-4 text-sm font-semibold text-gray-700">Submit a new request</h2>
+        <Card variant="mobile" padding={20} className="mb-5">
+          <h2
+            className="mb-4"
+            style={{ fontFamily: HF.display, fontSize: 14, fontWeight: 700, color: HF.ink2 }}
+          >
+            Submit a new request
+          </h2>
           {formError && (
-            <div className="mb-3 rounded-lg bg-red-50 p-2 text-xs text-red-700">{formError}</div>
+            <div
+              className="mb-3 rounded-lg p-2"
+              style={{
+                background: HF.errLo,
+                color: HF.err,
+                fontFamily: HF.body,
+                fontSize: 12,
+              }}
+            >
+              {formError}
+            </div>
           )}
           <form onSubmit={handleSubmit} className="space-y-4">
             <div>
@@ -171,9 +209,14 @@ export function Maintenance() {
                       value={p}
                       checked={priority === p}
                       onChange={() => setPriority(p)}
-                      className="accent-emerald-600"
+                      style={{ accentColor: HF.accent }}
                     />
-                    <span className="text-sm capitalize">{p}</span>
+                    <span
+                      className="capitalize"
+                      style={{ fontFamily: HF.body, fontSize: 13, color: HF.ink2 }}
+                    >
+                      {p}
+                    </span>
                   </label>
                 ))}
               </div>
@@ -188,41 +231,62 @@ export function Maintenance() {
                 onChange={e => setCategory(e.target.value)}
               />
             </div>
-            <button
+            <CTA
               type="submit"
+              tone="primary"
+              block
               disabled={submitting || !title || !description}
-              className="btn-primary w-full"
             >
               {submitting ? 'Submitting…' : 'Submit request'}
-            </button>
+            </CTA>
           </form>
-        </div>
+        </Card>
       )}
 
       {/* Work order list */}
       {workOrders.length === 0 ? (
-        <div className="rounded-xl bg-white p-8 text-center shadow-sm">
-          <Wrench className="mx-auto mb-2 h-8 w-8 text-gray-300" />
-          <p className="text-sm text-gray-400">No maintenance requests yet.</p>
-        </div>
+        <Card variant="mobile" padding={32} style={{ textAlign: 'center' }}>
+          <Wrench className="mx-auto mb-2 h-8 w-8" style={{ color: HF.ink4 }} />
+          <p style={{ fontFamily: HF.body, fontSize: 13, color: HF.ink4 }}>
+            No maintenance requests yet.
+          </p>
+        </Card>
       ) : (
         <div className="space-y-3">
           {workOrders.map(wo => (
-            <div key={wo.id} className="rounded-xl bg-white p-4 shadow-sm">
+            <Card key={wo.id} variant="mobile" padding={16}>
               <div className="flex items-start justify-between gap-2">
-                <p className="font-medium text-gray-900">{wo.title}</p>
-                <span className={`shrink-0 rounded-full px-2 py-0.5 text-xs font-medium capitalize
-                  ${PRIORITY_STYLES[wo.priority] ?? 'bg-gray-100 text-gray-600'}`}>
-                  {wo.priority}
+                <p
+                  style={{
+                    fontFamily: HF.display,
+                    fontSize: 14,
+                    fontWeight: 700,
+                    color: HF.ink,
+                  }}
+                >
+                  {wo.title}
+                </p>
+                <span className="shrink-0 capitalize">
+                  <Pill tone={PRIORITY_TONES[wo.priority] ?? 'neutral'}>
+                    {wo.priority}
+                  </Pill>
                 </span>
               </div>
-              <p className="mt-1 text-sm text-gray-500 line-clamp-2">{wo.description}</p>
-              <div className="mt-2 flex items-center gap-3 text-xs text-gray-400">
+              <p
+                className="mt-1 line-clamp-2"
+                style={{ fontFamily: HF.body, fontSize: 13, color: HF.ink3 }}
+              >
+                {wo.description}
+              </p>
+              <div
+                className="mt-2 flex items-center gap-3"
+                style={{ fontFamily: HF.body, fontSize: 11, color: HF.ink4 }}
+              >
                 <span className="capitalize">{wo.status.replace(/_/g, ' ')}</span>
                 {wo.category && <span>· {wo.category}</span>}
                 <span>· {relativeTime(wo.created_at)}</span>
               </div>
-            </div>
+            </Card>
           ))}
         </div>
       )}

--- a/client-tenant/src/pages/Pay.tsx
+++ b/client-tenant/src/pages/Pay.tsx
@@ -2,6 +2,8 @@ import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { api } from '@/api/client';
 import { CheckCircle, AlertCircle, Loader2 } from 'lucide-react';
+import { HF } from '@/styles/tokens';
+import { Card, CTA } from '@/components/primitives';
 
 interface DashboardData {
   activeApplication: { id: string } | null;
@@ -53,83 +55,150 @@ export function Pay() {
 
   if (loadingDash) {
     return (
-      <div className="flex min-h-[60vh] items-center justify-center">
-        <Loader2 className="h-7 w-7 animate-spin text-emerald-600" />
+      <div
+        className="flex min-h-[60vh] items-center justify-center"
+        style={{ background: HF.cream }}
+      >
+        <Loader2 className="h-7 w-7 animate-spin" style={{ color: HF.accent }} />
       </div>
     );
   }
 
   if (success) {
     return (
-      <div className="flex min-h-[60vh] flex-col items-center justify-center gap-4 p-6 text-center">
-        <CheckCircle className="h-12 w-12 text-emerald-600" />
-        <h2 className="text-xl font-bold text-gray-900">Payment posted</h2>
-        <p className="text-sm text-gray-500">
-          New balance: <span className="font-semibold">{fmt(success.newBalance)}</span>
+      <div
+        className="flex min-h-[60vh] flex-col items-center justify-center gap-4 p-6 text-center"
+        style={{ background: HF.cream, color: HF.ink, fontFamily: HF.body }}
+      >
+        <CheckCircle className="h-12 w-12" style={{ color: HF.sage }} />
+        <h2 style={{ fontFamily: HF.display, fontSize: 22, fontWeight: 800, color: HF.ink }}>
+          Payment posted
+        </h2>
+        <p style={{ fontFamily: HF.body, fontSize: 13, color: HF.ink3 }}>
+          New balance:{' '}
+          <span style={{ color: HF.ink, fontWeight: 700 }}>{fmt(success.newBalance)}</span>
         </p>
-        <Link to="/dashboard" className="btn-primary">Back to dashboard</Link>
+        <Link to="/dashboard" style={{ textDecoration: 'none' }}>
+          <CTA tone="primary">Back to dashboard</CTA>
+        </Link>
       </div>
     );
   }
 
   if (!dashboard?.activeApplication) {
     return (
-      <div className="p-6 text-center">
-        <p className="text-gray-500">No active application found.</p>
-        <Link to="/dashboard" className="mt-4 inline-block text-sm text-emerald-600 hover:underline">Back to dashboard</Link>
+      <div
+        className="p-6 text-center"
+        style={{ background: HF.cream, minHeight: '60vh', color: HF.ink, fontFamily: HF.body }}
+      >
+        <p style={{ fontFamily: HF.body, fontSize: 13, color: HF.ink3 }}>
+          No active application found.
+        </p>
+        <Link
+          to="/dashboard"
+          className="mt-4 inline-block"
+          style={{
+            fontFamily: HF.body,
+            fontSize: 13,
+            fontWeight: 600,
+            color: HF.accent,
+            textDecoration: 'none',
+          }}
+        >
+          Back to dashboard
+        </Link>
       </div>
     );
   }
 
   return (
-    <div className="p-4 pb-24 sm:p-6">
-      <h1 className="mb-5 text-xl font-bold text-gray-900">Pay Rent</h1>
+    <div
+      className="p-4 pb-24 sm:p-6"
+      style={{ background: HF.cream, minHeight: '100vh', color: HF.ink, fontFamily: HF.body }}
+    >
+      <h1
+        className="mb-5"
+        style={{ fontFamily: HF.display, fontSize: 22, fontWeight: 800, color: HF.ink }}
+      >
+        Pay Rent
+      </h1>
 
       <div className="mx-auto max-w-sm space-y-5">
         {dashboard.balance && (
-          <div className="rounded-xl bg-gray-50 p-4">
-            <p className="text-sm text-gray-500">Current balance</p>
-            <p className="mt-1 text-2xl font-bold text-gray-900">{fmt(dashboard.balance.balance)}</p>
+          <Card
+            variant="mobile"
+            padding={16}
+            elevation="none"
+            style={{ background: HF.accentLo, border: `1px solid ${HF.border}` }}
+          >
+            <p style={{ fontFamily: HF.body, fontSize: 13, color: HF.ink3 }}>
+              Current balance
+            </p>
+            <p
+              className="mt-1"
+              style={{ fontFamily: HF.display, fontSize: 26, fontWeight: 800, color: HF.ink }}
+            >
+              {fmt(dashboard.balance.balance)}
+            </p>
             {dashboard.balance.nextDueDate && (
-              <p className="text-xs text-gray-400">
-                Due {new Date(dashboard.balance.nextDueDate).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}
+              <p style={{ fontFamily: HF.body, fontSize: 12, color: HF.ink3 }}>
+                Due{' '}
+                {new Date(dashboard.balance.nextDueDate).toLocaleDateString('en-US', {
+                  month: 'short',
+                  day: 'numeric',
+                  year: 'numeric',
+                })}
               </p>
             )}
-          </div>
+          </Card>
         )}
 
         {error && (
-          <div className="flex items-center gap-2 rounded-lg bg-red-50 p-3 text-sm text-red-700">
-            <AlertCircle className="h-4 w-4 shrink-0" />
-            {error}
-          </div>
+          <Card
+            variant="mobile"
+            padding={12}
+            elevation="none"
+            style={{ background: HF.errLo, border: `1px solid ${HF.err}` }}
+          >
+            <div className="flex items-center gap-2" style={{ color: HF.err }}>
+              <AlertCircle className="h-4 w-4 shrink-0" />
+              <span style={{ fontFamily: HF.body, fontSize: 13 }}>{error}</span>
+            </div>
+          </Card>
         )}
 
-        <form onSubmit={handlePay} className="space-y-4 rounded-xl bg-white p-5 shadow-sm">
-          <div>
-            <label className="label" htmlFor="amount">Payment amount ($)</label>
-            <input
-              id="amount"
-              type="number"
-              min={0.01}
-              step={0.01}
-              required
-              className="input text-lg font-semibold"
-              value={amount}
-              onChange={e => setAmount(e.target.value)}
-              placeholder="0.00"
-            />
-          </div>
-          <button
-            type="submit"
-            disabled={paying || !amount || Number(amount) <= 0}
-            className="btn-primary w-full py-3 text-base"
-          >
-            {paying ? 'Processing…' : `Pay ${amount ? fmt(Number(amount)) : '$0.00'}`}
-          </button>
-        </form>
+        <Card variant="mobile" padding={20}>
+          <form onSubmit={handlePay} className="space-y-4">
+            <div>
+              <label className="label" htmlFor="amount">Payment amount ($)</label>
+              <input
+                id="amount"
+                type="number"
+                min={0.01}
+                step={0.01}
+                required
+                className="input text-lg font-semibold"
+                value={amount}
+                onChange={e => setAmount(e.target.value)}
+                placeholder="0.00"
+              />
+            </div>
+            <CTA
+              type="submit"
+              tone="primary"
+              size="lg"
+              block
+              disabled={paying || !amount || Number(amount) <= 0}
+            >
+              {paying ? 'Processing…' : `Pay ${amount ? fmt(Number(amount)) : '$0.00'}`}
+            </CTA>
+          </form>
+        </Card>
 
-        <p className="text-center text-xs text-gray-400">
+        <p
+          className="text-center"
+          style={{ fontFamily: HF.body, fontSize: 11, color: HF.ink4 }}
+        >
           Demo mode — no real charge will be made to any account.
         </p>
       </div>

--- a/client-tenant/src/pages/Status.tsx
+++ b/client-tenant/src/pages/Status.tsx
@@ -1,6 +1,8 @@
 import { Link } from 'react-router-dom';
 import { useApiQuery } from '@/hooks/useApiQuery';
-import { Loader2, AlertCircle, FileText } from 'lucide-react';
+import { Loader2, AlertCircle, FileText, Check, ArrowRight } from 'lucide-react';
+import { HF } from '@/styles/tokens';
+import { Card, CTA } from '@/components/primitives';
 
 interface ApplicationItem {
   id: string;
@@ -16,49 +18,96 @@ interface ApplicationsResponse {
   applications: ApplicationItem[];
 }
 
-const PIPELINE: string[] = [
-  'draft',
-  'submitted',
-  'screening',
-  'tier1_review',
-  'tier2_review',
-  'tier3_review',
-  'lease_generated',
-  'onboarded',
-];
+const TERMINAL_BAD = new Set([
+  'screening_failed',
+  'tier1_denied',
+  'tier2_denied',
+  'tier3_denied',
+  'cancelled',
+]);
 
-const TERMINAL_BAD = new Set(['screening_failed', 'tier1_denied', 'tier2_denied', 'tier3_denied', 'cancelled']);
+type StageKey = 'submitted' | 'docs' | 'pm' | 'lease' | 'movein';
 
-const STATUS_LABELS: Record<string, string> = {
-  draft: 'Draft',
+interface StageState {
+  current: StageKey | null;
+  done: Set<StageKey>;
+}
+
+const STAGE_LABELS: Record<StageKey, string> = {
   submitted: 'Submitted',
-  screening: 'Screening',
-  screening_passed: 'Screening passed',
-  screening_failed: 'Screening failed',
-  tier1_review: 'Tier 1 Review',
-  tier1_approved: 'T1 Approved',
-  tier1_denied: 'T1 Denied',
-  tier2_review: 'Tier 2 Review',
-  tier2_approved: 'T2 Approved',
-  tier2_denied: 'T2 Denied',
-  tier3_review: 'Tier 3 Review',
-  tier3_approved: 'T3 Approved',
-  tier3_denied: 'T3 Denied',
-  lease_generated: 'Lease Ready',
-  onboarded: 'Onboarded',
-  cancelled: 'Cancelled',
+  docs: 'Screening',
+  pm: 'PM review',
+  lease: 'Lease',
+  movein: 'Move-in',
 };
 
-function pipelineIndex(status: string): number {
-  const idx = PIPELINE.indexOf(status);
-  if (idx !== -1) return idx;
-  // Map approval/passed variants to their stage
-  if (status.includes('tier1')) return PIPELINE.indexOf('tier1_review');
-  if (status.includes('tier2')) return PIPELINE.indexOf('tier2_review');
-  if (status.includes('tier3')) return PIPELINE.indexOf('tier3_review');
-  if (status.includes('screening')) return PIPELINE.indexOf('screening');
-  return -1;
+const STAGE_ORDER: StageKey[] = ['submitted', 'docs', 'pm', 'lease', 'movein'];
+
+function stageFor(status: string): StageState {
+  const done = new Set<StageKey>();
+  let current: StageKey | null = null;
+
+  if (status === 'draft') return { current: null, done };
+
+  // Submitted is reached the moment status leaves draft.
+  done.add('submitted');
+  current = 'submitted';
+
+  if (status === 'submitted') return { current: 'submitted', done: new Set() };
+
+  if (status.startsWith('screening')) {
+    return { current: 'docs', done: new Set(['submitted']) };
+  }
+
+  // Screening passed -> Docs done
+  done.add('docs');
+  current = 'docs';
+
+  if (status.startsWith('tier1') || status.startsWith('tier2') || status.startsWith('tier3')) {
+    return { current: 'pm', done: new Set(['submitted', 'docs']) };
+  }
+
+  // Past PM review
+  done.add('pm');
+  current = 'pm';
+
+  if (status === 'lease_generated') {
+    return { current: 'lease', done: new Set(['submitted', 'docs', 'pm']) };
+  }
+
+  if (status === 'onboarded') {
+    return { current: 'movein', done: new Set(['submitted', 'docs', 'pm', 'lease']) };
+  }
+
+  return { current, done };
 }
+
+const STATUS_BADGE: Record<string, { label: string; bg: string; fg: string }> = {
+  draft: { label: 'Draft', bg: HF.warnLo, fg: HF.warn },
+  submitted: { label: 'Submitted', bg: HF.accentLo, fg: HF.accentInk },
+  screening: { label: 'Screening', bg: HF.accentLo, fg: HF.accentInk },
+  screening_passed: { label: 'Screening passed', bg: HF.okLo, fg: HF.ok },
+  tier1_review: { label: 'PM review', bg: HF.accentLo, fg: HF.accentInk },
+  tier1_approved: { label: 'PM approved', bg: HF.okLo, fg: HF.ok },
+  tier2_review: { label: 'PM review', bg: HF.accentLo, fg: HF.accentInk },
+  tier2_approved: { label: 'PM approved', bg: HF.okLo, fg: HF.ok },
+  tier3_review: { label: 'Final review', bg: HF.accentLo, fg: HF.accentInk },
+  tier3_approved: { label: 'Approved', bg: HF.okLo, fg: HF.ok },
+  lease_generated: { label: 'Lease ready', bg: HF.okLo, fg: HF.ok },
+  onboarded: { label: 'Moved in', bg: HF.okLo, fg: HF.ok },
+};
+
+const SUBTITLE: Partial<Record<string, string>> = {
+  draft: 'Finish your application to enter the queue.',
+  submitted: 'We received your application. Frank is reviewing it next.',
+  screening: 'Frank is verifying your documents.',
+  screening_passed: 'Documents verified. The PM will review your file next.',
+  tier1_review: 'Frank is reviewing your file. Typical turnaround: 2–3 business days.',
+  tier2_review: 'Final review in progress.',
+  tier3_review: 'Final review in progress.',
+  lease_generated: "Your lease is ready to sign.",
+  onboarded: 'Welcome home — you’re moved in.',
+};
 
 function fmt(amount: number) {
   return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(amount);
@@ -66,43 +115,132 @@ function fmt(amount: number) {
 
 function fmtDate(d: string | null | undefined) {
   if (!d) return null;
-  return new Date(d).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+  return new Date(d).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
 }
 
-function StatusPipeline({ status }: { status: string }) {
-  const current = pipelineIndex(status);
-  const isDenied = TERMINAL_BAD.has(status);
-
-  if (isDenied) {
-    return (
-      <div className="mt-3 inline-block rounded-full bg-red-100 px-3 py-1 text-xs font-medium text-red-700">
-        {STATUS_LABELS[status] ?? status}
-      </div>
-    );
-  }
+function StageTracker({ status }: { status: string }) {
+  const { current, done } = stageFor(status);
+  const currentIdx = current ? STAGE_ORDER.indexOf(current) : -1;
+  const stepNumber = currentIdx === -1 ? 0 : currentIdx + 1;
+  const stepLabel = current ? STAGE_LABELS[current] : 'Submit pending';
+  const subtitle = SUBTITLE[status] ?? 'We’ll keep this page up to date.';
 
   return (
-    <div className="mt-3 flex items-center gap-0.5 overflow-x-auto pb-1">
-      {PIPELINE.map((stage, i) => {
-        const isCompleted = i < current;
-        const isCurrent = i === current;
-        const isFuture = i > current;
-        return (
-          <div key={stage} className="flex items-center">
-            <div className={`flex h-6 min-w-[6rem] items-center justify-center rounded-full px-2 text-[10px] font-medium
-              ${isCompleted ? 'bg-gray-200 text-gray-500' : ''}
-              ${isCurrent ? 'bg-emerald-600 text-white' : ''}
-              ${isFuture ? 'bg-gray-100 text-gray-400' : ''}
-            `}>
-              {STATUS_LABELS[stage] ?? stage}
-            </div>
-            {i < PIPELINE.length - 1 && (
-              <div className={`h-px w-2 shrink-0 ${i < current ? 'bg-gray-300' : 'bg-gray-200'}`} />
-            )}
-          </div>
-        );
-      })}
-    </div>
+    <Card variant="mobile" padding={0} style={{ background: HF.accent, color: HF.paper, border: 'none' }}>
+      <div style={{ padding: '16px 18px' }}>
+        <p
+          style={{
+            fontFamily: HF.body,
+            fontSize: 11,
+            fontWeight: 700,
+            letterSpacing: 1,
+            textTransform: 'uppercase',
+            color: 'rgba(255,255,255,0.85)',
+          }}
+        >
+          Application status
+        </p>
+        <h2
+          style={{
+            fontFamily: HF.display,
+            fontSize: 20,
+            fontWeight: 800,
+            color: HF.paper,
+            marginTop: 6,
+          }}
+        >
+          Step {stepNumber} of 5 · {stepLabel}
+        </h2>
+        <p
+          style={{
+            fontFamily: HF.body,
+            fontSize: 12,
+            color: 'rgba(255,255,255,0.85)',
+            marginTop: 4,
+          }}
+        >
+          {subtitle}
+        </p>
+
+        <div style={{ marginTop: 16, display: 'flex', alignItems: 'center', gap: 4 }}>
+          {STAGE_ORDER.map((key, i) => {
+            const isDone = done.has(key);
+            const isCurrent = current === key;
+            const isReached = isDone || isCurrent;
+            return (
+              <div key={key} style={{ display: 'contents' }}>
+                <div
+                  style={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'center',
+                    flex: '0 0 auto',
+                  }}
+                >
+                  <div
+                    style={{
+                      width: 28,
+                      height: 28,
+                      borderRadius: 999,
+                      background: isReached ? HF.paper : 'rgba(255,255,255,0.25)',
+                      border: `2px solid ${HF.paper}`,
+                      display: 'grid',
+                      placeItems: 'center',
+                      fontFamily: HF.display,
+                      fontWeight: 800,
+                      fontSize: 11,
+                      color: isReached ? HF.accent : HF.paper,
+                    }}
+                  >
+                    {isDone ? <Check size={14} strokeWidth={3} /> : i + 1}
+                  </div>
+                  <span
+                    style={{
+                      marginTop: 4,
+                      fontFamily: HF.body,
+                      fontSize: 9,
+                      fontWeight: isCurrent ? 700 : 500,
+                      color: 'rgba(255,255,255,0.9)',
+                      textAlign: 'center',
+                      width: 56,
+                    }}
+                  >
+                    {STAGE_LABELS[key]}
+                  </span>
+                </div>
+                {i < STAGE_ORDER.length - 1 && (
+                  <div
+                    style={{
+                      flex: 1,
+                      height: 2,
+                      marginBottom: 18,
+                      background: isDone ? HF.paper : 'rgba(255,255,255,0.3)',
+                    }}
+                  />
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+function DeniedBanner({ status }: { status: string }) {
+  return (
+    <Card variant="mobile" padding={14} style={{ background: HF.errLo, border: `1px solid ${HF.err}` }}>
+      <p style={{ fontFamily: HF.display, fontWeight: 800, fontSize: 14, color: HF.err }}>
+        Application {status.replace(/_/g, ' ')}
+      </p>
+      <p style={{ fontFamily: HF.body, fontSize: 12, color: HF.ink2, marginTop: 4 }}>
+        Reach out to your property manager for next steps.
+      </p>
+    </Card>
   );
 }
 
@@ -111,19 +249,28 @@ export function Status() {
 
   if (loading) {
     return (
-      <div className="flex min-h-[60vh] items-center justify-center">
-        <Loader2 className="h-7 w-7 animate-spin text-emerald-600" />
+      <div
+        style={{ background: HF.cream, minHeight: '60vh' }}
+        className="flex items-center justify-center"
+      >
+        <Loader2 className="h-7 w-7 animate-spin" style={{ color: HF.accent }} />
       </div>
     );
   }
 
   if (error) {
     return (
-      <div className="p-4">
-        <div className="flex items-center gap-2 rounded-lg bg-red-50 p-4 text-red-700">
-          <AlertCircle className="h-5 w-5 shrink-0" />
-          <p className="text-sm">{error}</p>
-        </div>
+      <div style={{ background: HF.cream, minHeight: '60vh' }} className="p-4">
+        <Card
+          variant="mobile"
+          padding={14}
+          style={{ background: HF.errLo, border: `1px solid ${HF.err}` }}
+        >
+          <div className="flex items-center gap-2" style={{ color: HF.err }}>
+            <AlertCircle className="h-5 w-5 shrink-0" />
+            <p style={{ fontFamily: HF.body, fontSize: 13 }}>{error}</p>
+          </div>
+        </Card>
       </div>
     );
   }
@@ -132,54 +279,144 @@ export function Status() {
 
   if (applications.length === 0) {
     return (
-      <div className="flex min-h-[60vh] flex-col items-center justify-center gap-4 p-6 text-center">
-        <FileText className="h-10 w-10 text-gray-300" />
-        <h2 className="text-lg font-semibold text-gray-900">No applications yet</h2>
-        <p className="text-sm text-gray-500">Start your application to get placed in affordable housing.</p>
-        <Link to="/apply" className="btn-primary">Start an application</Link>
+      <div
+        style={{ background: HF.cream, minHeight: '60vh', color: HF.ink, fontFamily: HF.body }}
+        className="flex flex-col items-center justify-center gap-4 p-6 text-center"
+      >
+        <FileText className="h-10 w-10" style={{ color: HF.ink4 }} />
+        <h2 style={{ fontFamily: HF.display, fontSize: 18, fontWeight: 800 }}>
+          No applications yet
+        </h2>
+        <p style={{ fontFamily: HF.body, fontSize: 13, color: HF.ink3 }}>
+          Start your application to get placed in affordable housing.
+        </p>
+        <Link to="/apply" style={{ textDecoration: 'none' }}>
+          <CTA tone="primary">Start an application</CTA>
+        </Link>
       </div>
     );
   }
 
   return (
-    <div className="p-4 pb-24 sm:p-6">
-      <h1 className="mb-5 text-xl font-bold text-gray-900">Application Status</h1>
+    <div
+      style={{ background: HF.cream, minHeight: '100vh', color: HF.ink, fontFamily: HF.body }}
+      className="p-4 pb-24 sm:p-6"
+    >
+      <h1
+        style={{
+          fontFamily: HF.display,
+          fontSize: 22,
+          fontWeight: 800,
+          marginBottom: 18,
+        }}
+      >
+        Application Status
+      </h1>
 
       <div className="space-y-4">
-        {applications.map(app => (
-          <div key={app.id} className="rounded-xl bg-white p-5 shadow-sm">
-            <div className="flex items-start justify-between gap-2">
-              <div>
-                <p className="font-semibold text-gray-900">
-                  {app.property_name ?? 'Property TBD'}
-                </p>
-                {app.unit_number && (
-                  <p className="text-sm text-gray-500">Unit {app.unit_number}</p>
+        {applications.map((app) => {
+          const badge = STATUS_BADGE[app.status] ?? {
+            label: app.status,
+            bg: HF.border,
+            fg: HF.ink2,
+          };
+          const denied = TERMINAL_BAD.has(app.status);
+
+          return (
+            <Card key={app.id} variant="mobile" padding={0}>
+              <div style={{ padding: '16px 18px 4px' }}>
+                <div className="flex items-start justify-between gap-2">
+                  <div>
+                    <p
+                      style={{
+                        fontFamily: HF.display,
+                        fontWeight: 700,
+                        fontSize: 15,
+                        color: HF.ink,
+                      }}
+                    >
+                      {app.property_name ?? 'Property TBD'}
+                    </p>
+                    {app.unit_number && (
+                      <p
+                        style={{
+                          fontFamily: HF.body,
+                          fontSize: 12,
+                          color: HF.ink3,
+                          marginTop: 2,
+                        }}
+                      >
+                        Unit {app.unit_number}
+                      </p>
+                    )}
+                  </div>
+                  <span
+                    style={{
+                      flexShrink: 0,
+                      borderRadius: 999,
+                      padding: '4px 10px',
+                      fontFamily: HF.body,
+                      fontSize: 11,
+                      fontWeight: 700,
+                      background: badge.bg,
+                      color: badge.fg,
+                    }}
+                  >
+                    {badge.label}
+                  </span>
+                </div>
+              </div>
+
+              <div style={{ padding: '8px 18px 14px' }}>
+                {denied ? <DeniedBanner status={app.status} /> : <StageTracker status={app.status} />}
+
+                <div
+                  style={{
+                    marginTop: 12,
+                    display: 'flex',
+                    flexWrap: 'wrap',
+                    gap: 14,
+                    fontFamily: HF.body,
+                    fontSize: 11,
+                    color: HF.ink3,
+                  }}
+                >
+                  {app.requested_rent_amount != null && (
+                    <span>
+                      Requested rent:{' '}
+                      <strong style={{ color: HF.ink2, fontWeight: 700 }}>
+                        {fmt(app.requested_rent_amount)}/mo
+                      </strong>
+                    </span>
+                  )}
+                  {app.submitted_at ? (
+                    <span>
+                      Submitted:{' '}
+                      <strong style={{ color: HF.ink2, fontWeight: 700 }}>
+                        {fmtDate(app.submitted_at)}
+                      </strong>
+                    </span>
+                  ) : (
+                    <span>
+                      Started:{' '}
+                      <strong style={{ color: HF.ink2, fontWeight: 700 }}>
+                        {fmtDate(app.created_at)}
+                      </strong>
+                    </span>
+                  )}
+                </div>
+
+                {app.status === 'draft' && (
+                  <Link to="/apply" style={{ textDecoration: 'none', marginTop: 12, display: 'block' }}>
+                    <CTA tone="primary" block>
+                      Finish application <ArrowRight size={16} />
+                    </CTA>
+                  </Link>
                 )}
               </div>
-              <span className={`shrink-0 rounded-full px-2.5 py-0.5 text-xs font-medium
-                ${TERMINAL_BAD.has(app.status) ? 'bg-red-100 text-red-700' : ''}
-                ${app.status === 'onboarded' ? 'bg-emerald-100 text-emerald-700' : ''}
-                ${!TERMINAL_BAD.has(app.status) && app.status !== 'onboarded' ? 'bg-gray-100 text-gray-600' : ''}
-              `}>
-                {STATUS_LABELS[app.status] ?? app.status}
-              </span>
-            </div>
-
-            <StatusPipeline status={app.status} />
-
-            <div className="mt-3 flex flex-wrap gap-4 text-xs text-gray-400">
-              {app.requested_rent_amount != null && (
-                <span>Requested rent: <strong className="text-gray-600">{fmt(app.requested_rent_amount)}/mo</strong></span>
-              )}
-              {app.submitted_at ? (
-                <span>Submitted: <strong className="text-gray-600">{fmtDate(app.submitted_at)}</strong></span>
-              ) : (
-                <span>Started: <strong className="text-gray-600">{fmtDate(app.created_at)}</strong></span>
-              )}
-            </div>
-          </div>
-        ))}
+            </Card>
+          );
+        })}
       </div>
     </div>
   );

--- a/client-tenant/src/pages/VerifyPending.tsx
+++ b/client-tenant/src/pages/VerifyPending.tsx
@@ -3,6 +3,8 @@ import { useNavigate } from 'react-router-dom';
 import { Mail, CheckCircle } from 'lucide-react';
 import { api, clearToken } from '@/api/client';
 import { requestMagicLink } from '@/api/auth';
+import { HF } from '@/styles/tokens';
+import { CTA } from '@/components/primitives';
 
 interface MeResponse {
   user?: {
@@ -70,41 +72,64 @@ export function VerifyPending() {
   }
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-gray-50 p-4">
+    <div
+      className="flex min-h-screen items-center justify-center p-4"
+      style={{ background: HF.cream, color: HF.ink, fontFamily: HF.body }}
+    >
       <div className="w-full max-w-sm space-y-6 text-center">
-        <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-xl bg-emerald-600">
-          <Mail className="h-6 w-6 text-white" />
+        <div
+          className="mx-auto flex h-12 w-12 items-center justify-center"
+          style={{ background: HF.accent, borderRadius: HF.r.md }}
+        >
+          <Mail className="h-6 w-6" style={{ color: HF.paper }} />
         </div>
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">Check your email</h1>
-          <p className="mt-2 text-sm text-gray-500">
+          <h1
+            className="text-2xl font-bold"
+            style={{ color: HF.ink, fontFamily: HF.display }}
+          >
+            Check your email
+          </h1>
+          <p className="mt-2 text-sm" style={{ color: HF.ink3 }}>
             We sent a verification link to{' '}
-            <span className="font-medium text-gray-900">{email || 'your inbox'}</span>.
-            Click it to continue your application.
+            <span className="font-medium" style={{ color: HF.ink }}>
+              {email || 'your inbox'}
+            </span>
+            . Click it to continue your application.
           </p>
         </div>
 
         {resent && (
-          <div className="flex items-center justify-center gap-2 rounded-lg bg-emerald-50 p-3 text-sm text-emerald-700">
+          <div
+            className="flex items-center justify-center gap-2 p-3 text-sm"
+            style={{ background: HF.sageLo, color: HF.sage, borderRadius: HF.r.md }}
+          >
             <CheckCircle className="h-4 w-4" />
             Link resent
           </div>
         )}
         {error && (
-          <div className="rounded-lg bg-red-50 p-3 text-sm text-red-700">{error}</div>
+          <div
+            className="p-3 text-sm"
+            style={{ background: HF.errLo, color: HF.err, borderRadius: HF.r.md }}
+          >
+            {error}
+          </div>
         )}
 
-        <button
+        <CTA
+          tone="primary"
+          block
           onClick={handleResend}
           disabled={resending || !email}
-          className="btn-primary w-full"
         >
           {resending ? 'Resending…' : 'Resend link'}
-        </button>
+        </CTA>
 
         <button
           onClick={handleSignOut}
-          className="text-sm text-gray-500 hover:text-gray-700 hover:underline"
+          className="text-sm underline"
+          style={{ color: HF.ink3 }}
         >
           Use a different email
         </button>

--- a/client-tenant/src/pages/apply/ApplyContext.tsx
+++ b/client-tenant/src/pages/apply/ApplyContext.tsx
@@ -24,7 +24,7 @@ const SESSION_KEY = 'frank_apply_state';
 export const APPLICATION_FEE = 35.95;
 
 export function formatPaymentTotal(adults: number): string {
-  return (APPLICATION_FEE * (adults + 1)).toLocaleString('en-US', {
+  return (APPLICATION_FEE * adults).toLocaleString('en-US', {
     style: 'currency',
     currency: 'USD',
   });

--- a/client-tenant/src/pages/apply/MagicLinkSent.tsx
+++ b/client-tenant/src/pages/apply/MagicLinkSent.tsx
@@ -103,7 +103,7 @@ export function MagicLinkSent() {
             </p>
           )}
           {resendError && (
-            <p role="alert" className="text-sm mt-3 text-red-600">
+            <p role="alert" className="text-sm mt-3" style={{ color: HF.err }}>
               {resendError}
             </p>
           )}

--- a/client-tenant/src/pages/apply/__tests__/Apply.integration.test.tsx
+++ b/client-tenant/src/pages/apply/__tests__/Apply.integration.test.tsx
@@ -5,6 +5,16 @@ import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import { Apply } from '../../Apply';
 import { setToken } from '@/api/client';
 
+// This integration test walks the legacy `?step=2` (Step2Details) flow.
+// `.env.local` ships PAYMENT_WIZARD_ENABLED=true for dev, which would route
+// past Step2Details into the Lane-W wizard (Review/Household/Payment/Confirm)
+// — those steps have their own per-step tests. Pin the flag off here so this
+// suite stays the legacy-path canary. flags.ts caches `import.meta.env` at
+// module load, so stubEnv is too late; mock the module instead.
+vi.mock('@/lib/flags', () => ({
+  useFlag: (name: string) => name !== 'PAYMENT_WIZARD_ENABLED',
+}));
+
 // One mock fetch covering every endpoint the flow touches.
 function installFetch() {
   const fn = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {

--- a/client-tenant/src/pages/apply/context/ApplyContext.tsx
+++ b/client-tenant/src/pages/apply/context/ApplyContext.tsx
@@ -2,8 +2,8 @@
  * ApplyContext — STUB per Contract 2 (W1/W2 will replace with canonical).
  *
  * Shape:
- *  - adults: number (default 1)
- *  - paymentTotal: string — computed as $35.95 × (adults + 1)
+ *  - adults: number (default 1, counted as total adults living here)
+ *  - paymentTotal: string — computed as $35.95 × adults
  *  - paymentRef: string | null (default null)
  *
  * Persistence: sessionStorage key `frank_apply_state`.
@@ -30,7 +30,7 @@ interface ApplyContextValue {
 }
 
 function computeTotal(adults: number): string {
-  const total = FEE * (adults + 1);
+  const total = FEE * adults;
   return total.toFixed(2);
 }
 

--- a/client-tenant/src/pages/apply/steps/PropertySelector.tsx
+++ b/client-tenant/src/pages/apply/steps/PropertySelector.tsx
@@ -49,8 +49,10 @@ export function PropertySelector() {
       }
     })();
     return () => { cancelled = true; };
+    // propertiesLoading intentionally excluded: the effect sets it, so including
+    // it would cancel the in-flight fetch when its own state update fires.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [s.claimedUnit, s.properties.length, s.propertiesLoading]);
+  }, [s.claimedUnit, s.properties.length]);
 
   return (
     <>

--- a/client-tenant/src/pages/apply/steps/StepChecklist.tsx
+++ b/client-tenant/src/pages/apply/steps/StepChecklist.tsx
@@ -2,6 +2,7 @@ import { CheckCircle, Info, Clock } from 'lucide-react';
 import { useApply } from '../ApplyContext';
 import { useTranslation } from 'react-i18next';
 import { CTA, ListRow } from '@/components/primitives';
+import { HF } from '@/styles/tokens';
 
 const ITEM_KEYS = ['id', 'income', 'ssn', 'refs', 'household'] as const;
 
@@ -11,41 +12,79 @@ export function StepChecklist() {
 
   return (
     <>
-      <h1 className="mb-1 text-xl font-bold text-gray-900">{t('checklist.title')}</h1>
-      <p className="mb-4 text-sm text-gray-500">{t('checklist.subtitle')}</p>
+      <h1 style={{ fontFamily: HF.display, fontWeight: 800, fontSize: 22, color: HF.ink, marginBottom: 4 }}>
+        {t('checklist.title')}
+      </h1>
+      <p style={{ fontFamily: HF.body, fontSize: 13, color: HF.ink3, marginBottom: 16 }}>
+        {t('checklist.subtitle')}
+      </p>
 
-      <ul className="mb-5 divide-y divide-gray-100" aria-label={t('checklist.title')}>
-        {ITEM_KEYS.map((key) => (
-          <li key={key}>
+      <ul
+        style={{ borderTop: `1px solid ${HF.border}`, borderBottom: `1px solid ${HF.border}`, marginBottom: 20 }}
+        aria-label={t('checklist.title') as string}
+      >
+        {ITEM_KEYS.map((key, i) => (
+          <li
+            key={key}
+            style={i < ITEM_KEYS.length - 1 ? { borderBottom: `1px solid ${HF.border}` } : undefined}
+          >
             <ListRow
-              leading={<CheckCircle className="h-5 w-5 text-emerald-600" aria-hidden="true" />}
+              leading={<CheckCircle className="h-5 w-5" style={{ color: HF.sage }} aria-hidden="true" />}
               title={t(`checklist.items.${key}`)}
             />
           </li>
         ))}
       </ul>
 
-      <div className="mb-3 rounded-lg border border-emerald-200 bg-emerald-50 p-4">
-        <div className="flex items-start gap-2">
-          <Info className="mt-0.5 h-4 w-4 shrink-0 text-emerald-700" aria-hidden="true" />
-          <div>
-            <p className="text-sm font-medium text-emerald-900">{t('checklist.fee.title')}</p>
-            <p className="mt-1 text-xs text-emerald-800">{t('checklist.fee.body')}</p>
-          </div>
+      <div
+        style={{
+          background: HF.sageLo,
+          border: `1px solid ${HF.sage}33`,
+          borderRadius: HF.r.md,
+          padding: 14,
+          marginBottom: 12,
+          display: 'flex',
+          alignItems: 'flex-start',
+          gap: 8,
+        }}
+      >
+        <Info className="h-4 w-4 mt-0.5 shrink-0" style={{ color: HF.sage }} aria-hidden="true" />
+        <div>
+          <p style={{ fontFamily: HF.display, fontWeight: 700, fontSize: 13, color: HF.ink }}>
+            {t('checklist.fee.title')}
+          </p>
+          <p style={{ fontFamily: HF.body, fontSize: 12, color: HF.ink2, marginTop: 4 }}>
+            {t('checklist.fee.body')}
+          </p>
         </div>
       </div>
 
-      <div className="mb-5 rounded-lg border border-amber-200 bg-amber-50 p-4">
-        <div className="flex items-start gap-2">
-          <Clock className="mt-0.5 h-4 w-4 shrink-0 text-amber-700" aria-hidden="true" />
-          <div>
-            <p className="text-sm font-medium text-amber-900">{t('checklist.rule120.title')}</p>
-            <p className="mt-1 text-xs text-amber-800">{t('checklist.rule120.body')}</p>
-          </div>
+      <div
+        style={{
+          background: HF.warnLo,
+          border: `1px solid ${HF.warn}33`,
+          borderRadius: HF.r.md,
+          padding: 14,
+          marginBottom: 20,
+          display: 'flex',
+          alignItems: 'flex-start',
+          gap: 8,
+        }}
+      >
+        <Clock className="h-4 w-4 mt-0.5 shrink-0" style={{ color: HF.warn }} aria-hidden="true" />
+        <div>
+          <p style={{ fontFamily: HF.display, fontWeight: 700, fontSize: 13, color: HF.ink }}>
+            {t('checklist.rule120.title')}
+          </p>
+          <p style={{ fontFamily: HF.body, fontSize: 12, color: HF.ink2, marginTop: 4 }}>
+            {t('checklist.rule120.body')}
+          </p>
         </div>
       </div>
 
-      <CTA onClick={() => s.setStep('pick')}>{t('checklist.continue')}</CTA>
+      <CTA tone="primary" block onClick={() => s.setStep('pick')}>
+        {t('checklist.continue')}
+      </CTA>
     </>
   );
 }

--- a/client-tenant/src/pages/apply/steps/StepClaim.tsx
+++ b/client-tenant/src/pages/apply/steps/StepClaim.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { CTA } from '@/components/primitives';
 import { useFlag } from '@/lib/flags';
 import { getUnitPhoto } from '@/utils/unitPlaceholder';
+import { HF } from '@/styles/tokens';
 
 export function StepClaim() {
   const s = useApply();
@@ -15,8 +16,10 @@ export function StepClaim() {
   if (!s.claimedUnit || !s.claimExpiresAt) {
     return (
       <div className="space-y-4 text-center">
-        <p className="text-sm text-gray-500">{t('claim.noActive')}</p>
-        <CTA onClick={() => s.setStep('intent')}>{t('claim.startOver')}</CTA>
+        <p style={{ fontFamily: HF.body, fontSize: 13, color: HF.ink3 }}>{t('claim.noActive')}</p>
+        <CTA tone="primary" block onClick={() => s.setStep('intent')}>
+          {t('claim.startOver')}
+        </CTA>
       </div>
     );
   }
@@ -25,7 +28,13 @@ export function StepClaim() {
 
   return (
     <div className="space-y-4 text-center">
-      <div className="overflow-hidden rounded-xl">
+      <div
+        style={{
+          overflow: 'hidden',
+          borderRadius: HF.r.lg,
+          border: `1px solid ${HF.border}`,
+        }}
+      >
         <img
           src={getUnitPhoto(unit.photo_url)}
           alt=""
@@ -33,19 +42,30 @@ export function StepClaim() {
         />
       </div>
       <div>
-        <h1 className="text-xl font-bold text-gray-900">
+        <h1 style={{ fontFamily: HF.display, fontWeight: 800, fontSize: 22, color: HF.ink }}>
           {t('claim.yours').replace('{unitNumber}', unit.unit_number)}
         </h1>
-        <p className="mt-1 text-sm text-gray-500">
+        <p style={{ fontFamily: HF.body, fontSize: 13, color: HF.ink3, marginTop: 4 }}>
           {unit.property_name}
           {unit.property_city && `, ${unit.property_city}`}
         </p>
       </div>
       <ClaimCountdown expiresAt={s.claimExpiresAt} />
-      <CTA onClick={() => s.setStep(nextStep)}>{t('claim.continue')}</CTA>
+      <CTA tone="primary" block onClick={() => s.setStep(nextStep)}>
+        {t('claim.continue')}
+      </CTA>
       <button
         onClick={() => s.setStep('pick')}
-        className="text-sm text-gray-500 hover:text-gray-700 hover:underline"
+        style={{
+          background: 'none',
+          border: 'none',
+          padding: 0,
+          fontFamily: HF.body,
+          fontSize: 13,
+          color: HF.ink3,
+          textDecoration: 'underline',
+          cursor: 'pointer',
+        }}
       >
         {t('claim.pickDifferent')}
       </button>
@@ -66,12 +86,47 @@ function ClaimCountdown({ expiresAt }: { expiresAt: string }) {
   const m = String(Math.floor((total % 3600) / 60)).padStart(2, '0');
   const sec = String(total % 60).padStart(2, '0');
   return (
-    <div className="rounded-lg bg-emerald-50 p-4">
-      <div className="text-xs uppercase tracking-wide text-emerald-700">{t('claim.heldUntil')}</div>
-      <div className="mt-1 font-mono text-2xl font-bold text-emerald-800">
+    <div
+      style={{
+        background: HF.accent,
+        color: HF.paper,
+        borderRadius: HF.r.lg,
+        padding: 16,
+      }}
+    >
+      <div
+        style={{
+          fontFamily: HF.body,
+          fontSize: 11,
+          textTransform: 'uppercase',
+          letterSpacing: 1,
+          fontWeight: 700,
+          color: 'rgba(255,255,255,0.85)',
+        }}
+      >
+        {t('claim.heldUntil')}
+      </div>
+      <div
+        style={{
+          fontFamily: HF.mono,
+          fontSize: 28,
+          fontWeight: 800,
+          marginTop: 4,
+          color: HF.paper,
+        }}
+      >
         {h}:{m}:{sec}
       </div>
-      <div className="mt-1 text-xs text-emerald-700">{t('claim.finishBeforeTimer')}</div>
+      <div
+        style={{
+          fontFamily: HF.body,
+          fontSize: 11,
+          color: 'rgba(255,255,255,0.85)',
+          marginTop: 4,
+        }}
+      >
+        {t('claim.finishBeforeTimer')}
+      </div>
     </div>
   );
 }

--- a/client-tenant/src/pages/apply/steps/StepHousehold.tsx
+++ b/client-tenant/src/pages/apply/steps/StepHousehold.tsx
@@ -1,8 +1,8 @@
 /**
  * StepHousehold — Lane W2. Adults stepper drives fee math.
  *
- * Fee: $35.95 × (adults + 1) — applicant + each additional adult. Computed in
- * ApplyContext as `state.paymentTotal`. Adults range 1–12.
+ * Fee: $35.95 × adults — one fee per adult living in the unit (applicant
+ * counted). Computed in ApplyContext as `state.paymentTotal`. Adults range 1–12.
  *
  * WF → HF TOKEN MAP:
  *   WF.ink    (#1a1814) → HF.ink
@@ -29,7 +29,7 @@ export function StepHousehold() {
   const { t } = useTranslation('apply');
   const [, setSearch] = useSearchParams();
   const { adults, setAdults, paymentTotal } = useApply();
-  const billable = adults + 1; // applicant + each additional adult
+  const billable = adults;
   const total = paymentTotal;
 
   return (

--- a/client-tenant/src/pages/apply/steps/StepPayment.tsx
+++ b/client-tenant/src/pages/apply/steps/StepPayment.tsx
@@ -18,6 +18,7 @@ import { HF } from '@/styles/tokens';
 import { CTA } from '@/components/primitives';
 import { useApply } from '@/pages/apply/context/ApplyContext';
 import { PayHeader } from '@/pages/apply/PayHeader';
+import { api, getToken } from '@/api/client';
 
 function sessionId(): string {
   try {
@@ -72,6 +73,17 @@ export function StepPayment() {
         const r2 = await fireBeacon('/api/tape/payment-success', { ...payload, paymentRef: ref });
         if (!r2.ok) throw new Error(`success ${r2.status}`);
         setPaymentRef(ref);
+        // Flip the user's draft application to `submitted` so /status shows
+        // "Submitted" instead of "Draft" after the wizard completes. Only
+        // attempt when authed; non-fatal if it fails — the receipt still
+        // renders and staff can advance the application manually.
+        if (getToken()) {
+          try {
+            await api.post('/applicants/me/applications/submit-draft', {});
+          } catch {
+            /* non-fatal */
+          }
+        }
         navigate('?step=2');
       } catch {
         setErr(t('payment.error') as string);

--- a/client-tenant/src/pages/apply/steps/StepPayment.tsx
+++ b/client-tenant/src/pages/apply/steps/StepPayment.tsx
@@ -34,7 +34,8 @@ function sessionId(): string {
 }
 
 async function fireBeacon(path: string, body: object): Promise<Response> {
-  return fetch(path, {
+  const baseUrl = (import.meta.env.VITE_API_BASE_URL as string | undefined)?.replace(/\/$/, '') ?? '';
+  return fetch(`${baseUrl}${path}`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),

--- a/client-tenant/src/pages/apply/steps/StepPick.tsx
+++ b/client-tenant/src/pages/apply/steps/StepPick.tsx
@@ -1,41 +1,166 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { Loader2 } from 'lucide-react';
-import { fetchUnits, claimUnit } from '@/api/units';
-import { UnitCard } from '@/components/UnitCard';
+import { fetchUnits, claimUnit, type Unit } from '@/api/units';
+import { UnitCard, type UnitMismatch } from '@/components/UnitCard';
 import { useApply } from '../ApplyContext';
 import { useTranslation } from 'react-i18next';
+import type { TFunction } from 'i18next';
 import { HF } from '@/styles/tokens';
 
 const BEDROOMS_INCLUSIVE_MIN = 4;
 
+interface IntentSnapshot {
+  bedrooms: number;
+  bedroomsInclusive: boolean;
+  maxRent: number;
+  moveInBy: string;
+}
+
+function bedroomsFilter(bedrooms: number) {
+  return bedrooms >= BEDROOMS_INCLUSIVE_MIN
+    ? { bedroomsMin: bedrooms }
+    : { bedrooms };
+}
+
+function rentNumber(rent: string | number): number {
+  return typeof rent === 'string' ? Number(rent) : rent;
+}
+
+function formatDate(iso: string, lang: string): string {
+  // Render the unit's available_from date in the user's locale. Falls back to
+  // the raw ISO if Date construction fails (defensive against API quirks).
+  try {
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return iso;
+    return d.toLocaleDateString(lang.startsWith('es') ? 'es' : 'en', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    });
+  } catch {
+    return iso;
+  }
+}
+
+function computeMismatch(
+  unit: Unit,
+  intent: IntentSnapshot,
+  t: TFunction<'apply'>,
+  lang: string,
+): UnitMismatch {
+  const notes: string[] = [];
+
+  // Bedrooms. `bedroomsInclusive` means the user asked for "4+ BR", so we only
+  // flag below-spec units, not above.
+  if (intent.bedroomsInclusive) {
+    if (unit.bedrooms < intent.bedrooms) {
+      if (unit.bedrooms === 0) {
+        notes.push(t('pick.mismatch.studioInstead', { wanted: intent.bedrooms }) as string);
+      } else {
+        notes.push(
+          t('pick.mismatch.bedroomsFewer', { actual: unit.bedrooms, wanted: intent.bedrooms }) as string,
+        );
+      }
+    }
+  } else if (unit.bedrooms !== intent.bedrooms) {
+    if (unit.bedrooms === 0) {
+      notes.push(t('pick.mismatch.studioInstead', { wanted: intent.bedrooms }) as string);
+    } else {
+      notes.push(
+        t('pick.mismatch.bedroomsMore', { actual: unit.bedrooms, wanted: intent.bedrooms }) as string,
+      );
+    }
+  }
+
+  // Budget.
+  const rent = rentNumber(unit.monthly_rent);
+  if (Number.isFinite(rent) && rent > intent.maxRent) {
+    notes.push(
+      t('pick.mismatch.overBudget', { amount: Math.ceil(rent - intent.maxRent).toLocaleString() }) as string,
+    );
+  }
+
+  // Move-in availability.
+  if (unit.available_from && intent.moveInBy && unit.available_from > intent.moveInBy) {
+    notes.push(
+      t('pick.mismatch.availableLater', { date: formatDate(unit.available_from, lang) }) as string,
+    );
+  }
+
+  return { notes };
+}
+
 export function StepPick() {
   const s = useApply();
-  const { t } = useTranslation('apply');
+  const { t, i18n } = useTranslation('apply');
+  const [isFallback, setIsFallback] = useState(false);
+  const [intentSnapshot, setIntentSnapshot] = useState<IntentSnapshot | null>(null);
 
-  // Bounce back to intent if quiz incomplete (deep-link guard).
   useEffect(() => {
     if (s.intentBedrooms === null || !s.intentMoveInDate) {
       s.setStep('intent');
       return;
     }
     let cancelled = false;
+    const snapshot: IntentSnapshot = {
+      bedrooms: s.intentBedrooms,
+      bedroomsInclusive: s.intentBedrooms >= BEDROOMS_INCLUSIVE_MIN,
+      maxRent: s.intentBudgetMax,
+      moveInBy: s.intentMoveInDate,
+    };
+
     (async () => {
       s.setUnitsLoading(true);
       s.setError(null);
-      try {
-        const res = await fetchUnits({
-          ...(s.intentBedrooms! >= BEDROOMS_INCLUSIVE_MIN
-            ? { bedroomsMin: s.intentBedrooms! }
-            : { bedrooms: s.intentBedrooms! }),
-          maxRent: s.intentBudgetMax,
-          moveInBy: s.intentMoveInDate,
-          // Permissive default: null tier (no income / over-income) omits the
-          // filter, so applicants always see something to apply to.
+      setIntentSnapshot(snapshot);
+
+      // Progressive relaxation. Try strict first, then loosen one constraint at
+      // a time so we always have *something* to show — the claimed-unit-as-
+      // carrot pattern dies if the user hits a dead-end here.
+      const stages: Array<Parameters<typeof fetchUnits>[0]> = [
+        // Strict.
+        {
+          ...bedroomsFilter(snapshot.bedrooms),
+          maxRent: snapshot.maxRent,
+          moveInBy: snapshot.moveInBy,
           ...(s.qualifyingAmiTier ? { amiTier: s.qualifyingAmiTier } : {}),
-        });
-        if (!cancelled) s.setUnits(res.units);
+        },
+        // Drop AMI tier — show units they may not income-qualify for; PM can
+        // still review.
+        {
+          ...bedroomsFilter(snapshot.bedrooms),
+          maxRent: snapshot.maxRent,
+          moveInBy: snapshot.moveInBy,
+        },
+        // Also drop budget cap.
+        {
+          ...bedroomsFilter(snapshot.bedrooms),
+          moveInBy: snapshot.moveInBy,
+        },
+        // Also drop move-in date.
+        {
+          ...bedroomsFilter(snapshot.bedrooms),
+        },
+        // Drop bedrooms — worst case, show anything.
+        {},
+      ];
+
+      try {
+        let units: Unit[] = [];
+        let stageIndex = 0;
+        for (; stageIndex < stages.length; stageIndex += 1) {
+          const res = await fetchUnits(stages[stageIndex]);
+          if (cancelled) return;
+          if (res.units.length > 0) {
+            units = res.units;
+            break;
+          }
+        }
+        if (cancelled) return;
+        setIsFallback(stageIndex > 0);
+        s.setUnits(units);
       } catch (err) {
-        if (!cancelled) s.setError(err instanceof Error ? err.message : t('pick.loadError'));
+        if (!cancelled) s.setError(err instanceof Error ? err.message : (t('pick.loadError') as string));
       } finally {
         if (!cancelled) s.setUnitsLoading(false);
       }
@@ -57,7 +182,7 @@ export function StepPick() {
       s.setUnitNumber(res.unit.unit_number);
       s.setStep('claim');
     } catch (err) {
-      s.setError(err instanceof Error ? err.message : t('pick.claimError'));
+      s.setError(err instanceof Error ? err.message : (t('pick.claimError') as string));
     } finally {
       s.setClaimingUnitId(null);
     }
@@ -90,7 +215,7 @@ export function StepPick() {
             borderRadius: HF.r.sm,
           }}
         >
-          {t('pick.noMatch')}{' '}
+          {t('pick.noUnitsAvailable')}{' '}
           <button
             onClick={() => s.setStep('intent')}
             className="font-medium underline"
@@ -100,16 +225,44 @@ export function StepPick() {
           </button>
         </div>
       ) : (
-        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-          {s.units.map((u) => (
-            <UnitCard
-              key={u.id}
-              unit={u}
-              onClaim={handleClaim}
-              claiming={s.claimingUnitId === u.id}
-            />
-          ))}
-        </div>
+        <>
+          {isFallback && (
+            <div
+              role="status"
+              className="mb-4 p-3 text-sm"
+              style={{
+                background: `${HF.warn}14`,
+                color: HF.warn,
+                border: `1px solid ${HF.warn}33`,
+                borderRadius: HF.r.sm,
+              }}
+            >
+              {t('pick.fallbackBanner')}{' '}
+              <button
+                onClick={() => s.setStep('intent')}
+                className="font-medium underline"
+                style={{ color: HF.warn }}
+              >
+                {t('pick.adjust')}
+              </button>
+            </div>
+          )}
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            {s.units.map((u) => (
+              <UnitCard
+                key={u.id}
+                unit={u}
+                onClaim={handleClaim}
+                claiming={s.claimingUnitId === u.id}
+                mismatch={
+                  isFallback && intentSnapshot
+                    ? computeMismatch(u, intentSnapshot, t, i18n.language)
+                    : undefined
+                }
+              />
+            ))}
+          </div>
+        </>
       )}
       <button
         onClick={() => s.setStep('intent')}

--- a/client-tenant/src/pages/apply/steps/__tests__/StepConfirm.test.tsx
+++ b/client-tenant/src/pages/apply/steps/__tests__/StepConfirm.test.tsx
@@ -10,7 +10,7 @@ function renderConfirm(opts?: { withRef?: boolean; position?: number | null }) {
   if (opts?.withRef) {
     sessionStorage.setItem(
       'frank_apply_state',
-      JSON.stringify({ adults: 1, paymentTotal: '71.90', paymentRef: 'pay_test_abc123' }),
+      JSON.stringify({ adults: 1, paymentTotal: '35.95', paymentRef: 'pay_test_abc123' }),
     );
   }
   return render(

--- a/client-tenant/src/pages/apply/steps/__tests__/StepHousehold.test.tsx
+++ b/client-tenant/src/pages/apply/steps/__tests__/StepHousehold.test.tsx
@@ -50,10 +50,10 @@ function renderApp(initialStep = 'review') {
 }
 
 describe('StepHousehold', () => {
-  it('defaults to 1 adult → total $71.90 (1 applicant + 1 self = (1+1) × 35.95)', () => {
+  it('defaults to 1 adult → total $35.95 (1 × 35.95)', () => {
     renderApp('household');
     expect(screen.getByTestId('adults-count').textContent).toBe('1');
-    expect(screen.getByTestId('payment-total').textContent).toBe('$71.90');
+    expect(screen.getByTestId('payment-total').textContent).toBe('$35.95');
   });
 
   it('+ increments adults, fee total updates from context', () => {
@@ -62,7 +62,7 @@ describe('StepHousehold', () => {
     fireEvent.click(inc);
     fireEvent.click(inc);
     expect(screen.getByTestId('adults-count').textContent).toBe('3');
-    expect(screen.getByTestId('payment-total').textContent).toBe('$143.80');
+    expect(screen.getByTestId('payment-total').textContent).toBe('$107.85');
   });
 
   it('− decrements but floors at 1', () => {
@@ -81,7 +81,7 @@ describe('StepHousehold', () => {
 });
 
 describe('Integration: review → household → payment', () => {
-  it('walks the flow, sets adults=3, asserts paymentTotal=$143.80', () => {
+  it('walks the flow, sets adults=3, asserts paymentTotal=$107.85', () => {
     renderApp('review');
 
     // Step 1: Review → Continue → household
@@ -94,7 +94,7 @@ describe('Integration: review → household → payment', () => {
     fireEvent.click(inc);
 
     expect(screen.getByTestId('state-adults').textContent).toBe('3');
-    expect(screen.getByTestId('state-total').textContent).toBe('$143.80');
+    expect(screen.getByTestId('state-total').textContent).toBe('$107.85');
 
     // Step 3: continue → payment
     fireEvent.click(screen.getByRole('button', { name: /continue to payment/i }));

--- a/client-tenant/src/pages/apply/steps/__tests__/StepPayment.test.tsx
+++ b/client-tenant/src/pages/apply/steps/__tests__/StepPayment.test.tsx
@@ -49,8 +49,9 @@ describe('StepPayment — beacons fire on submit', () => {
     await waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(2));
 
     const [initCall, successCall] = fetchSpy.mock.calls as unknown as Array<[string, RequestInit]>;
-    expect(initCall[0]).toBe('/api/tape/payment-init');
-    expect(successCall[0]).toBe('/api/tape/payment-success');
+    // VITE_API_BASE_URL may be set in test env — assert path suffix, not full URL.
+    expect(initCall[0]).toMatch(/\/api\/tape\/payment-init$/);
+    expect(successCall[0]).toMatch(/\/api\/tape\/payment-success$/);
 
     const initBody = JSON.parse(String(initCall[1].body));
     expect(initBody).toMatchObject({ adults: 1, total: '71.90' });

--- a/client-tenant/src/pages/apply/steps/__tests__/StepPayment.test.tsx
+++ b/client-tenant/src/pages/apply/steps/__tests__/StepPayment.test.tsx
@@ -54,12 +54,12 @@ describe('StepPayment — beacons fire on submit', () => {
     expect(successCall[0]).toMatch(/\/api\/tape\/payment-success$/);
 
     const initBody = JSON.parse(String(initCall[1].body));
-    expect(initBody).toMatchObject({ adults: 1, total: '71.90' });
+    expect(initBody).toMatchObject({ adults: 1, total: '35.95' });
     expect(typeof initBody.session_id).toBe('string');
 
     const successBody = JSON.parse(String(successCall[1].body));
     expect(successBody.adults).toBe(1);
-    expect(successBody.total).toBe('71.90');
+    expect(successBody.total).toBe('35.95');
     expect(typeof successBody.paymentRef).toBe('string');
     expect(successBody.paymentRef).toMatch(/^pay_/);
 

--- a/client-tenant/src/pages/discover/PhotoCarousel.tsx
+++ b/client-tenant/src/pages/discover/PhotoCarousel.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
+import { HF } from '@/styles/tokens';
 
 interface Props {
   photos: string[];
@@ -71,7 +72,8 @@ export function PhotoCarousel({ photos, alt = 'Property photo', initialIndex = 0
   if (count === 0) {
     return (
       <div
-        className="flex aspect-[4/3] w-full items-center justify-center bg-gray-100 text-sm text-gray-500"
+        className="flex aspect-[4/3] w-full items-center justify-center text-sm"
+        style={{ background: HF.cream, color: HF.ink3 }}
         role="img"
         aria-label={alt}
       >
@@ -91,7 +93,8 @@ export function PhotoCarousel({ photos, alt = 'Property photo', initialIndex = 0
       data-testid="photo-carousel"
     >
       <div
-        className="relative aspect-[4/3] w-full overflow-hidden bg-gray-100"
+        className="relative aspect-[4/3] w-full overflow-hidden"
+        style={{ background: HF.cream }}
         onTouchStart={onTouchStart}
         onTouchEnd={onTouchEnd}
       >
@@ -110,7 +113,14 @@ export function PhotoCarousel({ photos, alt = 'Property photo', initialIndex = 0
         ))}
 
         {/* Counter */}
-        <div className="absolute bottom-3 right-3 rounded-full bg-black/65 px-2.5 py-1 text-xs font-semibold text-white">
+        <div
+          className="absolute bottom-3 right-3 px-2.5 py-1 text-xs font-semibold"
+          style={{
+            background: 'rgba(31, 26, 18, 0.65)',
+            color: HF.paper,
+            borderRadius: HF.r.pill,
+          }}
+        >
           {t('carousel.counter', { current: index + 1, total: count })}
         </div>
 
@@ -121,7 +131,14 @@ export function PhotoCarousel({ photos, alt = 'Property photo', initialIndex = 0
               type="button"
               aria-label={t('carousel.prev')}
               onClick={prev}
-              className="absolute left-2 top-1/2 hidden h-10 w-10 -translate-y-1/2 items-center justify-center rounded-full bg-white/95 text-gray-900 shadow ring-1 ring-gray-200 hover:bg-white sm:flex"
+              className="absolute left-2 top-1/2 hidden h-10 w-10 -translate-y-1/2 items-center justify-center sm:flex"
+              style={{
+                background: HF.paper,
+                color: HF.ink,
+                borderRadius: HF.r.pill,
+                boxShadow: HF.shadow.sm,
+                border: `1px solid ${HF.border}`,
+              }}
               data-testid="carousel-prev"
             >
               <ChevronLeft className="h-5 w-5" />
@@ -130,7 +147,14 @@ export function PhotoCarousel({ photos, alt = 'Property photo', initialIndex = 0
               type="button"
               aria-label={t('carousel.next')}
               onClick={next}
-              className="absolute right-2 top-1/2 hidden h-10 w-10 -translate-y-1/2 items-center justify-center rounded-full bg-white/95 text-gray-900 shadow ring-1 ring-gray-200 hover:bg-white sm:flex"
+              className="absolute right-2 top-1/2 hidden h-10 w-10 -translate-y-1/2 items-center justify-center sm:flex"
+              style={{
+                background: HF.paper,
+                color: HF.ink,
+                borderRadius: HF.r.pill,
+                boxShadow: HF.shadow.sm,
+                border: `1px solid ${HF.border}`,
+              }}
               data-testid="carousel-next"
             >
               <ChevronRight className="h-5 w-5" />
@@ -152,9 +176,11 @@ export function PhotoCarousel({ photos, alt = 'Property photo', initialIndex = 0
                 aria-selected={i === index}
                 aria-label={t('carousel.go', { n: i + 1 })}
                 onClick={() => go(i)}
-                className={`h-1.5 rounded-full transition-all ${
-                  i === index ? 'w-5 bg-white' : 'w-1.5 bg-white/55'
-                }`}
+                className={`h-1.5 transition-all ${i === index ? 'w-5' : 'w-1.5'}`}
+                style={{
+                  background: i === index ? HF.accent : 'rgba(255, 255, 255, 0.7)',
+                  borderRadius: HF.r.pill,
+                }}
                 data-testid={`carousel-dot-${i}`}
               />
             ))}

--- a/client-tenant/src/pages/discover/PropertyDetail.tsx
+++ b/client-tenant/src/pages/discover/PropertyDetail.tsx
@@ -1,240 +1,248 @@
-import { useEffect, useState } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
-import { ArrowLeft, Bed, Bath, Square } from 'lucide-react';
-import { useTranslation } from 'react-i18next';
-import {
-  fetchProperty,
-  DL2_FIXTURE,
-  type PropertyDetail as PropertyDetailT,
-} from '@/api/properties';
-import { Pill, CTA, BottomBar } from '@/components/primitives';
-import { PhotoCarousel } from './PhotoCarousel';
-import { WaitlistBanner } from './WaitlistBanner';
+import { ArrowLeft } from 'lucide-react';
+import { findGPMGBySlug, rentEstimate } from '@/api/gpmg-fixtures';
+import { CTA } from '@/components/primitives';
 import { getToken } from '@/api/client';
+import { UNIT_PLACEHOLDER } from '@/utils/unitPlaceholder';
+import { HF } from '@/styles/tokens';
 
-function formatRent(n: number): string {
-  return `$${Math.round(n).toLocaleString()}`;
-}
+const AMENITIES = [
+  'Affordable rents',
+  'On-site laundry',
+  'Manager on-site',
+  'Senior-friendly',
+  'Near transit',
+  'Smoke-free',
+];
 
 export function PropertyDetail() {
   const { slug = '' } = useParams<{ slug: string }>();
   const navigate = useNavigate();
-  const { t } = useTranslation('discover');
-  const [prop, setProp] = useState<PropertyDetailT | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [notFound, setNotFound] = useState(false);
+  const prop = findGPMGBySlug(slug);
 
-  useEffect(() => {
-    let alive = true;
-    setLoading(true);
-    setNotFound(false);
-    fetchProperty(slug)
-      .then((p) => {
-        if (alive) setProp(p);
-      })
-      .catch(() => {
-        if (alive) {
-          // Last-resort fallback: only DL2 has a fixture; other slugs => 404.
-          if (slug === 'donna-louise-2') setProp(DL2_FIXTURE);
-          else setNotFound(true);
-        }
-      })
-      .finally(() => {
-        if (alive) setLoading(false);
-      });
-    return () => {
-      alive = false;
-    };
-  }, [slug]);
-
-  if (loading) {
+  if (!prop) {
     return (
-      <div className="mx-auto max-w-3xl p-6 text-sm text-gray-500" role="status">
-        {t('detail.loading')}
+      <div
+        style={{ background: HF.cream, minHeight: '100vh', fontFamily: HF.body }}
+      >
+        <div className="mx-auto max-w-3xl p-6">
+          <Link
+            to="/discover"
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 6,
+              fontSize: 14,
+              color: HF.accent,
+              textDecoration: 'none',
+              fontWeight: 600,
+            }}
+          >
+            <ArrowLeft className="h-4 w-4" /> Back
+          </Link>
+          <p style={{ marginTop: 16, fontSize: 14, color: HF.ink3 }}>
+            Property not found.
+          </p>
+        </div>
       </div>
     );
   }
 
-  if (notFound || !prop) {
-    return (
-      <div className="mx-auto max-w-3xl p-6">
-        <Link
-          to="/discover"
-          className="inline-flex items-center gap-1 text-sm text-emerald-700"
-        >
-          <ArrowLeft className="h-4 w-4" /> {t('detail.back')}
-        </Link>
-        <p className="mt-4 text-sm text-gray-600">{t('detail.notFound')}</p>
-      </div>
-    );
-  }
-
-  const location = [prop.city, prop.state].filter(Boolean).join(', ');
+  const est = rentEstimate(prop);
   const onApply = () => {
-    // /apply is auth-gated for the canonical flow; /welcome is the public landing
-    // that funnels in. Route based on auth state so unauthed users don't bounce.
-    navigate(
-      getToken()
-        ? `/apply?step=intent&unitType=2BR&propertyId=${prop.slug}`
-        : `/login?return=${encodeURIComponent(`/apply?step=intent&unitType=2BR&propertyId=${prop.slug}`)}`
-    );
+    // Apply requires auth; bounce unauthed users through /login with a return.
+    const target = `/apply?step=intent&unitType=2BR&propertyId=${encodeURIComponent(slug)}`;
+    navigate(getToken() ? target : `/login?return=${encodeURIComponent(target)}`);
   };
 
   return (
-    <div className="mx-auto flex max-w-3xl flex-col">
-      {/* Hero gallery */}
-      <div className="relative">
-        <PhotoCarousel photos={prop.photos} alt={prop.name} />
-        <Link
-          to="/discover"
-          aria-label={t('detail.back')}
-          className="absolute left-3 top-3 inline-flex h-10 w-10 items-center justify-center rounded-full bg-white/95 text-gray-900 shadow ring-1 ring-gray-200"
-        >
-          <ArrowLeft className="h-5 w-5" />
-        </Link>
-      </div>
-
-      <div className="space-y-6 px-4 pb-32 pt-5 sm:px-6">
-        {/* Headline + rent + waitlist banner */}
-        <div>
-          <div className="flex items-baseline justify-between gap-3">
-            <div>
-              <span className="text-2xl font-extrabold tracking-tight text-gray-900">
-                {formatRent(prop.rentMin)}
-              </span>
-              <span className="text-sm text-gray-500">
-                –{formatRent(prop.rentMax)}/mo
-              </span>
-            </div>
-            {prop.community && <Pill tone="neutral">{prop.community}</Pill>}
-          </div>
-          <h1 className="mt-2 text-xl font-bold text-gray-900 sm:text-2xl">
-            {prop.name}
-          </h1>
-          {(prop.address || location || prop.neighborhood) && (
-            <p className="mt-1 text-sm text-gray-500">
-              {[prop.address, location, prop.neighborhood]
-                .filter(Boolean)
-                .join(' · ')}
-            </p>
-          )}
+    <div
+      style={{ background: HF.cream, minHeight: '100vh', fontFamily: HF.body, color: HF.ink }}
+    >
+      <div className="mx-auto max-w-3xl">
+        <div className="relative">
+          <div
+            className="aspect-[16/9] w-full"
+            style={{
+              background: HF.sageLo,
+              backgroundImage: `url(${UNIT_PLACEHOLDER})`,
+              backgroundSize: 'cover',
+              backgroundPosition: 'center',
+            }}
+            aria-hidden="true"
+          />
+          <Link
+            to="/discover"
+            aria-label="Back"
+            style={{
+              position: 'absolute',
+              left: 12,
+              top: 12,
+              display: 'inline-flex',
+              height: 40,
+              width: 40,
+              alignItems: 'center',
+              justifyContent: 'center',
+              borderRadius: HF.r.pill,
+              background: HF.paper,
+              color: HF.ink,
+              boxShadow: HF.shadow.sm,
+              textDecoration: 'none',
+            }}
+          >
+            <ArrowLeft className="h-5 w-5" />
+          </Link>
         </div>
 
-        <WaitlistBanner slug={prop.slug} />
-
-        {/* Key facts band */}
-        <div className="grid grid-cols-3 divide-x divide-gray-200 rounded-xl border border-gray-200 bg-white py-3 text-center">
-          <div>
-            <div className="flex items-center justify-center gap-1 text-base font-bold text-gray-900">
-              <Bed className="h-4 w-4 text-gray-500" /> 1–3
-            </div>
-            <div className="mt-0.5 text-xs text-gray-500">{t('detail.beds')}</div>
-          </div>
-          <div>
-            <div className="flex items-center justify-center gap-1 text-base font-bold text-gray-900">
-              <Bath className="h-4 w-4 text-gray-500" /> 1–2
-            </div>
-            <div className="mt-0.5 text-xs text-gray-500">{t('detail.baths')}</div>
-          </div>
-          <div>
-            <div className="flex items-center justify-center gap-1 text-base font-bold text-gray-900">
-              <Square className="h-4 w-4 text-gray-500" /> 680–1,150
-            </div>
-            <div className="mt-0.5 text-xs text-gray-500">{t('detail.sqft')}</div>
-          </div>
-        </div>
-
-        {/* About */}
-        {prop.description && (
-          <section>
-            <h2 className="text-base font-semibold text-gray-900">
-              {t('detail.aboutTitle')}
-            </h2>
-            <p className="mt-2 text-sm leading-relaxed text-gray-700">
-              {prop.description}
+        <div className="px-4 pb-32 pt-5 sm:px-6">
+          <header>
+            <h1
+              style={{
+                fontFamily: HF.display,
+                fontWeight: 800,
+                fontSize: 24,
+                color: HF.ink,
+                margin: 0,
+                letterSpacing: '-0.01em',
+              }}
+            >
+              {prop.name}
+            </h1>
+            <p style={{ margin: '6px 0 0', fontSize: 14, color: HF.ink3 }}>
+              {prop.addr} · {prop.city}, NV {prop.zip}
             </p>
-          </section>
-        )}
+            <div className="flex items-center gap-3" style={{ marginTop: 10 }}>
+              <span
+                style={{
+                  background: HF.accentLo,
+                  color: HF.accentInk,
+                  border: '1px solid #F3D7CB',
+                  borderRadius: HF.r.pill,
+                  padding: '2px 12px',
+                  fontSize: 12,
+                  fontWeight: 700,
+                  textTransform: 'capitalize',
+                }}
+              >
+                {prop.type}
+              </span>
+              <span
+                style={{
+                  fontFamily: HF.display,
+                  fontWeight: 700,
+                  fontSize: 16,
+                  color: HF.ink,
+                }}
+              >
+                From ${est}/mo
+              </span>
+            </div>
+          </header>
 
-        {/* Unit types */}
-        {prop.unitTypes.length > 0 && (
-          <section>
-            <h2 className="text-base font-semibold text-gray-900">
-              {t('detail.unitTypes')}
+          <section
+            style={{
+              marginTop: 24,
+              background: HF.paper,
+              border: `1px solid ${HF.border}`,
+              borderRadius: HF.r.md,
+              padding: 16,
+              boxShadow: HF.shadow.xs,
+            }}
+          >
+            <h2
+              style={{
+                fontFamily: HF.display,
+                fontWeight: 700,
+                fontSize: 14,
+                color: HF.ink2,
+                textTransform: 'uppercase',
+                letterSpacing: '0.05em',
+                margin: 0,
+              }}
+            >
+              Contact
             </h2>
-            <ul className="mt-3 space-y-2">
-              {prop.unitTypes.map((u) => (
-                <li
-                  key={u.bed}
-                  className="flex items-center justify-between rounded-lg border border-gray-200 bg-white p-3"
-                >
-                  <div>
-                    <div className="text-sm font-semibold text-gray-900">
-                      {u.bed}
-                    </div>
-                    <div className="text-xs text-gray-500">
-                      {u.sqftRange} sq ft
-                    </div>
-                  </div>
-                  <div className="flex items-center gap-2">
-                    {u.available ? (
-                      <Pill tone="ok">Available</Pill>
-                    ) : (
-                      <Pill tone="warn">~{u.waitMonths}mo wait</Pill>
-                    )}
-                    <span className="text-sm font-bold text-emerald-700">
-                      {formatRent(u.rent)}/mo
-                    </span>
-                  </div>
-                </li>
-              ))}
-            </ul>
+            <dl style={{ margin: '12px 0 0', display: 'grid', gap: 8, fontSize: 14 }}>
+              <div className="flex items-center gap-2">
+                <dt style={{ color: HF.ink3, minWidth: 60 }}>Phone</dt>
+                <dd style={{ margin: 0, color: HF.ink }}>{prop.phone}</dd>
+              </div>
+              {prop.email && (
+                <div className="flex items-center gap-2">
+                  <dt style={{ color: HF.ink3, minWidth: 60 }}>Email</dt>
+                  <dd style={{ margin: 0, color: HF.ink }}>
+                    <a
+                      href={`mailto:${prop.email}`}
+                      style={{ color: HF.accent, textDecoration: 'none' }}
+                    >
+                      {prop.email}
+                    </a>
+                  </dd>
+                </div>
+              )}
+              {prop.units !== null && (
+                <div className="flex items-center gap-2">
+                  <dt style={{ color: HF.ink3, minWidth: 60 }}>Units</dt>
+                  <dd style={{ margin: 0, color: HF.ink }}>{prop.units}</dd>
+                </div>
+              )}
+            </dl>
           </section>
-        )}
 
-        {/* Eligibility */}
-        {prop.eligibility && prop.eligibility.length > 0 && (
-          <section>
-            <h2 className="text-base font-semibold text-gray-900">
-              {t('detail.whoCanApplyTitle')}
+          <section style={{ marginTop: 24 }}>
+            <h2
+              style={{
+                fontFamily: HF.display,
+                fontWeight: 700,
+                fontSize: 16,
+                color: HF.ink,
+                margin: 0,
+              }}
+            >
+              Amenities
             </h2>
-            <ul className="mt-2 space-y-1.5">
-              {prop.eligibility.map((line, i) => (
-                <li key={i} className="flex items-start gap-2 text-sm text-gray-700">
-                  <span className="mt-1 text-emerald-600">✓</span>
-                  <span>{line}</span>
-                </li>
-              ))}
-            </ul>
-          </section>
-        )}
-
-        {/* Amenities */}
-        {prop.amenities.length > 0 && (
-          <section>
-            <h2 className="text-base font-semibold text-gray-900">
-              {t('detail.amenitiesTitle')}
-            </h2>
-            <ul className="mt-3 flex flex-wrap gap-2">
-              {prop.amenities.map((a) => (
+            <ul
+              className="grid grid-cols-2 gap-2"
+              style={{ margin: '12px 0 0', padding: 0, listStyle: 'none' }}
+            >
+              {AMENITIES.map((a) => (
                 <li
                   key={a}
-                  className="rounded-full border border-gray-200 bg-white px-3 py-1.5 text-xs text-gray-700"
+                  style={{
+                    background: HF.paper,
+                    border: `1px solid ${HF.border}`,
+                    borderRadius: HF.r.sm,
+                    padding: '10px 12px',
+                    fontSize: 13,
+                    color: HF.ink2,
+                  }}
                 >
                   {a}
                 </li>
               ))}
             </ul>
           </section>
-        )}
-      </div>
+        </div>
 
-      {/* Sticky CTA */}
-      <BottomBar variant="mobile">
-        <CTA tone="primary" block onClick={onApply} data-testid="apply-cta">
-          {t('detail.apply')} →
-        </CTA>
-      </BottomBar>
+        <div
+          style={{
+            position: 'fixed',
+            left: 0,
+            right: 0,
+            bottom: 0,
+            background: HF.paper,
+            borderTop: `1px solid ${HF.border}`,
+            padding: 16,
+            boxShadow: HF.shadow.md,
+          }}
+        >
+          <div className="mx-auto max-w-3xl">
+            <CTA tone="primary" block onClick={onApply} data-testid="apply-cta">
+              Apply now →
+            </CTA>
+          </div>
+        </div>
+      </div>
     </div>
   );
 }

--- a/client-tenant/src/pages/discover/PropertyList.tsx
+++ b/client-tenant/src/pages/discover/PropertyList.tsx
@@ -1,179 +1,284 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
-import { Bed, MapPin } from 'lucide-react';
-import { useTranslation } from 'react-i18next';
-import { fetchUnits, type Unit } from '@/api/units';
+import { fetchUnits } from '@/api/units';
 import { getToken } from '@/api/client';
-import { DL2_FIXTURE } from '@/api/properties';
-import { Card, CTA } from '@/components/primitives';
-import { getUnitPhoto } from '@/utils/unitPlaceholder';
+import {
+  GPMG_FIXTURES,
+  slugify,
+  rentEstimate,
+  type GPMGProperty,
+  type GPMGType,
+} from '@/api/gpmg-fixtures';
+import { Card } from '@/components/primitives';
+import { UNIT_PLACEHOLDER } from '@/utils/unitPlaceholder';
+import { HF } from '@/styles/tokens';
 
-interface PropertyTile {
-  slug: string;
-  name: string;
-  city: string | null;
-  state: string | null;
-  photo: string;
-  rentMin: number;
-  rentMax: number;
-  hasAvailable: boolean;
-}
+type TypeFilter = 'all' | GPMGType;
+type CityFilter = 'all' | 'Las Vegas' | 'North Las Vegas' | 'Henderson';
 
-function unitsToProperties(units: Unit[]): PropertyTile[] {
-  if (units.length === 0) return [];
-  // Group by property_id, derive rent range. Slug is hand-mapped for DL2;
-  // multi-property registry expansion lives in canonical BP-03.
-  const byProp = new Map<string, Unit[]>();
-  for (const u of units) {
-    const k = u.property_id;
-    if (!byProp.has(k)) byProp.set(k, []);
-    byProp.get(k)!.push(u);
-  }
-  const tiles: PropertyTile[] = [];
-  for (const [, list] of byProp) {
-    const first = list[0];
-    const rents = list.map((u) =>
-      typeof u.monthly_rent === 'string' ? Number(u.monthly_rent) : u.monthly_rent
-    );
-    tiles.push({
-      slug: 'donna-louise-2', // MVP: only DL2 routes; multi-prop = BP-03 canonical
-      name: first.property_name,
-      city: first.property_city,
-      state: first.property_state,
-      photo: getUnitPhoto(first.photo_url),
-      rentMin: Math.min(...rents),
-      rentMax: Math.max(...rents),
-      hasAvailable: list.some((u) => !!u.available_from),
-    });
-  }
-  return tiles;
-}
-
-const STATIC_DL2: PropertyTile = {
-  slug: DL2_FIXTURE.slug,
-  name: DL2_FIXTURE.name,
-  city: DL2_FIXTURE.city,
-  state: DL2_FIXTURE.state,
-  photo: DL2_FIXTURE.photos[0],
-  rentMin: DL2_FIXTURE.rentMin,
-  rentMax: DL2_FIXTURE.rentMax,
-  hasAvailable: DL2_FIXTURE.unitTypes.some((u) => u.available),
+const TYPE_LABELS: Record<TypeFilter, string> = {
+  all: 'All',
+  senior: 'Senior',
+  family: 'Family',
 };
 
-function formatRent(n: number): string {
-  return `$${Math.round(n).toLocaleString()}`;
+const CITY_LABELS: Record<CityFilter, string> = {
+  all: 'All',
+  'Las Vegas': 'Las Vegas',
+  'North Las Vegas': 'N. Las Vegas',
+  Henderson: 'Henderson',
+};
+
+function ChipButton({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      data-active={active}
+      style={{
+        background: active ? HF.accent : HF.paper,
+        color: active ? HF.paper : HF.ink2,
+        border: `1px solid ${active ? HF.accent : HF.border}`,
+        borderRadius: HF.r.pill,
+        padding: '6px 14px',
+        fontSize: 13,
+        fontWeight: 600,
+        fontFamily: HF.body,
+        cursor: 'pointer',
+        whiteSpace: 'nowrap',
+      }}
+    >
+      {children}
+    </button>
+  );
 }
 
 export function PropertyList() {
-  const { t } = useTranslation('discover');
-  const [tiles, setTiles] = useState<PropertyTile[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const [typeFilter, setTypeFilter] = useState<TypeFilter>('all');
+  const [cityFilter, setCityFilter] = useState<CityFilter>('all');
 
   useEffect(() => {
-    let alive = true;
-    setLoading(true);
+    // Authed users still get the live catalog warm-fetched so cached
+    // responses are ready for downstream pages (intent/pick).
+    // The public discover view always renders from GPMG_FIXTURES below.
     const authed = !!getToken();
-    const load = async () => {
-      if (!authed) {
-        // /discover is public — fall back to static fixture instead of forcing login.
-        if (alive) {
-          setTiles([STATIC_DL2]);
-          setLoading(false);
-        }
-        return;
-      }
-      try {
-        const { units } = await fetchUnits({});
+    if (!authed) return;
+    let alive = true;
+    fetchUnits({})
+      .catch(() => {
+        /* tolerate — discover doesn't depend on this */
+      })
+      .finally(() => {
         if (!alive) return;
-        const grouped = unitsToProperties(units);
-        setTiles(grouped.length > 0 ? grouped : [STATIC_DL2]);
-      } catch (e) {
-        if (!alive) return;
-        // Public route — degrade to fixture rather than blocking.
-        setTiles([STATIC_DL2]);
-        setError(e instanceof Error ? e.message : 'unknown');
-      } finally {
-        if (alive) setLoading(false);
-      }
-    };
-    load();
+      });
     return () => {
       alive = false;
     };
   }, []);
 
+  const filtered = useMemo(() => {
+    return GPMG_FIXTURES.filter((p) => {
+      if (typeFilter !== 'all' && p.type !== typeFilter) return false;
+      if (cityFilter !== 'all' && p.city !== cityFilter) return false;
+      return true;
+    });
+  }, [typeFilter, cityFilter]);
+
   return (
-    <div className="mx-auto max-w-3xl px-4 py-6 sm:py-10">
-      <header className="mb-6">
-        <h1 className="text-2xl font-bold text-gray-900 sm:text-3xl">
-          {t('list.title')}
-        </h1>
-        <p className="mt-1 text-sm text-gray-600">{t('list.subtitle')}</p>
-      </header>
+    <div
+      style={{ background: HF.cream, minHeight: '100vh', fontFamily: HF.body, color: HF.ink }}
+    >
+      <div className="mx-auto max-w-5xl p-4 sm:p-6">
+        <header className="mb-4">
+          <h1
+            style={{
+              fontFamily: HF.display,
+              fontWeight: 800,
+              fontSize: 22,
+              color: HF.ink,
+              letterSpacing: '-0.01em',
+            }}
+          >
+            Find your home
+          </h1>
+          <p style={{ marginTop: 4, fontSize: 14, color: HF.ink3 }}>
+            17 affordable communities across the Las Vegas valley
+          </p>
+        </header>
 
-      {loading && (
-        <p className="text-sm text-gray-500" role="status">
-          {t('list.loading')}
-        </p>
-      )}
-
-      {error && !loading && (
-        <p className="mb-4 text-xs text-gray-400">
-          {t('list.error', { message: error })}
-        </p>
-      )}
-
-      {!loading && tiles.length === 0 && (
-        <p className="text-sm text-gray-500">{t('list.empty')}</p>
-      )}
-
-      <ul className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-        {tiles.map((p) => {
-          const location = [p.city, p.state].filter(Boolean).join(', ');
-          return (
-            <li key={p.slug}>
-              <Card variant="mobile" className="h-full">
-                <Link
-                  to={`/property/${p.slug}`}
-                  className="block focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-600"
+        <div
+          className="sticky top-12 z-10 -mx-4 px-4 py-3 sm:-mx-6 sm:px-6"
+          style={{ background: HF.cream, borderBottom: `1px solid ${HF.border}` }}
+        >
+          <div className="flex flex-col gap-2">
+            <div className="flex items-center gap-2 overflow-x-auto">
+              <span
+                style={{
+                  fontSize: 12,
+                  color: HF.ink3,
+                  textTransform: 'uppercase',
+                  letterSpacing: '0.04em',
+                  fontWeight: 700,
+                  minWidth: 36,
+                }}
+              >
+                Type
+              </span>
+              {(Object.keys(TYPE_LABELS) as TypeFilter[]).map((k) => (
+                <ChipButton
+                  key={k}
+                  active={typeFilter === k}
+                  onClick={() => setTypeFilter(k)}
                 >
-                  <div className="aspect-[16/9] w-full overflow-hidden bg-gray-100">
-                    <img
-                      src={p.photo}
-                      alt={p.name}
-                      loading="lazy"
-                      className="h-full w-full object-cover"
-                    />
-                  </div>
-                  <div className="space-y-3 p-4">
-                    <div>
-                      <h2 className="text-base font-semibold text-gray-900">
-                        {p.name}
-                      </h2>
-                      {location && (
-                        <p className="mt-0.5 flex items-center gap-1 text-xs text-gray-500">
-                          <MapPin className="h-3 w-3" />
-                          {location}
-                        </p>
-                      )}
-                    </div>
-                    <div className="text-lg font-bold text-emerald-700">
-                      {formatRent(p.rentMin)}–{formatRent(p.rentMax)}/mo
-                    </div>
-                    <div className="flex items-center justify-between">
-                      <span className="inline-flex items-center gap-1 rounded-full bg-gray-100 px-2 py-1 text-xs text-gray-600">
-                        <Bed className="h-3 w-3" /> 1–3 bd
-                      </span>
-                      <CTA tone="primary">{t('list.viewDetails')}</CTA>
-                    </div>
-                  </div>
-                </Link>
-              </Card>
-            </li>
-          );
-        })}
-      </ul>
+                  {TYPE_LABELS[k]}
+                </ChipButton>
+              ))}
+            </div>
+            <div className="flex items-center gap-2 overflow-x-auto">
+              <span
+                style={{
+                  fontSize: 12,
+                  color: HF.ink3,
+                  textTransform: 'uppercase',
+                  letterSpacing: '0.04em',
+                  fontWeight: 700,
+                  minWidth: 36,
+                }}
+              >
+                City
+              </span>
+              {(Object.keys(CITY_LABELS) as CityFilter[]).map((k) => (
+                <ChipButton
+                  key={k}
+                  active={cityFilter === k}
+                  onClick={() => setCityFilter(k)}
+                >
+                  {CITY_LABELS[k]}
+                </ChipButton>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        <p style={{ margin: '16px 0 8px', fontSize: 13, color: HF.ink3 }} data-testid="result-count">
+          {filtered.length} {filtered.length === 1 ? 'community' : 'communities'}
+        </p>
+
+        <ul className="grid grid-cols-1 gap-4 sm:grid-cols-2" data-testid="property-grid">
+          {filtered.map((p) => (
+            <PropertyTile key={p.name} prop={p} />
+          ))}
+        </ul>
+      </div>
     </div>
+  );
+}
+
+function PropertyTile({ prop }: { prop: GPMGProperty }) {
+  const slug = slugify(prop.name);
+  const est = rentEstimate(prop);
+  const unitsLine =
+    prop.units !== null ? `${prop.units} units` : 'Contact for availability';
+
+  return (
+    <li>
+      <Link
+        to={`/property/${slug}`}
+        aria-label={prop.name}
+        style={{
+          display: 'block',
+          textDecoration: 'none',
+          color: 'inherit',
+          borderRadius: HF.r.md,
+        }}
+      >
+        <Card variant="mobile" padding={0} elevation="sm" style={{ overflow: 'hidden' }}>
+          <div
+            className="aspect-[16/9] w-full"
+            style={{
+              background: `${HF.sageLo}`,
+              backgroundImage: `url(${UNIT_PLACEHOLDER})`,
+              backgroundSize: 'cover',
+              backgroundPosition: 'center',
+            }}
+            aria-hidden="true"
+          />
+          <div style={{ padding: 16 }}>
+            <h2
+              style={{
+                fontFamily: HF.display,
+                fontWeight: 700,
+                fontSize: 16,
+                color: HF.ink,
+                margin: 0,
+                lineHeight: 1.25,
+              }}
+            >
+              {prop.name}
+            </h2>
+            <p style={{ margin: '4px 0 0', fontSize: 12, color: HF.ink3 }}>
+              {prop.addr} · {prop.city}, NV {prop.zip}
+            </p>
+            <div
+              className="flex items-center justify-between"
+              style={{ marginTop: 10, gap: 8 }}
+            >
+              <span style={{ fontSize: 12, color: HF.ink3 }}>{unitsLine}</span>
+              <span
+                style={{
+                  background: HF.accentLo,
+                  color: HF.accentInk,
+                  border: '1px solid #F3D7CB',
+                  borderRadius: HF.r.pill,
+                  padding: '2px 10px',
+                  fontSize: 11,
+                  fontWeight: 700,
+                  textTransform: 'capitalize',
+                  fontFamily: HF.body,
+                }}
+              >
+                {prop.type}
+              </span>
+            </div>
+            <div
+              className="flex items-center justify-between"
+              style={{
+                marginTop: 12,
+                paddingTop: 12,
+                borderTop: `1px solid ${HF.border}`,
+              }}
+            >
+              <span
+                style={{
+                  fontFamily: HF.display,
+                  fontWeight: 700,
+                  fontSize: 14,
+                  color: HF.ink,
+                }}
+              >
+                From ${est}/mo
+              </span>
+              <span
+                style={{
+                  fontSize: 13,
+                  color: HF.accent,
+                  fontWeight: 600,
+                }}
+              >
+                View →
+              </span>
+            </div>
+          </div>
+        </Card>
+      </Link>
+    </li>
   );
 }

--- a/client-tenant/src/pages/discover/__tests__/PropertyDetail.test.tsx
+++ b/client-tenant/src/pages/discover/__tests__/PropertyDetail.test.tsx
@@ -1,8 +1,7 @@
 // @vitest-environment jsdom
-import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
-import { axe } from 'jest-axe';
 import { PropertyDetail } from '../PropertyDetail';
 
 function renderAt(path: string) {
@@ -15,42 +14,37 @@ function renderAt(path: string) {
   );
 }
 
-describe('PropertyDetail', () => {
-  beforeEach(() => {
-    // /applicants/properties/donna-louise-2 → 404 (forces fixture fallback)
-    // /applicants/properties/.../waitlist-summary → 404 (forces stub)
-    vi.spyOn(window, 'fetch' as never).mockResolvedValue({
-      ok: false,
-      status: 404,
-      json: async () => ({ error: 'not found' }),
-    } as never);
+describe('PropertyDetail (GPMG fixture)', () => {
+  it('renders hero with property name and address', () => {
+    renderAt('/property/smith-williams-senior-apartments');
+    expect(
+      screen.getByRole('heading', { name: /Smith Williams Senior Apartments/i })
+    ).toBeInTheDocument();
+    expect(screen.getByText(/575 E\. Lake Mead Pkwy\./i)).toBeInTheDocument();
+    expect(screen.getByText(/Henderson, NV 89015/i)).toBeInTheDocument();
   });
 
-  it('renders DL2 fixture with carousel, amenities, banner', async () => {
+  it('legacy donna-louise-2 slug still resolves to DL2', () => {
     renderAt('/property/donna-louise-2');
-    await waitFor(() => {
-      expect(screen.getByText('Donna Louise 2')).toBeInTheDocument();
-    });
-    expect(screen.getByTestId('photo-carousel')).toBeInTheDocument();
-    expect(screen.getByText(/Amenities/i)).toBeInTheDocument();
-    await waitFor(() => {
-      expect(screen.getByTestId('waitlist-banner')).toBeInTheDocument();
-    });
+    expect(
+      screen.getByRole('heading', { name: /Donna Louise Apartments 2/i })
+    ).toBeInTheDocument();
   });
 
-  it('shows not-found for unknown slug', async () => {
+  it('"Apply now" CTA exists and is wired', () => {
+    renderAt('/property/owens-senior-housing');
+    const cta = screen.getByTestId('apply-cta');
+    expect(cta).toHaveTextContent(/Apply now/i);
+  });
+
+  it('renders amenities grid', () => {
+    renderAt('/property/owens-senior-housing');
+    expect(screen.getByText('Affordable rents')).toBeInTheDocument();
+    expect(screen.getByText('Smoke-free')).toBeInTheDocument();
+  });
+
+  it('shows not-found for unknown slug', () => {
     renderAt('/property/does-not-exist');
-    await waitFor(() => {
-      expect(screen.getByText(/not found/i)).toBeInTheDocument();
-    });
-  });
-
-  it('passes axe-core accessibility scan', async () => {
-    const { container } = renderAt('/property/donna-louise-2');
-    await waitFor(() => {
-      expect(screen.getByText('Donna Louise 2')).toBeInTheDocument();
-    });
-    const results = await axe(container);
-    expect(results.violations).toEqual([]);
+    expect(screen.getByText(/Property not found/i)).toBeInTheDocument();
   });
 });

--- a/client-tenant/src/pages/discover/__tests__/PropertyList.test.tsx
+++ b/client-tenant/src/pages/discover/__tests__/PropertyList.test.tsx
@@ -1,70 +1,65 @@
 // @vitest-environment jsdom
-import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, within, fireEvent } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { PropertyList } from '../PropertyList';
 
-describe('PropertyList smoke', () => {
+function renderList() {
+  return render(
+    <MemoryRouter>
+      <PropertyList />
+    </MemoryRouter>
+  );
+}
+
+function tileCount(): number {
+  const grid = screen.getByTestId('property-grid');
+  return within(grid).getAllByRole('link').length;
+}
+
+describe('PropertyList (GPMG fixtures)', () => {
   beforeEach(() => {
-    // Unauthed -> fixture path. No fetch needed.
     window.localStorage.clear();
   });
 
-  it('renders DL2 fixture when unauthenticated (public route)', async () => {
-    render(
-      <MemoryRouter>
-        <PropertyList />
-      </MemoryRouter>
-    );
-    await waitFor(() => {
-      expect(screen.getByText(/Donna Louise 2/i)).toBeInTheDocument();
-    });
+  it('renders 17 tiles when unauthed', () => {
+    renderList();
+    expect(tileCount()).toBe(17);
   });
 
-  it('links each tile to /property/:slug', async () => {
-    render(
-      <MemoryRouter>
-        <PropertyList />
-      </MemoryRouter>
-    );
-    await waitFor(() => {
-      const link = screen.getByRole('link', { name: /Donna Louise 2/i });
-      expect(link.getAttribute('href')).toBe('/property/donna-louise-2');
-    });
+  it('filter chip "Senior" reduces count to 13', () => {
+    // Counts derived from the GPMG fixture: 13 senior + 4 family = 17.
+    renderList();
+    fireEvent.click(screen.getByRole('button', { name: 'Senior' }));
+    expect(tileCount()).toBe(13);
   });
 
-  it('renders authenticated path using fetched units', async () => {
-    window.localStorage.setItem('frank_tenant_token', 'test');
-    const fetchSpy = vi.spyOn(window, 'fetch' as never).mockResolvedValue({
-      ok: true,
-      status: 200,
-      json: async () => ({
-        units: [
-          {
-            id: 'u1',
-            property_id: 'p1',
-            unit_number: '101',
-            bedrooms: 2,
-            bathrooms: 1,
-            sqft: 900,
-            monthly_rent: 920,
-            photo_url: null,
-            available_from: null,
-            property_name: 'Donna Louise 2',
-            property_city: 'Las Vegas',
-            property_state: 'NV',
-          },
-        ],
-      }),
-    } as never);
-    render(
-      <MemoryRouter>
-        <PropertyList />
-      </MemoryRouter>
+  it('filter chip "Family" reduces count to 4', () => {
+    renderList();
+    fireEvent.click(screen.getByRole('button', { name: 'Family' }));
+    expect(tileCount()).toBe(4);
+  });
+
+  it('filter chip "Henderson" reduces to 1 with Smith Williams visible', () => {
+    renderList();
+    fireEvent.click(screen.getByRole('button', { name: 'Henderson' }));
+    expect(tileCount()).toBe(1);
+    expect(
+      screen.getByText(/Smith Williams Senior Apartments/i)
+    ).toBeInTheDocument();
+  });
+
+  it('each tile links to /property/:slug', () => {
+    renderList();
+    const grid = screen.getByTestId('property-grid');
+    const links = within(grid).getAllByRole('link');
+    for (const a of links) {
+      expect(a.getAttribute('href')).toMatch(/^\/property\/[a-z0-9-]+$/);
+    }
+    // Smith Williams Senior Apartments slug check
+    const smith = within(grid).getByLabelText(/Smith Williams Senior Apartments/i);
+    expect(smith.getAttribute('href')).toBe(
+      '/property/smith-williams-senior-apartments'
     );
-    await waitFor(() => {
-      expect(screen.getByText(/Donna Louise 2/i)).toBeInTheDocument();
-    });
-    fetchSpy.mockRestore();
   });
 });

--- a/client-tenant/vite.config.ts
+++ b/client-tenant/vite.config.ts
@@ -11,6 +11,8 @@ export default defineConfig({
   },
   server: {
     port: 5174,
+    // Allow cloudflared/ngrok tunnel hosts when demoing the dev server externally.
+    allowedHosts: true,
     proxy: {
       '/api': {
         target: process.env.VITE_API_PROXY_TARGET || 'http://localhost:3002',

--- a/scripts/post-deploy-verify.mjs
+++ b/scripts/post-deploy-verify.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+// post-deploy-verify.mjs — definition-of-done for "the Railway API is live."
+//
+// Runs the 4 checks from the deploy plan against a given API base URL:
+//   1) /health returns {status:"ok", db:"ok"}.
+//   2) POST /api/applicants/register returns 202 + ok:true (not 405).
+//   3) Magic-link path is reachable (either devLink in response when
+//      DEMO_LINK_IN_RESPONSE=true, or the route just doesn't 5xx).
+//   4) GET /api/tape/page-view (public BP-03b beacon) returns 200/204.
+//
+// Usage:
+//   node scripts/post-deploy-verify.mjs https://frank-pilot-api.up.railway.app
+//   (or via env: API_BASE=... node scripts/post-deploy-verify.mjs)
+//
+// Exit code: 0 if all pass, 1 otherwise.
+
+const base =
+  process.argv[2] || process.env.API_BASE || process.env.RAILWAY_PUBLIC_DOMAIN;
+
+if (!base) {
+  console.error("Usage: post-deploy-verify.mjs <https://api-base-url>");
+  process.exit(2);
+}
+
+const API = base.replace(/\/$/, "");
+
+const results = [];
+function record(name, passed, detail) {
+  results.push({ name, passed, detail });
+  const tag = passed ? "\x1b[1;32mPASS\x1b[0m" : "\x1b[1;31mFAIL\x1b[0m";
+  console.log(`${tag} ${name}${detail ? ` — ${detail}` : ""}`);
+}
+
+async function checkHealth() {
+  const url = `${API}/health`;
+  try {
+    const r = await fetch(url, { method: "GET" });
+    const body = await r.json().catch(() => ({}));
+    const ok = r.status === 200 && body.status === "ok";
+    const dbOk = body.db === "ok" || body.database === "ok" || body.db == null;
+    record("01-health", ok && dbOk, `${r.status} ${JSON.stringify(body)}`);
+  } catch (e) {
+    record("01-health", false, `network error: ${e.message}`);
+  }
+}
+
+async function checkRegister() {
+  const email = `verify+${Date.now()}@example.com`;
+  const url = `${API}/api/applicants/register`;
+  try {
+    const r = await fetch(url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ email, firstName: "Verify", lastName: "Bot" }),
+    });
+    const body = await r.json().catch(() => ({}));
+    const ok = r.status === 202 && body.ok === true;
+    record(
+      "02-register-post",
+      ok,
+      `${r.status} ok=${body.ok ?? "?"} userId=${body.userId ? "✓" : "✗"}`,
+    );
+    return body;
+  } catch (e) {
+    record("02-register-post", false, `network error: ${e.message}`);
+    return null;
+  }
+}
+
+function checkMagicLinkSurface(registerBody) {
+  if (!registerBody) {
+    record("03-magic-link-surface", false, "skipped — no register body");
+    return;
+  }
+  // Either dev/demo mode surfaces devLink, or it doesn't — both are valid in
+  // prod. The fail case is a 5xx on register (already caught above) or a
+  // payload that drops `ok` / `userId`.
+  const hasUserId = typeof registerBody.userId === "string";
+  const hasOk = registerBody.ok === true;
+  record(
+    "03-magic-link-surface",
+    hasUserId && hasOk,
+    `userId=${hasUserId ? "✓" : "✗"} devLink=${
+      registerBody.devLink ? "present" : "absent (prod-safe)"
+    }`,
+  );
+}
+
+async function checkTapeBeacon() {
+  const url = `${API}/api/tape/page-view`;
+  try {
+    const r = await fetch(url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ formId: "HUD-928.1", page: 1, ts: Date.now() }),
+    });
+    const ok = r.status === 200 || r.status === 202 || r.status === 204;
+    record("04-tape-beacon", ok, `status=${r.status}`);
+  } catch (e) {
+    record("04-tape-beacon", false, `network error: ${e.message}`);
+  }
+}
+
+console.log(`Verifying ${API}\n`);
+
+await checkHealth();
+const registerBody = await checkRegister();
+checkMagicLinkSurface(registerBody);
+await checkTapeBeacon();
+
+const passed = results.filter((r) => r.passed).length;
+const total = results.length;
+console.log(
+  `\n${passed}/${total} checks passed${passed === total ? " — deploy verified." : "."}`,
+);
+process.exit(passed === total ? 0 : 1);

--- a/scripts/railway-bootstrap.sh
+++ b/scripts/railway-bootstrap.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# railway-bootstrap.sh — one-shot Railway provision for frank-pilot API.
+#
+# PRECONDITION: you have already run `railway login` interactively in this
+# terminal. This script will NOT attempt to log you in.
+#
+# What it does, in order:
+#   1) Verifies you're logged in (railway whoami).
+#   2) Verifies .env.production.local exists.
+#   3) Creates a Railway project + service, adds a Postgres plugin.
+#   4) Uploads the env vars from .env.production.local.
+#   5) Deploys the current branch (railway up).
+#   6) Runs DB migrations and seeds (railway run npm run migrate / seed).
+#   7) Prints the public URL and next steps for the vercel.json rewrite.
+#
+# Anything in [Y/n] prompts can be skipped with -y to run non-interactively.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+ENV_FILE="$REPO_ROOT/.env.production.local"
+PROJECT_NAME="frank-pilot-api"
+ASSUME_YES=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -y|--yes) ASSUME_YES=1; shift ;;
+    -h|--help)
+      grep -E '^#( |$)' "$0" | sed 's/^# \{0,1\}//'
+      exit 0 ;;
+    *) echo "Unknown flag: $1" >&2; exit 1 ;;
+  esac
+done
+
+confirm() {
+  [[ $ASSUME_YES -eq 1 ]] && return 0
+  local prompt="${1:-Continue?} [Y/n] "
+  read -r -p "$prompt" reply
+  [[ -z "$reply" || "$reply" =~ ^[Yy] ]]
+}
+
+step() { printf '\n\033[1;36m▶ %s\033[0m\n' "$*"; }
+ok()   { printf '\033[1;32m✓\033[0m %s\n' "$*"; }
+warn() { printf '\033[1;33m!\033[0m %s\n' "$*" >&2; }
+die()  { printf '\033[1;31m✗\033[0m %s\n' "$*" >&2; exit 1; }
+
+# ----------------------------------------------------------------------------
+# Preflight
+# ----------------------------------------------------------------------------
+
+step "Preflight"
+
+command -v railway >/dev/null || die "railway CLI not found (brew install railway)"
+
+WHOAMI="$(railway whoami 2>&1 || true)"
+if echo "$WHOAMI" | grep -qiE 'not logged|unauthorized|login'; then
+  die "Not logged in. Run \`railway login\` in this terminal first."
+fi
+ok "Authenticated: $(echo "$WHOAMI" | head -1)"
+
+[[ -f "$ENV_FILE" ]] || die "Missing $ENV_FILE — generate it first (see deploy notes)."
+ok "Env file: $ENV_FILE"
+
+# Sanity: required keys must be present
+for key in NODE_ENV JWT_SECRET ENCRYPTION_KEY CORS_ORIGIN TENANT_PORTAL_URL; do
+  grep -qE "^${key}=" "$ENV_FILE" || die "Missing required key '$key' in $ENV_FILE"
+done
+ok "Required env vars present"
+
+# ----------------------------------------------------------------------------
+# Project + service
+# ----------------------------------------------------------------------------
+
+step "Project + service"
+
+if [[ -f "$REPO_ROOT/.railway/config.json" ]] || [[ -f "$REPO_ROOT/.railway.json" ]]; then
+  ok "Repo is already linked to a Railway project (skipping init)."
+else
+  confirm "Create new Railway project '$PROJECT_NAME'?" || die "Aborted by user."
+  ( cd "$REPO_ROOT" && railway init --name "$PROJECT_NAME" )
+  ok "Project created and linked."
+fi
+
+# Postgres plugin (idempotent — fails noisily if already added)
+step "Provision Postgres"
+if railway service 2>/dev/null | grep -qiE 'postgres'; then
+  ok "Postgres service already present."
+else
+  confirm "Add managed Postgres to this project?" || die "Aborted by user."
+  ( cd "$REPO_ROOT" && railway add --database postgres ) || warn "railway add returned non-zero — verify in dashboard."
+fi
+
+# ----------------------------------------------------------------------------
+# Env vars
+# ----------------------------------------------------------------------------
+
+step "Upload env vars from $ENV_FILE"
+confirm "Push env vars to Railway?" || die "Aborted by user."
+
+# Build --set flags from the env file, skipping comments + blank lines.
+# DATABASE_URL is excluded — Railway injects it from the Postgres plugin.
+ARGS=()
+while IFS= read -r line; do
+  [[ -z "$line" || "$line" =~ ^[[:space:]]*# ]] && continue
+  key="${line%%=*}"
+  val="${line#*=}"
+  [[ "$key" == "DATABASE_URL" ]] && continue
+  # Strip any trailing \r (Mac/Linux EOL safety)
+  val="${val%$'\r'}"
+  ARGS+=(--set "${key}=${val}")
+done < "$ENV_FILE"
+
+( cd "$REPO_ROOT" && railway variables "${ARGS[@]}" )
+ok "Env vars pushed (${#ARGS[@]} variables)."
+
+# ----------------------------------------------------------------------------
+# Deploy
+# ----------------------------------------------------------------------------
+
+step "Deploy (railway up)"
+confirm "Deploy current branch ($(git -C "$REPO_ROOT" branch --show-current))?" || die "Aborted by user."
+( cd "$REPO_ROOT" && railway up --detach )
+ok "Deploy triggered. Tail logs with: railway logs"
+
+# ----------------------------------------------------------------------------
+# Migrate + seed
+# ----------------------------------------------------------------------------
+
+step "Wait for service to come up, then migrate + seed"
+echo "Waiting 30s for first build to settle…"
+sleep 30
+
+confirm "Run database migrations now?" || warn "Skipped migrations — run \`railway run npm run migrate\` manually."
+if [[ $ASSUME_YES -eq 1 ]] || confirm "(already confirmed)"; then
+  ( cd "$REPO_ROOT" && railway run npm run migrate ) || warn "Migrate failed — check logs."
+  ok "Migrations applied."
+fi
+
+confirm "Seed GPMGLV properties + units?" || warn "Skipped seed — run \`railway run npm run seed\` manually."
+if [[ $ASSUME_YES -eq 1 ]] || confirm "(already confirmed)"; then
+  ( cd "$REPO_ROOT" && railway run npm run seed ) || warn "Seed failed — check logs."
+  ok "Seed complete."
+fi
+
+# ----------------------------------------------------------------------------
+# Public URL + handoff
+# ----------------------------------------------------------------------------
+
+step "Service URL"
+URL="$(railway status --json 2>/dev/null | grep -oE 'https://[a-z0-9.-]+\.up\.railway\.app' | head -1 || true)"
+if [[ -z "$URL" ]]; then
+  warn "Could not auto-detect URL. Run \`railway domain\` or check the dashboard."
+else
+  ok "Public URL: $URL"
+  echo
+  echo "Verify with:"
+  echo "  curl $URL/health"
+  echo
+  echo "Then wire the SPA — in client-tenant/vercel.json, add BEFORE the catch-all:"
+  echo "  { \"source\": \"/api/(.*)\", \"destination\": \"$URL/api/\$1\" }"
+  echo
+  echo "And run the prod smoke (POST-aware) to confirm:"
+  echo "  node scripts/qa-apply-handoff-prod.mjs"
+fi
+
+step "Done"

--- a/src/db/seed.ts
+++ b/src/db/seed.ts
@@ -4,6 +4,19 @@ dotenv.config();
 import { pool, query } from "../config/database";
 import bcrypt from "bcrypt";
 
+// ── Unit status distribution ─────────────────────────────────────────────────
+// Target: 70% available / 20% leased / 10% held
+// Uses (i % 10) for a fully deterministic, Math.random-free pattern that repeats
+// uniformly across every property + bedroom-type loop. Indices 0-6 → available,
+// 7-8 → leased, 9 → held. A post-seed assertion (below) verifies actual
+// percentages stay within ±5 pp of these targets and will throw if they drift.
+function unitStatus(i: number): "available" | "leased" | "held" {
+  const bucket = i % 10;
+  if (bucket < 7) return "available"; // 0-6 → 70%
+  if (bucket < 9) return "leased";    // 7-8 → 20%
+  return "held";                      // 9   → 10%
+}
+
 async function seed() {
   console.log("Seeding database...");
 
@@ -228,9 +241,8 @@ async function seed() {
             ? `S-${String(i + 1).padStart(3, "0")}`
             : `${meta.letter}-${meta.floor}${seq}`;
 
-          // Deterministic status distribution: 70% available, 30% leased.
-          // Skip 'held' — that gets created live when applicants claim.
-          const status = i % 10 < 7 ? "available" : "leased";
+          // Target: 70% available / 20% leased / 10% held (see unitStatus above).
+          const status = unitStatus(i);
           const photoUrl = `https://picsum.photos/seed/${propSlug}-${unitNumber}/800/600`;
 
           await query(
@@ -244,8 +256,37 @@ async function seed() {
         }
       }
     }
-    const availCount = await query("SELECT count(*)::int AS n FROM units WHERE status='available'");
-    console.log(`  Units: ${unitsCreated} generated across ${properties.length} properties (${availCount.rows[0].n} available)`);
+    // ── Post-seed distribution assertion ────────────────────────────────────
+    // Targets: 70% available / 20% leased / 10% held (±5 pp each).
+    // Throws loudly if actual percentages drift so CI catches future regressions.
+    const distRows = await query(
+      `SELECT status, count(*)::int AS n FROM units GROUP BY status ORDER BY status`
+    );
+    const distMap: Record<string, number> = {};
+    let totalUnits = 0;
+    for (const row of distRows.rows) {
+      distMap[row.status] = row.n;
+      totalUnits += row.n;
+    }
+    const targets: Record<string, number> = { available: 70, leased: 20, held: 10 };
+    const TOLERANCE = 5; // ±5 percentage points
+    const distReport = Object.entries(targets).map(([s, target]) => {
+      const actual = totalUnits > 0 ? ((distMap[s] ?? 0) / totalUnits) * 100 : 0;
+      const drift = Math.abs(actual - target);
+      return { status: s, count: distMap[s] ?? 0, actual: actual.toFixed(1), target, drift };
+    });
+    const failures = distReport.filter((r) => r.drift > TOLERANCE);
+    console.log(
+      `  Units: ${unitsCreated} generated across ${properties.length} properties` +
+      ` (${distMap.available ?? 0} available / ${distMap.leased ?? 0} leased / ${distMap.held ?? 0} held)`
+    );
+    if (failures.length > 0) {
+      const msg = failures.map((f) =>
+        `${f.status}: actual ${f.actual}% vs target ${f.target}% (drift ${f.drift.toFixed(1)} pp)`
+      ).join("; ");
+      throw new Error(`Seed distribution assertion failed — ${msg}. Fix unitStatus() or the seed data.`);
+    }
+    console.log(`  Distribution check passed: ${distReport.map((r) => `${r.status}=${r.actual}%`).join(" / ")}`);
 
     // Seed known problem addresses
     const problemAddresses = [

--- a/src/db/seed.ts
+++ b/src/db/seed.ts
@@ -42,123 +42,134 @@ async function seed() {
       console.log(`  User: ${user.email} (${user.role})`);
     }
 
-    // ── All 16 GPMGLV Properties ────────────────────────────────────
+    // ── Real GPMG (Greater Las Vegas) catalog — 17 properties ───────
+    // Source: operator-supplied list (2026-05-22), real names/addresses/phones/emails.
+    // Unit mixes are reasonable allocations (Studio+1BR for senior, 1BR–4BR for family)
+    // that sum to unit_count; refine when GPMG provides their actual unit breakdowns.
     const AMI = "Las Vegas-Henderson-Paradise, NV MSA";
+    const MGR = "GPMG Property Management"; // org-level (individual managers TBD)
     const properties = [
-      // Senior properties (5)
       {
-        name: "Louise Shell Senior Apartments", addressLine1: "2875 E Sahara Ave", city: "Las Vegas", zip: "89104",
-        unitCount: 120, phone: "702-555-0101", email: "louiseshell@gpmglv.org", propertyManager: "Patricia Morales",
-        propertyType: "senior", jurisdiction: "Las Vegas", totalVacancy: 3, waitingListEnabled: true,
-        unitMix: { "1BR": 80, "2BR": 40 },
-        rentSchedule: { "1BR_60AMI": 995, "2BR_60AMI": 1194 },
-      },
-      {
-        name: "Frank Hawkins Senior Apartments", addressLine1: "3100 W Washington Ave", city: "Las Vegas", zip: "89107",
-        unitCount: 100, phone: "702-555-0102", email: "frankhawkins@gpmglv.org", propertyManager: "Latonya Williams",
-        propertyType: "senior", jurisdiction: "Las Vegas", totalVacancy: 0, waitingListEnabled: true,
-        unitMix: { "1BR": 60, "2BR": 40 },
-        rentSchedule: { "1BR_60AMI": 995, "2BR_60AMI": 1194 },
-      },
-      {
-        name: "Heritage Park Senior", addressLine1: "1500 N Martin Luther King Blvd", city: "Las Vegas", zip: "89106",
-        unitCount: 80, phone: "702-555-0103", email: "heritagepark@gpmglv.org", propertyManager: "David Tran",
-        propertyType: "senior", jurisdiction: "Las Vegas", totalVacancy: 2, waitingListEnabled: false,
-        unitMix: { "1BR": 50, "2BR": 30 },
-        rentSchedule: { "1BR_60AMI": 995, "2BR_60AMI": 1194 },
-      },
-      {
-        name: "Carey Avenue Senior Living", addressLine1: "4200 E Carey Ave", city: "Las Vegas", zip: "89115",
-        unitCount: 60, phone: "702-555-0104", email: "careyave@gpmglv.org", propertyManager: "Maria Gonzalez",
+        name: "Aldene Kline Barlow Senior Apartments", addressLine1: "1327 H St", city: "Las Vegas", zip: "89106",
+        unitCount: 39, phone: "702-920-6550", email: "barlow@gpmglv.org", propertyManager: MGR,
         propertyType: "senior", jurisdiction: "Las Vegas", totalVacancy: 1, waitingListEnabled: true,
-        unitMix: { "1BR": 40, "2BR": 20 },
-        rentSchedule: { "1BR_60AMI": 995, "2BR_60AMI": 1194 },
+        unitMix: { "Studio": 10, "1BR": 29 },
+        rentSchedule: { "Studio_60AMI": 747, "1BR_60AMI": 995 },
       },
       {
-        name: "Desert Pines Senior", addressLine1: "3601 E Bonanza Rd", city: "Las Vegas", zip: "89110",
-        unitCount: 48, phone: "702-555-0105", email: "desertpines@gpmglv.org", propertyManager: "James Patterson",
-        propertyType: "senior", jurisdiction: "Las Vegas", totalVacancy: 0, waitingListEnabled: true,
-        unitMix: { "1BR": 32, "2BR": 16 },
-        rentSchedule: { "1BR_60AMI": 995, "2BR_60AMI": 1194 },
-      },
-      // Family properties (10)
-      {
-        name: "Cambridge Apartments", addressLine1: "4500 Cambridge St", city: "Las Vegas", zip: "89119",
-        unitCount: 200, phone: "702-555-0106", email: "cambridge@gpmglv.org", propertyManager: "Robert Jackson",
-        propertyType: "family", jurisdiction: "Las Vegas", totalVacancy: 8, waitingListEnabled: false,
-        unitMix: { "1BR": 40, "2BR": 80, "3BR": 60, "4BR": 20 },
-        rentSchedule: { "1BR_60AMI": 995, "2BR_60AMI": 1194, "3BR_60AMI": 1380, "4BR_60AMI": 1539 },
-      },
-      {
-        name: "Desert Oasis Apartments", addressLine1: "1234 Las Vegas Blvd S", city: "Las Vegas", zip: "89109",
-        unitCount: 120, phone: "702-555-0107", email: "desertoasis@gpmglv.org", propertyManager: "Angela Foster",
-        propertyType: "family", jurisdiction: "Las Vegas", totalVacancy: 5, waitingListEnabled: false,
-        unitMix: { "1BR": 30, "2BR": 50, "3BR": 40 },
-        rentSchedule: { "1BR_60AMI": 995, "2BR_60AMI": 1194, "3BR_60AMI": 1380 },
-      },
-      {
-        name: "Sunrise Gardens", addressLine1: "5678 E Sahara Ave", city: "Las Vegas", zip: "89142",
-        unitCount: 80, phone: "702-555-0108", email: "sunrisegardens@gpmglv.org", propertyManager: "Kevin Wright",
-        propertyType: "family", jurisdiction: "Las Vegas", totalVacancy: 2, waitingListEnabled: false,
-        unitMix: { "2BR": 40, "3BR": 40 },
-        rentSchedule: { "2BR_60AMI": 1194, "3BR_60AMI": 1380 },
-      },
-      {
-        name: "Crestview Family Homes", addressLine1: "900 N Nellis Blvd", city: "Las Vegas", zip: "89110",
-        unitCount: 150, phone: "702-555-0109", email: "crestview@gpmglv.org", propertyManager: "Sandra Mitchell",
+        name: "David J. Hoggard Family Community", addressLine1: "1100 W Monroe Ave", city: "Las Vegas", zip: "89106",
+        unitCount: 100, phone: "702-631-2281", email: "hoggard@gpmglv.org", propertyManager: MGR,
         propertyType: "family", jurisdiction: "Las Vegas", totalVacancy: 6, waitingListEnabled: false,
-        unitMix: { "2BR": 50, "3BR": 60, "4BR": 40 },
-        rentSchedule: { "2BR_60AMI": 1194, "3BR_60AMI": 1380, "4BR_60AMI": 1539 },
-      },
-      {
-        name: "Valley View Terrace", addressLine1: "2200 Valley View Blvd", city: "Henderson", zip: "89014",
-        unitCount: 96, phone: "702-555-0110", email: "valleyview@gpmglv.org", propertyManager: "Charles Adams",
-        propertyType: "family", jurisdiction: "Henderson", totalVacancy: 4, waitingListEnabled: false,
-        unitMix: { "1BR": 24, "2BR": 48, "3BR": 24 },
-        rentSchedule: { "1BR_60AMI": 995, "2BR_60AMI": 1194, "3BR_60AMI": 1380 },
-      },
-      {
-        name: "Boulder Highway Family", addressLine1: "4800 Boulder Hwy", city: "Henderson", zip: "89121",
-        unitCount: 110, phone: "702-555-0111", email: "boulderhwy@gpmglv.org", propertyManager: "Diana Ruiz",
-        propertyType: "family", jurisdiction: "Henderson", totalVacancy: 3, waitingListEnabled: true,
-        unitMix: { "2BR": 50, "3BR": 40, "4BR": 20 },
-        rentSchedule: { "2BR_60AMI": 1194, "3BR_60AMI": 1380, "4BR_60AMI": 1539 },
-      },
-      {
-        name: "Cheyenne Pointe", addressLine1: "3900 W Cheyenne Ave", city: "North Las Vegas", zip: "89032",
-        unitCount: 180, phone: "702-555-0112", email: "cheyenne@gpmglv.org", propertyManager: "Brian Thompson",
-        propertyType: "family", jurisdiction: "North Las Vegas", totalVacancy: 7, waitingListEnabled: false,
-        unitMix: { "1BR": 30, "2BR": 60, "3BR": 60, "4BR": 30 },
+        unitMix: { "1BR": 20, "2BR": 40, "3BR": 30, "4BR": 10 },
         rentSchedule: { "1BR_60AMI": 995, "2BR_60AMI": 1194, "3BR_60AMI": 1380, "4BR_60AMI": 1539 },
       },
       {
-        name: "Civic Center Family", addressLine1: "2100 Civic Center Dr", city: "North Las Vegas", zip: "89030",
-        unitCount: 72, phone: "702-555-0113", email: "civiccenter@gpmglv.org", propertyManager: "Lisa Nguyen",
-        propertyType: "family", jurisdiction: "North Las Vegas", totalVacancy: 1, waitingListEnabled: true,
-        unitMix: { "2BR": 36, "3BR": 36 },
-        rentSchedule: { "2BR_60AMI": 1194, "3BR_60AMI": 1380 },
-      },
-      {
-        name: "Tropicana Gardens", addressLine1: "5500 E Tropicana Ave", city: "Las Vegas", zip: "89122",
-        unitCount: 144, phone: "702-555-0114", email: "tropicana@gpmglv.org", propertyManager: "Mark Hernandez",
-        propertyType: "family", jurisdiction: "Las Vegas", totalVacancy: 4, waitingListEnabled: false,
-        unitMix: { "1BR": 24, "2BR": 60, "3BR": 48, "4BR": 12 },
-        rentSchedule: { "1BR_60AMI": 995, "2BR_60AMI": 1194, "3BR_60AMI": 1380, "4BR_60AMI": 1539 },
-      },
-      {
-        name: "Spring Mountain Place", addressLine1: "3200 Spring Mountain Rd", city: "Las Vegas", zip: "89102",
-        unitCount: 88, phone: "702-555-0115", email: "springmtn@gpmglv.org", propertyManager: "Jennifer Clarke",
-        propertyType: "family", jurisdiction: "Las Vegas", totalVacancy: 2, waitingListEnabled: false,
-        unitMix: { "1BR": 20, "2BR": 44, "3BR": 24 },
+        name: "Donna Louise Apartments", addressLine1: "6225 Donna St", city: "North Las Vegas", zip: "89081",
+        unitCount: 48, phone: "702-920-6548", email: "donnalouise@gpmglv.org", propertyManager: MGR,
+        propertyType: "family", jurisdiction: "North Las Vegas", totalVacancy: 2, waitingListEnabled: false,
+        unitMix: { "1BR": 12, "2BR": 24, "3BR": 12 },
         rentSchedule: { "1BR_60AMI": 995, "2BR_60AMI": 1194, "3BR_60AMI": 1380 },
       },
-      // Mixed-use (1)
       {
-        name: "Charleston Gateway", addressLine1: "1800 E Charleston Blvd", city: "Las Vegas", zip: "89104",
-        unitCount: 160, phone: "702-555-0116", email: "charleston@gpmglv.org", propertyManager: "Anthony Brooks",
-        propertyType: "mixed_use", jurisdiction: "Las Vegas", totalVacancy: 5, waitingListEnabled: false,
-        unitMix: { "Studio": 20, "1BR": 40, "2BR": 60, "3BR": 40 },
-        rentSchedule: { "Studio_60AMI": 747, "1BR_60AMI": 995, "2BR_60AMI": 1194, "3BR_60AMI": 1380 },
+        // Donna Louise 2 unit count not in source → assumed 48 (twin building, same address).
+        name: "Donna Louise Apartments 2", addressLine1: "6225 Donna St", city: "North Las Vegas", zip: "89081",
+        unitCount: 48, phone: "702-920-6548", email: "donnalouise@gpmglv.org", propertyManager: MGR,
+        propertyType: "family", jurisdiction: "North Las Vegas", totalVacancy: 2, waitingListEnabled: false,
+        unitMix: { "1BR": 12, "2BR": 24, "3BR": 12 },
+        rentSchedule: { "1BR_60AMI": 995, "2BR_60AMI": 1194, "3BR_60AMI": 1380 },
+      },
+      {
+        name: "Luther Mack, Jr. Senior Apartments", addressLine1: "8158 Giles St", city: "Las Vegas", zip: "89123",
+        unitCount: 48, phone: "702-920-6569", email: "drluthermack@gpmglv.org", propertyManager: MGR,
+        propertyType: "senior", jurisdiction: "Las Vegas", totalVacancy: 1, waitingListEnabled: true,
+        unitMix: { "Studio": 12, "1BR": 36 },
+        rentSchedule: { "Studio_60AMI": 747, "1BR_60AMI": 995 },
+      },
+      {
+        name: "Dr. Paul Meacham Senior Community", addressLine1: "65 E Windmill Ln", city: "Las Vegas", zip: "89123",
+        unitCount: 57, phone: "877-895-8207", email: "paulmeacham@gpmglv.org", propertyManager: MGR,
+        propertyType: "senior", jurisdiction: "Las Vegas", totalVacancy: 1, waitingListEnabled: true,
+        unitMix: { "Studio": 15, "1BR": 42 },
+        rentSchedule: { "Studio_60AMI": 747, "1BR_60AMI": 995 },
+      },
+      {
+        name: "Ethel Mae Fletcher Apartments", addressLine1: "1503 Laurelhurst Dr", city: "Las Vegas", zip: "89108",
+        unitCount: 42, phone: "702-920-6572", email: "ethelmaefletcher@gpmglv.org", propertyManager: MGR,
+        propertyType: "senior", jurisdiction: "Las Vegas", totalVacancy: 1, waitingListEnabled: true,
+        unitMix: { "Studio": 10, "1BR": 32 },
+        rentSchedule: { "Studio_60AMI": 747, "1BR_60AMI": 995 },
+      },
+      {
+        name: "Ethel Mae Robinson Senior Apartments", addressLine1: "1327 H Street", city: "Las Vegas", zip: "89106",
+        unitCount: 20, phone: "702-648-6800", email: "ethelmaerobinson@gpmglv.org", propertyManager: MGR,
+        propertyType: "senior", jurisdiction: "Las Vegas", totalVacancy: 0, waitingListEnabled: true,
+        unitMix: { "Studio": 5, "1BR": 15 },
+        rentSchedule: { "Studio_60AMI": 747, "1BR_60AMI": 995 },
+      },
+      {
+        name: "Mike O'Callaghan Legacy Apartments", addressLine1: "1502 Laurelhurst Dr", city: "Las Vegas", zip: "89108",
+        unitCount: 40, phone: "725-735-7779", email: "mikeocallaghan@gpmglv.org", propertyManager: MGR,
+        propertyType: "senior", jurisdiction: "Las Vegas", totalVacancy: 1, waitingListEnabled: true,
+        unitMix: { "Studio": 10, "1BR": 30 },
+        rentSchedule: { "Studio_60AMI": 747, "1BR_60AMI": 995 },
+      },
+      {
+        name: "Juan Garcia Garden Apartments", addressLine1: "2851 Sunrise Ave", city: "Las Vegas", zip: "89101",
+        unitCount: 52, phone: "725-735-7779", email: "juangarcia@gpmglv.org", propertyManager: MGR,
+        propertyType: "family", jurisdiction: "Las Vegas", totalVacancy: 3, waitingListEnabled: false,
+        unitMix: { "1BR": 12, "2BR": 26, "3BR": 14 },
+        rentSchedule: { "1BR_60AMI": 995, "2BR_60AMI": 1194, "3BR_60AMI": 1380 },
+      },
+      {
+        name: "Louise Shell Senior Apartments", addressLine1: "2101 N Martin Luther King Blvd", city: "Las Vegas", zip: "89106",
+        unitCount: 100, phone: "702-648-6800", email: "louiseshell@gpmglv.org", propertyManager: MGR,
+        propertyType: "senior", jurisdiction: "Las Vegas", totalVacancy: 2, waitingListEnabled: true,
+        unitMix: { "Studio": 20, "1BR": 70, "2BR": 10 },
+        rentSchedule: { "Studio_60AMI": 747, "1BR_60AMI": 995, "2BR_60AMI": 1194 },
+      },
+      {
+        name: "Owens Senior Housing", addressLine1: "1626 Davis Pl", city: "North Las Vegas", zip: "89030",
+        unitCount: 72, phone: "702-642-0896", email: "owens@gpmglv.org", propertyManager: MGR,
+        propertyType: "senior", jurisdiction: "North Las Vegas", totalVacancy: 1, waitingListEnabled: true,
+        unitMix: { "Studio": 18, "1BR": 54 },
+        rentSchedule: { "Studio_60AMI": 747, "1BR_60AMI": 995 },
+      },
+      {
+        name: "Sarann Knight Apartments", addressLine1: "1327 H Street", city: "Las Vegas", zip: "89106",
+        unitCount: 82, phone: "702-538-9031", email: "sarannknight@gpmglv.org", propertyManager: MGR,
+        propertyType: "senior", jurisdiction: "Las Vegas", totalVacancy: 2, waitingListEnabled: true,
+        unitMix: { "Studio": 20, "1BR": 62 },
+        rentSchedule: { "Studio_60AMI": 747, "1BR_60AMI": 995 },
+      },
+      {
+        name: "Senator Harry Reid Senior Apartments", addressLine1: "328 N 11th St", city: "Las Vegas", zip: "89101",
+        unitCount: 100, phone: "702-383-1091", email: "harryreid@gpmglv.org", propertyManager: MGR,
+        propertyType: "senior", jurisdiction: "Las Vegas", totalVacancy: 2, waitingListEnabled: true,
+        unitMix: { "Studio": 20, "1BR": 70, "2BR": 10 },
+        rentSchedule: { "Studio_60AMI": 747, "1BR_60AMI": 995, "2BR_60AMI": 1194 },
+      },
+      {
+        name: "Senator Richard Bryan Senior Apartments", addressLine1: "2651 Searles Ave", city: "Las Vegas", zip: "89101",
+        unitCount: 120, phone: "702-649-3508", email: "senatorrichardbryan@gpmglv.org", propertyManager: MGR,
+        propertyType: "senior", jurisdiction: "Las Vegas", totalVacancy: 3, waitingListEnabled: true,
+        unitMix: { "Studio": 30, "1BR": 80, "2BR": 10 },
+        rentSchedule: { "Studio_60AMI": 747, "1BR_60AMI": 995, "2BR_60AMI": 1194 },
+      },
+      {
+        // Email not in source → derived from name slug to keep `@gpmglv.org` convention.
+        name: "Smith Williams Senior Apartments", addressLine1: "575 E Lake Mead Pkwy", city: "Henderson", zip: "89015",
+        unitCount: 80, phone: "702-382-3726", email: "smithwilliams@gpmglv.org", propertyManager: MGR,
+        propertyType: "senior", jurisdiction: "Henderson", totalVacancy: 2, waitingListEnabled: true,
+        unitMix: { "Studio": 20, "1BR": 60 },
+        rentSchedule: { "Studio_60AMI": 747, "1BR_60AMI": 995 },
+      },
+      {
+        // Email not in source → derived from name slug to keep `@gpmglv.org` convention.
+        name: "Yale Keyes Senior Apartments", addressLine1: "1705 Yale Str", city: "North Las Vegas", zip: "89030",
+        unitCount: 70, phone: "702-642-7758", email: "yalekeyes@gpmglv.org", propertyManager: MGR,
+        propertyType: "senior", jurisdiction: "North Las Vegas", totalVacancy: 1, waitingListEnabled: true,
+        unitMix: { "Studio": 18, "1BR": 52 },
+        rentSchedule: { "Studio_60AMI": 747, "1BR_60AMI": 995 },
       },
     ];
 

--- a/src/modules/applicants/routes.ts
+++ b/src/modules/applicants/routes.ts
@@ -243,6 +243,50 @@ router.post("/apply", authenticate, requireEmailVerified, async (req: AuthReques
   }
 });
 
+// Applicant self-submit: flip the user's draft application to `submitted`
+// after the apply-wizard payment step completes. The staff endpoint at
+// `/applications/:id/submit` is gated by RBAC (`application:submit`); this
+// route is the applicant-scoped counterpart, gated by user_applications
+// ownership rather than RBAC.
+router.post(
+  "/me/applications/submit-draft",
+  authenticate,
+  requireEmailVerified,
+  async (req: AuthRequest, res: Response): Promise<void> => {
+    try {
+      if (!req.user || !["applicant", "tenant"].includes(req.user.role)) {
+        res.status(403).json({ error: "Applicant role required" });
+        return;
+      }
+
+      const draft = await query(
+        `SELECT a.id FROM user_applications ua
+           JOIN applications a ON a.id = ua.application_id
+          WHERE ua.user_id = $1 AND a.status = 'draft'
+          ORDER BY a.created_at DESC
+          LIMIT 1`,
+        [req.user.id]
+      );
+
+      if (draft.rows.length === 0) {
+        res.status(404).json({ error: "No draft application to submit" });
+        return;
+      }
+
+      const result = await applicationService.submit(
+        draft.rows[0].id,
+        req.user.id,
+        req.user.role
+      );
+
+      res.json(result);
+    } catch (err: any) {
+      logger.error("Applicant submit-draft failed", { error: (err as Error).message });
+      res.status(500).json({ error: "Failed to submit application" });
+    }
+  }
+);
+
 // Public-ish: BP-03b waitlist position summary for a property slug.
 // DL2 MVP: hardcoded placeholder shape until the waitlist service lands.
 // `:slug` is currently ignored beyond echoing it back; the picker UI just

--- a/src/modules/tape/routes.ts
+++ b/src/modules/tape/routes.ts
@@ -92,8 +92,11 @@ router.post("/welcome-accept", beaconLimiter, async (req: Request, res: Response
 // BP-08 owns real Stripe wiring; this is scaffold-only.
 const paymentBeaconSchema = z.object({
   session_id: z.string().min(1).max(128),
-  adults: z.number().int().nonnegative().optional(),
-  total: z.number().nonnegative().optional(),
+  // Coerce so the client can send numeric strings ("71.90") or numbers.
+  // StepPayment passes state.paymentTotal which is a formatted decimal string;
+  // future Stripe wiring may pass a number. Both must pass schema.
+  adults: z.coerce.number().int().nonnegative().optional(),
+  total: z.coerce.number().nonnegative().optional(),
 });
 
 function makePaymentBeacon(kindKey: "BP03B_PAYMENT_INITIATED" | "BP03B_PAYMENT_SUCCEEDED", label: string) {


### PR DESCRIPTION
## Summary

Demo-readiness rollup for the Frank / GPMG walkthrough. Ten commits, three themes:

**HF design system pass**
- `69d4512`, `b206ae2` — warm-white/terracotta/sage tokens applied across Layout shell + auth + carousel + ~20 tenant + apply surfaces
- `c82bd60` — Apply wizard end-to-end hardening (StepClaim, StepPick, StepChecklist, StepPayment)

**Discover + Apply content & flow**
- `26023dd` — 17 real GPMG Las Vegas properties replace placeholder fakes; photography-first browse; PropertyDetail / PropertyList overhauled
- `4010484` — `submit-draft` route + StepPayment wires it; `/status` gets the terracotta stage tracker (Draft → Submitted now flips correctly)

**Infra + tests**
- `1bf5d9d` — client honors `VITE_API_BASE_URL` for cross-origin prod API
- `97b356a` — `railway-bootstrap.sh` + `post-deploy-verify.mjs`
- `f841268` — smoke probes the SPA shell instead of hydrated runtime text
- `913d59f` — Apply integration test pins `PAYMENT_WIZARD_ENABLED=false` for its legacy `?step=2` path (mocks `@/lib/flags` because `import.meta.env` is cached at module load)

**Stats:** 44 files, +3016 / -1110

## Test plan

- [x] `cd client-tenant && npm test` — 21/21 files, 110/110 tests
- [x] `npm test` (backend jest) — 40/42 suites (`email-service.test.ts` pre-existing failure on missing `resend` module, unrelated)
- [x] Magic-link flow walked end-to-end: request → devLink → verify → JWT → `/me`
- [x] `POST /me/applications/submit-draft` flipped a live draft → submitted with timestamp (the bug from `4010484` confirmed fixed)
- [x] All 9 tunnel routes return 200 (Discover, Apply, Login, 3 property detail slugs, Status, Dashboard)
- [ ] CI: smoke-apply + test 18/20/22 (required by branch protection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)