### PR TITLE
test(apply): pin PAYMENT_WIZARD_ENABLED off in legacy integration test

### DIFF
--- a/client-tenant/src/pages/apply/__tests__/Apply.integration.test.tsx
+++ b/client-tenant/src/pages/apply/__tests__/Apply.integration.test.tsx
@@ -5,6 +5,16 @@ import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom';
 import { Apply } from '../../Apply';
 import { setToken } from '@/api/client';
 
+// This integration test walks the legacy `?step=2` (Step2Details) flow.
+// `.env.local` ships PAYMENT_WIZARD_ENABLED=true for dev, which would route
+// past Step2Details into the Lane-W wizard (Review/Household/Payment/Confirm)
+// — those steps have their own per-step tests. Pin the flag off here so this
+// suite stays the legacy-path canary. flags.ts caches `import.meta.env` at
+// module load, so stubEnv is too late; mock the module instead.
+vi.mock('@/lib/flags', () => ({
+  useFlag: (name: string) => name !== 'PAYMENT_WIZARD_ENABLED',
+}));
+
 // One mock fetch covering every endpoint the flow touches.
 function installFetch() {
   const fn = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {


### PR DESCRIPTION
## Summary
- `Apply.integration.test.tsx` walks the legacy `?step=2` (Step2Details) flow. When a dev has `VITE_PAYMENT_WIZARD_ENABLED=true` in `.env.local` (which the repo ships for local dev), `StepClaim` routes to `step='review'` (Lane-W wizard) instead and the test fails finding the "application details" heading.
- `flags.ts` captures `import.meta.env` at module load, so `vi.stubEnv` is too late. Mock the module directly with `vi.mock('@/lib/flags', ...)` so the legacy-path canary stays deterministic regardless of `.env.local`.
- CI passes without this fix today (CI has no `.env.local`) — this is a local-dev determinism fix. Wizard-on path has its own per-step tests.

## Backstory
This was the only unique commit on the closed PR #67 (the rest of #67 was independently shipped via #66). Reopening as a one-file PR.

## Test plan
- [x] `npx vitest run src/pages/apply/__tests__/Apply.integration.test.tsx` — 3/3 pass on fresh branch with `.env.local` containing `VITE_PAYMENT_WIZARD_ENABLED=true`
- [ ] CI smoke-apply + node 18/20/22 matrix green

🤖 Generated with [Claude Code](https://claude.com/claude-code)