### PR TITLE
feat(ami): finish W0 Phase 2 — embed calculator in wizard + landing mount + units?amiTier filter (gpmglv wedge #2)

### DIFF
--- a/client-tenant/src/i18n/en/apply.json
+++ b/client-tenant/src/i18n/en/apply.json
@@ -54,6 +54,14 @@
       "2": "2 BR",
       "3": "3 BR",
       "4plus": "4+ BR"
+    },
+    "ami": {
+      "sectionTitle": "Income — for affordable pre-qualification",
+      "sectionHint": "Optional. We use this to show you only the units you qualify for.",
+      "incomeLabel": "Gross annual income (USD)",
+      "incomePlaceholder": "e.g. 42000",
+      "qualifies": "You qualify for {{tier}} units.",
+      "overIncome": "Over income for affordable tiers. Market-rate units may still fit."
     }
   },
   "checklist": {

--- a/client-tenant/src/i18n/es/apply.json
+++ b/client-tenant/src/i18n/es/apply.json
@@ -54,6 +54,14 @@
       "2": "2 Rec",
       "3": "3 Rec",
       "4plus": "4+ Rec"
+    },
+    "ami": {
+      "sectionTitle": "Ingresos — para precalificación asequible",
+      "sectionHint": "Opcional. Lo usamos para mostrarte solo las unidades para las que calificas.",
+      "incomeLabel": "Ingreso anual bruto (USD)",
+      "incomePlaceholder": "ej. 42000",
+      "qualifies": "Calificas para unidades {{tier}}.",
+      "overIncome": "Sobre el límite de ingresos para tarifas asequibles. Aún pueden encajar unidades a precio de mercado."
     }
   },
   "checklist": {

--- a/client-tenant/src/pages/apply/steps/StepIntent.tsx
+++ b/client-tenant/src/pages/apply/steps/StepIntent.tsx
@@ -237,19 +237,36 @@ export function StepIntent() {
             ))}
           </select>
         </div>
-        <div>
+        <div
+          style={{
+            marginTop: 8,
+            paddingTop: 12,
+            borderTop: `1px dashed ${HF.border}`,
+          }}
+        >
+          <div
+            style={{
+              fontFamily: HF.display,
+              fontSize: 13,
+              fontWeight: 700,
+              color: HF.ink,
+              letterSpacing: 0.2,
+            }}
+          >
+            {t('intent.ami.sectionTitle')}
+          </div>
+          <div style={{ fontSize: 12, color: HF.ink3, marginTop: 2, marginBottom: 8 }}>
+            {t('intent.ami.sectionHint')}
+          </div>
           <label style={labelStyle} htmlFor="intentIncome">
-            Gross annual income (USD)
-            <span className="ml-2 text-xs" style={{ fontWeight: 400, color: HF.ink3 }}>
-              Optional — used to pre-qualify you for affordable units.
-            </span>
+            {t('intent.ami.incomeLabel')}
           </label>
           <input
             id="intentIncome"
             type="text"
             inputMode="numeric"
             style={inputStyle}
-            placeholder="e.g. 42000"
+            placeholder={t('intent.ami.incomePlaceholder')}
             value={incomeStr}
             onChange={(e) => setIncomeStr(e.target.value)}
             aria-describedby="intentIncomeStatus"
@@ -262,11 +279,11 @@ export function StepIntent() {
           >
             {incomeNum == null ? null : previewTier ? (
               <span style={{ fontWeight: 500, color: HF.sage }}>
-                You qualify for {formatAmiTier(previewTier)} units.
+                {t('intent.ami.qualifies', { tier: formatAmiTier(previewTier) })}
               </span>
             ) : (
               <span style={{ fontWeight: 500, color: HF.warn }}>
-                Over income for affordable tiers. Market-rate units may still fit.
+                {t('intent.ami.overIncome')}
               </span>
             )}
           </div>

--- a/src/__tests__/unit-claim.test.ts
+++ b/src/__tests__/unit-claim.test.ts
@@ -244,6 +244,96 @@ describe("GET /applicants/units", () => {
       .set("Authorization", `Bearer ${token}`);
     expect(res.status).toBe(403);
   });
+
+  // W0 — AMI tier filter coverage. The filter is the backend half of the
+  // landing → apply → discover cold-open: visitor types income on the
+  // welcome calculator, the tier flows into `qualifyingAmiTier`, and the
+  // unit list shows only set-asides at-or-above that tier.
+  describe("?amiTier= filter (W0)", () => {
+    it("with amiTier=50 — restricts set-aside whitelist to ['50','60','80']% AMI", async () => {
+      mockUsersRow(applicant, VERIFIED_AT);
+      mockQuery.mockResolvedValueOnce({ rows: [] } as any);
+      const token = generateToken(applicant);
+      const res = await request(app)
+        .get("/applicants/units?amiTier=50")
+        .set("Authorization", `Bearer ${token}`);
+      expect(res.status).toBe(200);
+      const sql = mockQuery.mock.calls[1][0] as string;
+      const params = mockQuery.mock.calls[1][1] as unknown[];
+      // Filter is appended as an ANY($n) clause on p.ami_set_aside, with the
+      // market-rate (null/empty) fallback preserved so unaffordable applicants
+      // still see market-rate inventory when no tier matches.
+      expect(sql).toContain("p.ami_set_aside = ANY($1)");
+      expect(sql).toContain("p.ami_set_aside IS NULL OR p.ami_set_aside = ''");
+      expect(params).toEqual([["50% AMI", "60% AMI", "80% AMI"]]);
+    });
+
+    it("with amiTier=30 — includes every higher tier in the whitelist", async () => {
+      mockUsersRow(applicant, VERIFIED_AT);
+      mockQuery.mockResolvedValueOnce({ rows: [] } as any);
+      const token = generateToken(applicant);
+      const res = await request(app)
+        .get("/applicants/units?amiTier=30")
+        .set("Authorization", `Bearer ${token}`);
+      expect(res.status).toBe(200);
+      const params = mockQuery.mock.calls[1][1] as unknown[];
+      expect(params).toEqual([["30% AMI", "50% AMI", "60% AMI", "80% AMI"]]);
+    });
+
+    it("with amiTier=80 — whitelist contains only the top tier", async () => {
+      mockUsersRow(applicant, VERIFIED_AT);
+      mockQuery.mockResolvedValueOnce({ rows: [] } as any);
+      const token = generateToken(applicant);
+      const res = await request(app)
+        .get("/applicants/units?amiTier=80")
+        .set("Authorization", `Bearer ${token}`);
+      expect(res.status).toBe(200);
+      const params = mockQuery.mock.calls[1][1] as unknown[];
+      expect(params).toEqual([["80% AMI"]]);
+    });
+
+    it("rejects an invalid amiTier value with 400 (loud, not silent drop)", async () => {
+      mockUsersRow(applicant, VERIFIED_AT);
+      const token = generateToken(applicant);
+      const res = await request(app)
+        .get("/applicants/units?amiTier=70")
+        .set("Authorization", `Bearer ${token}`);
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatch(/invalid amiTier/i);
+      expect(res.body.allowed).toEqual(["30", "50", "60", "80"]);
+      // No DB query should have been issued for the units fetch (auth row is
+      // already shifted off the queue at this point).
+      expect(mockQuery).toHaveBeenCalledTimes(1);
+    });
+
+    it("rejects garbage strings with 400 (no SQL injection vector)", async () => {
+      mockUsersRow(applicant, VERIFIED_AT);
+      const token = generateToken(applicant);
+      const res = await request(app)
+        .get("/applicants/units?amiTier=' OR '1'='1")
+        .set("Authorization", `Bearer ${token}`);
+      expect(res.status).toBe(400);
+      expect(mockQuery).toHaveBeenCalledTimes(1);
+    });
+
+    it("without amiTier — returns the full list (no AMI condition appended)", async () => {
+      mockUsersRow(applicant, VERIFIED_AT);
+      mockQuery.mockResolvedValueOnce({
+        rows: [
+          { id: "u1", monthly_rent: 1500 },
+          { id: "u2", monthly_rent: 1600 },
+        ],
+      } as any);
+      const token = generateToken(applicant);
+      const res = await request(app)
+        .get("/applicants/units")
+        .set("Authorization", `Bearer ${token}`);
+      expect(res.status).toBe(200);
+      expect(res.body.units).toHaveLength(2);
+      const sql = mockQuery.mock.calls[1][0] as string;
+      expect(sql).not.toMatch(/p\.ami_set_aside = ANY/);
+    });
+  });
 });
 
 describe("POST /applicants/claim-unit/:id", () => {

--- a/src/modules/applicants/routes.ts
+++ b/src/modules/applicants/routes.ts
@@ -785,15 +785,27 @@ router.get(
       const propertyId = typeof req.query.propertyId === "string" ? req.query.propertyId : undefined;
 
       // W0 AMI filter — narrow to set-asides the applicant qualifies for.
-      // Tier '50' qualifies for ['50','60','80']% units (and market-rate);
-      // missing/invalid param → no filter (permissive default).
+      // Tier '50' qualifies for ['50','60','80']% units (and market-rate).
+      // The legal set is the union from `client-tenant/src/lib/ami.ts:AmiTier`
+      // (HUD LIHTC tier table). Validate strictly so that a typo in the
+      // query string (`?amiTier=70`) becomes a loud 400 instead of a silent
+      // "full list" surprise — this matches the W0 contract that any tier
+      // shown to the user must be one the calculator actually emits.
       const AMI_TIER_ORDER = ["30", "50", "60", "80"] as const;
-      const amiTierRaw =
-        typeof req.query.amiTier === "string" ? req.query.amiTier : undefined;
-      const amiTier =
-        amiTierRaw && (AMI_TIER_ORDER as readonly string[]).includes(amiTierRaw)
-          ? (amiTierRaw as (typeof AMI_TIER_ORDER)[number])
-          : undefined;
+      const amiTierSchema = z.enum(AMI_TIER_ORDER);
+      let amiTier: (typeof AMI_TIER_ORDER)[number] | undefined;
+      if (req.query.amiTier !== undefined) {
+        const parsed = amiTierSchema.safeParse(req.query.amiTier);
+        if (!parsed.success) {
+          res.status(400).json({
+            error: "Invalid amiTier",
+            details: parsed.error.errors,
+            allowed: AMI_TIER_ORDER,
+          });
+          return;
+        }
+        amiTier = parsed.data;
+      }
 
       const conditions: string[] = [
         "(u.status = 'available' OR (u.status = 'held' AND u.claim_expires_at < NOW()))",


### PR DESCRIPTION
## Summary

Closes out the **AMI pre-qualifier wedge #2** from the gpmglv competitive teardown. Phase 1 already shipped the calculator component, ApplyContext fields, wizardTestUtils extension, StepReview integration, and the WelcomeShell landing mount. This PR finishes the contract:

- **Backend hardening**: `/applicants/units?amiTier=` now strictly validates with zod and returns a loud `400 { error, allowed[] }` on a bad tier. The previous silent-drop fallback ("invalid? return everything") was a surprise vector for the W0 surface — any tier the API accepts must be one the calculator actually emits (`30 | 50 | 60 | 80`).
- **i18n**: extracts the inline AMI copy in `StepIntent` to `intent.ami.*` keys (EN + ES) — `sectionTitle`, `sectionHint`, `incomeLabel`, `incomePlaceholder`, `qualifies`, `overIncome`. Wraps the income input in a section header so the surface reads as deliberate instead of bolted-on.

## Files

- `src/modules/applicants/routes.ts` — zod enum + 400 on invalid amiTier
- `src/__tests__/unit-claim.test.ts` — 6 new tests for the filter contract
- `client-tenant/src/pages/apply/steps/StepIntent.tsx` — i18n + section heading
- `client-tenant/src/i18n/en/apply.json` — `intent.ami` block
- `client-tenant/src/i18n/es/apply.json` — `intent.ami` block (Spanish)

## Design notes (UX seam)

**Why no literal `<AmiCalculator/>` embed inside `StepIntent`'s form**: the calculator renders its own `<form>` and `onResult` only fires on calculator submit. Nesting a form is invalid HTML; if `hideCta` suppressed the submit, `onResult` would never fire. The existing hand-rolled inline implementation already satisfies the functional contract — captures income → computes tier via `qualifyAmiTier()` → persists to `ApplyContext` (`grossAnnualIncome`, `qualifyingAmiTier`, `qualifyingAmiCalculatedAt`, `qualifyingHouseholdSize`). Keeping the calculator hardcoded inside `StepIntent` also preserves the 8 `AmiCalculator` tests untouched.

**Landing mount note**: WelcomeShell forwards `?hh=&income=&amiTier=` to **`/apply`** (the wizard) rather than `/discover` as the prompt suggested. `/discover` is owned by another agent in flight on wedge #8 — the constraint explicitly forbade touching it. The handoff target is still functionally correct: the wizard's StepIntent prefill picks the params up post-verify and the user lands on Pick with the same AMI-aware unit list.

## Out of scope

Per "don't widen the wedge":
- Confetti, email reminders, multi-language tier explanations beyond a single label
- `AmiCalculator`'s own copy stays hardcoded (touching it would break shipped tests, not required for Phase 2)
- `/discover` deep-link target swap (wedge #8 territory)

## Test plan

- [x] `client-tenant`: 112/112 vitest pass
- [x] `server`: 30/30 `unit-claim.test.ts` pass (24 prior + 6 new W0 filter tests)
- [x] `server` full suite: 827/842 pass, 1 pre-existing fail (`email-service.test.ts` — `resend` package not in node_modules, unrelated to this PR), 14 skipped
- [x] `tsc -b` clean on both packages
- [x] HF tokens only (no raw hex introduced)
- [x] EN + ES copy parity for new strings
- [ ] CI smoke-apply green
- [ ] CI test 18/20/22 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)