### PR TITLE
fix(qa): clear qaBuffer after snapshot so subsequent clicks aren't poisoned

### DIFF
--- a/client-tenant/src/components/dev/ScreenshotButton.tsx
+++ b/client-tenant/src/components/dev/ScreenshotButton.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Camera, Check, X, Loader2, Copy } from 'lucide-react';
-import { getQaBuffer, type QaEntry } from '@/lib/qaBuffer';
+import { getQaBuffer, clearQaBuffer, type QaEntry } from '@/lib/qaBuffer';
 
 const STORAGE_KEY = 'frank_qa';
 const TOKEN_KEY = 'frank_tenant_token';
@@ -144,8 +144,10 @@ export function ScreenshotButton() {
     try {
       // Snapshot the qaBuffer BEFORE toPng() runs — html-to-image inlines fonts
       // by fetching them, which would otherwise flood the 25-entry buffer and
-      // push real app traffic out.
+      // push real app traffic out. Then clear so the next camera click starts
+      // fresh and doesn't inherit this click's font-fetch + self-upload noise.
       const qaSnapshot = getQaBuffer();
+      clearQaBuffer();
 
       const { toPng } = await import('html-to-image');
       const node = document.body;


### PR DESCRIPTION
The original 2 commits from this PR already shipped to main via PR #73 (stacked merge). This PR now carries only the follow-up fix.

## Summary

- Each camera click triggers `html-to-image` (which fetches fonts) and our own PNG + JSON uploads. Without clearing, the next click's snapshot inherits all that noise and the 25-entry cap pushes out real app traffic.
- One-line behavior change: after snapshotting the buffer (already done before `toPng`), now also `clearQaBuffer()` so each click starts fresh.

## Tunnel verification

| State | qaBuffer contents (route `/login` after magic-link POST) |
|-------|-------|
| Before this fix, 2nd click | 22 font GETs + 1 data: URL + 2 self-uploads (real POST pushed out) |
| After this fix, 2nd click | 1 entry: `POST /api/auth/magic-link/request` 200 821ms (JSON shrunk 130KB → 1KB) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)