### PR TITLE
feat(deploy): wire prod /api/* to live Railway backend

### DIFF
--- a/.railwayignore
+++ b/.railwayignore
@@ -1,0 +1,11 @@
+.claude/
+client-tenant/node_modules/
+client-tenant/dist/
+node_modules/
+dist/
+logs/
+*.log
+.DS_Store
+.git/
+docs/intel/raw/
+server/tape/*.ndjson

--- a/client-tenant/.env.example
+++ b/client-tenant/.env.example
@@ -13,3 +13,11 @@ VITE_API_BASE_URL=
 VITE_PROPERTY_DL2_ENABLED=true
 VITE_MOBILE_APPLY_ENABLED=true
 VITE_PAYMENT_WIZARD_ENABLED=false
+
+# QA / debug screenshot button (src/components/dev/ScreenshotButton.tsx).
+# When both are set, the camera button uploads the screenshot AND a debug
+# JSON sidecar to the `frank-qa-screenshots` bucket, then copies both URLs
+# to the clipboard for pasting into Claude. Leave empty to disable upload
+# (button still works, only triggers local download).
+VITE_SUPABASE_URL=
+VITE_SUPABASE_PUBLISHABLE_KEY=

--- a/client-tenant/src/components/dev/ScreenshotButton.tsx
+++ b/client-tenant/src/components/dev/ScreenshotButton.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Camera, Check, X, Loader2, Copy } from 'lucide-react';
-import { getQaBuffer } from '@/lib/qaBuffer';
+import { getQaBuffer, type QaEntry } from '@/lib/qaBuffer';
 
 const STORAGE_KEY = 'frank_qa';
 const TOKEN_KEY = 'frank_tenant_token';
@@ -81,7 +81,7 @@ function dumpStorage(store: Storage | undefined): Record<string, string> {
   return out;
 }
 
-function buildDebugPayload(pngUrl: string | null): Record<string, unknown> {
+function buildDebugPayload(pngUrl: string | null, qaBufferSnapshot: QaEntry[]): Record<string, unknown> {
   const token = (() => { try { return window.localStorage.getItem(TOKEN_KEY); } catch { return null; } })();
   const claims = token ? decodeJwtClaims(token) : null;
   return {
@@ -116,7 +116,7 @@ function buildDebugPayload(pngUrl: string | null): Record<string, unknown> {
       localStorage: dumpStorage(typeof window !== 'undefined' ? window.localStorage : undefined),
       sessionStorage: dumpStorage(typeof window !== 'undefined' ? window.sessionStorage : undefined),
     },
-    qaBuffer: getQaBuffer(),
+    qaBuffer: qaBufferSnapshot,
   };
 }
 
@@ -142,6 +142,11 @@ export function ScreenshotButton() {
     setMsg('');
     setBundle(null);
     try {
+      // Snapshot the qaBuffer BEFORE toPng() runs — html-to-image inlines fonts
+      // by fetching them, which would otherwise flood the 25-entry buffer and
+      // push real app traffic out.
+      const qaSnapshot = getQaBuffer();
+
       const { toPng } = await import('html-to-image');
       const node = document.body;
       const dataUrl = await toPng(node, {
@@ -186,7 +191,7 @@ export function ScreenshotButton() {
         return;
       }
 
-      const debugPayload = buildDebugPayload(pngUrl);
+      const debugPayload = buildDebugPayload(pngUrl, qaSnapshot);
       let jsonUrl: string;
       try {
         jsonUrl = await uploadToSupabase(JSON.stringify(debugPayload, null, 2), jsonName, 'application/json');

--- a/client-tenant/src/components/dev/ScreenshotButton.tsx
+++ b/client-tenant/src/components/dev/ScreenshotButton.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useState } from 'react';
 import { Camera, Check, X, Loader2, Copy } from 'lucide-react';
+import { getQaBuffer } from '@/lib/qaBuffer';
 
 const STORAGE_KEY = 'frank_qa';
+const TOKEN_KEY = 'frank_tenant_token';
 
 const SUPA_URL = import.meta.env.VITE_SUPABASE_URL as string | undefined;
 const SUPA_KEY = import.meta.env.VITE_SUPABASE_PUBLISHABLE_KEY as string | undefined;
@@ -38,33 +40,99 @@ async function dataUrlToBlob(dataUrl: string): Promise<Blob> {
   return (await fetch(dataUrl)).blob();
 }
 
-async function uploadToSupabase(blob: Blob, filename: string): Promise<string> {
+async function uploadToSupabase(body: BodyInit, filename: string, contentType: string): Promise<string> {
   if (!SUPA_URL || !SUPA_KEY) throw new Error('Supabase storage env vars missing');
-  const path = `${filename}`;
-  const res = await fetch(`${SUPA_URL}/storage/v1/object/${BUCKET}/${path}`, {
+  const res = await fetch(`${SUPA_URL}/storage/v1/object/${BUCKET}/${filename}`, {
     method: 'POST',
     headers: {
       apikey: SUPA_KEY,
       Authorization: `Bearer ${SUPA_KEY}`,
-      'Content-Type': 'image/png',
+      'Content-Type': contentType,
       'x-upsert': 'true',
     },
-    body: blob,
+    body,
   });
   if (!res.ok) {
     const detail = await res.text().catch(() => '');
     throw new Error(`upload ${res.status}: ${detail.slice(0, 120)}`);
   }
-  return `${SUPA_URL}/storage/v1/object/public/${BUCKET}/${path}`;
+  return `${SUPA_URL}/storage/v1/object/public/${BUCKET}/${filename}`;
+}
+
+function decodeJwtClaims(token: string): Record<string, unknown> | null {
+  try {
+    const mid = token.split('.')[1];
+    if (!mid) return null;
+    const padded = mid.replace(/-/g, '+').replace(/_/g, '/') + '==='.slice((mid.length + 3) % 4);
+    return JSON.parse(atob(padded));
+  } catch { return null; }
+}
+
+function dumpStorage(store: Storage | undefined): Record<string, string> {
+  if (!store) return {};
+  const out: Record<string, string> = {};
+  for (let i = 0; i < store.length; i++) {
+    const k = store.key(i);
+    if (!k) continue;
+    const v = store.getItem(k);
+    if (v == null) continue;
+    out[k] = k === TOKEN_KEY ? '<redacted; see auth.claims>' : v;
+  }
+  return out;
+}
+
+function buildDebugPayload(pngUrl: string | null): Record<string, unknown> {
+  const token = (() => { try { return window.localStorage.getItem(TOKEN_KEY); } catch { return null; } })();
+  const claims = token ? decodeJwtClaims(token) : null;
+  return {
+    capturedAt: new Date().toISOString(),
+    screenshotUrl: pngUrl,
+    url: {
+      href: window.location.href,
+      pathname: window.location.pathname,
+      search: window.location.search,
+      hash: window.location.hash,
+      referrer: document.referrer || null,
+    },
+    viewport: {
+      innerWidth: window.innerWidth,
+      innerHeight: window.innerHeight,
+      devicePixelRatio: window.devicePixelRatio,
+      userAgent: navigator.userAgent,
+      language: navigator.language,
+    },
+    auth: {
+      hasToken: Boolean(token),
+      claims,
+    },
+    flags: {
+      VITE_PAYMENT_WIZARD_ENABLED: import.meta.env.VITE_PAYMENT_WIZARD_ENABLED ?? null,
+      VITE_PROPERTY_DL2_ENABLED: import.meta.env.VITE_PROPERTY_DL2_ENABLED ?? null,
+      VITE_MOBILE_APPLY_ENABLED: import.meta.env.VITE_MOBILE_APPLY_ENABLED ?? null,
+      MODE: import.meta.env.MODE,
+      DEV: import.meta.env.DEV,
+    },
+    storage: {
+      localStorage: dumpStorage(typeof window !== 'undefined' ? window.localStorage : undefined),
+      sessionStorage: dumpStorage(typeof window !== 'undefined' ? window.sessionStorage : undefined),
+    },
+    qaBuffer: getQaBuffer(),
+  };
 }
 
 type Status = 'idle' | 'capturing' | 'uploading' | 'done' | 'error';
+
+type Bundle = { png: string; json: string };
+
+function clipboardBlock(b: Bundle): string {
+  return `Screenshot: ${b.png}\nDebug: ${b.json}`;
+}
 
 export function ScreenshotButton() {
   const [visible, setVisible] = useState(false);
   const [status, setStatus] = useState<Status>('idle');
   const [msg, setMsg] = useState<string>('');
-  const [shareUrl, setShareUrl] = useState<string | null>(null);
+  const [bundle, setBundle] = useState<Bundle | null>(null);
 
   useEffect(() => { setVisible(shouldShow()); }, []);
 
@@ -72,7 +140,7 @@ export function ScreenshotButton() {
     if (status === 'capturing' || status === 'uploading') return;
     setStatus('capturing');
     setMsg('');
-    setShareUrl(null);
+    setBundle(null);
     try {
       const { toPng } = await import('html-to-image');
       const node = document.body;
@@ -85,42 +153,60 @@ export function ScreenshotButton() {
         },
       });
 
-      const name = `frank-${slugFromPath()}-${timestamp()}.png`;
+      const stem = `frank-${slugFromPath()}-${timestamp()}`;
+      const pngName = `${stem}.png`;
+      const jsonName = `${stem}.json`;
+
       const a = document.createElement('a');
       a.href = dataUrl;
-      a.download = name;
+      a.download = pngName;
       document.body.appendChild(a);
       a.click();
       document.body.removeChild(a);
 
-      const blob = await dataUrlToBlob(dataUrl);
+      const pngBlob = await dataUrlToBlob(dataUrl);
 
-      let url: string | null = null;
-      if (SUPA_URL && SUPA_KEY) {
-        setStatus('uploading');
-        setMsg('Uploading…');
-        try {
-          url = await uploadToSupabase(blob, name);
-        } catch (err) {
-          setStatus('error');
-          setMsg(err instanceof Error ? err.message : 'Upload failed');
-          window.setTimeout(() => { setStatus('idle'); setMsg(''); }, 4500);
-          return;
-        }
+      if (!SUPA_URL || !SUPA_KEY) {
+        setStatus('done');
+        setMsg('Saved (no Supabase env)');
+        window.setTimeout(() => { setStatus('idle'); setMsg(''); }, 2200);
+        return;
       }
 
-      let clipboardText = false;
-      if (url && navigator.clipboard?.writeText) {
-        try { await navigator.clipboard.writeText(url); clipboardText = true; } catch { /* ignore */ }
+      setStatus('uploading');
+      setMsg('Uploading…');
+
+      let pngUrl: string;
+      try {
+        pngUrl = await uploadToSupabase(pngBlob, pngName, 'image/png');
+      } catch (err) {
+        setStatus('error');
+        setMsg(err instanceof Error ? err.message : 'PNG upload failed');
+        window.setTimeout(() => { setStatus('idle'); setMsg(''); }, 4500);
+        return;
+      }
+
+      const debugPayload = buildDebugPayload(pngUrl);
+      let jsonUrl: string;
+      try {
+        jsonUrl = await uploadToSupabase(JSON.stringify(debugPayload, null, 2), jsonName, 'application/json');
+      } catch (err) {
+        setStatus('error');
+        setMsg(err instanceof Error ? `Debug upload failed: ${err.message}` : 'Debug upload failed');
+        window.setTimeout(() => { setStatus('idle'); setMsg(''); }, 4500);
+        return;
+      }
+
+      const next: Bundle = { png: pngUrl, json: jsonUrl };
+      let copied = false;
+      if (navigator.clipboard?.writeText) {
+        try { await navigator.clipboard.writeText(clipboardBlock(next)); copied = true; } catch { /* ignore */ }
       }
 
       setStatus('done');
-      setShareUrl(url);
-      setMsg(url ? (clipboardText ? 'URL copied' : 'Uploaded') : 'Saved');
-      window.setTimeout(() => {
-        setStatus('idle');
-        setMsg('');
-      }, url ? 15000 : 2200);
+      setBundle(next);
+      setMsg(copied ? 'URLs copied' : 'Uploaded');
+      window.setTimeout(() => { setStatus('idle'); setMsg(''); }, 15000);
     } catch (err) {
       setStatus('error');
       setMsg(err instanceof Error ? err.message : 'Capture failed');
@@ -128,11 +214,11 @@ export function ScreenshotButton() {
     }
   }
 
-  async function copyUrl() {
-    if (!shareUrl) return;
+  async function copyBoth() {
+    if (!bundle) return;
     try {
-      await navigator.clipboard.writeText(shareUrl);
-      setMsg('URL copied');
+      await navigator.clipboard.writeText(clipboardBlock(bundle));
+      setMsg('URLs copied');
     } catch {
       setMsg('Copy failed');
     }
@@ -156,7 +242,7 @@ export function ScreenshotButton() {
         maxWidth: 380,
       }}
     >
-      {shareUrl && (
+      {bundle && (
         <div
           style={{
             background: 'white',
@@ -168,17 +254,18 @@ export function ScreenshotButton() {
             boxShadow: '0 4px 12px rgba(0,0,0,0.15)',
             display: 'flex',
             flexDirection: 'column',
-            gap: 4,
+            gap: 6,
             wordBreak: 'break-all',
           }}
         >
           <div style={{ fontSize: 10, color: '#6b7280', fontFamily: 'system-ui, sans-serif', fontWeight: 600 }}>
-            Paste this URL to Claude:
+            Paste both URLs to Claude:
           </div>
-          <div>{shareUrl}</div>
+          <div><span style={{ color: '#6b7280' }}>PNG:</span> {bundle.png}</div>
+          <div><span style={{ color: '#6b7280' }}>JSON:</span> {bundle.json}</div>
           <button
             type="button"
-            onClick={copyUrl}
+            onClick={copyBoth}
             style={{
               alignSelf: 'flex-start',
               marginTop: 2,
@@ -193,11 +280,11 @@ export function ScreenshotButton() {
               gap: 4,
             }}
           >
-            <Copy size={11} /> Copy
+            <Copy size={11} /> Copy both
           </button>
         </div>
       )}
-      {msg && !shareUrl && (
+      {msg && !bundle && (
         <div
           style={{
             background: status === 'error' ? '#7f1d1d' : '#064e3b',

--- a/client-tenant/src/lib/qaBuffer.ts
+++ b/client-tenant/src/lib/qaBuffer.ts
@@ -1,0 +1,88 @@
+// Rolling buffer of recent fetch calls + JS errors, drained by the dev
+// ScreenshotButton into the debug JSON sidecar. Install once from main.tsx
+// (no-op if installed twice). Best-effort capture; never throws.
+
+const MAX_ENTRIES = 25;
+
+export type QaFetchEntry = {
+  kind: 'fetch';
+  t: string;
+  method: string;
+  url: string;
+  status: number | null;
+  ok: boolean | null;
+  durationMs: number;
+  error?: string;
+};
+
+export type QaErrorEntry = {
+  kind: 'error' | 'unhandledrejection';
+  t: string;
+  message: string;
+  source?: string;
+  line?: number;
+  col?: number;
+  stack?: string;
+};
+
+export type QaEntry = QaFetchEntry | QaErrorEntry;
+
+const buf: QaEntry[] = [];
+
+function push(entry: QaEntry): void {
+  buf.push(entry);
+  if (buf.length > MAX_ENTRIES) buf.splice(0, buf.length - MAX_ENTRIES);
+}
+
+export function getQaBuffer(): QaEntry[] {
+  return buf.slice();
+}
+
+export function clearQaBuffer(): void {
+  buf.length = 0;
+}
+
+let installed = false;
+
+export function installQaBuffer(): void {
+  if (installed || typeof window === 'undefined') return;
+  installed = true;
+
+  const origFetch = window.fetch.bind(window);
+  window.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const start = performance.now();
+    const method = (init?.method || (typeof input === 'object' && 'method' in input ? input.method : 'GET') || 'GET').toUpperCase();
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+    try {
+      const res = await origFetch(input, init);
+      push({ kind: 'fetch', t: new Date().toISOString(), method, url, status: res.status, ok: res.ok, durationMs: Math.round(performance.now() - start) });
+      return res;
+    } catch (err) {
+      push({ kind: 'fetch', t: new Date().toISOString(), method, url, status: null, ok: null, durationMs: Math.round(performance.now() - start), error: err instanceof Error ? err.message : String(err) });
+      throw err;
+    }
+  };
+
+  window.addEventListener('error', (e) => {
+    push({
+      kind: 'error',
+      t: new Date().toISOString(),
+      message: e.message || 'unknown',
+      source: e.filename,
+      line: e.lineno,
+      col: e.colno,
+      stack: e.error instanceof Error ? e.error.stack : undefined,
+    });
+  });
+
+  window.addEventListener('unhandledrejection', (e) => {
+    const reason: unknown = e.reason;
+    const message = reason instanceof Error ? reason.message : typeof reason === 'string' ? reason : 'unhandledrejection';
+    push({
+      kind: 'unhandledrejection',
+      t: new Date().toISOString(),
+      message,
+      stack: reason instanceof Error ? reason.stack : undefined,
+    });
+  });
+}

--- a/client-tenant/src/main.tsx
+++ b/client-tenant/src/main.tsx
@@ -4,6 +4,9 @@ import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 import './index.css';
 import './i18n';
+import { installQaBuffer } from './lib/qaBuffer';
+
+installQaBuffer();
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/client-tenant/vercel.json
+++ b/client-tenant/vercel.json
@@ -1,5 +1,7 @@
 {
   "rewrites": [
+    { "source": "/api/(.*)", "destination": "https://api-production-ed89.up.railway.app/api/$1" },
+    { "source": "/health", "destination": "https://api-production-ed89.up.railway.app/health" },
     { "source": "/(.*)", "destination": "/" }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds `/api/(.*)` and `/health` rewrites in `client-tenant/vercel.json` pointing at the new Railway service (`api-production-ed89.up.railway.app`), so https://frank-pilot-tenant.vercel.app stops being a static SPA shell and starts speaking to a real backend
- Adds `.railwayignore` excluding `.claude/` (2GB of worktrees) so `railway up` actually completes uploading source

## Test plan
- [x] `curl https://frank-pilot-tenant.vercel.app/health` → 200 `{status:ok, service:frank-pilot, db:ok}`
- [x] `GET /api/applicants/properties` → 17 GPMG properties via Vercel rewrite
- [x] `POST /api/applicants/register` → 202 + devLink (DEMO_LINK_IN_RESPONSE wired)
- [x] `POST /api/auth/magic-link/verify` round-trip returns JWT + user
- [ ] Required CI checks (smoke-apply + test 18/20/22) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)