### PR TITLE
feat(security): Turnstile + rate-limit on public forms (gpmglv wedge #13)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,3 +50,17 @@ LOFT_API_KEY=changeme
 # HUD Integration
 HUD_API_URL=https://api.hud.example.com
 HUD_API_KEY=changeme
+
+# Cloudflare Turnstile (wedge #13 — anti-spam on public forms)
+# Server-side secret. Defaults to the Cloudflare well-known dev secret which
+# always passes verification — the verify-turnstile middleware short-circuits
+# in this mode. Replace with the real secret from your Turnstile dashboard
+# in production (and pair with VITE_TURNSTILE_SITE_KEY on the client).
+TURNSTILE_SECRET_KEY=1x0000000000000000000000000000000AA
+
+# Client-side site key. Read by Vite as VITE_TURNSTILE_SITE_KEY. The dev key
+# below renders the widget in pass-through mode (auto-issues a test token).
+# Replace with the real site key in production. Lives in this file (not the
+# client-tenant `.env`) because Vite reads from process env at build time —
+# CI and Railway should set both vars together.
+VITE_TURNSTILE_SITE_KEY=1x00000000000000000000AA

--- a/client-tenant/.env.example
+++ b/client-tenant/.env.example
@@ -21,3 +21,10 @@ VITE_PAYMENT_WIZARD_ENABLED=false
 # (button still works, only triggers local download).
 VITE_SUPABASE_URL=
 VITE_SUPABASE_PUBLISHABLE_KEY=
+
+# Cloudflare Turnstile site key (wedge #13 — anti-spam on public forms).
+# The dev key below renders the widget in pass-through mode and synchronously
+# yields a `test-token-dev` token so the Welcome → Claim smoke stays green
+# without a real key configured. Replace with the production site key on
+# Vercel when going live; pair with TURNSTILE_SECRET_KEY on the API host.
+VITE_TURNSTILE_SITE_KEY=1x00000000000000000000AA

--- a/client-tenant/src/api/auth.ts
+++ b/client-tenant/src/api/auth.ts
@@ -8,8 +8,19 @@ interface MagicLinkVerifyResponse {
   token: string;
 }
 
-export async function requestMagicLink(email: string): Promise<MagicLinkRequestResponse> {
-  return api.post<MagicLinkRequestResponse>('/auth/magic-link/request', { email });
+// wedge #13: optional Turnstile token. Senders that don't have a widget on
+// screen (e.g. an in-app resend from a session that already passed Turnstile
+// at register time) can omit it — the server still rate-limits, and in dev
+// the verify-turnstile middleware bypasses when TURNSTILE_SECRET_KEY is
+// unset. Production resend surfaces must mount the widget.
+export async function requestMagicLink(
+  email: string,
+  turnstileToken?: string,
+): Promise<MagicLinkRequestResponse> {
+  return api.post<MagicLinkRequestResponse>('/auth/magic-link/request', {
+    email,
+    ...(turnstileToken ? { turnstileToken } : {}),
+  });
 }
 
 export async function verifyMagicLink(token: string): Promise<MagicLinkVerifyResponse> {

--- a/client-tenant/src/components/TurnstileWidget.tsx
+++ b/client-tenant/src/components/TurnstileWidget.tsx
@@ -1,0 +1,202 @@
+/**
+ * Cloudflare Turnstile widget (gpmglv wedge #13 — anti-spam).
+ *
+ * gpmglv.com's public forms have no captcha. We mount this on our register +
+ * magic-link forms to gate bot signups. The widget is rendered lazily — the
+ * Turnstile script is appended to <head> via a React effect on first mount
+ * of this component. This is intentional: wedge #14 (SEO indexing) is editing
+ * `index.html` in parallel; modifying the document head from a component
+ * keeps these two wedges from colliding.
+ *
+ * Dev/test bypass: when VITE_TURNSTILE_SITE_KEY is unset OR equals the
+ * Cloudflare well-known test key `1x00000000000000000000AA`, the widget
+ * skips the real Turnstile flow and synchronously schedules `onVerify` with
+ * the sentinel string `test-token-dev`. This is critical for the Welcome →
+ * Claim e2e smoke (CI doesn't have a real site key) and for unit tests.
+ *
+ * The bypass token is paired with the server-side dev secret
+ * `1x0000000000000000000000000000000AA`, which the verify-turnstile
+ * middleware also short-circuits on. So in dev: widget ships `test-token-dev`,
+ * server skips siteverify, smoke stays green. In prod: real key, real secret,
+ * full verification.
+ */
+import { useEffect, useRef } from "react";
+
+const DEV_SITE_KEY = "1x00000000000000000000AA";
+const TURNSTILE_SCRIPT_SRC =
+  "https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit";
+
+declare global {
+  interface Window {
+    turnstile?: {
+      render: (
+        container: HTMLElement,
+        params: {
+          sitekey: string;
+          callback?: (token: string) => void;
+          "expired-callback"?: () => void;
+          "error-callback"?: () => void;
+          theme?: "light" | "dark" | "auto";
+          size?: "normal" | "compact" | "flexible";
+        }
+      ) => string;
+      remove?: (widgetId: string) => void;
+      reset?: (widgetId?: string) => void;
+    };
+  }
+}
+
+export interface TurnstileWidgetProps {
+  /**
+   * Cloudflare site key. Defaults to `VITE_TURNSTILE_SITE_KEY` from env.
+   * If unset, empty, or matches Cloudflare's dev test key, the widget runs
+   * in bypass mode (auto-fires `onVerify('test-token-dev')`).
+   */
+  siteKey?: string;
+  onVerify: (token: string) => void;
+  onExpire?: () => void;
+  onError?: () => void;
+  /** Optional theme — Cloudflare default is `auto`. */
+  theme?: "light" | "dark" | "auto";
+  /** Optional size — `flexible` recommended for narrow forms. */
+  size?: "normal" | "compact" | "flexible";
+  /**
+   * Test seam — let tests assert bypass behaviour without futzing with
+   * import.meta.env. Defaults to reading the env var.
+   */
+  forceBypassForTests?: boolean;
+}
+
+function resolveSiteKey(propKey?: string): string {
+  if (propKey && propKey.trim() !== "") return propKey;
+  // import.meta.env is statically rewritten by Vite at build time — guard
+  // for SSR/test environments where it may be undefined.
+  const envKey =
+    (typeof import.meta !== "undefined" &&
+      (import.meta as ImportMeta & { env?: Record<string, string> }).env
+        ?.VITE_TURNSTILE_SITE_KEY) ||
+    "";
+  return envKey;
+}
+
+export function isTurnstileBypass(siteKey: string): boolean {
+  if (!siteKey || siteKey.trim() === "") return true;
+  if (siteKey === DEV_SITE_KEY) return true;
+  return false;
+}
+
+function ensureTurnstileScript(): Promise<void> {
+  if (typeof window === "undefined") return Promise.resolve();
+  if (window.turnstile) return Promise.resolve();
+
+  const existing = document.querySelector<HTMLScriptElement>(
+    `script[src^="${TURNSTILE_SCRIPT_SRC.split("?")[0]}"]`
+  );
+  if (existing) {
+    if (window.turnstile) return Promise.resolve();
+    return new Promise((resolve) => {
+      existing.addEventListener("load", () => resolve(), { once: true });
+      existing.addEventListener("error", () => resolve(), { once: true });
+    });
+  }
+
+  return new Promise((resolve) => {
+    const script = document.createElement("script");
+    script.src = TURNSTILE_SCRIPT_SRC;
+    script.async = true;
+    script.defer = true;
+    script.onload = () => resolve();
+    // Resolve even on load error so the form isn't permanently stuck. The
+    // submit handler still gates on a non-empty token, so a failed load
+    // means the user can't submit — which is the desired fail-closed mode.
+    script.onerror = () => resolve();
+    document.head.appendChild(script);
+  });
+}
+
+export function TurnstileWidget({
+  siteKey,
+  onVerify,
+  onExpire,
+  onError,
+  theme = "auto",
+  size = "flexible",
+  forceBypassForTests,
+}: TurnstileWidgetProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const widgetIdRef = useRef<string | null>(null);
+  // Refs keep the latest callbacks accessible inside the async render
+  // without re-mounting the widget every time a parent re-renders. Turnstile
+  // mount is expensive and the widget keeps internal state we don't want to
+  // throw away on each parent state tick.
+  const onVerifyRef = useRef(onVerify);
+  const onExpireRef = useRef(onExpire);
+  const onErrorRef = useRef(onError);
+
+  useEffect(() => {
+    onVerifyRef.current = onVerify;
+    onExpireRef.current = onExpire;
+    onErrorRef.current = onError;
+  }, [onVerify, onExpire, onError]);
+
+  const resolvedKey = resolveSiteKey(siteKey);
+  const bypass = forceBypassForTests || isTurnstileBypass(resolvedKey);
+
+  useEffect(() => {
+    if (bypass) {
+      // Fire bypass token on next tick so callers wiring `onVerify` in the
+      // same render pass see it after their state hooks settle. The smoke
+      // test waits >1s before clicking Continue, so this lands well before.
+      const id = setTimeout(() => {
+        onVerifyRef.current("test-token-dev");
+      }, 0);
+      return () => clearTimeout(id);
+    }
+
+    let cancelled = false;
+    void (async () => {
+      await ensureTurnstileScript();
+      if (cancelled) return;
+      if (!window.turnstile || !containerRef.current) return;
+
+      try {
+        widgetIdRef.current = window.turnstile.render(containerRef.current, {
+          sitekey: resolvedKey,
+          theme,
+          size,
+          callback: (token: string) => onVerifyRef.current(token),
+          "expired-callback": () => onExpireRef.current?.(),
+          "error-callback": () => onErrorRef.current?.(),
+        });
+      } catch {
+        onErrorRef.current?.();
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      if (widgetIdRef.current && window.turnstile?.remove) {
+        try {
+          window.turnstile.remove(widgetIdRef.current);
+        } catch {
+          /* widget may already be torn down */
+        }
+        widgetIdRef.current = null;
+      }
+    };
+  }, [bypass, resolvedKey, theme, size]);
+
+  // Bypass mode renders nothing visible — the smoke test selects the
+  // continue CTA by text and doesn't expect a captcha block to appear.
+  if (bypass) return null;
+
+  return (
+    <div
+      ref={containerRef}
+      data-testid="turnstile-widget"
+      aria-label="Captcha verification"
+    />
+  );
+}
+
+export default TurnstileWidget;

--- a/client-tenant/src/components/__tests__/TurnstileWidget.test.tsx
+++ b/client-tenant/src/components/__tests__/TurnstileWidget.test.tsx
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+/**
+ * Tests for src/components/TurnstileWidget.tsx (gpmglv wedge #13 — anti-spam).
+ *
+ * The critical behaviour: when the widget runs in bypass mode (dev key or
+ * unset env var), it MUST synchronously schedule onVerify('test-token-dev')
+ * so the Welcome → Claim e2e smoke can submit the register form without a
+ * real Cloudflare challenge. If this regresses, CI smoke breaks and PRs stop
+ * merging.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import { TurnstileWidget, isTurnstileBypass } from '../TurnstileWidget';
+
+describe('TurnstileWidget — bypass mode (smoke contract)', () => {
+  it('auto-fires onVerify("test-token-dev") within ~200ms in bypass mode', async () => {
+    const onVerify = vi.fn();
+    render(<TurnstileWidget onVerify={onVerify} forceBypassForTests />);
+
+    // setTimeout(..., 0) lands on a macrotask. waitFor polls until satisfied
+    // or the 1s default timeout — we cap at 200ms to keep this aligned with
+    // the spec ("auto-fires after ~100ms").
+    await waitFor(
+      () => {
+        expect(onVerify).toHaveBeenCalledWith('test-token-dev');
+      },
+      { timeout: 200 },
+    );
+
+    // Bypass mode must not render any visible widget DOM (the smoke test
+    // doesn't expect a captcha to appear and the test key wouldn't render
+    // meaningfully anyway).
+    // (Asserted indirectly: the component returns null in bypass mode.)
+  });
+
+  it('bypasses when no siteKey prop is supplied and VITE_TURNSTILE_SITE_KEY is unset', async () => {
+    // Empty key → bypass mode regardless of forceBypassForTests.
+    const onVerify = vi.fn();
+    render(<TurnstileWidget siteKey="" onVerify={onVerify} />);
+    await waitFor(() => expect(onVerify).toHaveBeenCalledWith('test-token-dev'), {
+      timeout: 200,
+    });
+  });
+
+  it('isTurnstileBypass predicate matches Cloudflare dev key + empty string', () => {
+    expect(isTurnstileBypass('')).toBe(true);
+    expect(isTurnstileBypass('1x00000000000000000000AA')).toBe(true);
+    expect(isTurnstileBypass('real-site-key-zzz')).toBe(false);
+  });
+});

--- a/client-tenant/src/pages/Login.tsx
+++ b/client-tenant/src/pages/Login.tsx
@@ -4,6 +4,7 @@ import { Mail, ArrowRight } from 'lucide-react';
 import { requestMagicLink } from '@/api/auth';
 import { HF } from '@/styles/tokens';
 import { CTA, Card } from '@/components/primitives';
+import { TurnstileWidget } from '@/components/TurnstileWidget';
 
 export function Login() {
   const navigate = useNavigate();
@@ -12,13 +13,18 @@ export function Login() {
   const [sent, setSent] = useState(false);
   const [devLink, setDevLink] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  // wedge #13: bot-gate the magic-link request. In dev / smoke the widget
+  // bypasses to `test-token-dev`; in prod a real Cloudflare challenge fires.
+  const [turnstileToken, setTurnstileToken] = useState<string>('');
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     setError(null);
     setLoading(true);
     try {
-      const res = (await requestMagicLink(email)) as { devLink?: string };
+      const res = (await requestMagicLink(email, turnstileToken || undefined)) as {
+        devLink?: string;
+      };
       setSent(true);
       if (res.devLink) {
         setDevLink(res.devLink);
@@ -116,6 +122,7 @@ export function Login() {
                 }}
               />
             </label>
+            <TurnstileWidget onVerify={setTurnstileToken} />
             <CTA type="submit" tone="primary" size="lg" disabled={loading || !email} block>
               {loading ? 'Sending…' : 'Send magic link'}
             </CTA>

--- a/client-tenant/src/pages/apply/steps/Step1Register.tsx
+++ b/client-tenant/src/pages/apply/steps/Step1Register.tsx
@@ -1,7 +1,9 @@
+import { useState } from 'react';
 import { api } from '@/api/client';
 import { useApply } from '../ApplyContext';
 import { useTranslation } from 'react-i18next';
 import { CTA } from '@/components/primitives';
+import { TurnstileWidget } from '@/components/TurnstileWidget';
 import { HF } from '@/styles/tokens';
 
 const labelStyle = {
@@ -28,6 +30,11 @@ const inputStyle = {
 export function Step1Register() {
   const s = useApply();
   const { t } = useTranslation('apply');
+  // wedge #13: Turnstile token issued by the widget on successful challenge.
+  // In dev / smoke (VITE_TURNSTILE_SITE_KEY unset or dev key) the widget
+  // auto-fires `onVerify('test-token-dev')` synchronously so the smoke
+  // (Welcome → Claim e2e) keeps passing without a real key configured.
+  const [turnstileToken, setTurnstileToken] = useState<string>('');
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -39,6 +46,7 @@ export function Step1Register() {
         firstName: s.firstName,
         lastName: s.lastName,
         phone: s.phone || undefined,
+        turnstileToken: turnstileToken || undefined,
       });
       if (res.devLink) s.setDevLink(res.devLink);
       s.setStep('verify');
@@ -102,6 +110,7 @@ export function Step1Register() {
             placeholder={t('register.phonePlaceholder')}
           />
         </div>
+        <TurnstileWidget onVerify={setTurnstileToken} />
         <CTA
           type="submit"
           disabled={s.loading || !s.email || !s.firstName || !s.lastName}

--- a/src/__tests__/auth-magic-link-rate-limit.test.ts
+++ b/src/__tests__/auth-magic-link-rate-limit.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Tests for the wedge #13 per-IP rate limit on POST /auth/magic-link/request.
+ *
+ * The existing per-(ip, email) limit caps a single IP to 5 requests/min for
+ * the same email. But because the key includes the email, a botnet from one
+ * IP cycling through fresh email addresses defeats it (every key is fresh).
+ * This test mounts the auth router and proves that the per-IP limiter (30/min)
+ * trips on the 31st request even when each request uses a different email.
+ *
+ * The same supertest agent is used across all requests so express-rate-limit
+ * sees a single IP. Each request uses a unique email so the per-(ip,email)
+ * limiter's bucket is always fresh — isolating the per-IP limiter under test.
+ */
+import express from "express";
+import request from "supertest";
+
+jest.mock("../modules/auth/magic-link-service", () => ({
+  // createMagicLink returns null → the route still 200s but skips
+  // logMagicLink / Resend. Keeps the test fast and deterministic.
+  createMagicLink: jest.fn().mockResolvedValue(null),
+  verifyMagicLink: jest.fn(),
+  logMagicLink: jest.fn(),
+}));
+jest.mock("../config/database", () => ({ query: jest.fn(), transaction: jest.fn() }));
+jest.mock("../utils/logger", () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+import authRouter from "../modules/auth/routes";
+
+const ORIGINAL_SECRET = process.env.TURNSTILE_SECRET_KEY;
+
+beforeAll(() => {
+  // Ensure verify-turnstile bypasses — we're isolating the rate-limit behaviour.
+  delete process.env.TURNSTILE_SECRET_KEY;
+});
+afterAll(() => {
+  if (ORIGINAL_SECRET !== undefined) {
+    process.env.TURNSTILE_SECRET_KEY = ORIGINAL_SECRET;
+  }
+});
+
+const app = express();
+app.use(express.json());
+app.use("/auth", authRouter);
+
+describe("wedge #13: per-IP rate limit on POST /auth/magic-link/request", () => {
+  it("trips 429 on the 31st request from one IP even when the email rotates", async () => {
+    // 30 fresh emails → per-(ip,email) bucket never fills (each is unused).
+    // The per-IP limiter caps at 30/min, so the 31st request must 429.
+    const agent = request.agent(app);
+
+    for (let i = 0; i < 30; i++) {
+      const res = await agent
+        .post("/auth/magic-link/request")
+        .send({ email: `bot+${Date.now()}-${i}@example.com` });
+      // Each call is expected to land at 200 (route always responds ok regardless
+      // of whether the email exists, per the no-enumeration policy).
+      expect(res.status).toBe(200);
+    }
+
+    const limited = await agent
+      .post("/auth/magic-link/request")
+      .send({ email: `bot+${Date.now()}-final@example.com` });
+
+    expect(limited.status).toBe(429);
+    expect(limited.body.error).toMatch(/too many requests/i);
+  }, 30_000);
+});

--- a/src/__tests__/turnstile-middleware.test.ts
+++ b/src/__tests__/turnstile-middleware.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Tests for src/middleware/verify-turnstile.ts (gpmglv wedge #13 — anti-spam).
+ *
+ * Coverage:
+ *   1. Bypass path: TURNSTILE_SECRET_KEY unset → next() called, no fetch
+ *   2. Bypass path: TURNSTILE_SECRET_KEY === dev sentinel → next() called
+ *   3. Verify path with real secret: missing token → 403
+ *   4. Verify path with real secret: success from siteverify → next() called
+ *   5. Verify path with real secret: failure from siteverify → 403
+ *   6. Verify path with real secret: siteverify network throw → 403 (fail closed)
+ *
+ * Strategy: mount the middleware in a minimal Express app, stub global fetch
+ * for the real-secret cases. Save/restore TURNSTILE_SECRET_KEY per-test so we
+ * don't leak env across the suite.
+ */
+import express, { Request, Response } from "express";
+import request from "supertest";
+import { verifyTurnstile, isTurnstileBypassed } from "../middleware/verify-turnstile";
+
+jest.mock("../utils/logger", () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+function buildApp(fetchImpl?: typeof fetch) {
+  const app = express();
+  app.use(express.json());
+  app.post(
+    "/probe",
+    verifyTurnstile(fetchImpl ? { fetchImpl } : {}),
+    (_req: Request, res: Response) => {
+      res.status(200).json({ ok: true });
+    }
+  );
+  return app;
+}
+
+describe("verify-turnstile middleware", () => {
+  const ORIGINAL_SECRET = process.env.TURNSTILE_SECRET_KEY;
+
+  afterEach(() => {
+    if (ORIGINAL_SECRET === undefined) {
+      delete process.env.TURNSTILE_SECRET_KEY;
+    } else {
+      process.env.TURNSTILE_SECRET_KEY = ORIGINAL_SECRET;
+    }
+    jest.clearAllMocks();
+  });
+
+  describe("bypass paths", () => {
+    it("passes through with no token when TURNSTILE_SECRET_KEY is unset", async () => {
+      delete process.env.TURNSTILE_SECRET_KEY;
+      expect(isTurnstileBypassed()).toBe(true);
+      const fetchStub = jest.fn() as unknown as typeof fetch;
+      const app = buildApp(fetchStub);
+      const res = await request(app).post("/probe").send({});
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      // Critical: bypass must NOT make any outbound siteverify call.
+      expect(fetchStub).not.toHaveBeenCalled();
+    });
+
+    it("passes through with no token when TURNSTILE_SECRET_KEY equals the dev sentinel", async () => {
+      process.env.TURNSTILE_SECRET_KEY = "1x0000000000000000000000000000000AA";
+      expect(isTurnstileBypassed()).toBe(true);
+      const fetchStub = jest.fn() as unknown as typeof fetch;
+      const app = buildApp(fetchStub);
+      const res = await request(app).post("/probe").send({});
+      expect(res.status).toBe(200);
+      expect(fetchStub).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("real-secret path", () => {
+    beforeEach(() => {
+      process.env.TURNSTILE_SECRET_KEY = "real-secret-xyz";
+    });
+
+    it("rejects with 403 when no token is supplied", async () => {
+      const fetchStub = jest.fn() as unknown as typeof fetch;
+      const app = buildApp(fetchStub);
+      const res = await request(app).post("/probe").send({});
+      expect(res.status).toBe(403);
+      expect(res.body.error).toBe("turnstile_verification_failed");
+      // Should fast-fail without making a siteverify call.
+      expect(fetchStub).not.toHaveBeenCalled();
+    });
+
+    it("calls siteverify with the supplied token and allows on success", async () => {
+      const fetchStub = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ success: true }),
+      }) as unknown as typeof fetch;
+
+      const app = buildApp(fetchStub);
+      const res = await request(app)
+        .post("/probe")
+        .send({ turnstileToken: "client-issued-token" });
+
+      expect(res.status).toBe(200);
+      expect(fetchStub).toHaveBeenCalledTimes(1);
+      const [url, init] = (fetchStub as jest.Mock).mock.calls[0];
+      expect(url).toBe(
+        "https://challenges.cloudflare.com/turnstile/v0/siteverify"
+      );
+      expect((init as RequestInit).method).toBe("POST");
+      // Body is URLSearchParams stringified — assert the secret + response made it.
+      const bodyStr = String((init as RequestInit).body);
+      expect(bodyStr).toContain("secret=real-secret-xyz");
+      expect(bodyStr).toContain("response=client-issued-token");
+    });
+
+    it("rejects with 403 when siteverify returns success: false", async () => {
+      const fetchStub = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ success: false, "error-codes": ["invalid-input-response"] }),
+      }) as unknown as typeof fetch;
+
+      const app = buildApp(fetchStub);
+      const res = await request(app)
+        .post("/probe")
+        .send({ turnstileToken: "bad-token" });
+
+      expect(res.status).toBe(403);
+      expect(res.body.error).toBe("turnstile_verification_failed");
+    });
+
+    it("rejects with 403 (fail-closed) when siteverify throws", async () => {
+      const fetchStub = jest
+        .fn()
+        .mockRejectedValue(new Error("network down")) as unknown as typeof fetch;
+
+      const app = buildApp(fetchStub);
+      const res = await request(app)
+        .post("/probe")
+        .send({ turnstileToken: "any-token" });
+
+      expect(res.status).toBe(403);
+      expect(res.body.error).toBe("turnstile_verification_failed");
+    });
+  });
+});

--- a/src/middleware/verify-turnstile.ts
+++ b/src/middleware/verify-turnstile.ts
@@ -1,0 +1,130 @@
+/**
+ * Cloudflare Turnstile verification middleware (gpmglv wedge #13 — anti-spam).
+ *
+ * gpmglv.com's waitlist + contact forms have NO visible captcha (audit
+ * §Per-Page Dumps). This middleware closes that gap on our public POST
+ * surfaces (register, magic-link/request). Order in the route chain:
+ *
+ *   rate-limit  →  verify-turnstile  →  handler
+ *
+ * Dev/test bypass: when `TURNSTILE_SECRET_KEY` is unset, empty, or equals
+ * Cloudflare's well-known dev secret `1x0000000000000000000000000000000AA`,
+ * the middleware passes through without calling siteverify. This keeps the
+ * Welcome→Claim smoke green (CI doesn't have a real key) and lets every test
+ * skip the captcha without mocking fetch. Set a real secret in prod.
+ *
+ * On failure: 403 { error: 'turnstile_verification_failed' }.
+ *
+ * Why a config token field rather than always reading `req.body.turnstileToken`:
+ * future forms might pass the widget response under a different name (e.g.
+ * `cf-turnstile-response` direct from the Turnstile widget DOM). Keep this
+ * flexible at the middleware factory level so callers can wire either shape.
+ */
+import { Request, Response, NextFunction } from "express";
+import { logger } from "../utils/logger";
+
+const TURNSTILE_DEV_SECRET = "1x0000000000000000000000000000000AA";
+const SITEVERIFY_URL = "https://challenges.cloudflare.com/turnstile/v0/siteverify";
+
+export interface VerifyTurnstileOptions {
+  /** Body field that holds the widget response token. Default: `turnstileToken`. */
+  tokenField?: string;
+  /**
+   * Override fetch implementation — primarily for tests. Defaults to global
+   * `fetch` (Node 18+).
+   */
+  fetchImpl?: typeof fetch;
+}
+
+interface TurnstileResponse {
+  success: boolean;
+  "error-codes"?: string[];
+  challenge_ts?: string;
+  hostname?: string;
+  action?: string;
+  cdata?: string;
+}
+
+/**
+ * Returns true if the current environment configuration means "skip the
+ * remote siteverify call and just pass." Centralized so the same predicate
+ * drives both the route-level bypass and the test assertions.
+ */
+export function isTurnstileBypassed(): boolean {
+  const secret = process.env.TURNSTILE_SECRET_KEY;
+  if (!secret || secret.trim() === "") return true;
+  if (secret === TURNSTILE_DEV_SECRET) return true;
+  return false;
+}
+
+export function verifyTurnstile(options: VerifyTurnstileOptions = {}) {
+  const tokenField = options.tokenField ?? "turnstileToken";
+  // Resolve fetch lazily so tests that set globalThis.fetch after import
+  // still see their mock. Without this, capturing `fetch` at module-load
+  // pins the value before vi.stubGlobal/jest.spyOn runs.
+  const getFetch = (): typeof fetch =>
+    options.fetchImpl ?? (globalThis.fetch as typeof fetch);
+
+  return async function turnstileMiddleware(
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<void> {
+    if (isTurnstileBypassed()) {
+      next();
+      return;
+    }
+
+    const token =
+      typeof req.body?.[tokenField] === "string"
+        ? (req.body[tokenField] as string)
+        : "";
+    if (!token) {
+      res.status(403).json({ error: "turnstile_verification_failed" });
+      return;
+    }
+
+    try {
+      const fetchFn = getFetch();
+      const form = new URLSearchParams();
+      form.append("secret", process.env.TURNSTILE_SECRET_KEY as string);
+      form.append("response", token);
+      // remoteip is optional but recommended — Cloudflare uses it for risk
+      // scoring. Empty string is fine when behind layered proxies.
+      form.append("remoteip", req.ip ?? "");
+
+      const cfRes = await fetchFn(SITEVERIFY_URL, {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: form.toString(),
+      });
+
+      if (!cfRes.ok) {
+        logger.warn("Turnstile siteverify non-2xx", { status: cfRes.status });
+        res.status(403).json({ error: "turnstile_verification_failed" });
+        return;
+      }
+
+      const body = (await cfRes.json()) as TurnstileResponse;
+      if (!body.success) {
+        logger.warn("Turnstile verification rejected", {
+          errors: body["error-codes"],
+        });
+        res.status(403).json({ error: "turnstile_verification_failed" });
+        return;
+      }
+
+      next();
+    } catch (err) {
+      // Fail closed: any siteverify outage shouldn't silently let signups
+      // through. Operators can flip TURNSTILE_SECRET_KEY to the dev sentinel
+      // to disable the check during an incident.
+      logger.error("Turnstile siteverify error", {
+        error: (err as Error).message,
+      });
+      res.status(403).json({ error: "turnstile_verification_failed" });
+    }
+  };
+}
+
+export const TURNSTILE_DEV_SECRET_KEY = TURNSTILE_DEV_SECRET;

--- a/src/modules/applicants/routes.ts
+++ b/src/modules/applicants/routes.ts
@@ -4,6 +4,7 @@ import rateLimit, { ipKeyGenerator } from "express-rate-limit";
 import { query, transaction } from "../../config/database";
 import { authenticate, AuthRequest } from "../../middleware/auth";
 import { requireEmailVerified } from "../../middleware/scope";
+import { verifyTurnstile } from "../../middleware/verify-turnstile";
 import { createMagicLink, logMagicLink, sendMagicLink } from "../auth/magic-link-service";
 import { ApplicationService } from "../application/service";
 import { createApplicationSchema } from "../application/validation";
@@ -18,12 +19,30 @@ const registerSchema = z.object({
   firstName: z.string().min(1).max(100),
   lastName: z.string().min(1).max(100),
   phone: z.string().max(20).optional(),
+  // wedge #13: Cloudflare Turnstile widget response. Optional in the schema
+  // because dev/test bypass the middleware entirely (smoke + unit tests run
+  // without TURNSTILE_SECRET_KEY); production fails at verify-turnstile with
+  // 403 turnstile_verification_failed if missing or invalid.
+  turnstileToken: z.string().optional(),
 });
 
 const registerLimiter = rateLimit({
   windowMs: 60 * 1000,
   max: 5,
   keyGenerator: (req) => `${ipKeyGenerator(req.ip ?? "")}:${(req.body?.email ?? "").toLowerCase()}`,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: "Too many requests, try again in a minute" },
+});
+
+// wedge #13: per-IP ceiling on register attempts. The (ip,email) limiter
+// above resets every time a bot cycles the email field — a single IP could
+// otherwise burn through arbitrarily many fresh accounts. 30/min/IP gives
+// real users on shared NATs plenty of room while neutering bulk-signup bots.
+const registerIpLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 30,
+  keyGenerator: (req) => ipKeyGenerator(req.ip ?? ""),
   standardHeaders: true,
   legacyHeaders: false,
   message: { error: "Too many requests, try again in a minute" },
@@ -87,7 +106,12 @@ const unitWriteLimiter = rateLimit({
 
 // Public: register as an applicant. Idempotent — if the email already exists as
 // an applicant, we reissue a magic link instead of erroring (no email enumeration).
-router.post("/register", registerLimiter, async (req: Request, res: Response): Promise<void> => {
+router.post(
+  "/register",
+  registerIpLimiter,
+  registerLimiter,
+  verifyTurnstile(),
+  async (req: Request, res: Response): Promise<void> => {
   const t0 = Date.now();
   try {
     const parsed = registerSchema.safeParse(req.body);
@@ -179,7 +203,8 @@ router.post("/register", registerLimiter, async (req: Request, res: Response): P
     // branch the email landed in.
     await respondAtFloor(res, t0, 500, { error: "Registration failed" });
   }
-});
+  }
+);
 
 // Authenticated as applicant with a verified email: submit the application
 // form. requireEmailVerified gates this — see WARN #2.

--- a/src/modules/auth/routes.ts
+++ b/src/modules/auth/routes.ts
@@ -3,14 +3,21 @@ import { z } from "zod";
 import rateLimit, { ipKeyGenerator } from "express-rate-limit";
 import { createMagicLink, verifyMagicLink, logMagicLink } from "./magic-link-service";
 import { authenticate, AuthRequest } from "../../middleware/auth";
+import { verifyTurnstile } from "../../middleware/verify-turnstile";
 import { logger } from "../../utils/logger";
 
 const router: Router = Router();
 
 const requestSchema = z.object({
   email: z.string().email(),
+  // wedge #13: Turnstile widget response. Optional in the schema because
+  // dev/test bypass the middleware entirely; production gates rejection
+  // inside verify-turnstile (403 turnstile_verification_failed).
+  turnstileToken: z.string().optional(),
 });
 
+// Per (ip, email) limit — 5/min — keeps the existing tight bucket so a single
+// attacker can't flood one inbox.
 const magicLinkLimiter = rateLimit({
   windowMs: 60 * 1000,
   max: 5,
@@ -20,33 +27,52 @@ const magicLinkLimiter = rateLimit({
   message: { error: "Too many requests, try again in a minute" },
 });
 
-router.post("/magic-link/request", magicLinkLimiter, async (req, res) => {
-  try {
-    const parsed = requestSchema.safeParse(req.body);
-    if (!parsed.success) {
-      res.status(400).json({ error: "Valid email required" });
-      return;
-    }
+// wedge #13: per-IP bucket on top of the per-(ip,email) one. The existing
+// limiter is keyed on email too, so a botnet from one IP that cycles email
+// addresses defeats it (every key is fresh). 30/min/IP is generous for legit
+// users on shared NATs but stops a single source from blasting many inboxes.
+const magicLinkIpLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 30,
+  keyGenerator: (req) => ipKeyGenerator(req.ip ?? ""),
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: "Too many requests, try again in a minute" },
+});
 
-    const result = await createMagicLink(parsed.data.email);
-
-    // Always respond with success — don't leak which emails exist.
-    if (result) {
-      logMagicLink(parsed.data.email, result.link);
-      // In dev, surface the link in the response so it's clickable for demos.
-      // Fail-closed: only leak when NODE_ENV is explicitly "development".
-      // If the env var is unset on Railway, this stays redacted (WARN #3).
-      if (process.env.NODE_ENV === "development") {
-        res.json({ ok: true, devLink: result.link });
+router.post(
+  "/magic-link/request",
+  magicLinkIpLimiter,
+  magicLinkLimiter,
+  verifyTurnstile(),
+  async (req, res) => {
+    try {
+      const parsed = requestSchema.safeParse(req.body);
+      if (!parsed.success) {
+        res.status(400).json({ error: "Valid email required" });
         return;
       }
+
+      const result = await createMagicLink(parsed.data.email);
+
+      // Always respond with success — don't leak which emails exist.
+      if (result) {
+        logMagicLink(parsed.data.email, result.link);
+        // In dev, surface the link in the response so it's clickable for demos.
+        // Fail-closed: only leak when NODE_ENV is explicitly "development".
+        // If the env var is unset on Railway, this stays redacted (WARN #3).
+        if (process.env.NODE_ENV === "development") {
+          res.json({ ok: true, devLink: result.link });
+          return;
+        }
+      }
+      res.json({ ok: true });
+    } catch (err) {
+      logger.error("Magic-link request failed", { error: (err as Error).message });
+      res.status(500).json({ error: "Failed to send link" });
     }
-    res.json({ ok: true });
-  } catch (err) {
-    logger.error("Magic-link request failed", { error: (err as Error).message });
-    res.status(500).json({ error: "Failed to send link" });
   }
-});
+);
 
 const verifySchema = z.object({
   token: z.string().min(20),


### PR DESCRIPTION
## Summary

Anti-spam wedge for public-facing forms. Mounts Cloudflare Turnstile on the two public POST surfaces (`/applicants/register` + `/auth/magic-link/request`), adds a server-side `siteverify` middleware, and stacks a per-IP rate-limit ring on top of the existing per-(ip,email) buckets so a botnet from one source can't defeat the limiter by cycling addresses.

**Bypass contract (smoke-critical):** when `TURNSTILE_SECRET_KEY`/`VITE_TURNSTILE_SITE_KEY` are unset OR set to the Cloudflare dev sentinels, both client and server fall through unconditionally. Welcome -> Claim e2e smoke keeps passing without a real key configured.

## Inventory (a) — rate-limit coverage BEFORE this PR

| Route | Limit | Key | Notes |
|---|---|---|---|
| `POST /applicants/register` | 5/min | `${ip}:${email.toLowerCase()}` | defeatable by cycling emails |
| `POST /auth/magic-link/request` | 5/min | `${ip}:${email.toLowerCase()}` | same |
| `POST /properties/:slug/waitlist-join` | already requires `authenticate + requireEmailVerified` | n/a | not public |
| `POST /messaging/*` | auth-gated | n/a | not public |

No standalone public waitlist form, no public contact form. `joinWaitlist` exists in `client-tenant/src/api/properties.ts` but is only called from authenticated property pages.

## Routes now protected (b)

| Route | Outer ring (NEW) | Inner ring | Turnstile |
|---|---|---|---|
| `POST /applicants/register` | 30/min per IP (IPv6-safe via `ipKeyGenerator`) | 5/min per (ip,email) | `verifyTurnstile()` (bypass when secret unset/dev) |
| `POST /auth/magic-link/request` | 30/min per IP | 5/min per (ip,email) | `verifyTurnstile()` |
| `POST /auth/magic-link/verify` | unchanged — server-issued token only, not a spam surface |  |  |

Both limiters return `429 { error: "Too many requests, try again in a minute" }` with `RateLimit-*` standard headers (express-rate-limit default).

## Standalone waitlist / contact forms (c)

None exist. `client-tenant` ships no standalone waitlist or contact UI. The `joinWaitlist` API client is only invoked from authenticated property surfaces. Turnstile is only mounted where it adds value: the two unauthenticated POST entry points.

## Merge-conflict risk with wedge #14 (d)

Rebased on `origin/main` (currently at `5b17bd6`, includes wedge #14 #74 + iOS fix #75) — clean, **no conflicts**. The widget loads the Turnstile script via React `useEffect` (`ensureTurnstileScript()`), explicitly NOT via `client-tenant/index.html`, so wedge #14 head edits don't intersect. No touches to robots/sitemap/JsonLd/PropertyDetail/index.html/package.json build script.

## Files touched (absolute paths)

**Server:**
- `/Users/a13xperi/projects/frank-pilot/.claude/worktrees/agent-a17214026b2750478/src/middleware/verify-turnstile.ts` (NEW)
- `/Users/a13xperi/projects/frank-pilot/.claude/worktrees/agent-a17214026b2750478/src/modules/applicants/routes.ts`
- `/Users/a13xperi/projects/frank-pilot/.claude/worktrees/agent-a17214026b2750478/src/modules/auth/routes.ts`
- `/Users/a13xperi/projects/frank-pilot/.claude/worktrees/agent-a17214026b2750478/src/__tests__/turnstile-middleware.test.ts` (NEW)
- `/Users/a13xperi/projects/frank-pilot/.claude/worktrees/agent-a17214026b2750478/src/__tests__/auth-magic-link-rate-limit.test.ts` (NEW)

**Client:**
- `/Users/a13xperi/projects/frank-pilot/.claude/worktrees/agent-a17214026b2750478/client-tenant/src/components/TurnstileWidget.tsx` (NEW)
- `/Users/a13xperi/projects/frank-pilot/.claude/worktrees/agent-a17214026b2750478/client-tenant/src/components/__tests__/TurnstileWidget.test.tsx` (NEW)
- `/Users/a13xperi/projects/frank-pilot/.claude/worktrees/agent-a17214026b2750478/client-tenant/src/pages/Login.tsx`
- `/Users/a13xperi/projects/frank-pilot/.claude/worktrees/agent-a17214026b2750478/client-tenant/src/pages/apply/steps/Step1Register.tsx`
- `/Users/a13xperi/projects/frank-pilot/.claude/worktrees/agent-a17214026b2750478/client-tenant/src/api/auth.ts`

**Env:**
- `/Users/a13xperi/projects/frank-pilot/.claude/worktrees/agent-a17214026b2750478/.env.example`
- `/Users/a13xperi/projects/frank-pilot/.claude/worktrees/agent-a17214026b2750478/client-tenant/.env.example`

## Hard constraints respected

- No edits to `client-tenant/src/api/gpmg-fixtures.ts`, `src/db/seed.ts`, `Apply.tsx`/`ApplyContext.tsx`/other `apply/steps/**` (except `Step1Register.tsx` — wizard-register exception per spec), `WelcomeShell.tsx`, `discover/**`, `ami.ts`, `pricing.ts`, `availability.ts`
- No edits to wedge #14 in-flight files: `robots.txt`, `sitemap.xml`, `generate-sitemap.ts`, `PropertyJsonLd.tsx`, `PropertyDetail.tsx`, `index.html`, `package.json` build script section
- No real keys committed (only Cloudflare's public dev sentinels)

## Test plan

- [ ] CI: `smoke-apply (Welcome -> Claim e2e)` green (bypass contract holds end-to-end)
- [ ] CI: `test (18) / test (20) / test (22)` green
- [ ] Local: `npx jest --runInBand` -> 864 tests pass
- [ ] Local: `cd client-tenant && npx vitest run` -> 143 tests pass (incl. 3 new widget tests)
- [ ] Local: `npm run build` (server) + `cd client-tenant && npm run build` clean
- [ ] Manual smoke (post-merge, with prod keys set on Vercel/Railway): register form shows visible Turnstile, magic-link form shows visible Turnstile, both submit and complete normally
- [ ] Manual rate-limit smoke: rapid 31x POST `/applicants/register` from same IP -> 429 on 31st

DO NOT MERGE — Alex will merge after review.