### PR TITLE
feat(privacy): cookie banner + privacy/cookies policy + consent store (gpmglv wedge #15)

### DIFF
--- a/client-tenant/src/App.tsx
+++ b/client-tenant/src/App.tsx
@@ -18,6 +18,10 @@ import { WaitlistPosition } from '@/pages/waitlist/Position';
 import { WaitlistFasterList } from '@/pages/waitlist/FasterList';
 import { MagicLinkSent } from '@/pages/apply/MagicLinkSent';
 import { ScreenshotButton } from '@/components/dev/ScreenshotButton';
+import { CookieBanner } from '@/components/CookieBanner';
+import { SiteFooter } from '@/components/SiteFooter';
+import { PrivacyPolicy } from '@/pages/legal/PrivacyPolicy';
+import { CookiesPolicy } from '@/pages/legal/CookiesPolicy';
 import { getToken } from '@/api/client';
 
 function RootRedirect() {
@@ -38,6 +42,10 @@ export default function App() {
       <Route path="/auth/callback" element={<AuthCallback />} />
       <Route path="/verify-pending" element={<VerifyPending />} />
 
+      {/* gpmglv wedge #15 — public legal pages, no auth gate */}
+      <Route path="/privacy" element={<PrivacyPolicy />} />
+      <Route path="/cookies" element={<CookiesPolicy />} />
+
       {/* BP-03b — waitlist screens (public; carrot pulls applicant back into flow) */}
       <Route path="/waitlist/position" element={<WaitlistPosition />} />
       <Route path="/waitlist/position/:slug" element={<WaitlistPosition />} />
@@ -56,6 +64,8 @@ export default function App() {
 
       <Route path="*" element={<Navigate to="/" replace />} />
     </Routes>
+    <SiteFooter />
+    <CookieBanner />
     <ScreenshotButton />
     </>
   );

--- a/client-tenant/src/components/CookieBanner.tsx
+++ b/client-tenant/src/components/CookieBanner.tsx
@@ -1,0 +1,160 @@
+/**
+ * CookieBanner — bottom-fixed consent prompt.
+ *
+ * Mounts globally (see App.tsx). Shows when `useConsent().recordedAt === null`.
+ * Three actions:
+ *   - Accept all  → all categories on, banner dismisses
+ *   - Reject non-essential → only essentials, banner dismisses
+ *   - Customize  → opens the preferences modal
+ *
+ * Esc dismisses to a "reject non-essential" state, matching the
+ * privacy-preserving default. The banner is `role="dialog"` (a soft
+ * dialog — not modal) and keyboard-reachable. No focus trap, on
+ * purpose — it's a banner, the user can still interact with the page.
+ *
+ * gpmglv wedge #15.
+ */
+
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { HF } from '@/styles/tokens';
+import { useConsent } from '@/state/consent';
+import { CookiePreferencesModal } from './CookiePreferencesModal';
+
+export function CookieBanner() {
+  const { t } = useTranslation('legal');
+  const { needsChoice, acceptAll, rejectAll } = useConsent();
+  const [modalOpen, setModalOpen] = useState(false);
+
+  // Esc dismisses to "reject non-essential" — the privacy-preserving
+  // default if the user wants to make the banner go away without
+  // explicitly choosing. The modal handles its own Esc.
+  useEffect(() => {
+    if (!needsChoice || modalOpen) return;
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') rejectAll();
+    }
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [needsChoice, modalOpen, rejectAll]);
+
+  // Modal can be opened from this banner or from the footer link, so
+  // we always render <CookiePreferencesModal /> — but when the user
+  // has already recorded a choice, no banner is shown.
+  if (!needsChoice) {
+    return (
+      <CookiePreferencesModal
+        open={modalOpen}
+        onClose={() => setModalOpen(false)}
+      />
+    );
+  }
+
+  return (
+    <>
+      <div
+        role="dialog"
+        aria-labelledby="cookie-banner-title"
+        aria-label={t('banner.ariaLabel')}
+        data-testid="cookie-banner"
+        className="fixed inset-x-0 bottom-0 z-50 flex justify-center px-3 pb-3 sm:px-4 sm:pb-4"
+        style={{ pointerEvents: 'none' }}
+      >
+        <div
+          className="w-full max-w-3xl"
+          style={{
+            background: HF.paper,
+            border: `1px solid ${HF.border}`,
+            borderRadius: HF.r.lg,
+            boxShadow: HF.shadow.lg,
+            color: HF.ink,
+            fontFamily: HF.body,
+            pointerEvents: 'auto',
+            padding: 16,
+          }}
+        >
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:gap-4">
+            <div className="flex-1 text-sm">
+              <h2
+                id="cookie-banner-title"
+                className="mb-1 text-base font-semibold"
+                style={{ fontFamily: HF.display, color: HF.ink }}
+              >
+                {t('banner.title')}
+              </h2>
+              <p style={{ color: HF.ink2, lineHeight: 1.5 }}>
+                {t('banner.body')}
+              </p>
+              <p className="mt-2 text-xs" style={{ color: HF.ink3 }}>
+                <a
+                  href="/privacy"
+                  style={{ color: HF.accent, textDecoration: 'underline' }}
+                >
+                  {t('banner.privacyLink')}
+                </a>
+                <span aria-hidden="true"> · </span>
+                <a
+                  href="/cookies"
+                  style={{ color: HF.accent, textDecoration: 'underline' }}
+                >
+                  {t('banner.cookiesLink')}
+                </a>
+              </p>
+            </div>
+            <div className="flex flex-col-reverse gap-2 sm:flex-col sm:items-stretch sm:justify-center">
+              <button
+                type="button"
+                data-testid="cookie-banner-customize"
+                onClick={() => setModalOpen(true)}
+                className="text-sm font-medium"
+                style={{
+                  background: 'transparent',
+                  color: HF.ink2,
+                  border: `1px solid ${HF.border}`,
+                  borderRadius: HF.r.md,
+                  padding: '8px 12px',
+                }}
+              >
+                {t('banner.customize')}
+              </button>
+              <button
+                type="button"
+                data-testid="cookie-banner-reject-all"
+                onClick={rejectAll}
+                className="text-sm font-medium"
+                style={{
+                  background: HF.paper,
+                  color: HF.ink,
+                  border: `1px solid ${HF.borderHi}`,
+                  borderRadius: HF.r.md,
+                  padding: '8px 12px',
+                }}
+              >
+                {t('banner.rejectAll')}
+              </button>
+              <button
+                type="button"
+                data-testid="cookie-banner-accept-all"
+                onClick={acceptAll}
+                className="text-sm font-semibold"
+                style={{
+                  background: HF.accent,
+                  color: '#FFFFFF',
+                  border: `1px solid ${HF.accent}`,
+                  borderRadius: HF.r.md,
+                  padding: '8px 12px',
+                }}
+              >
+                {t('banner.acceptAll')}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+      <CookiePreferencesModal
+        open={modalOpen}
+        onClose={() => setModalOpen(false)}
+      />
+    </>
+  );
+}

--- a/client-tenant/src/components/CookiePreferencesModal.tsx
+++ b/client-tenant/src/components/CookiePreferencesModal.tsx
@@ -1,0 +1,276 @@
+/**
+ * CookiePreferencesModal — per-category opt-in.
+ *
+ * Opened from CookieBanner "Customize" and from the footer
+ * "Cookie preferences" link. Four toggle rows: Essential (always on,
+ * disabled), Functional, Analytics, Marketing.
+ *
+ * Save commits all four choices to the consent store at once (so
+ * recordedAt is set exactly once per Save). Cancel closes without
+ * writing.
+ *
+ * gpmglv wedge #15.
+ */
+
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { HF } from '@/styles/tokens';
+import {
+  useConsent,
+  setCategory,
+  type ConsentCategory,
+} from '@/state/consent';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+type Draft = Record<ConsentCategory, boolean>;
+
+function draftFromState(s: {
+  functional?: boolean;
+  analytics?: boolean;
+  marketing?: boolean;
+}): Draft {
+  return {
+    functional: s.functional === true,
+    analytics: s.analytics === true,
+    marketing: s.marketing === true,
+  };
+}
+
+export function CookiePreferencesModal({ open, onClose }: Props) {
+  const { t } = useTranslation('legal');
+  const consent = useConsent();
+  const [draft, setDraft] = useState<Draft>(() => draftFromState(consent));
+
+  // Re-sync draft when the modal opens or the underlying consent state
+  // changes from elsewhere (e.g. another tab via storage event — not
+  // currently wired but cheap to be defensive).
+  useEffect(() => {
+    if (open) setDraft(draftFromState(consent));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  // Esc closes — modal version, separate from the banner's Esc handler.
+  useEffect(() => {
+    if (!open) return;
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') onClose();
+    }
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  function handleSave() {
+    // Single Save commits all three non-essential categories. We call
+    // setCategory for each so recordedAt updates and the listeners
+    // emit. Order is irrelevant — the store has no race because writes
+    // are synchronous.
+    setCategory('functional', draft.functional);
+    setCategory('analytics', draft.analytics);
+    setCategory('marketing', draft.marketing);
+    onClose();
+  }
+
+  const categories: Array<{
+    key: 'essential' | ConsentCategory;
+    enabled: boolean;
+    disabled: boolean;
+    onToggle?: (v: boolean) => void;
+  }> = [
+    { key: 'essential', enabled: true, disabled: true },
+    {
+      key: 'functional',
+      enabled: draft.functional,
+      disabled: false,
+      onToggle: (v) => setDraft((d) => ({ ...d, functional: v })),
+    },
+    {
+      key: 'analytics',
+      enabled: draft.analytics,
+      disabled: false,
+      onToggle: (v) => setDraft((d) => ({ ...d, analytics: v })),
+    },
+    {
+      key: 'marketing',
+      enabled: draft.marketing,
+      disabled: false,
+      onToggle: (v) => setDraft((d) => ({ ...d, marketing: v })),
+    },
+  ];
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="cookie-prefs-title"
+      data-testid="cookie-preferences-modal"
+      className="fixed inset-0 z-[60] flex items-end justify-center sm:items-center"
+      style={{ background: 'rgba(31, 26, 18, 0.45)' }}
+      onClick={(e) => {
+        // Click outside the inner card closes — outer is the backdrop.
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div
+        className="w-full max-w-lg overflow-y-auto"
+        style={{
+          background: HF.paper,
+          borderTopLeftRadius: HF.r.lg,
+          borderTopRightRadius: HF.r.lg,
+          borderBottomLeftRadius: HF.r.lg,
+          borderBottomRightRadius: HF.r.lg,
+          maxHeight: '85vh',
+          color: HF.ink,
+          fontFamily: HF.body,
+          padding: 20,
+          margin: 12,
+        }}
+      >
+        <h2
+          id="cookie-prefs-title"
+          className="text-lg font-semibold"
+          style={{ fontFamily: HF.display, color: HF.ink }}
+        >
+          {t('modal.title')}
+        </h2>
+        <p
+          className="mt-1 text-sm"
+          style={{ color: HF.ink2, lineHeight: 1.5 }}
+        >
+          {t('modal.intro')}
+        </p>
+
+        <ul className="mt-4 space-y-3">
+          {categories.map((cat) => (
+            <li
+              key={cat.key}
+              className="flex items-start gap-3"
+              style={{
+                border: `1px solid ${HF.border}`,
+                borderRadius: HF.r.md,
+                padding: 12,
+                background: HF.paperHi,
+              }}
+            >
+              <div className="flex-1">
+                <div
+                  className="text-sm font-semibold"
+                  style={{ color: HF.ink }}
+                >
+                  {t(`modal.categories.${cat.key}.label`)}
+                </div>
+                <div
+                  className="mt-1 text-xs"
+                  style={{ color: HF.ink2, lineHeight: 1.5 }}
+                >
+                  {t(`modal.categories.${cat.key}.description`)}
+                </div>
+              </div>
+              <ToggleSwitch
+                category={cat.key}
+                checked={cat.enabled}
+                disabled={cat.disabled}
+                onChange={cat.onToggle}
+                label={t(`modal.categories.${cat.key}.label`)}
+              />
+            </li>
+          ))}
+        </ul>
+
+        <div className="mt-5 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+          <button
+            type="button"
+            data-testid="cookie-preferences-cancel"
+            onClick={onClose}
+            className="text-sm font-medium"
+            style={{
+              background: 'transparent',
+              color: HF.ink2,
+              border: `1px solid ${HF.border}`,
+              borderRadius: HF.r.md,
+              padding: '8px 14px',
+            }}
+          >
+            {t('modal.cancel')}
+          </button>
+          <button
+            type="button"
+            data-testid="cookie-preferences-save"
+            onClick={handleSave}
+            className="text-sm font-semibold"
+            style={{
+              background: HF.accent,
+              color: '#FFFFFF',
+              border: `1px solid ${HF.accent}`,
+              borderRadius: HF.r.md,
+              padding: '8px 14px',
+            }}
+          >
+            {t('modal.save')}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ToggleSwitch({
+  category,
+  checked,
+  disabled,
+  onChange,
+  label,
+}: {
+  category: 'essential' | ConsentCategory;
+  checked: boolean;
+  disabled: boolean;
+  onChange?: (v: boolean) => void;
+  label: string;
+}) {
+  return (
+    <label
+      className="relative inline-flex shrink-0 cursor-pointer items-center"
+      style={{ width: 44, height: 24, cursor: disabled ? 'not-allowed' : 'pointer' }}
+    >
+      <input
+        type="checkbox"
+        data-testid={`cookie-prefs-toggle-${category}`}
+        aria-label={label}
+        checked={checked}
+        disabled={disabled}
+        onChange={(e) => onChange?.(e.target.checked)}
+        className="sr-only"
+      />
+      <span
+        aria-hidden="true"
+        style={{
+          position: 'absolute',
+          inset: 0,
+          background: checked ? HF.accent : HF.borderHi,
+          opacity: disabled ? 0.6 : 1,
+          borderRadius: HF.r.pill,
+          transition: 'background 120ms ease',
+        }}
+      />
+      <span
+        aria-hidden="true"
+        style={{
+          position: 'absolute',
+          top: 2,
+          left: checked ? 22 : 2,
+          width: 20,
+          height: 20,
+          background: '#FFFFFF',
+          borderRadius: '50%',
+          boxShadow: HF.shadow.xs,
+          transition: 'left 120ms ease',
+        }}
+      />
+    </label>
+  );
+}

--- a/client-tenant/src/components/SiteFooter.tsx
+++ b/client-tenant/src/components/SiteFooter.tsx
@@ -1,0 +1,80 @@
+/**
+ * SiteFooter — minimal global footer.
+ *
+ * Mounted alongside CookieBanner in App.tsx so it appears on every
+ * route. Three links: Privacy, Cookies, Cookie preferences (opens the
+ * preferences modal via the consent store's clearAndReprompt + a small
+ * local event — actually, we mount our own modal here so we don't need
+ * to coordinate with the banner).
+ *
+ * Visually subtle so it doesn't fight existing per-page layouts.
+ *
+ * gpmglv wedge #15.
+ */
+
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { HF } from '@/styles/tokens';
+import { CookiePreferencesModal } from './CookiePreferencesModal';
+
+export function SiteFooter() {
+  const { t } = useTranslation('legal');
+  const [prefsOpen, setPrefsOpen] = useState(false);
+
+  return (
+    <>
+      <footer
+        data-testid="site-footer"
+        className="px-4 py-4 text-xs sm:px-6 sm:py-5"
+        style={{
+          background: HF.cream,
+          color: HF.ink3,
+          borderTop: `1px solid ${HF.border}`,
+          fontFamily: HF.body,
+        }}
+      >
+        <div className="mx-auto flex max-w-6xl flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <span style={{ color: HF.ink3 }}>{t('footer.tagline')}</span>
+          <nav
+            className="flex flex-wrap items-center gap-x-4 gap-y-2"
+            aria-label="Legal"
+          >
+            <Link
+              to="/privacy"
+              style={{ color: HF.ink2, textDecoration: 'underline' }}
+            >
+              {t('footer.privacy')}
+            </Link>
+            <Link
+              to="/cookies"
+              style={{ color: HF.ink2, textDecoration: 'underline' }}
+            >
+              {t('footer.cookies')}
+            </Link>
+            <button
+              type="button"
+              data-testid="footer-cookie-preferences"
+              onClick={() => setPrefsOpen(true)}
+              style={{
+                color: HF.ink2,
+                textDecoration: 'underline',
+                background: 'transparent',
+                border: 'none',
+                padding: 0,
+                cursor: 'pointer',
+                font: 'inherit',
+              }}
+            >
+              {t('footer.preferences')}
+            </button>
+          </nav>
+        </div>
+      </footer>
+      <CookiePreferencesModal
+        open={prefsOpen}
+        onClose={() => setPrefsOpen(false)}
+      />
+    </>
+  );
+}

--- a/client-tenant/src/components/__tests__/CookieBanner.test.tsx
+++ b/client-tenant/src/components/__tests__/CookieBanner.test.tsx
@@ -1,0 +1,78 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { CookieBanner } from '../CookieBanner';
+import {
+  CONSENT_STORAGE_KEY,
+  _rehydrateForTests,
+  getConsentSnapshot,
+} from '@/state/consent';
+
+function renderBanner() {
+  return render(
+    <MemoryRouter>
+      <CookieBanner />
+    </MemoryRouter>,
+  );
+}
+
+describe('CookieBanner', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    _rehydrateForTests();
+  });
+
+  it('renders when recordedAt is null (fresh visit)', () => {
+    renderBanner();
+    expect(screen.getByTestId('cookie-banner')).toBeInTheDocument();
+  });
+
+  it('hides after Accept all is clicked', async () => {
+    const user = userEvent.setup();
+    renderBanner();
+    await user.click(screen.getByTestId('cookie-banner-accept-all'));
+    expect(screen.queryByTestId('cookie-banner')).not.toBeInTheDocument();
+    expect(getConsentSnapshot().functional).toBe(true);
+    expect(getConsentSnapshot().marketing).toBe(true);
+  });
+
+  it('hides after Reject non-essential is clicked', async () => {
+    const user = userEvent.setup();
+    renderBanner();
+    await user.click(screen.getByTestId('cookie-banner-reject-all'));
+    expect(screen.queryByTestId('cookie-banner')).not.toBeInTheDocument();
+    const s = getConsentSnapshot();
+    expect(s.essential).toBe(true);
+    expect(s.functional).toBe(false);
+    expect(s.analytics).toBe(false);
+    expect(s.marketing).toBe(false);
+  });
+
+  it('Customize opens the preferences modal', async () => {
+    const user = userEvent.setup();
+    renderBanner();
+    expect(
+      screen.queryByTestId('cookie-preferences-modal'),
+    ).not.toBeInTheDocument();
+    await user.click(screen.getByTestId('cookie-banner-customize'));
+    expect(screen.getByTestId('cookie-preferences-modal')).toBeInTheDocument();
+  });
+
+  it('does NOT render when consent was previously recorded', () => {
+    window.localStorage.setItem(
+      CONSENT_STORAGE_KEY,
+      JSON.stringify({
+        essential: true,
+        functional: true,
+        analytics: false,
+        marketing: false,
+        recordedAt: '2026-05-22T00:00:00.000Z',
+      }),
+    );
+    _rehydrateForTests();
+    renderBanner();
+    expect(screen.queryByTestId('cookie-banner')).not.toBeInTheDocument();
+  });
+});

--- a/client-tenant/src/components/__tests__/CookiePreferencesModal.test.tsx
+++ b/client-tenant/src/components/__tests__/CookiePreferencesModal.test.tsx
@@ -1,0 +1,63 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { CookiePreferencesModal } from '../CookiePreferencesModal';
+import { _rehydrateForTests, getConsentSnapshot } from '@/state/consent';
+
+describe('CookiePreferencesModal', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    _rehydrateForTests();
+  });
+
+  it('renders nothing when open=false', () => {
+    render(<CookiePreferencesModal open={false} onClose={() => {}} />);
+    expect(
+      screen.queryByTestId('cookie-preferences-modal'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders when open=true', () => {
+    render(<CookiePreferencesModal open={true} onClose={() => {}} />);
+    expect(screen.getByTestId('cookie-preferences-modal')).toBeInTheDocument();
+  });
+
+  it('essential toggle is disabled (cannot be turned off)', () => {
+    render(<CookiePreferencesModal open={true} onClose={() => {}} />);
+    const essentialToggle = screen.getByTestId('cookie-prefs-toggle-essential');
+    expect(essentialToggle).toBeDisabled();
+    expect(essentialToggle).toBeChecked();
+  });
+
+  it('Save commits current draft to consent store', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    render(<CookiePreferencesModal open={true} onClose={onClose} />);
+
+    // Toggle analytics on
+    await user.click(screen.getByTestId('cookie-prefs-toggle-analytics'));
+    // Save
+    await user.click(screen.getByTestId('cookie-preferences-save'));
+
+    const s = getConsentSnapshot();
+    expect(s.analytics).toBe(true);
+    expect(s.functional).toBe(false); // default-off
+    expect(s.marketing).toBe(false);
+    expect(s.recordedAt).not.toBeNull();
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('Cancel closes without writing', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    render(<CookiePreferencesModal open={true} onClose={onClose} />);
+
+    await user.click(screen.getByTestId('cookie-prefs-toggle-marketing'));
+    await user.click(screen.getByTestId('cookie-preferences-cancel'));
+
+    expect(onClose).toHaveBeenCalled();
+    expect(getConsentSnapshot().recordedAt).toBeNull();
+    expect(getConsentSnapshot().marketing).toBeUndefined();
+  });
+});

--- a/client-tenant/src/i18n/en/legal.json
+++ b/client-tenant/src/i18n/en/legal.json
@@ -1,0 +1,128 @@
+{
+  "banner": {
+    "title": "Your privacy, your choice",
+    "body": "We use essential cookies to keep you signed in and your application secure. With your permission, we'd also use functional and analytics cookies to improve the experience. Marketing cookies are off by default.",
+    "acceptAll": "Accept all",
+    "rejectAll": "Reject non-essential",
+    "customize": "Customize",
+    "privacyLink": "Privacy policy",
+    "cookiesLink": "Cookies",
+    "ariaLabel": "Cookie consent"
+  },
+  "modal": {
+    "title": "Cookie preferences",
+    "intro": "Pick what's on. Essential cookies are required for sign-in and security — those can't be turned off. Save your choice and you can come back to it any time from the footer.",
+    "save": "Save preferences",
+    "cancel": "Cancel",
+    "categories": {
+      "essential": {
+        "label": "Essential",
+        "description": "Sign-in session and security. Required — can't be turned off."
+      },
+      "functional": {
+        "label": "Functional",
+        "description": "Remembers your language preference and similar choices that personalize the experience."
+      },
+      "analytics": {
+        "label": "Analytics",
+        "description": "Helps us see which screens are confusing so we can fix them. We don't run any analytics today — this is plumbing for the future."
+      },
+      "marketing": {
+        "label": "Marketing",
+        "description": "Ad and conversion tracking. Off by default. We don't run any marketing pixels today."
+      }
+    }
+  },
+  "footer": {
+    "privacy": "Privacy",
+    "cookies": "Cookies",
+    "preferences": "Cookie preferences",
+    "tagline": "Frank Pilot — affordable housing, treated with the respect it deserves."
+  },
+  "privacy": {
+    "title": "Privacy policy",
+    "lastUpdated": "Last updated: 22 May 2026",
+    "intro": "Frank Pilot is the tenant-facing portal operated by Community Development Programs Center of Nevada (CDPC). We collect and process applicant data because federal affordable-housing programs require it — HUD income certification, fair-housing reporting, and FCRA-governed screening. This policy explains exactly what we collect, why, and who sees it.",
+    "sections": {
+      "whatWeCollect": {
+        "title": "What we collect",
+        "body": "Account information — your name, email address, and a hashed password. Household composition — the number of people in your household, their relationship to you, and the ages of any minors (required for unit-size eligibility under 24 CFR §5.403). Income and AMI tier — gross annual household income, employment status, and your computed Area Median Income (AMI) tier. Application data — preferred unit type, intent date, accommodation requests, and selected property. Identity verification — government-issued ID for screening when you reach that stage. Communications — messages you send through the portal and our responses."
+      },
+      "whyWeCollect": {
+        "title": "Why we collect it",
+        "body": "Eligibility determination under HUD income limits and the Low-Income Housing Tax Credit (LIHTC) program. Fair-housing reporting required under the Fair Housing Act and HUD's affirmatively furthering fair housing rule. Tenant screening under the Fair Credit Reporting Act (FCRA) — you'll receive separate adverse-action notices if your application is denied based on a consumer report. Lease execution and ongoing tenancy management. Anti-fraud — we keep a record of applications to prevent duplicate or fraudulent submissions."
+      },
+      "whoWeShareWith": {
+        "title": "Who we share with",
+        "body": "By default: nobody outside CDPC. When you take specific actions, limited data goes to specific vendors: Resend (email delivery) receives your email address when we send you a magic-link or status notification — it does not see your application data. Stripe (payment processing) receives payment-method details if you pay rent through the portal — Stripe is PCI-DSS Level 1 compliant. Our database is hosted on Postgres infrastructure (currently Railway during the pilot) inside the United States. We do not sell your data. We do not share with marketers. We do not run analytics or advertising pixels today."
+      },
+      "retention": {
+        "title": "How long we keep it",
+        "body": "Active applications and tenancies — retained for the duration of your relationship with CDPC. Denied or withdrawn applications — retained for 36 months to satisfy fair-housing recordkeeping under 24 CFR §107.30, then deleted. Audit logs — retained for 7 years to satisfy LIHTC compliance auditing. Communications — retained for 3 years."
+      },
+      "yourRights": {
+        "title": "Your rights",
+        "body": "You can request a copy of all data we hold on you, ask us to correct anything wrong, withdraw your application at any time (and we'll delete supporting documents within 36 months per the retention schedule above), and ask us to delete your account once you have no active tenancy. If you believe you were discriminated against, you can file a complaint with HUD at 1-800-669-9777 or directly with us — we're required to investigate and document the response."
+      },
+      "contact": {
+        "title": "How to reach us",
+        "body": "Email privacy questions to privacy@cdpcnv.org. For tenancy questions, use the messaging panel in your portal."
+      }
+    }
+  },
+  "cookies": {
+    "title": "Cookies policy",
+    "lastUpdated": "Last updated: 22 May 2026",
+    "intro": "Frank Pilot uses browser storage (cookies and localStorage) for sign-in and a small number of personalisation features. We don't use third-party tracking cookies. We don't run analytics or advertising pixels today.",
+    "tableHeaders": {
+      "name": "Name",
+      "purpose": "Purpose",
+      "type": "Storage"
+    },
+    "categories": {
+      "essential": {
+        "title": "Essential",
+        "description": "Required for sign-in and security. Can't be turned off — the app doesn't work without these.",
+        "items": [
+          {
+            "name": "frank_tenant_token",
+            "purpose": "Your signed-in session (JWT). Sent on every API request to prove you're you.",
+            "type": "localStorage"
+          },
+          {
+            "name": "cf_clearance / __cf_bm",
+            "purpose": "Cloudflare bot-protection tokens (set by Cloudflare in front of our portal). Transient.",
+            "type": "Cookie (third-party, only on networks that route through Cloudflare)"
+          }
+        ]
+      },
+      "functional": {
+        "title": "Functional",
+        "description": "Personalisation. Off until you accept Functional cookies.",
+        "items": [
+          {
+            "name": "i18nextLng",
+            "purpose": "Your selected language (English or Spanish), so you don't have to pick it every visit.",
+            "type": "localStorage"
+          },
+          {
+            "name": "fp.consent.v1",
+            "purpose": "Records the cookie-banner choice you made on this device so we don't keep asking. This one is technically essential — it's how we honor your no-consent choice — but it stores nothing about you.",
+            "type": "localStorage"
+          }
+        ]
+      },
+      "analytics": {
+        "title": "Analytics",
+        "description": "We don't run any analytics today. If we ever add usage instrumentation, it'll be listed here and gated on this category.",
+        "items": []
+      },
+      "marketing": {
+        "title": "Marketing",
+        "description": "We don't run marketing pixels today and have no plans to. This category is included so the choice is yours if anything ever changes.",
+        "items": []
+      }
+    },
+    "managePreferences": "You can change your choice any time using the \"Cookie preferences\" link in the footer."
+  }
+}

--- a/client-tenant/src/i18n/es/legal.json
+++ b/client-tenant/src/i18n/es/legal.json
@@ -1,0 +1,128 @@
+{
+  "banner": {
+    "title": "Tu privacidad, tu decisión",
+    "body": "Usamos cookies esenciales para mantenerte conectado y proteger tu solicitud. Con tu permiso, también usaríamos cookies funcionales y de análisis para mejorar la experiencia. Las cookies de marketing están desactivadas por defecto.",
+    "acceptAll": "Aceptar todo",
+    "rejectAll": "Rechazar no esenciales",
+    "customize": "Personalizar",
+    "privacyLink": "Política de privacidad",
+    "cookiesLink": "Cookies",
+    "ariaLabel": "Consentimiento de cookies"
+  },
+  "modal": {
+    "title": "Preferencias de cookies",
+    "intro": "Elige qué activar. Las cookies esenciales son necesarias para iniciar sesión y para la seguridad — esas no se pueden desactivar. Guarda tu decisión y podrás volver a ella en cualquier momento desde el pie de página.",
+    "save": "Guardar preferencias",
+    "cancel": "Cancelar",
+    "categories": {
+      "essential": {
+        "label": "Esenciales",
+        "description": "Sesión de inicio y seguridad. Obligatorias — no se pueden desactivar."
+      },
+      "functional": {
+        "label": "Funcionales",
+        "description": "Recuerdan tu idioma preferido y elecciones similares que personalizan la experiencia."
+      },
+      "analytics": {
+        "label": "Análisis",
+        "description": "Nos ayudan a ver qué pantallas confunden para poder arreglarlas. Hoy no usamos ningún sistema de análisis — esto es preparación para el futuro."
+      },
+      "marketing": {
+        "label": "Marketing",
+        "description": "Seguimiento publicitario y de conversión. Desactivado por defecto. Hoy no usamos píxeles de marketing."
+      }
+    }
+  },
+  "footer": {
+    "privacy": "Privacidad",
+    "cookies": "Cookies",
+    "preferences": "Preferencias de cookies",
+    "tagline": "Frank Pilot — vivienda asequible, tratada con el respeto que merece."
+  },
+  "privacy": {
+    "title": "Política de privacidad",
+    "lastUpdated": "Última actualización: 22 de mayo de 2026",
+    "intro": "Frank Pilot es el portal para inquilinos operado por Community Development Programs Center of Nevada (CDPC). Recopilamos y procesamos datos de los solicitantes porque los programas federales de vivienda asequible lo exigen — certificación de ingresos de HUD, informes de vivienda justa y verificación regida por la FCRA. Esta política explica exactamente qué recopilamos, por qué y quién lo ve.",
+    "sections": {
+      "whatWeCollect": {
+        "title": "Qué recopilamos",
+        "body": "Información de la cuenta — tu nombre, correo electrónico y contraseña en formato hash. Composición del hogar — número de personas en tu hogar, su relación contigo y las edades de los menores (requerido para la elegibilidad del tamaño de la unidad bajo 24 CFR §5.403). Ingresos y nivel AMI — ingresos brutos anuales del hogar, estado laboral y tu nivel calculado del Ingreso Medio del Área (AMI). Datos de la solicitud — tipo de unidad preferido, fecha de mudanza, solicitudes de adaptación razonable y propiedad seleccionada. Verificación de identidad — identificación oficial cuando llegues a esa etapa. Comunicaciones — mensajes que envías por el portal y nuestras respuestas."
+      },
+      "whyWeCollect": {
+        "title": "Por qué lo recopilamos",
+        "body": "Determinación de elegibilidad bajo los límites de ingresos de HUD y del programa LIHTC. Informes de vivienda justa requeridos por la Ley de Vivienda Justa y la regla de HUD de fomentar afirmativamente la vivienda justa. Verificación de inquilinos bajo la Ley de Informes de Crédito Justos (FCRA) — recibirás avisos de acción adversa por separado si tu solicitud es denegada según un informe del consumidor. Ejecución del contrato de arrendamiento y gestión de la tenencia. Antifraude — guardamos un registro de solicitudes para prevenir envíos duplicados o fraudulentos."
+      },
+      "whoWeShareWith": {
+        "title": "Con quién compartimos",
+        "body": "Por defecto: con nadie fuera de CDPC. Cuando realizas acciones específicas, datos limitados van a proveedores específicos: Resend (envío de correo) recibe tu dirección de correo cuando te enviamos un enlace mágico o notificación de estado — no ve los datos de tu solicitud. Stripe (procesamiento de pagos) recibe los detalles del método de pago si pagas el alquiler por el portal — Stripe cumple con PCI-DSS Nivel 1. Nuestra base de datos está alojada en infraestructura Postgres (actualmente Railway durante el piloto) dentro de Estados Unidos. No vendemos tus datos. No los compartimos con anunciantes. Hoy no usamos análisis ni píxeles publicitarios."
+      },
+      "retention": {
+        "title": "Cuánto tiempo los conservamos",
+        "body": "Solicitudes activas e inquilinatos — conservados durante la duración de tu relación con CDPC. Solicitudes denegadas o retiradas — conservadas durante 36 meses para cumplir con el mantenimiento de registros de vivienda justa bajo 24 CFR §107.30, luego se eliminan. Registros de auditoría — conservados durante 7 años para cumplir con la auditoría de cumplimiento del LIHTC. Comunicaciones — conservadas durante 3 años."
+      },
+      "yourRights": {
+        "title": "Tus derechos",
+        "body": "Puedes pedir una copia de todos los datos que tenemos sobre ti, pedir que corrijamos cualquier cosa incorrecta, retirar tu solicitud en cualquier momento (y eliminaremos los documentos de respaldo dentro de los 36 meses según el calendario de retención anterior), y pedir que eliminemos tu cuenta cuando ya no tengas un inquilinato activo. Si crees que fuiste discriminado/a, puedes presentar una queja ante HUD al 1-800-669-9777 o directamente con nosotros — estamos obligados a investigar y documentar la respuesta."
+      },
+      "contact": {
+        "title": "Cómo contactarnos",
+        "body": "Envía preguntas de privacidad a privacy@cdpcnv.org. Para preguntas sobre tu tenencia, usa el panel de mensajería en tu portal."
+      }
+    }
+  },
+  "cookies": {
+    "title": "Política de cookies",
+    "lastUpdated": "Última actualización: 22 de mayo de 2026",
+    "intro": "Frank Pilot usa almacenamiento del navegador (cookies y localStorage) para iniciar sesión y para un pequeño número de funciones de personalización. No usamos cookies de seguimiento de terceros. Hoy no usamos análisis ni píxeles publicitarios.",
+    "tableHeaders": {
+      "name": "Nombre",
+      "purpose": "Propósito",
+      "type": "Almacenamiento"
+    },
+    "categories": {
+      "essential": {
+        "title": "Esenciales",
+        "description": "Necesarias para iniciar sesión y para la seguridad. No se pueden desactivar — la aplicación no funciona sin ellas.",
+        "items": [
+          {
+            "name": "frank_tenant_token",
+            "purpose": "Tu sesión iniciada (JWT). Se envía en cada solicitud API para verificar que eres tú.",
+            "type": "localStorage"
+          },
+          {
+            "name": "cf_clearance / __cf_bm",
+            "purpose": "Tokens de protección anti-bots de Cloudflare (establecidos por Cloudflare frente a nuestro portal). Transitorios.",
+            "type": "Cookie (de terceros, solo en redes que pasan por Cloudflare)"
+          }
+        ]
+      },
+      "functional": {
+        "title": "Funcionales",
+        "description": "Personalización. Desactivadas hasta que aceptes las cookies funcionales.",
+        "items": [
+          {
+            "name": "i18nextLng",
+            "purpose": "Tu idioma seleccionado (inglés o español), para que no tengas que elegirlo cada vez.",
+            "type": "localStorage"
+          },
+          {
+            "name": "fp.consent.v1",
+            "purpose": "Registra la elección del banner de cookies en este dispositivo para que no sigamos preguntando. Esta es técnicamente esencial — es como respetamos tu decisión de no consentir — pero no almacena nada sobre ti.",
+            "type": "localStorage"
+          }
+        ]
+      },
+      "analytics": {
+        "title": "Análisis",
+        "description": "Hoy no usamos ningún sistema de análisis. Si alguna vez añadimos instrumentación de uso, aparecerá aquí y estará sujeta a esta categoría.",
+        "items": []
+      },
+      "marketing": {
+        "title": "Marketing",
+        "description": "Hoy no usamos píxeles de marketing y no hay planes de hacerlo. Esta categoría está incluida para que la decisión sea tuya si algo cambia.",
+        "items": []
+      }
+    },
+    "managePreferences": "Puedes cambiar tu elección en cualquier momento usando el enlace \"Preferencias de cookies\" en el pie de página."
+  }
+}

--- a/client-tenant/src/i18n/index.ts
+++ b/client-tenant/src/i18n/index.ts
@@ -1,20 +1,23 @@
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
+import { getConsentSnapshot } from '@/state/consent';
 
 import enCommon from './en/common.json';
 import enWelcome from './en/welcome.json';
 import enApply from './en/apply.json';
 import enWaitlist from './en/waitlist.json';
 import enDiscover from './en/discover.json';
+import enLegal from './en/legal.json';
 
 import esCommon from './es/common.json';
 import esWelcome from './es/welcome.json';
 import esApply from './es/apply.json';
 import esWaitlist from './es/waitlist.json';
 import esDiscover from './es/discover.json';
+import esLegal from './es/legal.json';
 
-export const NS = ['common', 'welcome', 'apply', 'waitlist', 'discover'] as const;
+export const NS = ['common', 'welcome', 'apply', 'waitlist', 'discover', 'legal'] as const;
 
 const resources = {
   en: {
@@ -23,6 +26,7 @@ const resources = {
     apply: enApply,
     waitlist: enWaitlist,
     discover: enDiscover,
+    legal: enLegal,
   },
   es: {
     common: esCommon,
@@ -30,8 +34,22 @@ const resources = {
     apply: esApply,
     waitlist: esWaitlist,
     discover: esDiscover,
+    legal: esLegal,
   },
 };
+
+// Language preference (i18nextLng) is "functional" storage under GDPR.
+// If the user has not yet granted Functional consent (either undefined or
+// explicitly false), we don't persist the choice — language resets each
+// reload until they opt in. This is the one real consequence the consent
+// store gates today; everything else is plumbing for the future.
+function functionalConsentGranted(): boolean {
+  try {
+    return getConsentSnapshot().functional === true;
+  } catch {
+    return false;
+  }
+}
 
 void i18n
   .use(LanguageDetector)
@@ -47,9 +65,22 @@ void i18n
       order: ['querystring', 'localStorage', 'navigator'],
       lookupQuerystring: 'lng',
       lookupLocalStorage: 'i18nextLng',
-      caches: ['localStorage'],
+      caches: functionalConsentGranted() ? ['localStorage'] : [],
     },
     returnNull: false,
   });
+
+// If a previous session persisted i18nextLng but the user hasn't (yet)
+// granted Functional consent, clear the cached preference so the choice
+// doesn't survive without consent. We re-write it lazily once they accept.
+if (!functionalConsentGranted()) {
+  try {
+    if (typeof window !== 'undefined') {
+      window.localStorage.removeItem('i18nextLng');
+    }
+  } catch {
+    /* best-effort */
+  }
+}
 
 export default i18n;

--- a/client-tenant/src/pages/legal/CookiesPolicy.tsx
+++ b/client-tenant/src/pages/legal/CookiesPolicy.tsx
@@ -1,0 +1,137 @@
+/**
+ * Public cookies policy — categorised list of every cookie or
+ * browser-storage entry Frank Pilot uses today. Itemised in
+ * i18n (en/es) legal.json so it stays accurate and translatable.
+ *
+ * Wedge #15.
+ */
+
+import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { HF } from '@/styles/tokens';
+
+const CATEGORY_KEYS = [
+  'essential',
+  'functional',
+  'analytics',
+  'marketing',
+] as const;
+
+interface CookieItem {
+  name: string;
+  purpose: string;
+  type: string;
+}
+
+export function CookiesPolicy() {
+  const { t } = useTranslation('legal');
+
+  return (
+    <div
+      className="min-h-screen"
+      style={{ background: HF.cream, color: HF.ink, fontFamily: HF.body }}
+    >
+      <article
+        className="mx-auto max-w-2xl px-4 py-8 sm:px-6 sm:py-12"
+        style={{ lineHeight: 1.6 }}
+      >
+        <header className="mb-6">
+          <Link
+            to="/welcome"
+            className="text-sm"
+            style={{ color: HF.accent, textDecoration: 'underline' }}
+          >
+            ← Frank Pilot
+          </Link>
+          <h1
+            className="mt-3 text-2xl font-semibold sm:text-3xl"
+            style={{ fontFamily: HF.display, color: HF.ink }}
+          >
+            {t('cookies.title')}
+          </h1>
+          <p className="mt-1 text-xs" style={{ color: HF.ink3 }}>
+            {t('cookies.lastUpdated')}
+          </p>
+        </header>
+
+        <p style={{ color: HF.ink2 }}>{t('cookies.intro')}</p>
+
+        {CATEGORY_KEYS.map((key) => {
+          const items = t(`cookies.categories.${key}.items`, {
+            returnObjects: true,
+          }) as CookieItem[] | undefined;
+          const safeItems = Array.isArray(items) ? items : [];
+
+          return (
+            <section key={key} className="mt-6">
+              <h2
+                className="text-lg font-semibold"
+                style={{ fontFamily: HF.display, color: HF.ink }}
+              >
+                {t(`cookies.categories.${key}.title`)}
+              </h2>
+              <p className="mt-1 text-sm" style={{ color: HF.ink2 }}>
+                {t(`cookies.categories.${key}.description`)}
+              </p>
+
+              {safeItems.length > 0 && (
+                <ul
+                  className="mt-3 space-y-2"
+                  style={{
+                    border: `1px solid ${HF.border}`,
+                    borderRadius: HF.r.md,
+                    background: HF.paperHi,
+                    padding: 12,
+                  }}
+                >
+                  {safeItems.map((item) => (
+                    <li
+                      key={item.name}
+                      className="text-xs sm:text-sm"
+                      style={{ color: HF.ink2 }}
+                    >
+                      <div
+                        className="font-mono font-semibold"
+                        style={{ color: HF.ink, fontFamily: HF.mono }}
+                      >
+                        {item.name}
+                      </div>
+                      <div className="mt-0.5">
+                        <span className="font-medium" style={{ color: HF.ink2 }}>
+                          {t('cookies.tableHeaders.purpose')}:
+                        </span>{' '}
+                        {item.purpose}
+                      </div>
+                      <div>
+                        <span className="font-medium" style={{ color: HF.ink2 }}>
+                          {t('cookies.tableHeaders.type')}:
+                        </span>{' '}
+                        {item.type}
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </section>
+          );
+        })}
+
+        <p
+          className="mt-8 text-xs"
+          style={{ color: HF.ink3, fontStyle: 'italic' }}
+        >
+          {t('cookies.managePreferences')}
+        </p>
+
+        <footer className="mt-6 text-xs" style={{ color: HF.ink3 }}>
+          <Link
+            to="/privacy"
+            style={{ color: HF.accent, textDecoration: 'underline' }}
+          >
+            Privacy policy
+          </Link>
+        </footer>
+      </article>
+    </div>
+  );
+}

--- a/client-tenant/src/pages/legal/PrivacyPolicy.tsx
+++ b/client-tenant/src/pages/legal/PrivacyPolicy.tsx
@@ -1,0 +1,81 @@
+/**
+ * Public privacy policy — plain language, accurate to what the codebase
+ * actually does today (Resend for email, Stripe for payments, Postgres
+ * hosted on Railway during the pilot, no analytics, no marketing pixels).
+ *
+ * Wedge #15: gpmglv.com competitor ships a thin policy. We ship one
+ * that names the HUD / FCRA obligations and itemises every third party.
+ */
+
+import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { HF } from '@/styles/tokens';
+
+const SECTION_KEYS = [
+  'whatWeCollect',
+  'whyWeCollect',
+  'whoWeShareWith',
+  'retention',
+  'yourRights',
+  'contact',
+] as const;
+
+export function PrivacyPolicy() {
+  const { t } = useTranslation('legal');
+
+  return (
+    <div
+      className="min-h-screen"
+      style={{ background: HF.cream, color: HF.ink, fontFamily: HF.body }}
+    >
+      <article
+        className="mx-auto max-w-2xl px-4 py-8 sm:px-6 sm:py-12"
+        style={{ lineHeight: 1.6 }}
+      >
+        <header className="mb-6">
+          <Link
+            to="/welcome"
+            className="text-sm"
+            style={{ color: HF.accent, textDecoration: 'underline' }}
+          >
+            ← Frank Pilot
+          </Link>
+          <h1
+            className="mt-3 text-2xl font-semibold sm:text-3xl"
+            style={{ fontFamily: HF.display, color: HF.ink }}
+          >
+            {t('privacy.title')}
+          </h1>
+          <p className="mt-1 text-xs" style={{ color: HF.ink3 }}>
+            {t('privacy.lastUpdated')}
+          </p>
+        </header>
+
+        <p style={{ color: HF.ink2 }}>{t('privacy.intro')}</p>
+
+        {SECTION_KEYS.map((k) => (
+          <section key={k} className="mt-6">
+            <h2
+              className="text-lg font-semibold"
+              style={{ fontFamily: HF.display, color: HF.ink }}
+            >
+              {t(`privacy.sections.${k}.title`)}
+            </h2>
+            <p className="mt-1" style={{ color: HF.ink2 }}>
+              {t(`privacy.sections.${k}.body`)}
+            </p>
+          </section>
+        ))}
+
+        <footer className="mt-10 text-xs" style={{ color: HF.ink3 }}>
+          <Link
+            to="/cookies"
+            style={{ color: HF.accent, textDecoration: 'underline' }}
+          >
+            Cookies policy
+          </Link>
+        </footer>
+      </article>
+    </div>
+  );
+}

--- a/client-tenant/src/pages/legal/__tests__/legal-routes.test.tsx
+++ b/client-tenant/src/pages/legal/__tests__/legal-routes.test.tsx
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { PrivacyPolicy } from '../PrivacyPolicy';
+import { CookiesPolicy } from '../CookiesPolicy';
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/privacy" element={<PrivacyPolicy />} />
+        <Route path="/cookies" element={<CookiesPolicy />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('legal routes', () => {
+  it('/privacy renders the privacy policy heading', () => {
+    renderAt('/privacy');
+    expect(
+      screen.getByRole('heading', { name: /privacy policy/i, level: 1 }),
+    ).toBeInTheDocument();
+    // Spot-check: one of the named section headings is present
+    expect(
+      screen.getByRole('heading', { name: /what we collect/i, level: 2 }),
+    ).toBeInTheDocument();
+  });
+
+  it('/privacy mentions the HUD/FCRA legal basis', () => {
+    renderAt('/privacy');
+    // Body text references the regulatory hook so we know the i18n loaded
+    expect(
+      screen.getAllByText(/HUD income certification|HUD income limits/i)
+        .length,
+    ).toBeGreaterThan(0);
+  });
+
+  it('/cookies renders the cookies policy heading', () => {
+    renderAt('/cookies');
+    expect(
+      screen.getByRole('heading', { name: /cookies policy/i, level: 1 }),
+    ).toBeInTheDocument();
+  });
+
+  it('/cookies lists frank_tenant_token under Essential', () => {
+    renderAt('/cookies');
+    expect(screen.getByText(/frank_tenant_token/)).toBeInTheDocument();
+  });
+
+  it('/cookies lists i18nextLng under Functional', () => {
+    renderAt('/cookies');
+    expect(screen.getByText(/i18nextLng/)).toBeInTheDocument();
+  });
+});

--- a/client-tenant/src/state/__tests__/consent.test.ts
+++ b/client-tenant/src/state/__tests__/consent.test.ts
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  CONSENT_STORAGE_KEY,
+  acceptAll,
+  rejectAll,
+  setCategory,
+  clearAndReprompt,
+  getConsentSnapshot,
+  _rehydrateForTests,
+} from '../consent';
+
+describe('consent store', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    _rehydrateForTests();
+  });
+
+  it('uses storage key fp.consent.v1', () => {
+    expect(CONSENT_STORAGE_KEY).toBe('fp.consent.v1');
+  });
+
+  it('starts with recordedAt=null (banner should show)', () => {
+    const s = getConsentSnapshot();
+    expect(s.recordedAt).toBeNull();
+    expect(s.essential).toBe(true);
+    expect(s.functional).toBeUndefined();
+    expect(s.analytics).toBeUndefined();
+    expect(s.marketing).toBeUndefined();
+  });
+
+  it('acceptAll() turns every category on and records timestamp', () => {
+    acceptAll();
+    const s = getConsentSnapshot();
+    expect(s.essential).toBe(true);
+    expect(s.functional).toBe(true);
+    expect(s.analytics).toBe(true);
+    expect(s.marketing).toBe(true);
+    expect(s.recordedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('acceptAll() persists to localStorage', () => {
+    acceptAll();
+    const raw = window.localStorage.getItem(CONSENT_STORAGE_KEY);
+    expect(raw).toBeTruthy();
+    const parsed = JSON.parse(raw!);
+    expect(parsed.functional).toBe(true);
+    expect(parsed.essential).toBe(true);
+    expect(typeof parsed.recordedAt).toBe('string');
+  });
+
+  it('rejectAll() leaves essential on but turns others off', () => {
+    rejectAll();
+    const s = getConsentSnapshot();
+    expect(s.essential).toBe(true);
+    expect(s.functional).toBe(false);
+    expect(s.analytics).toBe(false);
+    expect(s.marketing).toBe(false);
+    expect(s.recordedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('setCategory updates a single category and records', () => {
+    setCategory('analytics', true);
+    expect(getConsentSnapshot().analytics).toBe(true);
+    expect(getConsentSnapshot().functional).toBeUndefined();
+    expect(getConsentSnapshot().recordedAt).not.toBeNull();
+  });
+
+  it('clearAndReprompt resets state so banner shows again', () => {
+    acceptAll();
+    expect(getConsentSnapshot().recordedAt).not.toBeNull();
+    clearAndReprompt();
+    expect(getConsentSnapshot().recordedAt).toBeNull();
+    expect(getConsentSnapshot().functional).toBeUndefined();
+  });
+
+  it('rehydrates from pre-seeded localStorage (smoke-guard pattern)', () => {
+    const seeded = {
+      essential: true,
+      functional: true,
+      analytics: false,
+      marketing: false,
+      recordedAt: '2026-05-22T00:00:00.000Z',
+    };
+    window.localStorage.setItem(CONSENT_STORAGE_KEY, JSON.stringify(seeded));
+    _rehydrateForTests();
+    const s = getConsentSnapshot();
+    expect(s.functional).toBe(true);
+    expect(s.analytics).toBe(false);
+    expect(s.recordedAt).toBe('2026-05-22T00:00:00.000Z');
+  });
+
+  it('ignores malformed localStorage gracefully', () => {
+    window.localStorage.setItem(CONSENT_STORAGE_KEY, 'not-json{');
+    _rehydrateForTests();
+    expect(getConsentSnapshot().recordedAt).toBeNull();
+  });
+});

--- a/client-tenant/src/state/consent.ts
+++ b/client-tenant/src/state/consent.ts
@@ -1,0 +1,218 @@
+/**
+ * Consent store (gpmglv wedge #15).
+ *
+ * Frank-Pilot collects sensitive applicant data (AMI tier, household
+ * composition, income, identity). Affordable-housing tenants are a
+ * protected class — privacy posture matters.
+ *
+ * Versus the gpmglv.com competitor:
+ *   - gpmglv sets no observable cookies on crawl
+ *   - gpmglv has a thin privacy policy
+ *   - Frank-Pilot ships a real consent banner backed by this store
+ *
+ * Categories (GDPR-style):
+ *   - essential — auth/session storage (frank_tenant_token). Can't be
+ *                 disabled; the app simply doesn't work without it.
+ *   - functional — language preference (i18nextLng) and similar
+ *                  UX-personalisation storage.
+ *   - analytics — usage instrumentation. Nothing wired today.
+ *   - marketing — ad/conversion pixels. Off by default. Nothing wired today.
+ *
+ * Storage:
+ *   - localStorage key `fp.consent.v1` (versioned so we can invalidate
+ *     when categories change).
+ *   - `recordedAt = null` means the user has not made a choice yet, so
+ *     the banner should be shown.
+ *
+ * No external deps — uses React's `useSyncExternalStore` so we don't
+ * pull in zustand for one tiny store.
+ */
+
+import { useSyncExternalStore } from 'react';
+
+export const CONSENT_STORAGE_KEY = 'fp.consent.v1';
+
+export type ConsentCategory = 'functional' | 'analytics' | 'marketing';
+
+export interface ConsentState {
+  /** Auth/session cookies — always on, can't be disabled. */
+  essential: true;
+  /** Language preference and similar UX personalisation. */
+  functional: boolean | undefined;
+  /** Usage instrumentation. */
+  analytics: boolean | undefined;
+  /** Ad/conversion pixels. Off by default. */
+  marketing: boolean | undefined;
+  /** ISO timestamp of when the user recorded their choice, or null. */
+  recordedAt: string | null;
+}
+
+const INITIAL_STATE: ConsentState = {
+  essential: true,
+  functional: undefined,
+  analytics: undefined,
+  marketing: undefined,
+  recordedAt: null,
+};
+
+function safeLocalStorage(): Storage | null {
+  try {
+    return typeof window !== 'undefined' ? window.localStorage : null;
+  } catch {
+    return null;
+  }
+}
+
+function readFromStorage(): ConsentState {
+  const ls = safeLocalStorage();
+  if (!ls) return { ...INITIAL_STATE };
+  try {
+    const raw = ls.getItem(CONSENT_STORAGE_KEY);
+    if (!raw) return { ...INITIAL_STATE };
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') return { ...INITIAL_STATE };
+    return {
+      essential: true,
+      functional:
+        typeof parsed.functional === 'boolean' ? parsed.functional : undefined,
+      analytics:
+        typeof parsed.analytics === 'boolean' ? parsed.analytics : undefined,
+      marketing:
+        typeof parsed.marketing === 'boolean' ? parsed.marketing : undefined,
+      recordedAt:
+        typeof parsed.recordedAt === 'string' && parsed.recordedAt
+          ? parsed.recordedAt
+          : null,
+    };
+  } catch {
+    return { ...INITIAL_STATE };
+  }
+}
+
+function writeToStorage(state: ConsentState): void {
+  const ls = safeLocalStorage();
+  if (!ls) return;
+  try {
+    ls.setItem(CONSENT_STORAGE_KEY, JSON.stringify(state));
+  } catch {
+    // Storage full / private mode — best-effort.
+  }
+}
+
+// ── Pub/sub store ────────────────────────────────────────────────────
+let current: ConsentState = readFromStorage();
+const listeners = new Set<() => void>();
+
+function emit(): void {
+  for (const l of listeners) l();
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+function getSnapshot(): ConsentState {
+  return current;
+}
+
+/**
+ * Server-side snapshot for SSR / hydration — must be a stable identity
+ * to satisfy React's `useSyncExternalStore` contract.
+ */
+const SERVER_SNAPSHOT: ConsentState = Object.freeze({ ...INITIAL_STATE });
+function getServerSnapshot(): ConsentState {
+  return SERVER_SNAPSHOT;
+}
+
+function setState(next: ConsentState): void {
+  current = next;
+  writeToStorage(next);
+  emit();
+}
+
+// ── Actions ──────────────────────────────────────────────────────────
+
+/** Accept all consent categories. Sets `recordedAt`. */
+export function acceptAll(): void {
+  setState({
+    essential: true,
+    functional: true,
+    analytics: true,
+    marketing: true,
+    recordedAt: new Date().toISOString(),
+  });
+}
+
+/**
+ * Reject all non-essential categories. `essential` is still true (we
+ * literally can't run the app without it). Sets `recordedAt` so the
+ * banner stops showing.
+ */
+export function rejectAll(): void {
+  setState({
+    essential: true,
+    functional: false,
+    analytics: false,
+    marketing: false,
+    recordedAt: new Date().toISOString(),
+  });
+}
+
+/** Update a single non-essential category. Sets `recordedAt`. */
+export function setCategory(category: ConsentCategory, value: boolean): void {
+  const next: ConsentState = {
+    ...current,
+    [category]: value,
+    recordedAt: new Date().toISOString(),
+  };
+  setState(next);
+}
+
+/**
+ * Wipe the recorded consent so the banner shows again. Used when the
+ * user explicitly asks to revisit their choice from the footer link.
+ */
+export function clearAndReprompt(): void {
+  setState({ ...INITIAL_STATE });
+}
+
+/**
+ * Test-only helper. Re-reads from storage (useful when a test seeds
+ * localStorage directly and wants the store to pick it up).
+ */
+export function _rehydrateForTests(): void {
+  current = readFromStorage();
+  emit();
+}
+
+// ── React hook ───────────────────────────────────────────────────────
+
+export interface UseConsentResult extends ConsentState {
+  /** True until the user has clicked Accept / Reject / Save. */
+  needsChoice: boolean;
+  acceptAll: () => void;
+  rejectAll: () => void;
+  setCategory: (category: ConsentCategory, value: boolean) => void;
+  clearAndReprompt: () => void;
+}
+
+export function useConsent(): UseConsentResult {
+  const state = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+  return {
+    ...state,
+    needsChoice: state.recordedAt === null,
+    acceptAll,
+    rejectAll,
+    setCategory,
+    clearAndReprompt,
+  };
+}
+
+// Convenience export so non-hook code (e.g. i18n init) can query state
+// without subscribing.
+export function getConsentSnapshot(): ConsentState {
+  return current;
+}

--- a/scripts/qa-apply-handoff-prod.mjs
+++ b/scripts/qa-apply-handoff-prod.mjs
@@ -36,6 +36,26 @@ function check(label, cond) {
 }
 
 const ctx = await browser.newContext({ viewport: VP });
+
+// gpmglv wedge #15 — pre-seed cookie consent so the banner doesn't
+// cover bottom-fixed CTAs.
+await ctx.addInitScript(() => {
+  try {
+    window.localStorage.setItem(
+      'fp.consent.v1',
+      JSON.stringify({
+        essential: true,
+        functional: true,
+        analytics: false,
+        marketing: false,
+        recordedAt: new Date().toISOString(),
+      }),
+    );
+  } catch {
+    /* best-effort */
+  }
+});
+
 const page = await ctx.newPage();
 page.on('pageerror', (e) => console.log('PAGE ERROR', e.message.slice(0, 200)));
 page.on('console', (m) => {

--- a/scripts/qa-apply-handoff.mjs
+++ b/scripts/qa-apply-handoff.mjs
@@ -31,6 +31,29 @@ function check(label, cond) {
 }
 
 const ctx = await browser.newContext({ viewport: VP });
+
+// gpmglv wedge #15 — the cookie banner shows on first visit. Pre-seed
+// localStorage with a "decided" consent record so the banner doesn't
+// cover the bottom-fixed CTAs the smoke test interacts with. Chosen:
+// option 1 (inject localStorage before navigation) — keeps the
+// e2e path identical to today and avoids an extra click.
+await ctx.addInitScript(() => {
+  try {
+    window.localStorage.setItem(
+      'fp.consent.v1',
+      JSON.stringify({
+        essential: true,
+        functional: true,
+        analytics: false,
+        marketing: false,
+        recordedAt: new Date().toISOString(),
+      }),
+    );
+  } catch {
+    /* best-effort */
+  }
+});
+
 const page = await ctx.newPage();
 page.on('pageerror', (e) => console.log('PAGE ERROR', e.message.slice(0, 200)));
 page.on('console', (m) => {


### PR DESCRIPTION
## Summary

**gpmglv wedge #15** — competitive privacy wedge against gpmglv.com (no observable `Set-Cookie` on crawl, thin privacy policy). Affordable-housing tenants are a protected class — privacy posture matters.

- Real cookie banner + per-category preferences modal (HF tokens, EN + ES)
- Public `/privacy` and `/cookies` policy pages with HUD/FCRA-grounded, plain-language copy and an honest itemised list of every cookie/localStorage entry the app sets today
- Typed consent store at `client-tenant/src/state/consent.ts` (versioned `fp.consent.v1`, no new deps — uses `useSyncExternalStore`)
- Global `SiteFooter` with `Privacy` / `Cookies` / `Cookie preferences` links
- One real consent consequence today: `i18nextLng` persistence is off until the user opts into Functional cookies

## Files touched

- `client-tenant/src/state/consent.ts` (new) + tests
- `client-tenant/src/components/CookieBanner.tsx` (new) + tests
- `client-tenant/src/components/CookiePreferencesModal.tsx` (new) + tests
- `client-tenant/src/components/SiteFooter.tsx` (new)
- `client-tenant/src/pages/legal/PrivacyPolicy.tsx` (new) + tests
- `client-tenant/src/pages/legal/CookiesPolicy.tsx` (new)
- `client-tenant/src/i18n/{en,es}/legal.json` (new namespace)
- `client-tenant/src/i18n/index.ts` (load `legal` ns; gate `i18nextLng` cache on Functional consent)
- `client-tenant/src/App.tsx` (`/privacy` + `/cookies` routes; mount banner + footer)
- `scripts/qa-apply-handoff{,prod}.mjs` (smoke-test guard — pre-seed `fp.consent.v1` via `addInitScript`)

## Audit findings

### What the codebase actually stores today

| Bucket | Item | Storage |
|---|---|---|
| Essential | `frank_tenant_token` (JWT) | `localStorage` |
| Essential | `fp.consent.v1` (records the banner choice) | `localStorage` |
| Essential | `cf_clearance` / `__cf_bm` (only when behind Cloudflare) | Cookie (third-party) |
| Functional | `i18nextLng` (language preference) | `localStorage` |
| Analytics | nothing — none wired today | — |
| Marketing | nothing — none wired today | — |

Server sets **no** cookies. JWT is in `localStorage` and sent as `Authorization: Bearer`. There are no analytics or marketing pixels.

### Third parties disclosed in `/privacy`

- **Resend** — email delivery (magic links + status notifications); sees only the recipient's address.
- **Stripe** — payment processing when a tenant pays rent through the portal; PCI-DSS Level 1.
- **Postgres on Railway** (pilot infra) — database host inside the US.
- **Cloudflare** — only on networks that proxy through it (sets transient `cf_clearance` / `__cf_bm`).

No mention of analytics or marketing because none are wired.

### Smoke-test guard

Chose **option 1**: pre-seed `localStorage['fp.consent.v1']` via `playwright.context.addInitScript(...)` before navigation. Faster than option 2 (extra click), keeps the existing 21-check regression path identical, and survives identically in `qa-apply-handoff.mjs` and `qa-apply-handoff-prod.mjs`.

### Merge-conflict risk with in-flight wedges

- **Wedge #14 (SEO)** — already merged (5b17bd6, f92f864). Rebased onto it, no conflicts — wedge #14 modifies `package.json` build script, `index.html`, and `PropertyDetail.tsx`, none of which this PR touches.
- **Wedge #13 (anti-spam / Turnstile)** — not landed. This PR doesn't touch `src/middleware/`, any auth route, `.env.example`, or any register/waitlist form. The only adjacency: wedge #13 may want a Turnstile mention under "Essential cookies" — the cookies page already lists Cloudflare's anti-bot tokens, which is the same vendor; a trivial copy edit when #13 lands.

## Test plan

- [x] `client-tenant`: `npx tsc -b` clean
- [x] `client-tenant`: 176/176 vitest tests pass (was 140)
- [x] `client-tenant`: `npm run build` clean
- [x] root: 857/857 server tests pass
- [x] Smoke-test guard verified: `addInitScript` seeds `fp.consent.v1` before first navigation, so `cookie-banner` testid never appears for the e2e flow
- [ ] CI green: `smoke-apply (Welcome → Claim e2e)` + `test (18 | 20 | 22)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)