### PR TITLE
fix(tests): repair email-service mock with virtual: true

### DIFF
--- a/src/__tests__/email-service.test.ts
+++ b/src/__tests__/email-service.test.ts
@@ -17,11 +17,19 @@ jest.mock("../utils/logger", () => ({
 }));
 
 const mockSend = jest.fn();
-jest.mock("resend", () => ({
-  Resend: jest.fn().mockImplementation(() => ({
-    emails: { send: mockSend },
-  })),
-}));
+jest.mock(
+  "resend",
+  () => ({
+    Resend: jest.fn().mockImplementation(() => ({
+      emails: { send: mockSend },
+    })),
+  }),
+  // `resend` is lazily `require()`'d inside email.ts only when RESEND_API_KEY
+  // is set in prod. We mock it virtually so the test doesn't depend on the SDK
+  // actually being present in node_modules (CI installs it from package.json,
+  // local dev caches can drift).
+  { virtual: true }
+);
 
 import { EmailService, __resetEmailServiceForTests } from "../modules/integrations/email";
 


### PR DESCRIPTION
## Summary

Repairs the `resend` Jest mock in `src/__tests__/email-service.test.ts` so the suite passes regardless of local `node_modules` state.

### Failure 1 — `email-service.test.ts` (FIXED)

The `'resend'` SDK is `require()`'d lazily inside `src/modules/integrations/email.ts` only when `RESEND_API_KEY` is set in production. The test's `jest.mock("resend", ...)` was failing module resolution in environments where `node_modules` predated the addition of `resend` to `package.json` (added in `093c7e5`, the Resend magic-link landing commit).

Fix: pass `{ virtual: true }` to `jest.mock` — the mock registers without requiring the package to be resolvable on disk. CI installs `resend@^4.8.0` from `package.json` normally; this just hardens the test against local install drift and keeps it self-contained (no install side-effects required to green the suite).

### Failure 2 — `bp03b-stamps.test.ts` / `POSITION_LETTER_SENT` (NO-OP — already green on main)

The brief flagged a missing `POSITION_LETTER_SENT` stamp event. Investigated and confirmed it does NOT reproduce on `origin/main`:
- `TAPE_STAMP_KINDS.POSITION_LETTER_SENT` is registered at `src/modules/tape/index.ts:31`
- `TAPE_CITATIONS.POSITION_LETTER_SENT` = `"HUD 4350.3 Ch. 4-14 + 4-16"` at `src/modules/tape/index.ts:43`
- `src/__tests__/tape/bp03b-stamps.test.ts` passes cleanly (7/7) including the dedicated test "5. Position Letter sent — fires on POST /applicants/claim-unit/:id success"

Likely this was already landed in a parallel merge sweep before this branch was cut. No tape engine or stamp catalog change needed.

## Test plan

- [x] `npx jest src/__tests__/email-service.test.ts` — 9/9 pass
- [x] `npx jest src/__tests__/tape/bp03b-stamps.test.ts` — 7/7 pass
- [x] Full `npx jest` run — 45 of 46 suites pass (1 skipped, 0 failed), 864 tests pass, 15 skipped, 0 failed