### PR TITLE
fix(qa-bundle): test mock + storage allowlist + screenshot slim

### DIFF
--- a/client-tenant/src/components/dev/ScreenshotButton.tsx
+++ b/client-tenant/src/components/dev/ScreenshotButton.tsx
@@ -68,12 +68,29 @@ function decodeJwtClaims(token: string): Record<string, unknown> | null {
   } catch { return null; }
 }
 
+// Allowlist of storage keys we know are safe to dump. Unknown keys are
+// dropped silently rather than emitted, to avoid leaking PII or 3rd-party
+// data (e.g. analytics blobs) into the debug bundle. Update when the app
+// starts using a new key worth seeing.
+const STORAGE_ALLOWLIST: ReadonlyArray<string | RegExp> = [
+  TOKEN_KEY,
+  STORAGE_KEY,
+  'i18nextLng',
+  'fp.consent.v1',
+  'pendingEmail',
+  /^frank_/,
+];
+
+function isAllowedStorageKey(key: string): boolean {
+  return STORAGE_ALLOWLIST.some((m) => (typeof m === 'string' ? m === key : m.test(key)));
+}
+
 function dumpStorage(store: Storage | undefined): Record<string, string> {
   if (!store) return {};
   const out: Record<string, string> = {};
   for (let i = 0; i < store.length; i++) {
     const k = store.key(i);
-    if (!k) continue;
+    if (!k || !isAllowedStorageKey(k)) continue;
     const v = store.getItem(k);
     if (v == null) continue;
     out[k] = k === TOKEN_KEY ? '<redacted; see auth.claims>' : v;
@@ -151,9 +168,14 @@ export function ScreenshotButton() {
 
       const { toPng } = await import('html-to-image');
       const node = document.body;
+      // skipFonts: cross-origin Google Fonts stylesheets block cssRules access
+      // and spam two SecurityError lines per capture; we render with system
+      // fonts instead. pixelRatio: 1 keeps QA PNGs ~75KB on retina (vs ~280KB
+      // at the device 2x) — plenty for visual review.
       const dataUrl = await toPng(node, {
         cacheBust: true,
-        pixelRatio: window.devicePixelRatio || 2,
+        pixelRatio: 1,
+        skipFonts: true,
         filter: (el) => {
           if (!(el instanceof HTMLElement)) return true;
           return el.dataset?.screenshotExclude !== '1';

--- a/client-tenant/src/lib/qaBuffer.ts
+++ b/client-tenant/src/lib/qaBuffer.ts
@@ -29,7 +29,29 @@ export type QaEntry = QaFetchEntry | QaErrorEntry;
 
 const buf: QaEntry[] = [];
 
+// Drop fetch entries that are clearly noise so the 25-entry window is reserved
+// for real app traffic (API calls, magic-link, payment, etc). Covers:
+//   - Vite HMR / module loading (/@vite/, /@id/, /__vite_ping, /node_modules/)
+//   - Built static assets (/assets/*.{js,css,map,woff,woff2,ttf,png,svg,jpg})
+//   - Cross-origin font CDNs (fonts.googleapis.com, fonts.gstatic.com)
+//   - Self-uploads to the QA screenshot bucket (would otherwise self-poison
+//     the buffer on every camera click).
+const NOISE_PATTERNS: RegExp[] = [
+  /\/@vite\//,
+  /\/@id\//,
+  /\/__vite_ping/,
+  /\/node_modules\//,
+  /\/assets\/[^?]+\.(?:js|css|map|woff2?|ttf|otf|eot|png|svg|jpg|jpeg|gif|webp|ico)(?:\?|$)/i,
+  /fonts\.(?:googleapis|gstatic)\.com/i,
+  /\/storage\/v1\/object\/(?:public\/)?frank-qa-screenshots\//,
+];
+
+function isNoise(url: string): boolean {
+  return NOISE_PATTERNS.some((re) => re.test(url));
+}
+
 function push(entry: QaEntry): void {
+  if (entry.kind === 'fetch' && isNoise(entry.url)) return;
   buf.push(entry);
   if (buf.length > MAX_ENTRIES) buf.splice(0, buf.length - MAX_ENTRIES);
 }

--- a/src/__tests__/email-service.test.ts
+++ b/src/__tests__/email-service.test.ts
@@ -17,11 +17,19 @@ jest.mock("../utils/logger", () => ({
 }));
 
 const mockSend = jest.fn();
-jest.mock("resend", () => ({
-  Resend: jest.fn().mockImplementation(() => ({
-    emails: { send: mockSend },
-  })),
-}));
+jest.mock(
+  "resend",
+  () => ({
+    Resend: jest.fn().mockImplementation(() => ({
+      emails: { send: mockSend },
+    })),
+  }),
+  // `resend` is lazily `require()`'d inside email.ts only when RESEND_API_KEY
+  // is set in prod. We mock it virtually so the test doesn't depend on the SDK
+  // actually being present in node_modules (CI installs it from package.json,
+  // local dev caches can drift).
+  { virtual: true }
+);
 
 import { EmailService, __resetEmailServiceForTests } from "../modules/integrations/email";
 


### PR DESCRIPTION
## Summary
Two small QA-bundle hygiene fixes that came out of yesterday's GPMG demo session:

- **`fix(tests)`**: wrap the `resend` jest mock with `{ virtual: true }` so the test doesn't depend on the SDK being present in `node_modules`. The `resend` package is `require()`'d lazily inside `email.ts` only when `RESEND_API_KEY` is set, so this is fine for CI and unblocks local dev caches that have drifted.
- **`fix(qa-bundle)`**:
  - Storage dump: allowlist known-safe keys (auth, i18n, consent, frank_*) so QA bundles can't leak 3rd-party analytics blobs into screenshots.
  - Fetch buffer: filter Vite HMR / asset / font / self-upload noise so the 25-entry window stays available for real app traffic.
  - Screenshot capture: pixelRatio:1 + skipFonts:true. ~75% smaller PNGs on retina and silences the cross-origin Google Fonts SecurityError chatter.

## Test plan
- [x] \`pnpm test src/__tests__/email-service.test.ts\` passes locally
- [ ] CI green (test 18/20/22, smoke-apply)
- [ ] Camera FAB on \`frank-pilot-tenant.vercel.app\` produces a smaller screenshot with no fonts.googleapis errors in network log

🤖 Generated with [Claude Code](https://claude.com/claude-code)