### PR TITLE
feat(bp-02): Lane C — event payload makers

### DIFF
--- a/src/modules/tape/events/hud-92006-supplement-captured.ts
+++ b/src/modules/tape/events/hud-92006-supplement-captured.ts
@@ -1,0 +1,53 @@
+/**
+ * BP-02 Compliance Tape — Event payload maker.
+ *
+ * Kind:     HUD_92006_SUPPLEMENT_CAPTURED
+ * Citation: HUD-92006
+ *
+ * HUD-92006 (Supplement to Application for Federally Assisted Housing) gives
+ * applicants the opportunity to designate a person to be notified in case of
+ * lease termination. This stamp records whether the applicant completed / opted
+ * into the HUD-92006 supplement form.
+ */
+
+import { TAPE_CITATIONS, TapeJsonLdPayload } from "../types";
+
+const KIND = "HUD_92006_SUPPLEMENT_CAPTURED" as const;
+
+export interface Hud92006SupplementCapturedInput {
+  /** The applicant who was offered the HUD-92006 supplement. */
+  applicantId: string;
+  /** Optional idempotency / session key. */
+  sessionId?: string;
+  /** ISO-8601 timestamp supplied by the caller — no clock calls here. */
+  capturedAt: string;
+  /**
+   * `true`  — applicant filled in the supplement (named a contact).
+   * `false` — applicant was offered the form but declined / left it blank.
+   */
+  supplementOptedIn: boolean;
+}
+
+/**
+ * Pure function — no IO, no DB, no clock.
+ * Caller is responsible for supplying `capturedAt`.
+ */
+export function makeHud92006SupplementCapturedPayload(
+  input: Hud92006SupplementCapturedInput
+): TapeJsonLdPayload {
+  const { applicantId, sessionId, capturedAt, supplementOptedIn } = input;
+
+  return {
+    "@context": "https://frank-pilot.example/compliance-tape/v1",
+    "@type": "ComplianceEvent.Hud92006SupplementCaptured",
+    actorId: null,
+    subjectId: applicantId,
+    ruleCitation: TAPE_CITATIONS[KIND],
+    evidence: {
+      applicantId,
+      capturedAt,
+      supplementOptedIn,
+      ...(sessionId !== undefined ? { sessionId } : {}),
+    },
+  };
+}

--- a/src/modules/tape/events/hud-928-1-fair-housing.ts
+++ b/src/modules/tape/events/hud-928-1-fair-housing.ts
@@ -1,0 +1,55 @@
+/**
+ * BP-02 Compliance Tape — Event payload maker.
+ *
+ * Kind:     HUD_928_1_FAIR_HOUSING_POSTED
+ * Citation: 24 CFR Part 110
+ *
+ * 24 CFR Part 110 (Equal Opportunity in Housing) requires that a HUD-928.1
+ * "Equal Housing Opportunity" poster or notice be displayed / posted. This
+ * stamp records that the notice was published on the given medium.
+ */
+
+import { TAPE_CITATIONS, TapeJsonLdPayload } from "../types";
+
+const KIND = "HUD_928_1_FAIR_HOUSING_POSTED" as const;
+
+/** The channel on which the fair housing notice was published. */
+export type FairHousingMedium = "web" | "print" | "office";
+
+export interface Hud9281FairHousingPostedInput {
+  /** Optional idempotency / session key. */
+  sessionId?: string;
+  /** Property (site) where the notice was posted. */
+  propertyId?: string;
+  /** ISO-8601 timestamp supplied by the caller — no clock calls here. */
+  postedAt: string;
+  /** Delivery channel for the HUD-928.1 notice. */
+  medium: FairHousingMedium;
+}
+
+/**
+ * Pure function — no IO, no DB, no clock.
+ * Caller is responsible for supplying `postedAt`.
+ *
+ * Note: this event is property-scoped, not applicant-scoped; subjectId is
+ * set to propertyId when available, otherwise "n/a".
+ */
+export function makeHud9281FairHousingPostedPayload(
+  input: Hud9281FairHousingPostedInput
+): TapeJsonLdPayload {
+  const { sessionId, propertyId, postedAt, medium } = input;
+
+  return {
+    "@context": "https://frank-pilot.example/compliance-tape/v1",
+    "@type": "ComplianceEvent.Hud9281FairHousingPosted",
+    actorId: null,
+    subjectId: propertyId ?? "n/a",
+    ruleCitation: TAPE_CITATIONS[KIND],
+    evidence: {
+      postedAt,
+      medium,
+      ...(sessionId !== undefined ? { sessionId } : {}),
+      ...(propertyId !== undefined ? { propertyId } : {}),
+    },
+  };
+}

--- a/src/modules/tape/events/index.ts
+++ b/src/modules/tape/events/index.ts
@@ -1,0 +1,35 @@
+/**
+ * BP-02 Compliance Tape — Lane C event payload makers.
+ *
+ * Re-exports every `make*Payload` function and its associated input type so
+ * callers can import from a single path.
+ *
+ * Usage:
+ *   import { makeWelcomeLetterDeliveredPayload } from "../tape/events";
+ */
+
+export {
+  makeWelcomeLetterDeliveredPayload,
+  type WelcomeLetterDeliveredInput,
+} from "./welcome-letter-delivered";
+
+export {
+  makeHud9281FairHousingPostedPayload,
+  type Hud9281FairHousingPostedInput,
+  type FairHousingMedium,
+} from "./hud-928-1-fair-housing";
+
+export {
+  makeWaitingListAppCapturedPayload,
+  type WaitingListAppCapturedInput,
+} from "./waiting-list-app-captured";
+
+export {
+  makeHud92006SupplementCapturedPayload,
+  type Hud92006SupplementCapturedInput,
+} from "./hud-92006-supplement-captured";
+
+export {
+  makePositionLetterSentPayload,
+  type PositionLetterSentInput,
+} from "./position-letter-sent";

--- a/src/modules/tape/events/position-letter-sent.ts
+++ b/src/modules/tape/events/position-letter-sent.ts
@@ -1,0 +1,57 @@
+/**
+ * BP-02 Compliance Tape — Event payload maker.
+ *
+ * Kind:     POSITION_LETTER_SENT
+ * Citation: HUD 4350.3 Ch. 4-14 + 4-16
+ *
+ * HUD 4350.3 Ch. 4-14 (notification of waiting list position) and Ch. 4-16
+ * (update letters) require that applicants be notified of their position on
+ * the waiting list and of any changes. This stamp records that a position
+ * letter was dispatched to a specific applicant.
+ */
+
+import { TAPE_CITATIONS, TapeJsonLdPayload } from "../types";
+
+const KIND = "POSITION_LETTER_SENT" as const;
+
+export interface PositionLetterSentInput {
+  /** The applicant who received the position letter. */
+  applicantId: string;
+  /** Optional idempotency / session key. */
+  sessionId?: string;
+  /** Property (site) for which the position applies. */
+  propertyId: string;
+  /** Bedroom size for which the applicant is queued. */
+  bedroomCount: number;
+  /** Applicant's current position on the waiting list (1-based). */
+  position: number;
+  /** ISO-8601 timestamp supplied by the caller — no clock calls here. */
+  sentAt: string;
+}
+
+/**
+ * Pure function — no IO, no DB, no clock.
+ * Caller is responsible for supplying `sentAt`.
+ */
+export function makePositionLetterSentPayload(
+  input: PositionLetterSentInput
+): TapeJsonLdPayload {
+  const { applicantId, sessionId, propertyId, bedroomCount, position, sentAt } =
+    input;
+
+  return {
+    "@context": "https://frank-pilot.example/compliance-tape/v1",
+    "@type": "ComplianceEvent.PositionLetterSent",
+    actorId: null,
+    subjectId: applicantId,
+    ruleCitation: TAPE_CITATIONS[KIND],
+    evidence: {
+      applicantId,
+      propertyId,
+      bedroomCount,
+      position,
+      sentAt,
+      ...(sessionId !== undefined ? { sessionId } : {}),
+    },
+  };
+}

--- a/src/modules/tape/events/waiting-list-app-captured.ts
+++ b/src/modules/tape/events/waiting-list-app-captured.ts
@@ -1,0 +1,53 @@
+/**
+ * BP-02 Compliance Tape — Event payload maker.
+ *
+ * Kind:     WAITING_LIST_APP_CAPTURED
+ * Citation: HUD 4350.3 Ch. 4-6
+ *
+ * HUD 4350.3 Ch. 4-6 requires properties to maintain a written waiting list
+ * and to record each application. This stamp records the moment an applicant's
+ * waiting-list application is captured (written) in the system.
+ */
+
+import { TAPE_CITATIONS, TapeJsonLdPayload } from "../types";
+
+const KIND = "WAITING_LIST_APP_CAPTURED" as const;
+
+export interface WaitingListAppCapturedInput {
+  /** The applicant whose application was captured. */
+  applicantId: string;
+  /** Optional idempotency / session key. */
+  sessionId?: string;
+  /** Property (site) the applicant is applying to. */
+  propertyId?: string;
+  /** Number of bedrooms requested; undefined when not yet declared. */
+  bedroomCount?: number;
+  /** ISO-8601 timestamp supplied by the caller — no clock calls here. */
+  capturedAt: string;
+}
+
+/**
+ * Pure function — no IO, no DB, no clock.
+ * Caller is responsible for supplying `capturedAt`.
+ */
+export function makeWaitingListAppCapturedPayload(
+  input: WaitingListAppCapturedInput
+): TapeJsonLdPayload {
+  const { applicantId, sessionId, propertyId, bedroomCount, capturedAt } =
+    input;
+
+  return {
+    "@context": "https://frank-pilot.example/compliance-tape/v1",
+    "@type": "ComplianceEvent.WaitingListAppCaptured",
+    actorId: null,
+    subjectId: applicantId,
+    ruleCitation: TAPE_CITATIONS[KIND],
+    evidence: {
+      applicantId,
+      capturedAt,
+      ...(sessionId !== undefined ? { sessionId } : {}),
+      ...(propertyId !== undefined ? { propertyId } : {}),
+      ...(bedroomCount !== undefined ? { bedroomCount } : {}),
+    },
+  };
+}

--- a/src/modules/tape/events/welcome-letter-delivered.ts
+++ b/src/modules/tape/events/welcome-letter-delivered.ts
@@ -1,0 +1,48 @@
+/**
+ * BP-02 Compliance Tape — Event payload maker.
+ *
+ * Kind:     WELCOME_LETTER_DELIVERED
+ * Citation: HUD 4350.3 Ch. 4-4
+ *
+ * HUD 4350.3 Ch. 4-4 requires that applicants receive a welcome / acknowledgment
+ * letter upon receipt of their application. This stamp records that delivery.
+ */
+
+import { TAPE_CITATIONS, TapeJsonLdPayload } from "../types";
+
+const KIND = "WELCOME_LETTER_DELIVERED" as const;
+
+export interface WelcomeLetterDeliveredInput {
+  /** The applicant who received the letter. */
+  applicantId: string;
+  /** Optional idempotency / session key. */
+  sessionId?: string;
+  /** Property (site) for which the application was received. */
+  propertyId?: string;
+  /** ISO-8601 timestamp supplied by the caller — no clock calls here. */
+  deliveredAt: string;
+}
+
+/**
+ * Pure function — no IO, no DB, no clock.
+ * Caller is responsible for supplying `deliveredAt`.
+ */
+export function makeWelcomeLetterDeliveredPayload(
+  input: WelcomeLetterDeliveredInput
+): TapeJsonLdPayload {
+  const { applicantId, sessionId, propertyId, deliveredAt } = input;
+
+  return {
+    "@context": "https://frank-pilot.example/compliance-tape/v1",
+    "@type": "ComplianceEvent.WelcomeLetterDelivered",
+    actorId: null,
+    subjectId: applicantId,
+    ruleCitation: TAPE_CITATIONS[KIND],
+    evidence: {
+      applicantId,
+      deliveredAt,
+      ...(sessionId !== undefined ? { sessionId } : {}),
+      ...(propertyId !== undefined ? { propertyId } : {}),
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Pure-function JSON-LD event payload makers for the 5 BP-03b compliance tape event kinds. Each maker lives in its own file under `src/modules/tape/events/`, with a barrel re-export at `index.ts`.

| Maker | Citation |
|---|---|
| `makeWelcomeLetterDeliveredPayload` | HUD 4350.3 Ch. 4-4 |
| `makeHud9281FairHousingPostedPayload` | 24 CFR Part 110 |
| `makeWaitingListAppCapturedPayload` | HUD 4350.3 Ch. 4-6 |
| `makeHud92006SupplementCapturedPayload` | HUD-92006 |
| `makePositionLetterSentPayload` | HUD 4350.3 Ch. 4-14 + 4-16 |

## Design notes

- **No IO, no DB, no clock** — all timestamps are caller-supplied.
- `actorId: null` for all makers — contracts §5: "Don't fabricate actorId — pass null for system events."
- `subjectId` is `applicantId` for applicant-scoped events; `propertyId ?? "n/a"` for the property-scoped HUD-928.1 event.
- `@context` → `"https://frank-pilot.example/compliance-tape/v1"` (stub URL per §7 until we own a public schema).
- `@type` follows `"ComplianceEvent.<EventName>"` pattern from §5.
- Optional fields (`sessionId`, `propertyId`, `bedroomCount`) are only included in `evidence` when provided, keeping the JSON-LD tidy for auditors.

## Depends on

**Phase 0 (already merged to main):** `src/modules/tape/types.ts` — provides `TapeJsonLdPayload`, `TapeStampKind`, and `TAPE_CITATIONS`.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json` runs clean (zero errors)
- [ ] Callers in Lane G can import from `src/modules/tape/events` and pass the output directly to `tape.stamp()` as `payload`
- [ ] Each `evidence` object contains auditor-readable fields matching the HUD citation scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)