### PR TITLE
feat(bp-02): Lane H — runbook

### DIFF
--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -4,6 +4,79 @@ Operational reference for Frank-Pilot CDPC operators.
 
 ---
 
+## Compliance Tape (BP-02)
+
+### What the Compliance Tape is
+
+The Compliance Tape is a hash-chained, append-only audit ledger stored in
+Postgres. Every regulated event — welcome letter delivery, fair-housing
+posting, waiting-list capture, HUD-92006 supplement, position letter — writes
+one row. Once written, a row cannot be edited or deleted; the database trigger
+rejects any attempt. Operators can only add new entries.
+
+### Operator-portal actions that write to the tape
+
+| Action | Tape Kind | HUD / CFR citation |
+| --- | --- | --- |
+| Welcome letter delivered | `WELCOME_LETTER_DELIVERED` | HUD 4350.3 Ch. 4-4 |
+| Fair-housing notice posted | `HUD_928_1_FAIR_HOUSING_POSTED` | 24 CFR Part 110 |
+| Applicant captured to waiting list | `WAITING_LIST_APP_CAPTURED` | HUD 4350.3 Ch. 4-6 |
+| HUD-92006 supplement filled | `HUD_92006_SUPPLEMENT_CAPTURED` | HUD-92006 |
+| Position letter sent | `POSITION_LETTER_SENT` | HUD 4350.3 Ch. 4-14 + 4-16 |
+
+### How to view the tape
+
+1. Sign into the operator portal as **Operator+**.
+2. Navigate to **Audit Log** (existing page). The **Compliance Tape** panel is
+   at the bottom.
+3. Enter an applicant ID. The table renders all tape entries for that
+   applicant in sequence order.
+
+### How to export a PDF for an applicant
+
+1. On the Compliance Tape panel, click **Export PDF**.
+2. The PDF contains every entry with its rule citation. The SHA-256 of the
+   latest entry appears in the footer.
+3. The file downloads as `compliance-tape-<applicantId>.pdf`.
+4. Use this for HUD attestations, legal requests, and internal audits.
+
+### How "Verify Chain" works
+
+- Click **Verify Chain**. The portal walks every entry, recomputes each row's
+  SHA-256, and confirms that each link is intact.
+- **Green badge "Verified ✓ (sequence N)"** — tape is intact.
+- **Red badge "Break at sequence M — \<reason\>"** — someone bypassed the
+  append-only safeguards (DB tamper or migration accident). Treat as a **P0
+  incident**: capture a screenshot of the page and escalate to engineering
+  immediately.
+
+### Rollout flag
+
+The new tape (v2) is gated by `COMPLIANCE_TAPE_V2_ENABLED`.
+
+| Environment | Status |
+| --- | --- |
+| Staging | ON once Lane B + Lane G ship |
+| Production | ON after one clean deploy cycle in staging |
+
+During cutover the system **dual-writes** — new Postgres tape and legacy NDJSON
+simultaneously. The NDJSON writer is removed in a follow-up PR once one full
+deploy cycle in staging is clean.
+
+### Where the data lives
+
+- **Table:** `compliance_tape` (Postgres)
+- **Append-only:** enforced by DB trigger — UPDATE, DELETE, and TRUNCATE are
+  all rejected by the database itself.
+- **Migration:** `src/db/migrations/2026-05-23-compliance-tape.sql`
+
+### Engineering reference
+
+- Contract: `docs/bp-02-contracts.md`
+- Source: `src/modules/tape/`
+
+---
+
 ## Compliance Tape (BP-03b)
 
 All HUD-cited touchpoints append to the BP-03b NDJSON ledger:


### PR DESCRIPTION
## Summary

- Adds a new **## Compliance Tape (BP-02)** section to `docs/operator-runbook.md` covering: what the tape is, which five portal actions write to it (with HUD/CFR citations), how to view/export/verify the chain, the `COMPLIANCE_TAPE_V2_ENABLED` rollout flag, and database + engineering references.
- No other files were modified; the new section is inserted above the existing BP-03b section and matches the runbook's heading style and voice.