### PR TITLE
feat(bp-02): Lane D — viewer routes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,7 @@ import applicantRoutes from "./modules/applicants/routes";
 import tenantRoutes from "./modules/tenant/routes";
 import messagesRoutes from "./modules/messages/routes";
 import tapeRoutes from "./modules/tape/routes";
+import { createTapeViewerRoutes } from "./modules/tape/routes-viewer";
 import { startScheduler } from "./scheduler";
 
 // Boot-time guardrails: in production, refuse to start without the secrets that
@@ -106,6 +107,25 @@ app.use("/api/applicants", applicantRoutes);
 // Stub module — see src/modules/tape/index.ts. Replace with canonical BP-02
 // helper when it lands.
 app.use("/api/tape", tapeRoutes);
+
+// BP-02 compliance tape viewer (operator-only: list, verify, export.pdf).
+// TODO(BP-02-Phase-2): Replace the stub service below with the real TapeService
+// from Lane B once it is wired. The stub returns 503 for all calls so the
+// routes exist in production but remain inert until Phase 2 completes.
+app.use(
+  "/api/compliance-tape",
+  createTapeViewerRoutes({
+    async list() {
+      throw Object.assign(new Error("service not wired"), { stub: true });
+    },
+    async verify() {
+      throw Object.assign(new Error("service not wired"), { stub: true });
+    },
+    async exportPdf() {
+      throw Object.assign(new Error("service not wired"), { stub: true });
+    },
+  })
+);
 
 // Password login (staff)
 app.post("/api/auth/login", async (req, res) => {

--- a/src/modules/tape/routes-viewer.ts
+++ b/src/modules/tape/routes-viewer.ts
@@ -1,0 +1,267 @@
+/**
+ * BP-02 Compliance Tape — operator viewer routes (Lane D).
+ *
+ * Exports a factory function so the service can be injected independently of
+ * Lane B's concrete implementation. The service argument is structurally
+ * typed — any object with the three methods satisfies the interface.
+ *
+ * All routes are operator-only (regional_manager+ via requirePermission("audit:view")).
+ * Mounted under /api/compliance-tape — see src/index.ts.
+ *
+ * v1 scope: applicant-scoped reads only.  Global scope returns 501.
+ */
+
+import { Router, Request, Response } from "express";
+import { z } from "zod";
+import { authenticate } from "../../middleware/auth";
+import { requirePermission } from "../../middleware/rbac";
+import type { TapeEntry, VerifyResult, TapeScope } from "./types";
+import type {
+  ListTapeResponse,
+  VerifyTapeResponse,
+  TapeErrorResponse,
+} from "./api-contract";
+import { logger } from "../../utils/logger";
+
+// ---------------------------------------------------------------------------
+// Structural interface for the injected service (Lane B wires the real impl).
+// Kept local so this file compiles without importing Lane B's module.
+// ---------------------------------------------------------------------------
+
+interface TapeViewerService {
+  list(
+    scope: TapeScope,
+    opts?: { limit?: number; afterSequence?: number }
+  ): Promise<TapeEntry[]>;
+  verify(scope: TapeScope): Promise<VerifyResult>;
+  exportPdf(scope: TapeScope): Promise<Buffer>;
+}
+
+// ---------------------------------------------------------------------------
+// Query-string validation schemas
+// ---------------------------------------------------------------------------
+
+const listQuerySchema = z.object({
+  applicantId: z.string().uuid().optional(),
+  afterSequence: z.coerce.number().int().nonnegative().optional(),
+  limit: z.coerce.number().int().min(1).max(200).optional(),
+});
+
+const scopedQuerySchema = z.object({
+  applicantId: z.string().uuid().optional(),
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Parse applicantId from a validated query object and resolve to a TapeScope,
+ *  or return a typed error to be sent as a 400/501. */
+function resolveScope(
+  applicantId: string | undefined
+):
+  | { ok: true; scope: TapeScope }
+  | { ok: false; status: 400 | 501; body: TapeErrorResponse } {
+  if (!applicantId) {
+    // No applicantId → global scope is not implemented in v1.
+    return {
+      ok: false,
+      status: 501,
+      body: {
+        error: "global scope not implemented in v1",
+        code: "global_scope_not_implemented",
+      },
+    };
+  }
+  return {
+    ok: true,
+    scope: { type: "applicant", applicantId },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Error helpers
+// ---------------------------------------------------------------------------
+
+/** True when the service threw the "not wired" stub error. */
+function isStubError(err: unknown): boolean {
+  return (
+    err instanceof Error &&
+    (err as Error & { stub?: boolean }).stub === true
+  );
+}
+
+/** Send a 503 stub response — used until Phase 2 wires the real service. */
+function stubUnavailable(res: Response): void {
+  const body: TapeErrorResponse = {
+    error: "service not yet available (Phase 2 pending)",
+    code: "internal",
+  };
+  res.status(503).json(body);
+}
+
+// ---------------------------------------------------------------------------
+// Router factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create the compliance tape viewer router.
+ *
+ * @param service  Structurally-typed tape service. Pass the real TapeService
+ *                 (Lane B) in Phase 2. Until then, a stub that returns 503 is
+ *                 mounted in src/index.ts — see TODO(BP-02-Phase-2) there.
+ */
+export function createTapeViewerRoutes(service: TapeViewerService): Router {
+  const router = Router();
+
+  // All three routes require authentication + operator-level permission.
+  router.use(authenticate, requirePermission("audit:view"));
+
+  // -------------------------------------------------------------------------
+  // GET /api/compliance-tape?applicantId=<uuid>[&afterSequence=N][&limit=N]
+  // -------------------------------------------------------------------------
+  router.get("/", async (req: Request, res: Response): Promise<void> => {
+    const parsed = listQuerySchema.safeParse(req.query);
+    if (!parsed.success) {
+      const body: TapeErrorResponse = {
+        error: "invalid query parameters",
+        code: "missing_scope",
+      };
+      res.status(400).json(body);
+      return;
+    }
+
+    const { applicantId, afterSequence, limit } = parsed.data;
+    const resolution = resolveScope(applicantId);
+    if (!resolution.ok) {
+      res.status(resolution.status).json(resolution.body);
+      return;
+    }
+
+    const { scope } = resolution;
+    try {
+      const entries = await service.list(scope, {
+        afterSequence,
+        limit: limit ?? 50,
+      });
+
+      // Determine hasMore: if we got exactly `limit` rows back, there may be more.
+      const effectiveLimit = limit ?? 50;
+      const hasMore = entries.length === effectiveLimit;
+
+      const body: ListTapeResponse = {
+        scope: scope as { type: "applicant"; applicantId: string },
+        entries,
+        hasMore,
+      };
+      res.status(200).json(body);
+    } catch (err) {
+      if (isStubError(err)) {
+        stubUnavailable(res);
+        return;
+      }
+      logger.error("compliance-tape list failed", {
+        error: (err as Error).message,
+        applicantId,
+      });
+      const body: TapeErrorResponse = {
+        error: "internal error",
+        code: "internal",
+      };
+      res.status(500).json(body);
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // GET /api/compliance-tape/verify?applicantId=<uuid>
+  // -------------------------------------------------------------------------
+  router.get("/verify", async (req: Request, res: Response): Promise<void> => {
+    const parsed = scopedQuerySchema.safeParse(req.query);
+    if (!parsed.success) {
+      const body: TapeErrorResponse = {
+        error: "invalid query parameters",
+        code: "missing_scope",
+      };
+      res.status(400).json(body);
+      return;
+    }
+
+    const resolution = resolveScope(parsed.data.applicantId);
+    if (!resolution.ok) {
+      res.status(resolution.status).json(resolution.body);
+      return;
+    }
+
+    const { scope } = resolution;
+    try {
+      const result: VerifyTapeResponse = await service.verify(scope);
+      res.status(200).json(result);
+    } catch (err) {
+      if (isStubError(err)) {
+        stubUnavailable(res);
+        return;
+      }
+      logger.error("compliance-tape verify failed", {
+        error: (err as Error).message,
+        applicantId: parsed.data.applicantId,
+      });
+      const body: TapeErrorResponse = {
+        error: "internal error",
+        code: "internal",
+      };
+      res.status(500).json(body);
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // GET /api/compliance-tape/export.pdf?applicantId=<uuid>
+  // -------------------------------------------------------------------------
+  router.get(
+    "/export.pdf",
+    async (req: Request, res: Response): Promise<void> => {
+      const parsed = scopedQuerySchema.safeParse(req.query);
+      if (!parsed.success) {
+        const body: TapeErrorResponse = {
+          error: "invalid query parameters",
+          code: "missing_scope",
+        };
+        res.status(400).json(body);
+        return;
+      }
+
+      const resolution = resolveScope(parsed.data.applicantId);
+      if (!resolution.ok) {
+        res.status(resolution.status).json(resolution.body);
+        return;
+      }
+
+      const { scope } = resolution;
+      const { applicantId } = scope as { type: "applicant"; applicantId: string };
+      try {
+        const pdfBuffer = await service.exportPdf(scope);
+        res.setHeader("Content-Type", "application/pdf");
+        res.setHeader(
+          "Content-Disposition",
+          `attachment; filename="compliance-tape-${applicantId}.pdf"`
+        );
+        res.status(200).send(pdfBuffer);
+      } catch (err) {
+        if (isStubError(err)) {
+          stubUnavailable(res);
+          return;
+        }
+        logger.error("compliance-tape export.pdf failed", {
+          error: (err as Error).message,
+          applicantId,
+        });
+        const body: TapeErrorResponse = {
+          error: "internal error",
+          code: "internal",
+        };
+        res.status(500).json(body);
+      }
+    }
+  );
+
+  return router;
+}


### PR DESCRIPTION
## Summary

Implements the three operator-only compliance tape viewer routes (BP-02 Lane D):

- **GET /api/compliance-tape?applicantId=\<uuid\>** — returns `ListTapeResponse` with paginated `TapeEntry[]` and `hasMore`. Supports `afterSequence` + `limit` (max 200, default 50). Missing `applicantId` returns `501 global_scope_not_implemented`.
- **GET /api/compliance-tape/verify?applicantId=\<uuid\>** — returns `VerifyResult` (re-runs hash chain check via injected service). Same 400/403/501 handling.
- **GET /api/compliance-tape/export.pdf?applicantId=\<uuid\>** — streams PDF buffer from service with `Content-Type: application/pdf` and `Content-Disposition: attachment; filename="compliance-tape-<applicantId>.pdf"`.

All routes sit behind `authenticate + requirePermission("audit:view")` (regional_manager+), matching the "operator-only" gate in the Phase 0 spec.

## Service wiring (Phase 2)

`createTapeViewerRoutes(service)` accepts a structurally-typed service interface — no hard import on Lane B. Mounted in `src/index.ts` with an inline stub that throws a `{ stub: true }` tagged error. Each route handler detects the stub and returns **503** rather than 500, so the endpoints are live in production but clearly inert until Phase 2 replaces the stub with the real `TapeService`.

`// TODO(BP-02-Phase-2)` comment in `src/index.ts` marks the wiring point.

## Test plan

- [ ] `npx tsc --noEmit` runs clean (verified)
- [ ] Only `src/modules/tape/routes-viewer.ts` (new) and `src/index.ts` (mount) changed — no contract files or BP-03b router touched
- [ ] `GET /api/compliance-tape?applicantId=<valid-uuid>` without auth → 401
- [ ] Same with auth but insufficient role → 403
- [ ] Same with operator role → 503 (stub active)
- [ ] `GET /api/compliance-tape` (no applicantId) → 501 `global_scope_not_implemented`
- [ ] `GET /api/compliance-tape?applicantId=not-a-uuid` → 400
- [ ] Phase 2: swap stub for real service, all three routes return real data

🤖 Generated with [Claude Code](https://claude.com/claude-code)