### PR TITLE
feat(bp-02): Lane G — dual-write 5 stamp sites behind COMPLIANCE_TAPE_V2_ENABLED

### DIFF
--- a/src/modules/applicants/routes.ts
+++ b/src/modules/applicants/routes.ts
@@ -9,6 +9,11 @@ import { createMagicLink, logMagicLink, sendMagicLink } from "../auth/magic-link
 import { ApplicationService } from "../application/service";
 import { createApplicationSchema } from "../application/validation";
 import { stampTape, TAPE_STAMP_KINDS } from "../tape";
+import {
+  stampV2WaitingListAppCaptured,
+  stampV2Hud92006SupplementCaptured,
+  stampV2PositionLetterSent,
+} from "../tape/v2-stamp";
 import { logger } from "../../utils/logger";
 
 const router: Router = Router();
@@ -255,6 +260,12 @@ router.post("/apply", authenticate, requireEmailVerified, async (req: AuthReques
       kind: TAPE_STAMP_KINDS.HUD_92006_SUPPLEMENT_CAPTURED,
       actor: req.user.id,
       payload: { application_id: created.id, email: req.user.email },
+    });
+    // BP-02 Lane G dual-write — gated on COMPLIANCE_TAPE_V2_ENABLED.
+    void stampV2Hud92006SupplementCaptured({
+      applicantId: req.user.id,
+      capturedAt: new Date().toISOString(),
+      supplementOptedIn: true,
     });
 
     res.status(201).json(created);
@@ -774,6 +785,12 @@ router.post(
         actor: req.user!.id,
         payload: { application_id: result, intent },
       });
+      // BP-02 Lane G dual-write — gated on COMPLIANCE_TAPE_V2_ENABLED.
+      void stampV2WaitingListAppCaptured({
+        applicantId: req.user!.id,
+        capturedAt: new Date().toISOString(),
+        bedroomCount: intent.bedrooms,
+      });
 
       res.json({ ok: true, application_id: result });
     } catch (err) {
@@ -1060,6 +1077,15 @@ router.post(
             unit_id: unitId,
             expires_at: result.expires_at,
           },
+        });
+        // BP-02 Lane G dual-write — gated on COMPLIANCE_TAPE_V2_ENABLED.
+        // position=1 reflects "claimant holds the unit" at claim time.
+        void stampV2PositionLetterSent({
+          applicantId: req.user!.id,
+          propertyId: result.unit.property_id,
+          bedroomCount: result.unit.bedrooms,
+          position: 1,
+          sentAt: new Date().toISOString(),
         });
       }
 

--- a/src/modules/tape/routes.ts
+++ b/src/modules/tape/routes.ts
@@ -10,6 +10,10 @@ import { Router, Request, Response } from "express";
 import { z } from "zod";
 import rateLimit, { ipKeyGenerator } from "express-rate-limit";
 import { stampTape, TAPE_STAMP_KINDS } from "./index";
+import {
+  stampV2WelcomeLetterDelivered,
+  stampV2Hud9281FairHousingPosted,
+} from "./v2-stamp";
 import { logger } from "../../utils/logger";
 
 const router: Router = Router();
@@ -47,6 +51,13 @@ router.post("/welcome-view", beaconLimiter, async (req: Request, res: Response):
       },
       sessionId: parsed.data.session_id,
     });
+    // BP-02 Lane G dual-write — gated on COMPLIANCE_TAPE_V2_ENABLED.
+    // medium="web" since this beacon fires from the in-browser Welcome page.
+    void stampV2Hud9281FairHousingPosted({
+      sessionId: parsed.data.session_id,
+      medium: "web",
+      postedAt: new Date().toISOString(),
+    });
     res.status(204).end();
   } catch (err) {
     logger.error("welcome-view beacon failed", { error: (err as Error).message });
@@ -77,6 +88,17 @@ router.post("/welcome-accept", beaconLimiter, async (req: Request, res: Response
       },
       sessionId: parsed.data.session_id,
     });
+    // BP-02 Lane G dual-write — gated on COMPLIANCE_TAPE_V2_ENABLED.
+    // Pre-auth beacon: email is the only identity available; the v2 chain
+    // uses it as the applicantId proxy until the user verifies and lands
+    // in `users`. Phase 3 will rebase on the verified users.id.
+    if (parsed.data.email) {
+      void stampV2WelcomeLetterDelivered({
+        applicantId: parsed.data.email,
+        deliveredAt: new Date().toISOString(),
+        sessionId: parsed.data.session_id,
+      });
+    }
     res.status(204).end();
   } catch (err) {
     logger.error("welcome-accept beacon failed", { error: (err as Error).message });

--- a/src/modules/tape/v2-stamp.ts
+++ b/src/modules/tape/v2-stamp.ts
@@ -1,0 +1,121 @@
+/**
+ * BP-02 Lane G — dual-write wrapper for the new compliance tape.
+ *
+ * Sits beside the legacy `stampTape()` (NDJSON ledger) and writes the same
+ * event to the new hash-chained Postgres tape if `COMPLIANCE_TAPE_V2_ENABLED`
+ * is set in env. The flag defaults off so this is a no-op until cutover.
+ *
+ * Errors are logged and swallowed — a tape write failure must never break
+ * the applicant flow. The legacy ledger remains the source of truth until
+ * Phase 3 retires it.
+ *
+ * Each wrapper forwards its argument directly to the matching Lane C maker,
+ * so call sites must provide everything the canonical JSON-LD shape needs.
+ * That's intentional: it forces touchpoint code to attest the full evidence
+ * set, not whatever happened to be in scope for the NDJSON stub.
+ */
+
+import { logger } from "../../utils/logger";
+import { createTapeService, type TapeService } from "./service";
+import { PgTapeRepository } from "./repository";
+import {
+  makeWelcomeLetterDeliveredPayload,
+  makeHud9281FairHousingPostedPayload,
+  makeWaitingListAppCapturedPayload,
+  makeHud92006SupplementCapturedPayload,
+  makePositionLetterSentPayload,
+  type WelcomeLetterDeliveredInput,
+  type Hud9281FairHousingPostedInput,
+  type WaitingListAppCapturedInput,
+  type Hud92006SupplementCapturedInput,
+  type PositionLetterSentInput,
+} from "./events";
+import { COMPLIANCE_TAPE_V2_FLAG, type TapeJsonLdPayload, type TapeStampKind } from "./types";
+
+function flagEnabled(): boolean {
+  return process.env[COMPLIANCE_TAPE_V2_FLAG] === "true";
+}
+
+let serviceCache: TapeService | null = null;
+function getService(): TapeService {
+  if (!serviceCache) {
+    serviceCache = createTapeService(new PgTapeRepository());
+  }
+  return serviceCache;
+}
+
+/** For tests. */
+export function resetTapeServiceCache(): void {
+  serviceCache = null;
+}
+
+async function stampV2(
+  kind: TapeStampKind,
+  payload: TapeJsonLdPayload,
+  sessionId?: string,
+): Promise<void> {
+  if (!flagEnabled()) return;
+  try {
+    await getService().stamp({ kind, payload, sessionId });
+  } catch (err) {
+    logger.error("Tape v2 stamp failed", {
+      kind,
+      error: (err as Error).message,
+    });
+  }
+}
+
+export async function stampV2WelcomeLetterDelivered(
+  input: WelcomeLetterDeliveredInput,
+): Promise<void> {
+  if (!flagEnabled()) return;
+  return stampV2(
+    "WELCOME_LETTER_DELIVERED",
+    makeWelcomeLetterDeliveredPayload(input),
+    input.sessionId,
+  );
+}
+
+export async function stampV2Hud9281FairHousingPosted(
+  input: Hud9281FairHousingPostedInput,
+): Promise<void> {
+  if (!flagEnabled()) return;
+  return stampV2(
+    "HUD_928_1_FAIR_HOUSING_POSTED",
+    makeHud9281FairHousingPostedPayload(input),
+    input.sessionId,
+  );
+}
+
+export async function stampV2WaitingListAppCaptured(
+  input: WaitingListAppCapturedInput,
+): Promise<void> {
+  if (!flagEnabled()) return;
+  return stampV2(
+    "WAITING_LIST_APP_CAPTURED",
+    makeWaitingListAppCapturedPayload(input),
+    input.sessionId,
+  );
+}
+
+export async function stampV2Hud92006SupplementCaptured(
+  input: Hud92006SupplementCapturedInput,
+): Promise<void> {
+  if (!flagEnabled()) return;
+  return stampV2(
+    "HUD_92006_SUPPLEMENT_CAPTURED",
+    makeHud92006SupplementCapturedPayload(input),
+    input.sessionId,
+  );
+}
+
+export async function stampV2PositionLetterSent(
+  input: PositionLetterSentInput,
+): Promise<void> {
+  if (!flagEnabled()) return;
+  return stampV2(
+    "POSITION_LETTER_SENT",
+    makePositionLetterSentPayload(input),
+    input.sessionId,
+  );
+}


### PR DESCRIPTION
## Summary

Final lane of the BP-02 Phase 1 fan-out. Wires the legacy `stampTape()` (NDJSON ledger) sites to also write to the new hash-chained Postgres tape, gated on `COMPLIANCE_TAPE_V2_ENABLED`.

- **New file**: `src/modules/tape/v2-stamp.ts` — one typed helper per BP-03b stamp kind. Each calls a singleton `createTapeService(new PgTapeRepository())`, swallows errors, no-ops when the flag is off.
- **5 dual-write sites**:
  1. `/api/tape/welcome-view` → `HUD_928_1_FAIR_HOUSING_POSTED`
  2. `/api/tape/welcome-accept` → `WELCOME_LETTER_DELIVERED`
  3. `/applicants/intent` → `WAITING_LIST_APP_CAPTURED`
  4. `/applicants/apply` → `HUD_92006_SUPPLEMENT_CAPTURED`
  5. `/applicants/claim-unit/:id` → `POSITION_LETTER_SENT`

## Cutover plan

1. Merge this PR (default state: flag off, no behavioral change)
2. Apply migration `2026-05-23-compliance-tape.sql` on prod (already shipped in Lane A #89 → merged)
3. Flip `COMPLIANCE_TAPE_V2_ENABLED=true` on Railway
4. Run apply smoke; verify chain through BP-19 viewer (`/audit-log` → Compliance Tape panel)
5. After 24h clean run, schedule Phase 3 (retire NDJSON, port auth.* stamps, rebase pre-auth events on verified users.id)

## Known gaps (Phase 3, not blocking)

- `welcome-accept` uses `email` as `applicantId` proxy (pre-auth); should rebase on verified users.id once that flow lands.
- `HUD_92006_SUPPLEMENT_CAPTURED` hardcodes `supplementOptedIn: true` at submit time; should derive from the actual supplement form response.
- `POSITION_LETTER_SENT` uses `position: 1` (claimant holds the unit at claim time); a true waitlist-position read could replace it.
- `auth.login` / `auth.magic_link_*` / `auth.email_verified` stamps (defined in Phase 0 types) not wired yet — no existing call sites in legacy stub.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `jest src/modules/tape/__tests__` — 32/32 (Lane F property tests pass on integrated state)
- [x] `jest src/__tests__/applicants-*` — 23/23 (no regression with flag off)
- [ ] CI: full test matrix + apply smoke
- [ ] Post-merge: flag-on regression on staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)