### PR TITLE
chore: sitemap host env-flip + Step1Register CTA portal swap

### DIFF
--- a/client-tenant/public/sitemap.xml
+++ b/client-tenant/public/sitemap.xml
@@ -1,121 +1,121 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://frank-pilot.vercel.app/</loc>
+    <loc>https://frank-pilot-tenant.vercel.app/</loc>
     <lastmod>2026-05-22</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://frank-pilot.vercel.app/discover</loc>
+    <loc>https://frank-pilot-tenant.vercel.app/discover</loc>
     <lastmod>2026-05-22</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
-    <loc>https://frank-pilot.vercel.app/apply</loc>
+    <loc>https://frank-pilot-tenant.vercel.app/apply</loc>
     <lastmod>2026-05-22</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://frank-pilot.vercel.app/discover/aldene-kline-barlow-senior-apartments</loc>
+    <loc>https://frank-pilot-tenant.vercel.app/discover/aldene-kline-barlow-senior-apartments</loc>
     <lastmod>2026-05-22</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://frank-pilot.vercel.app/discover/david-j-hoggard-family-community</loc>
+    <loc>https://frank-pilot-tenant.vercel.app/discover/david-j-hoggard-family-community</loc>
     <lastmod>2026-05-22</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://frank-pilot.vercel.app/discover/donna-louise-apartments</loc>
+    <loc>https://frank-pilot-tenant.vercel.app/discover/donna-louise-apartments</loc>
     <lastmod>2026-05-22</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://frank-pilot.vercel.app/discover/donna-louise-apartments-2</loc>
+    <loc>https://frank-pilot-tenant.vercel.app/discover/donna-louise-apartments-2</loc>
     <lastmod>2026-05-22</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://frank-pilot.vercel.app/discover/luther-mack-jr-senior-apartments</loc>
+    <loc>https://frank-pilot-tenant.vercel.app/discover/luther-mack-jr-senior-apartments</loc>
     <lastmod>2026-05-22</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://frank-pilot.vercel.app/discover/dr-paul-meacham-senior-community</loc>
+    <loc>https://frank-pilot-tenant.vercel.app/discover/dr-paul-meacham-senior-community</loc>
     <lastmod>2026-05-22</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://frank-pilot.vercel.app/discover/ethel-mae-fletcher-apartments</loc>
+    <loc>https://frank-pilot-tenant.vercel.app/discover/ethel-mae-fletcher-apartments</loc>
     <lastmod>2026-05-22</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://frank-pilot.vercel.app/discover/ethel-mae-robinson-senior-apartments</loc>
+    <loc>https://frank-pilot-tenant.vercel.app/discover/ethel-mae-robinson-senior-apartments</loc>
     <lastmod>2026-05-22</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://frank-pilot.vercel.app/discover/mike-o-callaghan-legacy-apartments</loc>
+    <loc>https://frank-pilot-tenant.vercel.app/discover/mike-o-callaghan-legacy-apartments</loc>
     <lastmod>2026-05-22</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://frank-pilot.vercel.app/discover/juan-garcia-garden-apartments</loc>
+    <loc>https://frank-pilot-tenant.vercel.app/discover/juan-garcia-garden-apartments</loc>
     <lastmod>2026-05-22</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://frank-pilot.vercel.app/discover/louise-shell-senior-apartments</loc>
+    <loc>https://frank-pilot-tenant.vercel.app/discover/louise-shell-senior-apartments</loc>
     <lastmod>2026-05-22</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://frank-pilot.vercel.app/discover/owens-senior-housing</loc>
+    <loc>https://frank-pilot-tenant.vercel.app/discover/owens-senior-housing</loc>
     <lastmod>2026-05-22</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://frank-pilot.vercel.app/discover/sarann-knight-apartments</loc>
+    <loc>https://frank-pilot-tenant.vercel.app/discover/sarann-knight-apartments</loc>
     <lastmod>2026-05-22</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://frank-pilot.vercel.app/discover/senator-harry-reid-senior-apartments</loc>
+    <loc>https://frank-pilot-tenant.vercel.app/discover/senator-harry-reid-senior-apartments</loc>
     <lastmod>2026-05-22</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://frank-pilot.vercel.app/discover/senator-richard-bryan-senior-apartments</loc>
+    <loc>https://frank-pilot-tenant.vercel.app/discover/senator-richard-bryan-senior-apartments</loc>
     <lastmod>2026-05-22</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://frank-pilot.vercel.app/discover/smith-williams-senior-apartments</loc>
+    <loc>https://frank-pilot-tenant.vercel.app/discover/smith-williams-senior-apartments</loc>
     <lastmod>2026-05-22</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://frank-pilot.vercel.app/discover/yale-keyes-senior-apartments</loc>
+    <loc>https://frank-pilot-tenant.vercel.app/discover/yale-keyes-senior-apartments</loc>
     <lastmod>2026-05-22</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>

--- a/client-tenant/scripts/generate-sitemap.mjs
+++ b/client-tenant/scripts/generate-sitemap.mjs
@@ -13,9 +13,11 @@
  * The output is also committed to the repo so `public/sitemap.xml` exists at
  * HEAD (Vercel serves `public/` even on first deploy).
  *
- * Host: hard-coded to https://frank-pilot.vercel.app — replace once a real
- * production domain is wired post-Railway. (No VITE_PUBLIC_SITE_URL pattern
- * exists in this repo yet; introduce one before changing this.)
+ * Host: read from the VITE_PUBLIC_SITE_URL environment variable at generation
+ * time; falls back to https://frank-pilot-tenant.vercel.app when the variable
+ * is not set (e.g. local dev, CI environments that don't inject it). Set
+ * VITE_PUBLIC_SITE_URL in your Vercel project environment variables to
+ * override for any deployment target.
  *
  * Node-version note: CI runs node 18/20/22. We avoid Node TS-strip features
  * (only available 22.6+ and behind a flag) by using esbuild's programmatic
@@ -33,8 +35,7 @@ const ROOT = path.resolve(__dirname, '..');
 const FIXTURE_PATH = path.join(ROOT, 'src', 'api', 'gpmg-fixtures.ts');
 const OUTPUT_PATH = path.join(ROOT, 'public', 'sitemap.xml');
 
-// Hard-coded for now; see file header for follow-up.
-const SITE_URL = 'https://frank-pilot.vercel.app';
+const SITE_URL = process.env.VITE_PUBLIC_SITE_URL || 'https://frank-pilot-tenant.vercel.app';
 
 const ROUTES = [
   { loc: '/', changefreq: 'monthly', priority: '1.0' },

--- a/client-tenant/src/pages/apply/steps/Step1Register.tsx
+++ b/client-tenant/src/pages/apply/steps/Step1Register.tsx
@@ -2,8 +2,8 @@ import { useState } from 'react';
 import { api } from '@/api/client';
 import { useApply } from '../ApplyContext';
 import { useTranslation } from 'react-i18next';
-import { CTA } from '@/components/primitives';
 import { TurnstileWidget } from '@/components/TurnstileWidget';
+import { StepCTA } from '../StepCTA';
 import { HF } from '@/styles/tokens';
 
 const labelStyle = {
@@ -65,7 +65,7 @@ export function Step1Register() {
       >
         {t('register.title')}
       </h1>
-      <form onSubmit={handleSubmit} className="space-y-4">
+      <form id="step1-register-form" onSubmit={handleSubmit} className="space-y-4">
         <div className="grid grid-cols-2 gap-3">
           <div>
             <label style={labelStyle} htmlFor="firstName">{t('register.firstName')}</label>
@@ -111,13 +111,14 @@ export function Step1Register() {
           />
         </div>
         <TurnstileWidget onVerify={setTurnstileToken} />
-        <CTA
-          type="submit"
-          disabled={s.loading || !s.email || !s.firstName || !s.lastName}
-        >
-          {s.loading ? t('register.submitting') : t('register.submit')}
-        </CTA>
       </form>
+      <StepCTA
+        type="submit"
+        form="step1-register-form"
+        disabled={s.loading || !s.email || !s.firstName || !s.lastName}
+      >
+        {s.loading ? t('register.submitting') : t('register.submit')}
+      </StepCTA>
     </>
   );
 }


### PR DESCRIPTION
## Summary

Two mechanical follow-ups parked from earlier sprints (#7 / #14), now unblocked:

- **Fix 1:** Sitemap generator now reads `VITE_PUBLIC_SITE_URL` at generation time instead of a hard-coded wrong host.
- **Fix 2:** `Step1Register` CTA migrated to the `StepCTA` portal pattern used by all other wizard steps.

## Fix 1 — sitemap host env-flip

**Before:** `const SITE_URL = 'https://frank-pilot.vercel.app';` (hard-coded, wrong prod host)

**After:** `const SITE_URL = process.env.VITE_PUBLIC_SITE_URL || 'https://frank-pilot-tenant.vercel.app';`

The committed `public/sitemap.xml` is regenerated — all 20 `<loc>` entries now use `frank-pilot-tenant.vercel.app`. The file-header comment is updated to document the env var pattern. No CI breakage: the fallback ensures the script works in environments that don't inject `VITE_PUBLIC_SITE_URL` (local dev, most CI runs).

## Fix 2 — Step1Register CTA portal swap

`Step1Register` was the only apply wizard step still using the legacy `<CTA type="submit">` pattern from before wedge #7 (PR #79). This PR swaps it to `<StepCTA>`.

**Key detail — `form="step1-register-form"` HTML5 attribute:** The `StepCTA` renders outside the `<form>` element (placed after the closing `</form>` tag). The HTML5 `form` attribute ties the submit button to the form by ID even when they're not ancestor/descendant in the DOM. This is especially important in the mobile-shell path where `createPortal` moves the button to a sticky bottom bar slot — without `form="..."`, the portaled submit button would not fire `handleSubmit`. On desktop/flag-off the `MobileStickyCtaContext` slot is `null`, so `StepCTA` falls back to inline rendering, pixel-stable with the old behaviour.

All props preserved: disabled state (`s.loading || !s.email || !s.firstName || !s.lastName`), button text via i18n keys. No `data-testid` attributes were present to preserve.

## Verification

- `tsc --noEmit` clean
- 197 vitest tests pass (32 test files)
- Smoke test (`apply-smoke.mjs`) is HTTP-only, unaffected by CTA DOM changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)