### PR TITLE
feat(qa): rrweb session replay as third bundle upload

### DIFF
--- a/client-tenant/.env.example
+++ b/client-tenant/.env.example
@@ -22,6 +22,14 @@ VITE_PAYMENT_WIZARD_ENABLED=false
 VITE_SUPABASE_URL=
 VITE_SUPABASE_PUBLISHABLE_KEY=
 
+# QA / debug session replay (src/lib/qaSessionReplay.ts).
+# rrweb records DOM mutations + clicks + console for a ~30-60s rolling buffer.
+# Drained by the camera button as a third .replay.json upload alongside PNG +
+# JSON. DEV mode auto-enables; set to `true` to also enable in a prod build
+# served with `?qa=1`. rrweb is lazy-imported so unsetting this leaves the
+# main bundle untouched.
+VITE_QA_SESSION_REPLAY_ENABLED=
+
 # Cloudflare Turnstile site key (wedge #13 — anti-spam on public forms).
 # The dev key below renders the widget in pass-through mode and synchronously
 # yields a `test-token-dev` token so the Welcome → Claim smoke stays green

--- a/client-tenant/package-lock.json
+++ b/client-tenant/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frank-pilot-client-tenant",
       "version": "0.1.0",
       "dependencies": {
+        "@rrweb/record": "^2.0.0-alpha.20",
         "html-to-image": "^1.11.13",
         "i18next": "^26.2.0",
         "i18next-browser-languagedetector": "^8.2.1",
@@ -1475,6 +1476,29 @@
         "win32"
       ]
     },
+    "node_modules/@rrweb/record": {
+      "version": "2.0.0-alpha.20",
+      "resolved": "https://registry.npmjs.org/@rrweb/record/-/record-2.0.0-alpha.20.tgz",
+      "integrity": "sha512-marVOU3Lc285mwLCp+vI6M/eJ+wZ6lcTa7fX0zcdmBsM+j5loXmMQjkmIvkji5+lAbkq5/w2cwto3GS0TaCjtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@rrweb/types": "^2.0.0-alpha.20",
+        "@rrweb/utils": "^2.0.0-alpha.20",
+        "rrweb": "^2.0.0-alpha.20"
+      }
+    },
+    "node_modules/@rrweb/types": {
+      "version": "2.0.0-alpha.20",
+      "resolved": "https://registry.npmjs.org/@rrweb/types/-/types-2.0.0-alpha.20.tgz",
+      "integrity": "sha512-RbnDgKxA/odwB1R4gF7eUUj+rdSrq6ROQJsnMw7MIsGzlbSYvJeZN8YY4XqU0G6sKJvXI6bSzk7w/G94jNwzhw==",
+      "license": "MIT"
+    },
+    "node_modules/@rrweb/utils": {
+      "version": "2.0.0-alpha.20",
+      "resolved": "https://registry.npmjs.org/@rrweb/utils/-/utils-2.0.0-alpha.20.tgz",
+      "integrity": "sha512-MTQOmhPRe39C0fYaCnnVYOufQsyGzwNXpUStKiyFSfGLUJrzuwhbRoUAKR5w6W2j5XuA0bIz3ZDIBztkquOhLw==",
+      "license": "MIT"
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -1635,6 +1659,12 @@
         "@types/deep-eql": "*",
         "assertion-error": "^2.0.1"
       }
+    },
+    "node_modules/@types/css-font-loading-module": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@types/css-font-loading-module/-/css-font-loading-module-0.0.7.tgz",
+      "integrity": "sha512-nl09VhutdjINdWyXxHWN/w9zlNCfr60JUqJbd24YXUuCwgeL0TpFSdElCwb6cxfB6ybE19Gjj4g0jsgkXxKv1Q==",
+      "license": "MIT"
     },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
@@ -1812,6 +1842,12 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@xstate/fsm": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@xstate/fsm/-/fsm-1.6.5.tgz",
+      "integrity": "sha512-b5o1I6aLNeYlU/3CPlj/Z91ybk1gUsKT+5NAJI+2W4UjvS5KLG28K9v5UvNoFVjHV8PajVZ00RH3vnjyQO7ZAw==",
+      "license": "MIT"
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -1930,6 +1966,15 @@
       "license": "MPL-2.0",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
     "node_modules/baseline-browser-mapping": {
@@ -2810,6 +2855,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -2833,7 +2884,6 @@
       "version": "3.3.12",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
       "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2927,7 +2977,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -2967,7 +3016,6 @@
       "version": "8.5.14",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
       "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -3407,6 +3455,40 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rrdom": {
+      "version": "2.0.0-alpha.20",
+      "resolved": "https://registry.npmjs.org/rrdom/-/rrdom-2.0.0-alpha.20.tgz",
+      "integrity": "sha512-hoqjS4662LtBp82qEz9GrqU36UpEmCvTA2Hns3qdF7cklLFFy3G+0Th8hLytJENleHHWxsB5nWJ3eXz5mSRxdQ==",
+      "license": "MIT",
+      "dependencies": {
+        "rrweb-snapshot": "^2.0.0-alpha.20"
+      }
+    },
+    "node_modules/rrweb": {
+      "version": "2.0.0-alpha.20",
+      "resolved": "https://registry.npmjs.org/rrweb/-/rrweb-2.0.0-alpha.20.tgz",
+      "integrity": "sha512-CZKDlm+j1VA50Ko3gnMbpvguCAleljsTNXPnVk9aeNP8o6T6kolRbISHyDZpqZ4G+bdDLlQOignPP3jEsXs8Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@rrweb/types": "^2.0.0-alpha.20",
+        "@rrweb/utils": "^2.0.0-alpha.20",
+        "@types/css-font-loading-module": "0.0.7",
+        "@xstate/fsm": "^1.4.0",
+        "base64-arraybuffer": "^1.0.1",
+        "mitt": "^3.0.0",
+        "rrdom": "^2.0.0-alpha.20",
+        "rrweb-snapshot": "^2.0.0-alpha.20"
+      }
+    },
+    "node_modules/rrweb-snapshot": {
+      "version": "2.0.0-alpha.20",
+      "resolved": "https://registry.npmjs.org/rrweb-snapshot/-/rrweb-snapshot-2.0.0-alpha.20.tgz",
+      "integrity": "sha512-YTNf9YVeaGRo/jxY3FKBge2c/Ojd/KTHmuWloUSB+oyPXuY73ZeeG873qMMmhIpqEn7hn7aBF1eWEQmP7wjf8A==",
+      "license": "MIT",
+      "dependencies": {
+        "postcss": "^8.4.38"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -3474,7 +3556,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"

--- a/client-tenant/package.json
+++ b/client-tenant/package.json
@@ -14,6 +14,7 @@
     "test:a11y": "vitest run --grep a11y"
   },
   "dependencies": {
+    "@rrweb/record": "^2.0.0-alpha.20",
     "html-to-image": "^1.11.13",
     "i18next": "^26.2.0",
     "i18next-browser-languagedetector": "^8.2.1",

--- a/client-tenant/src/components/dev/ScreenshotButton.tsx
+++ b/client-tenant/src/components/dev/ScreenshotButton.tsx
@@ -1,6 +1,16 @@
 import { useEffect, useState } from 'react';
 import { Camera, Check, X, Loader2, Copy } from 'lucide-react';
 import { getQaBuffer, clearQaBuffer, type QaEntry } from '@/lib/qaBuffer';
+import {
+  installQaReplay,
+  getQaReplayEvents,
+  clearQaReplay,
+  stopQaReplay,
+} from '@/lib/qaSessionReplay';
+
+function replayEnabled(): boolean {
+  return import.meta.env.DEV || import.meta.env.VITE_QA_SESSION_REPLAY_ENABLED === 'true';
+}
 
 const STORAGE_KEY = 'frank_qa';
 const TOKEN_KEY = 'frank_tenant_token';
@@ -98,12 +108,17 @@ function dumpStorage(store: Storage | undefined): Record<string, string> {
   return out;
 }
 
-function buildDebugPayload(pngUrl: string | null, qaBufferSnapshot: QaEntry[]): Record<string, unknown> {
+function buildDebugPayload(
+  pngUrl: string | null,
+  replayUrl: string | null,
+  qaBufferSnapshot: QaEntry[],
+): Record<string, unknown> {
   const token = (() => { try { return window.localStorage.getItem(TOKEN_KEY); } catch { return null; } })();
   const claims = token ? decodeJwtClaims(token) : null;
   return {
     capturedAt: new Date().toISOString(),
     screenshotUrl: pngUrl,
+    replayUrl,
     url: {
       href: window.location.href,
       pathname: window.location.pathname,
@@ -139,10 +154,12 @@ function buildDebugPayload(pngUrl: string | null, qaBufferSnapshot: QaEntry[]): 
 
 type Status = 'idle' | 'capturing' | 'uploading' | 'done' | 'error';
 
-type Bundle = { png: string; json: string };
+type Bundle = { png: string; json: string; replay: string | null };
 
 function clipboardBlock(b: Bundle): string {
-  return `Screenshot: ${b.png}\nDebug: ${b.json}`;
+  const lines = [`Screenshot: ${b.png}`, `Debug: ${b.json}`];
+  if (b.replay) lines.push(`Replay: ${b.replay}`);
+  return lines.join('\n');
 }
 
 export function ScreenshotButton() {
@@ -152,6 +169,11 @@ export function ScreenshotButton() {
   const [bundle, setBundle] = useState<Bundle | null>(null);
 
   useEffect(() => { setVisible(shouldShow()); }, []);
+
+  useEffect(() => {
+    if (!visible || !replayEnabled()) return;
+    void installQaReplay();
+  }, [visible]);
 
   async function capture() {
     if (status === 'capturing' || status === 'uploading') return;
@@ -165,6 +187,14 @@ export function ScreenshotButton() {
       // fresh and doesn't inherit this click's font-fetch + self-upload noise.
       const qaSnapshot = getQaBuffer();
       clearQaBuffer();
+
+      // Same idea for the rrweb buffer — stop the recorder BEFORE toPng() so
+      // its DOM-clone mutations aren't logged as events. Snapshot + clear,
+      // then re-install after toPng() returns so the next click captures
+      // fresh activity.
+      stopQaReplay();
+      const replaySnapshot = getQaReplayEvents();
+      clearQaReplay();
 
       const { toPng } = await import('html-to-image');
       const node = document.body;
@@ -182,9 +212,14 @@ export function ScreenshotButton() {
         },
       });
 
+      // Re-install the recorder now that toPng() has finished walking the DOM.
+      // Fire-and-forget — best-effort; we don't want to delay the upload.
+      if (replayEnabled()) void installQaReplay();
+
       const stem = `frank-${slugFromPath()}-${timestamp()}`;
       const pngName = `${stem}.png`;
       const jsonName = `${stem}.json`;
+      const replayName = `${stem}.replay.json`;
 
       const a = document.createElement('a');
       a.href = dataUrl;
@@ -215,7 +250,23 @@ export function ScreenshotButton() {
         return;
       }
 
-      const debugPayload = buildDebugPayload(pngUrl, qaSnapshot);
+      // Replay is best-effort: skip when empty, swallow upload failures so a
+      // broken rrweb upload never blocks the JSON sidecar (which is the most
+      // valuable file for Claude).
+      let replayUrl: string | null = null;
+      if (replaySnapshot.length > 0) {
+        try {
+          replayUrl = await uploadToSupabase(
+            JSON.stringify(replaySnapshot),
+            replayName,
+            'application/json',
+          );
+        } catch {
+          replayUrl = null;
+        }
+      }
+
+      const debugPayload = buildDebugPayload(pngUrl, replayUrl, qaSnapshot);
       let jsonUrl: string;
       try {
         jsonUrl = await uploadToSupabase(JSON.stringify(debugPayload, null, 2), jsonName, 'application/json');
@@ -226,7 +277,7 @@ export function ScreenshotButton() {
         return;
       }
 
-      const next: Bundle = { png: pngUrl, json: jsonUrl };
+      const next: Bundle = { png: pngUrl, json: jsonUrl, replay: replayUrl };
       let copied = false;
       if (navigator.clipboard?.writeText) {
         try { await navigator.clipboard.writeText(clipboardBlock(next)); copied = true; } catch { /* ignore */ }
@@ -292,6 +343,9 @@ export function ScreenshotButton() {
           </div>
           <div><span style={{ color: '#6b7280' }}>PNG:</span> {bundle.png}</div>
           <div><span style={{ color: '#6b7280' }}>JSON:</span> {bundle.json}</div>
+          {bundle.replay && (
+            <div><span style={{ color: '#6b7280' }}>Replay:</span> {bundle.replay}</div>
+          )}
           <button
             type="button"
             onClick={copyBoth}

--- a/client-tenant/src/lib/qaSessionReplay.ts
+++ b/client-tenant/src/lib/qaSessionReplay.ts
@@ -1,0 +1,74 @@
+// Lazy-loaded rrweb session-replay buffer for the QA debug bundle.
+// Mirrors qaBuffer.ts's module-level-singleton shape.
+//
+// Privacy — rrweb captures DOM mutations including form input values. Defaults:
+//   maskAllInputs: true            — every <input>/<textarea>/<select> value masked
+//   class="rr-block"               — full subtree excluded (auth widgets, payment iframes)
+//   class="rr-mask"                — text content replaced with asterisks
+//   [data-screenshot-exclude="1"]  — already honored by html-to-image; masked here too
+//
+// Memory — checkoutEveryNms rotates a two-bucket eventsMatrix; we trim to the
+// last MAX_BUCKETS inside the emit callback so an N-hour QA session does not
+// leak linearly.
+
+export type QaReplayEvent = unknown;
+
+const CHECKOUT_MS = 30_000;
+const MAX_BUCKETS = 2;
+
+let eventsMatrix: QaReplayEvent[][] = [[]];
+let stopFn: (() => void) | undefined;
+let installing: Promise<void> | null = null;
+
+export async function installQaReplay(): Promise<void> {
+  if (typeof window === 'undefined') return;
+  if (stopFn) return;
+  if (installing) return installing;
+
+  installing = (async () => {
+    try {
+      const mod = await import('@rrweb/record');
+      if (stopFn) return;
+      const handle = mod.record<QaReplayEvent>({
+        emit(event, isCheckout) {
+          if (isCheckout) {
+            eventsMatrix.push([]);
+            if (eventsMatrix.length > MAX_BUCKETS) {
+              eventsMatrix = eventsMatrix.slice(-MAX_BUCKETS);
+            }
+          }
+          eventsMatrix[eventsMatrix.length - 1].push(event);
+        },
+        checkoutEveryNms: CHECKOUT_MS,
+        maskAllInputs: true,
+        maskTextClass: 'rr-mask',
+        blockClass: 'rr-block',
+        maskTextSelector: '[data-screenshot-exclude="1"], [data-pii]',
+        recordCanvas: false,
+        collectFonts: false,
+      });
+      stopFn = handle ?? undefined;
+    } catch {
+      // best-effort; PNG + JSON sidecar continue without replay
+    } finally {
+      installing = null;
+    }
+  })();
+
+  return installing;
+}
+
+export function getQaReplayEvents(): QaReplayEvent[] {
+  return eventsMatrix.slice(-MAX_BUCKETS).flat();
+}
+
+export function clearQaReplay(): void {
+  eventsMatrix = [[]];
+}
+
+export function stopQaReplay(): void {
+  if (stopFn) {
+    try { stopFn(); } catch { /* ignore */ }
+    stopFn = undefined;
+  }
+}


### PR DESCRIPTION
## Summary
- Lazy-loaded rrweb recorder behind the existing DEV/`?qa=1` + `VITE_QA_SESSION_REPLAY_ENABLED=true` gate that already covers the camera button.
- On capture: stop recorder → snapshot rolling buffer → clear → upload as a third `*.replay.json` to the `frank-qa-screenshots` Supabase bucket → re-install. The JSON sidecar gains a `replayUrl` field so the PNG + JSON + replay triple cross-reference.
- New module `client-tenant/src/lib/qaSessionReplay.ts` owns recorder lifecycle. Module-level singleton with install/get/clear/stop API mirroring `qaBuffer.ts`.

## Privacy
- `maskAllInputs: true` — every `<input>`/`<textarea>`/`<select>` value masked.
- `blockClass: 'rr-block'` — full subtree excluded (auth widgets, payment iframes).
- `maskTextClass: 'rr-mask'` + `maskTextSelector: '[data-screenshot-exclude="1"], [data-pii]'` — reuses the attribute html-to-image already honors so the conventions stay aligned.
- `recordCanvas: false`, `collectFonts: false`.

## Correctness notes
- **html-to-image × rrweb interaction:** `stopQaReplay()` runs BEFORE `toPng()` so DOM clones don't pollute the recording; re-install fires after `toPng()` returns. Commented in code.
- **StrictMode-safe install:** `installing: Promise<void> | null` cache, not a boolean — concurrent double-mount calls share the same in-flight promise.
- **Bounded memory:** `eventsMatrix` trimmed to last 2 buckets inside the rrweb `emit` callback on every `isCheckout`. Without this an N-hour QA session leaks linearly.
- **Bundle isolation:** `@rrweb/record` lazy-imported via `await import()`. Verified via Vite build — splits into `dist/assets/record-*.js` (~57 KB gz) with zero leakage into the main entry.

## Verification
- `npm run build` — clean. `record-DXWdsdNN.js` 56.97 KB gz; main bundle unchanged.
- `npm test` — 197/197 in 32 files green.
- Playwright on `/login` against the dev server:
  - Lazy chunk fetched on camera-button mount (`/node_modules/.vite/deps/@rrweb_record.js` resource entry).
  - Typed `test-pii-must-be-masked@example.com`, `fresh-pii-value@example.test`, `post-reinstall-secret-token-xyz` — **0 leaks** in the serialized event stream, ~2.8k mask hits.
  - Clicked camera, buffer cleared from 62 → 4 events, then grew again as typing resumed — proves the re-install path works.

## Test plan
- [x] Build + unit tests pass
- [x] Playwright PII-leak assertion across two captures (pre + post re-install)
- [ ] Manual sanity: click 3-4 routes on a Vercel preview with `VITE_QA_SESSION_REPLAY_ENABLED=true`, confirm 3 POSTs to `frank-qa-screenshots/` (`.png`, `.json`, `.replay.json`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)