### PR TITLE
feat(apply): W0 AMI prefill on Step Intent + Review (gpmglv wedge #1)

### DIFF
--- a/client-tenant/src/i18n/en/apply.json
+++ b/client-tenant/src/i18n/en/apply.json
@@ -61,7 +61,10 @@
       "incomeLabel": "Gross annual income (USD)",
       "incomePlaceholder": "e.g. 42000",
       "qualifies": "You qualify for {{tier}} units.",
-      "overIncome": "Over income for affordable tiers. Market-rate units may still fit."
+      "overIncome": "Over income for affordable tiers. Market-rate units may still fit.",
+      "prefilledSummary": "Qualifying at {{tier}}",
+      "prefilledHint": "We carried this over from the welcome calculator. You can recalculate if your income changed.",
+      "recalculate": "Recalculate"
     }
   },
   "checklist": {
@@ -150,6 +153,8 @@
     "position": "Position",
     "openVacancy": "Vacancy",
     "lockedCriteria": "Your locked criteria",
+    "qualifyingTierLabel": "Qualifying AMI tier",
+    "qualifyingTierValue": "{{tier}}",
     "household": "Household of {{count}}",
     "bed": "BR",
     "confirmHeader": "Is this what you wanted?",

--- a/client-tenant/src/i18n/es/apply.json
+++ b/client-tenant/src/i18n/es/apply.json
@@ -61,7 +61,10 @@
       "incomeLabel": "Ingreso anual bruto (USD)",
       "incomePlaceholder": "ej. 42000",
       "qualifies": "Calificas para unidades {{tier}}.",
-      "overIncome": "Sobre el límite de ingresos para tarifas asequibles. Aún pueden encajar unidades a precio de mercado."
+      "overIncome": "Sobre el límite de ingresos para tarifas asequibles. Aún pueden encajar unidades a precio de mercado.",
+      "prefilledSummary": "Calificando para {{tier}}",
+      "prefilledHint": "Lo traímos de la calculadora de bienvenida. Puedes recalcularlo si tus ingresos cambiaron.",
+      "recalculate": "Recalcular"
     }
   },
   "checklist": {
@@ -150,6 +153,8 @@
     "position": "Posición",
     "openVacancy": "Hay vacancia",
     "lockedCriteria": "Tus criterios bloqueados",
+    "qualifyingTierLabel": "Categoría AMI calificante",
+    "qualifyingTierValue": "{{tier}}",
     "household": "Hogar de {{count}}",
     "bed": "RC",
     "confirmHeader": "¿Es esto lo que querías?",

--- a/client-tenant/src/pages/apply/steps/StepIntent.tsx
+++ b/client-tenant/src/pages/apply/steps/StepIntent.tsx
@@ -49,6 +49,13 @@ export function StepIntent() {
   const [search] = useSearchParams();
   const prefilled = useRef(false);
 
+  // Prefilled-mode: when the welcome AMI calculator already produced a tier
+  // (forwarded via ?amiTier= → ApplyContext on mount), we show a one-line
+  // summary + "Recalculate" rather than re-asking for income. The summary
+  // collapses to the full input when the applicant clicks Recalculate.
+  const [showAmiRecalc, setShowAmiRecalc] = useState(false);
+  const hasPrefilledTier = s.qualifyingAmiTier != null && !showAmiRecalc;
+
   // Welcome→Apply deep-link auth gate. POST /applicants/intent requires
   // authenticate + requireEmailVerified, so without a token submit will 401
   // and the API client will eject to /login — stranding handoff users who
@@ -255,39 +262,91 @@ export function StepIntent() {
           >
             {t('intent.ami.sectionTitle')}
           </div>
-          <div style={{ fontSize: 12, color: HF.ink3, marginTop: 2, marginBottom: 8 }}>
-            {t('intent.ami.sectionHint')}
-          </div>
-          <label style={labelStyle} htmlFor="intentIncome">
-            {t('intent.ami.incomeLabel')}
-          </label>
-          <input
-            id="intentIncome"
-            type="text"
-            inputMode="numeric"
-            autoComplete="off"
-            style={inputStyle}
-            placeholder={t('intent.ami.incomePlaceholder')}
-            value={incomeStr}
-            onChange={(e) => setIncomeStr(e.target.value)}
-            aria-describedby="intentIncomeStatus"
-          />
-          <div
-            id="intentIncomeStatus"
-            role="status"
-            aria-live="polite"
-            className="mt-2 min-h-[1.25rem] text-xs"
-          >
-            {incomeNum == null ? null : previewTier ? (
-              <span style={{ fontWeight: 500, color: HF.sage }}>
-                {t('intent.ami.qualifies', { tier: formatAmiTier(previewTier) })}
-              </span>
-            ) : (
-              <span style={{ fontWeight: 500, color: HF.warn }}>
-                {t('intent.ami.overIncome')}
-              </span>
-            )}
-          </div>
+          {hasPrefilledTier ? (
+            <>
+              <div style={{ fontSize: 12, color: HF.ink3, marginTop: 2, marginBottom: 8 }}>
+                {t('intent.ami.prefilledHint')}
+              </div>
+              <div
+                data-testid="intent-ami-prefilled"
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 8,
+                  padding: '10px 12px',
+                  borderRadius: HF.r.sm,
+                  background: HF.accentLo,
+                  border: `1px solid ${HF.accent}`,
+                }}
+              >
+                <span
+                  style={{
+                    fontWeight: 600,
+                    color: HF.accentInk,
+                    fontFamily: HF.body,
+                    fontSize: 14,
+                  }}
+                >
+                  {t('intent.ami.prefilledSummary', {
+                    tier: formatAmiTier(s.qualifyingAmiTier),
+                  })}
+                </span>
+                <button
+                  type="button"
+                  data-testid="intent-ami-recalc"
+                  onClick={() => setShowAmiRecalc(true)}
+                  style={{
+                    marginLeft: 'auto',
+                    background: 'transparent',
+                    border: 'none',
+                    color: HF.accent,
+                    fontSize: 12,
+                    textDecoration: 'underline',
+                    cursor: 'pointer',
+                    fontFamily: HF.body,
+                  }}
+                >
+                  {t('intent.ami.recalculate')}
+                </button>
+              </div>
+            </>
+          ) : (
+            <>
+              <div style={{ fontSize: 12, color: HF.ink3, marginTop: 2, marginBottom: 8 }}>
+                {t('intent.ami.sectionHint')}
+              </div>
+              <label style={labelStyle} htmlFor="intentIncome">
+                {t('intent.ami.incomeLabel')}
+              </label>
+              <input
+                id="intentIncome"
+                type="text"
+                inputMode="numeric"
+                autoComplete="off"
+                style={inputStyle}
+                placeholder={t('intent.ami.incomePlaceholder')}
+                value={incomeStr}
+                onChange={(e) => setIncomeStr(e.target.value)}
+                aria-describedby="intentIncomeStatus"
+              />
+              <div
+                id="intentIncomeStatus"
+                role="status"
+                aria-live="polite"
+                className="mt-2 min-h-[1.25rem] text-xs"
+              >
+                {incomeNum == null ? null : previewTier ? (
+                  <span style={{ fontWeight: 500, color: HF.sage }}>
+                    {t('intent.ami.qualifies', { tier: formatAmiTier(previewTier) })}
+                  </span>
+                ) : (
+                  <span style={{ fontWeight: 500, color: HF.warn }}>
+                    {t('intent.ami.overIncome')}
+                  </span>
+                )}
+              </div>
+            </>
+          )}
         </div>
         <StepCTA
           type="submit"

--- a/client-tenant/src/pages/apply/steps/StepReview.tsx
+++ b/client-tenant/src/pages/apply/steps/StepReview.tsx
@@ -84,6 +84,19 @@ export function StepReview() {
               <div style={{ fontSize: 9, color: HF.ink3, fontWeight: 600, letterSpacing: 1, textTransform: 'uppercase' }}>
                 {t('review.lockedCriteria')}
               </div>
+              {state.qualifyingAmiTier && (
+                <div
+                  data-testid="review-ami-tier-line"
+                  style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginTop: 6 }}
+                >
+                  <span style={{ fontSize: 11, color: HF.ink3, fontFamily: HF.body }}>
+                    {t('review.qualifyingTierLabel')}
+                  </span>
+                  <span style={{ fontFamily: HF.display, fontSize: 13, fontWeight: 700, color: HF.ink }}>
+                    {t('review.qualifyingTierValue', { tier: formatAmiTier(state.qualifyingAmiTier) })}
+                  </span>
+                </div>
+              )}
               <div style={{ display: 'flex', gap: 4, flexWrap: 'wrap', marginTop: 6 }}>
                 {incomeBand && <Pill>{incomeBand}</Pill>}
                 <Pill>{t('review.household', { count: householdSize })}</Pill>

--- a/client-tenant/src/pages/apply/steps/__tests__/StepIntent.test.tsx
+++ b/client-tenant/src/pages/apply/steps/__tests__/StepIntent.test.tsx
@@ -1,0 +1,40 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { StepIntent } from '../StepIntent';
+import { WizardTestProvider, type WizardSeed } from './wizardTestUtils';
+
+function renderAt(seed: WizardSeed = {}, initialPath = '/apply?step=intent') {
+  return render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <WizardTestProvider seed={seed}>
+        <Routes>
+          <Route path="/apply" element={<StepIntent />} />
+        </Routes>
+      </WizardTestProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe('StepIntent — W0 AMI prefill', () => {
+  it('shows the prefilled-tier chip when qualifyingAmiTier is already set', () => {
+    renderAt({ qualifyingAmiTier: '50', grossAnnualIncome: 40000 });
+    expect(screen.getByTestId('intent-ami-prefilled')).toBeInTheDocument();
+    expect(screen.getByText(/50%/)).toBeInTheDocument();
+    expect(screen.queryByLabelText(/gross annual income/i)).not.toBeInTheDocument();
+  });
+
+  it('Recalculate collapses the chip and reveals the income input', () => {
+    renderAt({ qualifyingAmiTier: '50', grossAnnualIncome: 40000 });
+    fireEvent.click(screen.getByTestId('intent-ami-recalc'));
+    expect(screen.queryByTestId('intent-ami-prefilled')).not.toBeInTheDocument();
+    expect(screen.getByLabelText(/gross annual income/i)).toBeInTheDocument();
+  });
+
+  it('falls back to the full income input when no tier is seeded', () => {
+    renderAt({ qualifyingAmiTier: null });
+    expect(screen.queryByTestId('intent-ami-prefilled')).not.toBeInTheDocument();
+    expect(screen.getByLabelText(/gross annual income/i)).toBeInTheDocument();
+  });
+});

--- a/client-tenant/src/pages/apply/steps/__tests__/StepReview.test.tsx
+++ b/client-tenant/src/pages/apply/steps/__tests__/StepReview.test.tsx
@@ -35,7 +35,7 @@ describe('StepReview', () => {
     renderAt();
     expect(screen.getByText(/Confirm what you're applying for/i)).toBeInTheDocument();
     expect(screen.getByText(/Donna Louise 2/i)).toBeInTheDocument();
-    expect(screen.getByText(/50% AMI/)).toBeInTheDocument();
+    expect(screen.getByTestId('review-ami-tier-line')).toHaveTextContent(/50% AMI/);
   });
 
   it('Continue advances to household via ?step=household', () => {


### PR DESCRIPTION
## Summary
- Welcome→Apply hand-off now surfaces the qualifying tier on Step Intent as a one-line summary chip with a **Recalculate** link, instead of re-asking for income that was already collected on the welcome calculator.
- Step Review's locked-criteria card gains an explicit *Qualifying AMI tier* line so the tier is visible alongside household + move-in before submit.
- Adds EN + ES strings for the three new keys.
- 3 new regression specs (`StepIntent.test.tsx`) + one existing `StepReview` spec re-pointed at the new `review-ami-tier-line` testid (since `50% AMI` now legitimately appears in both the new line and the existing pill row).

## Test plan
- [x] `npx vitest run src/pages/apply/` — 53/53 green locally (worktree)
- [ ] CI: `test (18)`, `test (20)`, `test (22)`, `smoke-apply` (Welcome→Claim e2e)
- [ ] Manual: welcome → calculator → forward `?amiTier=50&hh=2&income=40000` → Step Intent shows prefilled chip + Recalculate
- [ ] Manual: skip the welcome calculator entirely → Step Intent still shows the full income input

🤖 Generated with [Claude Code](https://claude.com/claude-code)