### PR TITLE
fix(vercel): exclude static files from SPA catch-all rewrite

### DIFF
--- a/client-tenant/vercel.json
+++ b/client-tenant/vercel.json
@@ -2,6 +2,6 @@
   "rewrites": [
     { "source": "/api/(.*)", "destination": "https://api-production-ed89.up.railway.app/api/$1" },
     { "source": "/health", "destination": "https://api-production-ed89.up.railway.app/health" },
-    { "source": "/(.*)", "destination": "/" }
+    { "source": "/((?!sitemap\\.xml$|robots\\.txt$|favicon\\.svg$|unit-placeholder\\.svg$|uh-demo/|assets/).*)", "destination": "/" }
   ]
 }


### PR DESCRIPTION
## Summary
- The catch-all rewrite `/(.*) → /` was eating `/sitemap.xml`, `/robots.txt`, and any other `public/` asset on production. Vercel rewrites bypass the filesystem, so the SPA `index.html` was served for every URL (verified: both endpoints returned `content-type: text/html` instead of `application/xml` / `text/plain`).
- Negative-lookahead on the catch-all source lets the static files through to the filesystem layer so the deployed sitemap matches what's checked into `public/`.

## Test plan
- [ ] CI smoke pipeline green
- [ ] Post-deploy: `curl -sI https://frank-pilot-tenant.vercel.app/sitemap.xml | grep content-type` should return `application/xml`
- [ ] Post-deploy: `curl -sI https://frank-pilot-tenant.vercel.app/robots.txt | grep content-type` should return `text/plain`
- [ ] Manual: SPA routes (`/welcome`, `/apply?step=intent`, etc.) still resolve to index.html

Discovered during gpmglv pre-demo verification — restores the SEO punch claimed in the demo runbook's 60-second cold open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)