### PR TITLE
fix(bp-02): Lane G flag-on smoke — UUID scope + ON CONFLICT index

### DIFF
--- a/src/db/migrations/2026-05-24-compliance-tape-idem-index.sql
+++ b/src/db/migrations/2026-05-24-compliance-tape-idem-index.sql
@@ -1,0 +1,20 @@
+-- BP-02 Compliance Tape — fix for Lane B/Lane A mismatch
+--
+-- The repository's `insert()` uses
+--   INSERT ... ON CONFLICT (kind, session_id) DO NOTHING
+-- to provide same-session idempotency (re-firing the same beacon for the same
+-- session_id is a no-op). Lane A's migration shipped without a unique index
+-- backing that clause, so the INSERT errors with
+--   "there is no unique or exclusion constraint matching the ON CONFLICT
+--    specification"
+-- the first time the dual-write fires under COMPLIANCE_TAPE_V2_ENABLED.
+--
+-- Non-partial unique on (kind, session_id). PostgreSQL's default NULL semantics
+-- treat each NULL as distinct, so stamps without a session_id remain insertable
+-- as separate rows (no idempotency guarantee — that's intentional; callers that
+-- want idempotency must provide a session_id). A partial index with a WHERE
+-- predicate would force the ON CONFLICT clause to repeat the predicate verbatim,
+-- which Lane B's INSERT does not — non-partial avoids that coupling.
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_compliance_tape_kind_session
+  ON compliance_tape (kind, session_id);

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -502,6 +502,14 @@ CREATE INDEX idx_compliance_tape_applicant_sequence
   ON compliance_tape (applicant_id, sequence)
   WHERE applicant_id IS NOT NULL;
 
+-- Backs the repository's ON CONFLICT (kind, session_id) idempotency clause.
+-- Non-partial: PostgreSQL's default NULL semantics treat each NULL as distinct,
+-- so stamps without a session_id remain insertable as separate rows (no
+-- idempotency unless caller passes a session_id). A partial index would force
+-- ON CONFLICT to repeat the WHERE predicate; non-partial avoids that.
+CREATE UNIQUE INDEX idx_compliance_tape_kind_session
+  ON compliance_tape (kind, session_id);
+
 CREATE OR REPLACE FUNCTION compliance_tape_reject_mutation()
   RETURNS trigger
   LANGUAGE plpgsql

--- a/src/modules/tape/events/hud-928-1-fair-housing.ts
+++ b/src/modules/tape/events/hud-928-1-fair-housing.ts
@@ -31,8 +31,10 @@ export interface Hud9281FairHousingPostedInput {
  * Pure function — no IO, no DB, no clock.
  * Caller is responsible for supplying `postedAt`.
  *
- * Note: this event is property-scoped, not applicant-scoped; subjectId is
- * set to propertyId when available, otherwise "n/a".
+ * Note: this event is property-scoped, not applicant-scoped. The service
+ * routes subjectId → compliance_tape.applicant_id (UUID column), so when
+ * propertyId is unknown subjectId must be null (= global-scope chain). A
+ * non-UUID sentinel like "n/a" trips the column type and the stamp errors.
  */
 export function makeHud9281FairHousingPostedPayload(
   input: Hud9281FairHousingPostedInput
@@ -43,7 +45,7 @@ export function makeHud9281FairHousingPostedPayload(
     "@context": "https://frank-pilot.example/compliance-tape/v1",
     "@type": "ComplianceEvent.Hud9281FairHousingPosted",
     actorId: null,
-    subjectId: propertyId ?? "n/a",
+    subjectId: propertyId ?? null,
     ruleCitation: TAPE_CITATIONS[KIND],
     evidence: {
       postedAt,

--- a/src/modules/tape/routes.ts
+++ b/src/modules/tape/routes.ts
@@ -10,10 +10,7 @@ import { Router, Request, Response } from "express";
 import { z } from "zod";
 import rateLimit, { ipKeyGenerator } from "express-rate-limit";
 import { stampTape, TAPE_STAMP_KINDS } from "./index";
-import {
-  stampV2WelcomeLetterDelivered,
-  stampV2Hud9281FairHousingPosted,
-} from "./v2-stamp";
+import { stampV2Hud9281FairHousingPosted } from "./v2-stamp";
 import { logger } from "../../utils/logger";
 
 const router: Router = Router();
@@ -88,17 +85,10 @@ router.post("/welcome-accept", beaconLimiter, async (req: Request, res: Response
       },
       sessionId: parsed.data.session_id,
     });
-    // BP-02 Lane G dual-write — gated on COMPLIANCE_TAPE_V2_ENABLED.
-    // Pre-auth beacon: email is the only identity available; the v2 chain
-    // uses it as the applicantId proxy until the user verifies and lands
-    // in `users`. Phase 3 will rebase on the verified users.id.
-    if (parsed.data.email) {
-      void stampV2WelcomeLetterDelivered({
-        applicantId: parsed.data.email,
-        deliveredAt: new Date().toISOString(),
-        sessionId: parsed.data.session_id,
-      });
-    }
+    // BP-02 v2 dual-write deliberately skipped: this beacon fires pre-auth
+    // and the only identity available is `email`, which can't be coerced
+    // into the UUID applicant_id column. Phase 3 ports this once the
+    // verified users.id is known after magic-link callback.
     res.status(204).end();
   } catch (err) {
     logger.error("welcome-accept beacon failed", { error: (err as Error).message });


### PR DESCRIPTION
## Why

Ran the apply smoke with `COMPLIANCE_TAPE_V2_ENABLED=true` after Lane G #90 landed and the dual-write threw on every fire. Three bugs the flag-off CI couldn't catch:

1. **Lane C HUD-928.1 maker** returned `subjectId: "n/a"` when `propertyId` was unknown. The service routes `subjectId` → `compliance_tape.applicant_id` (UUID column), so `"n/a"` trips the column type and the stamp errors. Fixed: `subjectId = propertyId ?? null` → global-scope chain when the property is unknown.

2. **Lane G `welcome-accept`** passed `email` as `applicantId` because the beacon is pre-auth and there's no verified `users.id` yet. Email isn't a UUID — same column-type error. Dropped the v2 call entirely; the legacy NDJSON stamp still fires. Phase 3 will port once the verified `users.id` is available after magic-link callback.

3. **Repository `ON CONFLICT (kind, session_id)`** had no backing unique index in Lane A's migration. Added `2026-05-24-compliance-tape-idem-index.sql` (and mirrored in `schema.ts`). Non-partial unique: default Postgres NULL semantics already treat each NULL `session_id` as distinct, so stamps without one remain insertable as separate rows.

## End-to-end verification (local, flag on)

```
$ curl -X POST :3002/api/tape/welcome-view -d '{"session_id":"X","state":"NY"}'
HTTP 204
$ curl -X POST :3002/api/tape/welcome-view -d '{"session_id":"X","state":"NY"}'  # replay
HTTP 204
$ psql -c 'SELECT count(*) FROM compliance_tape WHERE session_id='X''
1     # idempotent
$ psql -c 'SELECT prev_hash, entry_hash FROM compliance_tape ORDER BY sequence'
# row 1 prev = zeros (genesis)
# row N prev = row N-1 entry  ← chain intact
```

- 3 rows, global-scope (`applicant_id` NULL)
- Hash chain links verified
- Same-`session_id` replay → no duplicate (idempotent)
- Legacy NDJSON ledger unaffected

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `jest src/modules/tape/__tests__` 32/32 green
- [x] Local flag-on curl smoke produces a verifiable chain
- [ ] CI matrix (will run on push)
- [ ] Post-merge: production apply the new migration before flipping `COMPLIANCE_TAPE_V2_ENABLED=true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)