### PR TITLE
chore(docs): propagate 2026-05-22 findings — Vercel gap + gpmglv ship status + BP-02 rollout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,3 +64,12 @@ TURNSTILE_SECRET_KEY=1x0000000000000000000000000000000AA
 # client-tenant `.env`) because Vite reads from process env at build time —
 # CI and Railway should set both vars together.
 VITE_TURNSTILE_SITE_KEY=1x00000000000000000000AA
+
+# Compliance Tape v2 (BP-02 — Postgres hash-chained ledger).
+#   false (default) → legacy NDJSON ledger only (`server/tape/bp03b.ndjson`).
+#   true            → dual-write: NDJSON + `compliance_tape` Postgres table.
+# Cutover gate (per docs/bp-02-contracts.md + docs/operator-runbook.md
+# "Rollout status"): flip Railway to true only after one clean staging
+# deploy where `scripts/post-deploy-verify.mjs --verify-dual-write` shows
+# NDJSON line-count == compliance_tape row-count for the same session_id.
+COMPLIANCE_TAPE_V2_ENABLED=false

--- a/README.md
+++ b/README.md
@@ -289,6 +289,31 @@ Environment variables required for production:
 - `STRIPE_SECRET_KEY` — Stripe API key
 - Integration API keys as needed
 
+### Tenant client (Vercel)
+
+The `client-tenant` Vite SPA is hosted on Vercel at
+`frank-pilot-tenant.vercel.app`. As of 2026-05-22 the Vercel project does
+**not** auto-deploy on push to `main` — six merged PRs (between #71 and #95)
+served the stale #71 build until a manual deploy was run. Until the GitHub
+integration is re-linked in the Vercel dashboard, ship the tenant client
+with:
+
+```bash
+cd client-tenant && vercel --prod --yes
+```
+
+After deploy, verify both the API and the static-asset surface in one call:
+
+```bash
+node scripts/post-deploy-verify.mjs \
+  https://api-production-ed89.up.railway.app \
+  --site=https://frank-pilot-tenant.vercel.app
+```
+
+The `--site=` checks confirm `/sitemap.xml` and `/robots.txt` are served as
+static files (non-`text/html` content-type) — the regression that PR #95
+fixed via a negative-lookahead catch-all in `client-tenant/vercel.json`.
+
 ## Project Structure
 
 ```

--- a/docs/intel/gpmglv-gap-backlog.md
+++ b/docs/intel/gpmglv-gap-backlog.md
@@ -1,9 +1,20 @@
 # GPMGLV Gap Backlog — Competitive Build Tracker
 
 _Active backlog. Source: [`gpmglv-audit.md`](gpmglv-audit.md) + [`gpmglv-bp-03b-positioning.md`](gpmglv-bp-03b-positioning.md)._
-_Last updated: 2026-05-20._
+_Last updated: 2026-05-22._
 
 Every row is a wedge — a feature Frank-Pilot can ship where the evidence-based audit shows GPMGLV (and the "custom Next.js marketing site" tier of affordable-housing operator) has no answer. Pull tickets through this table to keep work grounded in actual competitor weakness, not opinions.
+
+## Recently shipped (as of 2026-05-22 @ `b376800`)
+
+| Wedge | Title | Shipped via | Demo surface |
+|---|---|---|---|
+| #2 | W0 AMI prefill (Welcome → Apply → Review) | PR #94 | `StepIntent`, `StepReview` |
+| #6 | i18n EN/ES parity + CI guard | PR #91 | All apply steps |
+| #7 | Mobile-first apply UX | PR #79 + #92 | Sticky CTA behind `MOBILE_APPLY_ENABLED` |
+| #14 | Sitemap + robots served as static assets | PR #95 | `vercel.json` negative-lookahead rewrite |
+
+The ranked table below reflects these shipped statuses inline.
 
 ## How to read this
 
@@ -17,19 +28,19 @@ Every row is a wedge — a feature Frank-Pilot can ship where the evidence-based
 | # | Wedge | gpmglv state (evidence) | Frank-Pilot anchor | Status | Cost | Punch | Lev |
 |---|---|---|---|---|---|---|---|
 | 1 | **Real online application** | Every "Apply now" = `href="#contact"` (audit §Apply Flow) | `client-tenant/src/pages/Apply.tsx` wizard | half-built — flag-gated | S | 5 | ★★★★★ |
-| 2 | **AMI pre-qualifier (W0)** | "Income-qualified" mentioned, zero AMI tables disclosed (audit §HUD) | `client-tenant/src/lib/ami.ts` + `components/AmiCalculator.tsx` | half-built — needs wiring | S–M | 5 | ★★★★★ |
+| 2 | **AMI pre-qualifier (W0)** | "Income-qualified" mentioned, zero AMI tables disclosed (audit §HUD) | `client-tenant/src/lib/ami.ts` + `components/AmiCalculator.tsx` | shipped 2026-05-22 (PR #94) | S–M | 5 | ★★★★★ |
 | 3 | **"Apply button does nothing" demo flip** | property page CTA = `#contact` anchor scroll-jump (audit §Per-Page Dumps) | demo script + landing page mount | none (asset, not feature) | S | 5 | ★★★★★ |
 | 4 | **Unit-claim FTU / "carrot" UX** | No unit-level state anywhere on gpmglv | unit-claim slice (PR #5 merged 2026-05-14, commit 58c1036) | shipped, low visibility | S (amplify) | 4 | ★★★★ |
 | 5 | **Position-aware waitlist** | Submit-and-wait black hole; no position field (audit §Waitlist) | Lane E waitlist banner | shipped, no position display | M | 4 | ★★★ |
-| 6 | **EN-ES from day one** | English-only, no language switcher (audit §Per-Page Dumps) | `src/i18n/{en,es}/` scaffold | scaffold — locales need filling | M | 3 | ★★★ |
-| 7 | **Mobile-first apply UX** | gpmglv site is responsive but apply = #contact = no flow to optimize | `MOBILE_APPLY_ENABLED` flag | flag exists, UX TBD | M–L | 3 | ★★ |
+| 6 | **EN-ES from day one** | English-only, no language switcher (audit §Per-Page Dumps) | `src/i18n/{en,es}/` scaffold | shipped 2026-05-22 (PR #91) | M | 3 | ★★★ |
+| 7 | **Mobile-first apply UX** | gpmglv site is responsive but apply = #contact = no flow to optimize | `MOBILE_APPLY_ENABLED` flag | shipped 2026-05-22 (PR #79 + #92) | M–L | 3 | ★★ |
 | 8 | **Live unit availability + filter** | 17 property cards, zero rent, zero availability dates (audit §Property Listing) | `client-tenant/src/pages/discover/PropertyList.tsx` | partial — cards exist, filters TBD | M | 3 | ★★ |
 | 9 | **Honest pricing / AMI disclosure on listings** | Zero rent figures public (audit §Property Listing) | `discover/PropertyList.tsx` + `UnitCard.tsx` | partial | S | 2 | ★★ |
 | 10 | **Real applicant accounts (auth)** | No login on tenant side (audit §Tenant Login) | wizard + magic-link infra | shipped (foundational) | n/a | 2 | ★★ |
 | 11 | **Eligibility-aware lead routing** | Generic "Community + Message" form, no structured signal (audit §Per-Page Dumps `/contact-us`) | W0 output → property filter | folds into #2 | n/a | n/a | — |
 | 12 | **Resident portal: rent pay / docs / lease** | gpmglv `/portal` = maintenance + message + lookup only (audit §Tenant Login) | NEW | none (stage 2, post-move-in) | L | 2 | ★ |
 | 13 | **Anti-spam (Turnstile / rate-limit)** | Waitlist + contact forms have no visible captcha (audit §Per-Page Dumps) | server-side rate limit + Turnstile/hCaptcha | none | S–M | 1 | ★ |
-| 14 | **SEO / sitemap / JSON-LD** | `robots.txt` 404, `sitemap.xml` 404 (audit §Robots/Sitemap) | infra | none | S | 1 | ★ |
+| 14 | **SEO / sitemap / JSON-LD** | `robots.txt` 404, `sitemap.xml` 404 (audit §Robots/Sitemap) | infra | partial — sitemap+robots static-serve fixed 2026-05-22 (PR #95) | S | 1 | ★ |
 | 15 | **Cookie banner / GDPR posture** | No `Set-Cookie` observed, thin privacy policy (audit §Cookies) | NEW | none | S | 1 | ★ |
 
 ## Top-5 detail

--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -63,6 +63,20 @@ During cutover the system **dual-writes** — new Postgres tape and legacy NDJSO
 simultaneously. The NDJSON writer is removed in a follow-up PR once one full
 deploy cycle in staging is clean.
 
+### Rollout status (as of 2026-05-22)
+
+| Env       | `COMPLIANCE_TAPE_V2_ENABLED` | Writes to        | Verify command |
+| --------- | ---------------------------- | ---------------- | -------------- |
+| local-dev | `true` (developer choice)    | Postgres + NDJSON | `node scripts/post-deploy-verify.mjs http://localhost:3000 --verify-dual-write` (requires `DATABASE_URL` to local Postgres) |
+| Railway prod | `false` (legacy NDJSON only) | NDJSON only      | `node scripts/post-deploy-verify.mjs https://api-production-ed89.up.railway.app` |
+
+**Cutover gate** (per [`docs/bp-02-contracts.md`](bp-02-contracts.md)): flip
+Railway to `true` only after one clean staging deploy where the dual-write
+parity check passes — NDJSON line-count == `compliance_tape` row-count for
+the same `session_id` over a representative window. Use
+`--verify-dual-write` against staging to confirm. Once parity has held for
+one full deploy cycle, remove the NDJSON writer in a follow-up PR.
+
 ### Where the data lives
 
 - **Table:** `compliance_tape` (Postgres)

--- a/scripts/post-deploy-verify.mjs
+++ b/scripts/post-deploy-verify.mjs
@@ -1,24 +1,44 @@
 #!/usr/bin/env node
 // post-deploy-verify.mjs — definition-of-done for "the Railway API is live."
 //
-// Runs the 4 checks from the deploy plan against a given API base URL:
+// Runs the 4 core checks from the deploy plan against a given API base URL:
 //   1) /health returns {status:"ok", db:"ok"}.
 //   2) POST /api/applicants/register returns 202 + ok:true (not 405).
 //   3) Magic-link path is reachable (either devLink in response when
 //      DEMO_LINK_IN_RESPONSE=true, or the route just doesn't 5xx).
 //   4) GET /api/tape/page-view (public BP-03b beacon) returns 200/204.
 //
+// Optional Vercel SPA static-asset checks (front-end domain):
+//   --site=https://frank-pilot-tenant.vercel.app
+//     Verifies /sitemap.xml and /robots.txt are served as static files
+//     (non-text/html content-type). Catches the catch-all rewrite
+//     regression where SPA HTML eats static assets.
+//
+// Optional BP-02 dual-write parity check (NDJSON ↔ Postgres):
+//   --verify-dual-write
+//     POSTs one tape beacon, then asserts that the same session_id appears
+//     in both the NDJSON ledger and the compliance_tape Postgres table.
+//     Requires COMPLIANCE_TAPE_V2_ENABLED=true and DATABASE_URL set.
+//
 // Usage:
 //   node scripts/post-deploy-verify.mjs https://frank-pilot-api.up.railway.app
-//   (or via env: API_BASE=... node scripts/post-deploy-verify.mjs)
+//   node scripts/post-deploy-verify.mjs https://api.../  --site=https://...vercel.app
+//   node scripts/post-deploy-verify.mjs https://api.../  --verify-dual-write
 //
 // Exit code: 0 if all pass, 1 otherwise.
 
-const base =
-  process.argv[2] || process.env.API_BASE || process.env.RAILWAY_PUBLIC_DOMAIN;
+const args = process.argv.slice(2);
+const flags = args.filter((a) => a.startsWith("--"));
+const positional = args.filter((a) => !a.startsWith("--"));
+const base = positional[0] || process.env.API_BASE || process.env.RAILWAY_PUBLIC_DOMAIN;
+const siteFlag = flags.find((f) => f.startsWith("--site="));
+const SITE = siteFlag ? siteFlag.slice("--site=".length).replace(/\/$/, "") : null;
+const VERIFY_DUAL_WRITE = flags.includes("--verify-dual-write");
 
 if (!base) {
-  console.error("Usage: post-deploy-verify.mjs <https://api-base-url>");
+  console.error(
+    "Usage: post-deploy-verify.mjs <https://api-base-url> [--site=https://...vercel.app] [--verify-dual-write]",
+  );
   process.exit(2);
 }
 
@@ -101,12 +121,104 @@ async function checkTapeBeacon() {
   }
 }
 
-console.log(`Verifying ${API}\n`);
+async function checkSitemapAndRobots() {
+  if (!SITE) return;
+  for (const path of ["/sitemap.xml", "/robots.txt"]) {
+    const expected = path === "/sitemap.xml" ? "xml" : "text";
+    try {
+      const r = await fetch(`${SITE}${path}`);
+      const ct = (r.headers.get("content-type") || "").toLowerCase();
+      const okStatus = r.ok;
+      const okType = ct.includes(expected) && !ct.includes("text/html");
+      record(
+        `05-static-${path.slice(1)}`,
+        okStatus && okType,
+        `status=${r.status} content-type=${ct || "(empty)"}`,
+      );
+    } catch (e) {
+      record(`05-static-${path.slice(1)}`, false, `network error: ${e.message}`);
+    }
+  }
+}
+
+async function checkDualWriteParity() {
+  if (!VERIFY_DUAL_WRITE) return;
+  if (process.env.COMPLIANCE_TAPE_V2_ENABLED !== "true") {
+    record(
+      "06-dual-write-parity",
+      false,
+      "COMPLIANCE_TAPE_V2_ENABLED is not 'true'; skipping",
+    );
+    return;
+  }
+  if (!process.env.DATABASE_URL) {
+    record(
+      "06-dual-write-parity",
+      false,
+      "DATABASE_URL not set; cannot check Postgres side",
+    );
+    return;
+  }
+  const sessionId = `verify-${Date.now()}`;
+  const url = `${API}/api/tape/page-view`;
+  try {
+    const r = await fetch(url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        session_id: sessionId,
+        formId: "HUD-928.1",
+        page: 1,
+        ts: Date.now(),
+      }),
+    });
+    if (!r.ok && r.status !== 202 && r.status !== 204) {
+      record("06-dual-write-parity", false, `beacon POST returned ${r.status}`);
+      return;
+    }
+    let pg;
+    try {
+      const { Client } = await import("pg");
+      pg = new Client({ connectionString: process.env.DATABASE_URL });
+      await pg.connect();
+      const { rows } = await pg.query(
+        "SELECT count(*)::int AS n FROM compliance_tape WHERE session_id = $1",
+        [sessionId],
+      );
+      const pgCount = rows[0]?.n ?? 0;
+      const ndjsonPath = process.env.TAPE_LEDGER_PATH || "server/tape/bp03b.ndjson";
+      const { readFile } = await import("node:fs/promises");
+      let ndjsonCount = 0;
+      try {
+        const text = await readFile(ndjsonPath, "utf8");
+        ndjsonCount = text
+          .split("\n")
+          .filter((l) => l.includes(`"session_id":"${sessionId}"`)).length;
+      } catch {
+        ndjsonCount = 0;
+      }
+      const ok = pgCount > 0 && ndjsonCount > 0 && pgCount === ndjsonCount;
+      record(
+        "06-dual-write-parity",
+        ok,
+        `pg=${pgCount} ndjson=${ndjsonCount} session=${sessionId}`,
+      );
+    } finally {
+      if (pg) await pg.end().catch(() => {});
+    }
+  } catch (e) {
+    record("06-dual-write-parity", false, `error: ${e.message}`);
+  }
+}
+
+console.log(`Verifying ${API}${SITE ? ` + ${SITE}` : ""}\n`);
 
 await checkHealth();
 const registerBody = await checkRegister();
 checkMagicLinkSurface(registerBody);
 await checkTapeBeacon();
+await checkSitemapAndRobots();
+await checkDualWriteParity();
 
 const passed = results.filter((r) => r.passed).length;
 const total = results.length;


### PR DESCRIPTION
## Summary
- Surfaces today's gpmglv pre-demo findings so a fresh session can reconstruct state from artifacts alone — no source-code changes, docs + verify script only.
- `scripts/post-deploy-verify.mjs` grows two optional checks: `--site=<vercel-domain>` (sitemap/robots content-type — guards against the PR #95 catch-all regression) and `--verify-dual-write` (BP-02 NDJSON↔Postgres parity for one beacon).
- `README.md` documents the **Vercel-doesn't-auto-deploy** gotcha (six PRs sat un-deployed today between #71 and #95) with the manual deploy command + the new verify invocation.
- `docs/intel/gpmglv-gap-backlog.md` adds a "Recently shipped (2026-05-22 @ b376800)" header and flips wedge rows: #2 (PR #94), #6 (PR #91), #7 (PR #79 + #92), #14 partial (PR #95).
- `docs/operator-runbook.md` gains a per-env "Rollout status" matrix for `COMPLIANCE_TAPE_V2_ENABLED`; `.env.example` annotates the flag with the cutover semantics.

## Test plan
- [ ] CI: four required gates (`test (18)/(20)/(22)`, `smoke-apply`) pass
- [ ] `node scripts/post-deploy-verify.mjs https://api-production-ed89.up.railway.app --site=https://frank-pilot-tenant.vercel.app` → 6/6 PASS (4 API + 2 static-asset)
- [ ] Without `--site` or `--verify-dual-write`, the script still behaves like the original (4 checks only)
- [ ] `grep -n "Tenant client (Vercel)" README.md` returns the new section
- [ ] `grep -n "Recently shipped" docs/intel/gpmglv-gap-backlog.md` returns the dated header
- [ ] `grep -n "Rollout status" docs/operator-runbook.md` returns the matrix
- [ ] `grep -n "COMPLIANCE_TAPE_V2_ENABLED" .env.example` returns the annotated line

## Follow-ups (out of scope for this PR)
- Re-link Vercel GitHub integration in the dashboard so push-to-main auto-deploys (currently manual via `vercel --prod --yes`).
- Wire CI to run `post-deploy-verify.mjs --site=...` automatically post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)