### PR TITLE
sec(cors): fail closed when CORS_ORIGIN unset (HIGH-2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,11 @@ DB_PASSWORD=changeme
 PORT=3000
 NODE_ENV=development
 
+# CORS — required. Comma-separated list of allowed origins. In prod set via Railway env.
+# Example: CORS_ORIGIN=https://frank-pilot-tenant.vercel.app,https://staff.example.com
+# Backend exits at startup if this is unset (HIGH-2, SECURITY-AUDIT-2026-05-21).
+CORS_ORIGIN=http://localhost:5174
+
 # JWT
 JWT_SECRET=changeme-use-a-real-secret
 JWT_EXPIRY=8h

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,7 +54,13 @@ const PORT = parseInt(process.env.PORT || "3000");
 
 // Security middleware
 app.use(helmet());
-app.use(cors({ origin: process.env.CORS_ORIGIN || "*" }));
+// HIGH-2 (SECURITY-AUDIT-2026-05-21): fail closed on CORS — refuse to boot
+// without an explicit allow-list. Wildcard fallback removed.
+const corsOrigin = process.env.CORS_ORIGIN;
+if (!corsOrigin) {
+  throw new Error("CORS_ORIGIN is required (no wildcard fallback)");
+}
+app.use(cors({ origin: corsOrigin.split(",").map((s) => s.trim()) }));
 app.use(express.json({ limit: "1mb" }));
 
 // Request logging (PII-safe)


### PR DESCRIPTION
## Summary

- Replace wildcard CORS fallback (`process.env.CORS_ORIGIN || "*"`) with a fail-closed check that throws at startup if `CORS_ORIGIN` is unset. Comma-separated origins are split and trimmed.
- Document `CORS_ORIGIN` in `.env.example` under the Server section with a localhost default for dev.

## Pre-merge gate

Before merging this PR, set `CORS_ORIGIN` on Railway prod AND staging environments. If the env var is missing when the next deploy boots, the backend exits at startup and frank-pilot-tenant.vercel.app goes down.

Suggested value: `CORS_ORIGIN=https://frank-pilot-tenant.vercel.app` (add staff URL if it exists, comma-separated).

Verification after setting:
1. Railway env vars include `CORS_ORIGIN` for both environments.
2. Trigger a redeploy and confirm `/health` returns 200 from the configured origin.
3. Confirm an arbitrary third-party origin (e.g. `https://evil.example.com`) is rejected by the browser preflight.

## Test plan

- `npx tsc --noEmit -p tsconfig.json` clean.
- Manual verification (post-merge, with env var set): boot the server, hit `/api/auth/magic-link/request` from the configured origin (200) and from an unconfigured origin (CORS-blocked by browser).
- Negative path (unit test deferred): the change is 3 lines of trivial logic (`if (!corsOrigin) throw; origin.split(",").map(s => s.trim())`). A unit test would tautologically restate the source; the failure mode is exercised end-to-end by the Railway boot itself. Extracting a `parseCorsOrigin` helper for isolated testing was considered but skipped to keep the diff to a single-file fix (per the audit fix shape) and because `src/index.ts` has heavy import-time side effects that make a `require('../index')` boot test brittle in jest.

## Audit ref

[`SECURITY-AUDIT-2026-05-21.md`](../blob/main/SECURITY-AUDIT-2026-05-21.md) — HIGH-2 (src/index.ts:57). Fixes the wildcard-CORS fallback that ships `*` to production if Railway is missing the env var.

🤖 Generated with [Claude Code](https://claude.com/claude-code)