### PR TITLE
sec(tenant): lift requireEmailVerified to router-level (HIGH-1)

### DIFF
--- a/src/__tests__/messages-routes.test.ts
+++ b/src/__tests__/messages-routes.test.ts
@@ -89,7 +89,13 @@ const unverifiedApplicant: AuthUser = {
 };
 
 describe("PR #4 P0 follow-ups — messaging routes", () => {
-  beforeEach(() => jest.clearAllMocks());
+  // resetAllMocks (not clearAllMocks) so unused mockResolvedValueOnce
+  // queue entries do not leak between tests. HIGH-1 lifted
+  // requireEmailVerified ahead of scopeToOwnApplications on the router
+  // chain, which means the unverified-path tests below no longer reach
+  // scopeToOwnApplications — their mockScopedApps stub would otherwise
+  // pollute the next test's queue.
+  beforeEach(() => jest.resetAllMocks());
 
   describe("P0 #1 / #5 — markRead IDOR scoped by application_id", () => {
     it("scopes the UPDATE by application_id so a foreign message cannot be flipped", async () => {
@@ -154,9 +160,9 @@ describe("PR #4 P0 follow-ups — messaging routes", () => {
 
       // authenticate users row — email_verified_at is null → emailVerified=false
       mockUsersRow(unverifiedApplicant, null);
-      // scopeToOwnApplications still runs (it's on the router-level chain)
-      mockScopedApps([ownedAppId]);
-      // requireEmailVerified should short-circuit BEFORE any further DB call.
+      // HIGH-1: requireEmailVerified now runs BEFORE scopeToOwnApplications
+      // on the router chain — no scopedApps stub needed for the unverified
+      // path, the chain short-circuits at requireEmailVerified.
 
       const res = await request(app)
         .post(`/tenant/applications/${ownedAppId}/messages`)
@@ -173,7 +179,7 @@ describe("PR #4 P0 follow-ups — messaging routes", () => {
       const token = generateToken(unverifiedApplicant, { emailVerified: false });
 
       mockUsersRow(unverifiedApplicant, null);
-      mockScopedApps([ownedAppId]);
+      // HIGH-1: see note above — scopeToOwnApplications is not reached.
 
       const res = await request(app)
         .post(`/tenant/applications/${ownedAppId}/messages/${someMsgId}/read`)

--- a/src/modules/tenant/__tests__/email-verified-gate.test.ts
+++ b/src/modules/tenant/__tests__/email-verified-gate.test.ts
@@ -1,0 +1,110 @@
+/**
+ * HIGH-1 (SECURITY-AUDIT-2026-05-21): tenant-portal `requireEmailVerified`
+ * lifted to the router-level chain at src/modules/tenant/routes.ts:45.
+ *
+ * Before this PR, the eight read/write routes below relied on
+ *   `authenticate + requireTenantRole + scopeToOwnApplications`
+ * alone, allowing any holder of a tenant/applicant JWT to read PII or
+ * post payment + maintenance mutations even after `email_verified_at`
+ * was administratively cleared. Two of the ten tenant routes
+ * (POST /messages, POST /messages/:msgId/read) already self-gated.
+ *
+ * The fix lifts `requireEmailVerified` into the router chain so all ten
+ * routes share the same WARN #2 floor. Each test below issues a JWT
+ * with `emailVerified: false` against a users row whose
+ * `email_verified_at = null`, then asserts `403 EMAIL_UNVERIFIED`.
+ *
+ * Mock order mirrors the new chain:
+ *   authenticate (mockUsersRow) → requireTenantRole (no query) →
+ *   requireEmailVerified (no query — short-circuits 403) →
+ *   scopeToOwnApplications (NOT reached on unverified path).
+ */
+import express from "express";
+import request from "supertest";
+import { generateToken, AuthUser } from "../../../middleware/auth";
+
+jest.mock("../../../config/database", () => ({
+  query: jest.fn(),
+  transaction: jest.fn(),
+}));
+jest.mock("../../../utils/logger", () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+import { query } from "../../../config/database";
+import tenantRouter from "../routes";
+
+const mockQuery = query as jest.MockedFunction<typeof query>;
+
+const app = express();
+app.use(express.json());
+app.use("/tenant", tenantRouter);
+
+// Stub the users row that authenticate() reads.
+function mockUsersRow(user: AuthUser, emailVerifiedAt: Date | null) {
+  mockQuery.mockResolvedValueOnce({
+    rows: [
+      {
+        id: user.id,
+        email: user.email,
+        role: user.role,
+        first_name: user.firstName,
+        last_name: user.lastName,
+        property_ids: user.propertyIds ?? [],
+        is_active: true,
+        email_verified_at: emailVerifiedAt,
+      },
+    ],
+  } as any);
+}
+
+const unverifiedApplicant: AuthUser = {
+  id: "user-applicant-unverified",
+  email: "unverified@example.com",
+  role: "applicant",
+  firstName: "Un",
+  lastName: "Verified",
+  propertyIds: [],
+  emailVerified: false,
+};
+
+describe("HIGH-1 — router-level requireEmailVerified gates all tenant routes", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  // Eight routes that previously had NO email-verified gate. With the
+  // router-level lift, an unverified applicant must hit 403 EMAIL_UNVERIFIED
+  // on every one of them — before any handler logic runs.
+  const newlyGatedRoutes: Array<["get" | "post", string]> = [
+    ["get", "/tenant/me"],
+    ["get", "/tenant/dashboard"],
+    ["get", "/tenant/applications/some-app-id/ledger"],
+    ["post", "/tenant/applications/some-app-id/pay"],
+    ["get", "/tenant/maintenance"],
+    ["post", "/tenant/maintenance"],
+    ["get", "/tenant/applications/some-app-id"],
+    ["get", "/tenant/applications/some-app-id/messages"],
+  ];
+
+  test.each(newlyGatedRoutes)(
+    "%s %s → 403 EMAIL_UNVERIFIED for an unverified applicant",
+    async (method, path) => {
+      const token = generateToken(unverifiedApplicant, { emailVerified: false });
+
+      // authenticate() reads users row; email_verified_at = null forces
+      // req.user.emailVerified = false regardless of the token claim.
+      mockUsersRow(unverifiedApplicant, null);
+      // scopeToOwnApplications is NOT reached because requireEmailVerified
+      // short-circuits with 403 first. No further mocks needed.
+
+      const req = (request(app) as any)[method](path).set(
+        "Authorization",
+        `Bearer ${token}`
+      );
+      const res =
+        method === "post" ? await req.send({}) : await req.send();
+
+      expect(res.status).toBe(403);
+      expect(res.body.code).toBe("EMAIL_UNVERIFIED");
+    }
+  );
+});

--- a/src/modules/tenant/routes.ts
+++ b/src/modules/tenant/routes.ts
@@ -41,8 +41,8 @@ const messageReadLimiter = rateLimit({
   message: { error: "Too many requests, slow down" },
 });
 
-// All tenant routes require auth + applicant/tenant role + scope
-router.use(authenticate, requireTenantRole, scopeToOwnApplications);
+// All tenant routes require auth + applicant/tenant role + email verified + scope
+router.use(authenticate, requireTenantRole, requireEmailVerified, scopeToOwnApplications);
 
 // ---------------------------------------------------------------
 // GET /api/tenant/me — current user
@@ -423,7 +423,6 @@ const messageBodySchema = z.object({
 
 router.post(
   "/applications/:applicationId/messages",
-  requireEmailVerified,
   messageWriteLimiter,
   async (req: AuthRequest, res: Response) => {
     try {
@@ -462,7 +461,6 @@ router.post(
 // ---------------------------------------------------------------
 router.post(
   "/applications/:applicationId/messages/:msgId/read",
-  requireEmailVerified,
   messageReadLimiter,
   async (req: AuthRequest, res: Response) => {
     try {


### PR DESCRIPTION
## Summary

Closes **HIGH-1** from [SECURITY-AUDIT-2026-05-21.md](../blob/main/SECURITY-AUDIT-2026-05-21.md). One-word fix on `src/modules/tenant/routes.ts:45` — lifts `requireEmailVerified` from the two self-gated message handlers up to the router-level chain so every tenant-portal route shares the WARN #2 floor.

Before:
```ts
router.use(authenticate, requireTenantRole, scopeToOwnApplications);
```

After:
```ts
router.use(authenticate, requireTenantRole, requireEmailVerified, scopeToOwnApplications);
```

The DB column `users.email_verified_at` is re-read by `authenticate()` on every request, so an administratively-cleared verification flag is honored immediately. No schema changes.

## Newly gated routes

Eight tenant routes that previously had no email-verified gate:

- `GET  /tenant/me`
- `GET  /tenant/dashboard`
- `GET  /tenant/applications/:applicationId/ledger`
- `POST /tenant/applications/:applicationId/pay`
- `GET  /tenant/maintenance`
- `POST /tenant/maintenance`
- `GET  /tenant/applications/:applicationId`
- `GET  /tenant/applications/:applicationId/messages`

The two already-gated routes (`POST /messages`, `POST /messages/:msgId/read`) keep the same behavior — the per-route `requireEmailVerified` argument is removed as redundant.

## Tests

- New `src/modules/tenant/__tests__/email-verified-gate.test.ts` — parameterized test (`test.each`) with one case per newly-gated route, asserting `403 { code: "EMAIL_UNVERIFIED" }` for an unverified-applicant JWT.
- `src/__tests__/messages-routes.test.ts` swaps `jest.clearAllMocks()` for `jest.resetAllMocks()` so unused `mockResolvedValueOnce` entries no longer leak between tests. The unverified-path tests there drop their `mockScopedApps` stubs since `requireEmailVerified` now short-circuits before `scopeToOwnApplications`.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [x] `npx jest src/modules/tenant src/__tests__/messages-routes.test.ts` — 13 passing (8 new + 5 existing)
- [x] `npx jest src/__tests__ src/modules/auth src/modules/tenant src/utils` — 872 passing, 15 pre-existing skips, 0 fails
- [x] `grep -c "requireEmailVerified" src/modules/tenant/routes.ts` returns `2` (import + router.use)

## Audit reference

> **HIGH-1**: Tenant portal routes `GET /dashboard`, `GET /applications/:id`, `GET /applications/:id/ledger`, `POST /applications/:id/pay`, `GET|POST /maintenance` do **NOT** require `requireEmailVerified`. Only `messages` write/read paths got the gate. Defeats half the purpose of WARN #2 — a token whose underlying account had `email_verified_at` administratively cleared still hits SSN-adjacent PII and can post fake ledger entries.

— SECURITY-AUDIT-2026-05-21.md line 10

🤖 Generated with [Claude Code](https://claude.com/claude-code)