### PR TITLE
sec(logger): redact PII keys from metadata (LOW-1)

### DIFF
--- a/src/utils/__tests__/logger.test.ts
+++ b/src/utils/__tests__/logger.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Tests for src/utils/logger.ts — specifically the piiFilterFormat winston
+ * format that walks metadata via sanitizeObject.
+ *
+ * Closes LOW-1 (SECURITY-AUDIT-2026-05-21): metadata containing `email`,
+ * `phone`, etc. used to be JSON-serialized into logs/combined.log unredacted.
+ * The structural fix wires sanitizeObject into the winston format chain so
+ * the redaction happens once for every logger call, regardless of call site.
+ *
+ * Approach: build a fresh logger with the same format chain as the configured
+ * one plus a CaptureTransport, so we observe the post-format `info` object
+ * that File transports would serialize to disk. This is the closest possible
+ * approximation to the on-disk log line without spamming actual files.
+ *
+ * Winston's stream pipeline is async, so each test awaits the logger's
+ * "data" event from the CaptureTransport before asserting.
+ */
+
+import winston from "winston";
+import Transport from "winston-transport";
+import { piiFilterFormat } from "../logger";
+
+// ── Capture transport ─────────────────────────────────────────────────────────
+
+class CaptureTransport extends Transport {
+  public lines: Record<string, unknown>[] = [];
+  log(info: Record<string, unknown>, callback: () => void): void {
+    // winston's File transport serializes `info` to JSON after the format
+    // chain runs. By the time `info` reaches a transport, all formats have
+    // mutated it. So capturing it here is what hits disk.
+    this.lines.push(info);
+    this.emit("logged", info);
+    callback();
+  }
+}
+
+function buildTestLogger(): { logger: winston.Logger; capture: CaptureTransport } {
+  const capture = new CaptureTransport();
+  const logger = winston.createLogger({
+    level: "info",
+    // Same format chain shape as src/utils/logger.ts production logger.
+    format: winston.format.combine(
+      piiFilterFormat(),
+      winston.format.timestamp({ format: "YYYY-MM-DD HH:mm:ss.SSS" }),
+      winston.format.errors({ stack: true }),
+      winston.format.json()
+    ),
+    defaultMeta: { service: "frank-pilot-test" },
+    transports: [capture],
+  });
+  return { logger, capture };
+}
+
+function logAndWait(
+  logger: winston.Logger,
+  capture: CaptureTransport,
+  fn: () => void
+): Promise<void> {
+  return new Promise((resolve) => {
+    capture.once("logged", () => resolve());
+    fn();
+  });
+}
+
+describe("logger PII redaction (LOW-1)", () => {
+  it("redacts email key in metadata (the original audit offender shape)", async () => {
+    const { logger, capture } = buildTestLogger();
+
+    await logAndWait(logger, capture, () =>
+      logger.info("Magic link issued", {
+        email: "alex@example.com",
+        link: "https://app/auth?token=[REDACTED]",
+      })
+    );
+
+    expect(capture.lines).toHaveLength(1);
+    const line = capture.lines[0];
+    expect(line.email).toBe("[REDACTED]");
+    // Non-PII metadata pass-through.
+    expect(line.link).toBe("https://app/auth?token=[REDACTED]");
+    // Winston structural fields preserved.
+    expect(line.message).toBe("Magic link issued");
+    expect(line.level).toBe("info");
+    expect(line.service).toBe("frank-pilot-test");
+  });
+
+  it("redacts phone key in metadata", async () => {
+    const { logger, capture } = buildTestLogger();
+
+    await logAndWait(logger, capture, () =>
+      logger.info("Adverse action notice", { phone: "555-123-4567", noticeId: "abc" })
+    );
+
+    expect(capture.lines).toHaveLength(1);
+    expect(capture.lines[0].phone).toBe("[REDACTED]");
+    expect(capture.lines[0].noticeId).toBe("abc");
+  });
+
+  it("redacts ssn key in metadata", async () => {
+    const { logger, capture } = buildTestLogger();
+
+    await logAndWait(logger, capture, () =>
+      logger.info("screening event", { ssn: "111-22-3333", applicationId: "app-1" })
+    );
+
+    expect(capture.lines).toHaveLength(1);
+    expect(capture.lines[0].ssn).toBe("[REDACTED]");
+    expect(capture.lines[0].applicationId).toBe("app-1");
+  });
+
+  it("still runs filterPII on the message string (regression guard)", async () => {
+    const { logger, capture } = buildTestLogger();
+
+    await logAndWait(logger, capture, () =>
+      logger.info("contact applicant at alex@example.com today", {})
+    );
+
+    expect(capture.lines).toHaveLength(1);
+    const msg = capture.lines[0].message as string;
+    expect(msg).toContain("[EMAIL-REDACTED]");
+    expect(msg).not.toContain("alex@example.com");
+  });
+
+  it("walks nested metadata objects", async () => {
+    const { logger, capture } = buildTestLogger();
+
+    await logAndWait(logger, capture, () =>
+      logger.info("user event", {
+        user: { email: "foo@bar.com", id: "user-123" },
+        action: "login",
+      })
+    );
+
+    expect(capture.lines).toHaveLength(1);
+    const user = capture.lines[0].user as Record<string, unknown>;
+    expect(user.email).toBe("[REDACTED]");
+    expect(user.id).toBe("user-123");
+    expect(capture.lines[0].action).toBe("login");
+  });
+
+  it("leaves non-PII fields untouched (no over-redaction)", async () => {
+    const { logger, capture } = buildTestLogger();
+
+    await logAndWait(logger, capture, () =>
+      logger.info("ordinary event", {
+        userId: "u-1",
+        role: "applicant",
+        attempt: 3,
+        normalField: "kept",
+      })
+    );
+
+    expect(capture.lines).toHaveLength(1);
+    const line = capture.lines[0];
+    expect(line.userId).toBe("u-1");
+    expect(line.role).toBe("applicant");
+    expect(line.attempt).toBe(3);
+    expect(line.normalField).toBe("kept");
+  });
+
+  it("redacts password and token keys in metadata", async () => {
+    const { logger, capture } = buildTestLogger();
+
+    await logAndWait(logger, capture, () =>
+      logger.info("auth event", {
+        password: "hunter2",
+        token: "jwt-abc",
+        requestId: "req-1",
+      })
+    );
+
+    expect(capture.lines).toHaveLength(1);
+    expect(capture.lines[0].password).toBe("[REDACTED]");
+    expect(capture.lines[0].token).toBe("[REDACTED]");
+    expect(capture.lines[0].requestId).toBe("req-1");
+  });
+
+  it("does NOT walk array elements (documents known gap from pii-filter.ts:56)", async () => {
+    // sanitizeObject deliberately skips arrays (`!Array.isArray(value)`).
+    // This test pins that behavior so a future fix is a conscious change,
+    // not an accidental one. Current offenders use flat objects, so this
+    // gap is acceptable for LOW-1.
+    const { logger, capture } = buildTestLogger();
+
+    await logAndWait(logger, capture, () =>
+      logger.info("batch event", {
+        recipients: [{ email: "leaks@example.com" }],
+      })
+    );
+
+    expect(capture.lines).toHaveLength(1);
+    const recipients = capture.lines[0].recipients as Array<Record<string, unknown>>;
+    // Element-level email is NOT redacted today — documented gap.
+    expect(recipients[0].email).toBe("leaks@example.com");
+  });
+});

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,9 +1,30 @@
 import winston from "winston";
-import { filterPII } from "./pii-filter";
+import { filterPII, sanitizeObject } from "./pii-filter";
 
-const piiFilterFormat = winston.format((info) => {
+/**
+ * Winston format that redacts PII from both the message string and the
+ * metadata object. Closes LOW-1 (SECURITY-AUDIT-2026-05-21): metadata
+ * containing `email`, `phone`, etc. was previously JSON-serialized into
+ * combined.log unredacted (e.g. `logger.info("Magic link issued", { email })`).
+ *
+ * Implementation note: sanitizeObject returns a fresh object built from
+ * Object.entries, which only walks string keys. Winston internally relies
+ * on Symbol-keyed properties (LEVEL, MESSAGE, SPLAT from triple-beam) to
+ * route the log line through transports. We therefore mutate `info` in place
+ * — overwriting only the string-keyed properties — so the symbol-keyed ones
+ * survive the format chain. Without this, transports never receive the line.
+ */
+export const piiFilterFormat = winston.format((info) => {
   if (typeof info.message === "string") {
     info.message = filterPII(info.message);
+  }
+  // sanitizeObject walks PII_KEYS (email/phone/ssn/dob/token/etc.) and
+  // recursively redacts nested objects. Winston's own string keys (level,
+  // message, timestamp, service) are not in PII_KEYS so they pass through
+  // unchanged.
+  const sanitized = sanitizeObject(info as unknown as Record<string, unknown>);
+  for (const key of Object.keys(sanitized)) {
+    (info as Record<string, unknown>)[key] = sanitized[key];
   }
   return info;
 });

--- a/src/utils/pii-filter.ts
+++ b/src/utils/pii-filter.ts
@@ -27,6 +27,12 @@ const PII_KEYS = [
   "date_of_birth",
   "dateOfBirth",
   "dob",
+  // LOW-1 (SECURITY-AUDIT-2026-05-21): metadata redaction targets — the
+  // audit calls out `logger.info("Magic link issued", { email })` and
+  // similar shapes leaking emails/phones into combined.log via Winston's
+  // JSON serializer.
+  "email",
+  "phone",
 ];
 
 export function filterPII(input: string): string {


### PR DESCRIPTION
## Summary
Closes **LOW-1** from `SECURITY-AUDIT-2026-05-21`. The winston `piiFilterFormat` previously only ran `filterPII()` against `info.message`; metadata was JSON-serialized into `logs/combined.log` unredacted. Any operator with log access (Railway, Datadog, etc.) could read which emails registered to a HUD-compliance program — a confidentiality breach for CDPC's protected-class tenant population even without inner application data.

**Structural fix**: wire `sanitizeObject` (already exported from `src/utils/pii-filter.ts`) into the winston format chain so it walks every logger call's metadata once. No call-site changes needed.

## Top offenders the audit cited (all now redacted at the format layer)
- `src/modules/auth/magic-link-service.ts:86` — `{ email, link }`
- `src/modules/applicants/routes.ts:179` — `{ email }`
- `src/modules/users/service.ts:132` — `{ userId, email, role }`

The fix is structural rather than per-call-site because the audit's recommended remediation was specifically: *"extend `filterPII` / a Winston format to walk the metadata object."* Fewer edges to miss when new `logger.info` calls are added in future.

## Plan deviations (documented for reviewers)
1. **PII_KEYS extended.** The plan claimed `PII_KEYS` already included `email`/`phone`/`ssn`/`dob`. It didn't — the list only had `ssn`/`credit_card`/`password`/`token`/`dob` (no `email`, no `phone`). I added `email` and `phone` to PII_KEYS targeted at the audit's explicit fix language: *"redact `email`/`phone`/`ssn` keys."* Without this, the structural wiring wouldn't actually achieve LOW-1's goal.
2. **Mutate in place, not return new object.** `sanitizeObject` returns a fresh object built from `Object.entries`, which only walks string keys. Winston relies on `Symbol(LEVEL)`, `Symbol(MESSAGE)`, `Symbol(SPLAT)` from `triple-beam` to route lines through transports. The naive `return sanitized` shape from the plan silently dropped every log line — verified via a debug repro. Fix: mutate `info` in place by overwriting only string-keyed properties, preserving the symbol side-channel.

## Known gap (deliberately deferred)
`sanitizeObject` does NOT walk array elements (`pii-filter.ts:56` → `!Array.isArray(value)`). A `logger.info` call shaped like `{ recipients: [{ email: "..." }] }` still leaks. None of the current offenders use that shape, and the plan called this out as out-of-scope for LOW-1. Pinned by a regression test (`does NOT walk array elements`) so future widening is a conscious decision, not an accidental one.

## Test plan
- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [x] `npx jest src/utils` — 8 new tests pass (`src/utils/__tests__/logger.test.ts`)
- [x] `npx jest` — full suite 904 pass / 15 skipped (49 suites), no regressions
- [x] Manual verification: 3 audit offenders still exist as cited; redaction confirmed via debug script that printed the post-format `info` object showing `email: "[REDACTED]"` in both the string-keyed payload and the `Symbol(message)` JSON serialization
- [ ] Reviewer: confirm the symbol-preservation comment in `logger.ts` is clear enough (the production codebase has no other Winston transport hand-rolling so future maintainers may not know about the `triple-beam` symbol invariant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)