### PR TITLE
feat(qa): operator QA bundle viewer (list + rrweb replay)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,3 +73,9 @@ VITE_TURNSTILE_SITE_KEY=1x00000000000000000000AA
 # deploy where `scripts/post-deploy-verify.mjs --verify-dual-write` shows
 # NDJSON line-count == compliance_tape row-count for the same session_id.
 COMPLIANCE_TAPE_V2_ENABLED=false
+
+# Supabase Storage (optional — enables /api/qa/bundles, the operator QA viewer).
+# When unset, the QA viewer returns an empty list with a hint banner instead
+# of failing. Service role key is server-only — never expose to the client.
+SUPABASE_URL=
+SUPABASE_SERVICE_ROLE_KEY=

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -11,7 +11,9 @@
         "lucide-react": "^0.460.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-router-dom": "^6.28.0"
+        "react-router-dom": "^6.28.0",
+        "rrweb": "^2.0.0-alpha.20",
+        "rrweb-player": "^1.0.0-alpha.4"
       },
       "devDependencies": {
         "@types/react": "^18.3.12",
@@ -1215,6 +1217,24 @@
         "win32"
       ]
     },
+    "node_modules/@rrweb/types": {
+      "version": "2.0.0-alpha.20",
+      "resolved": "https://registry.npmjs.org/@rrweb/types/-/types-2.0.0-alpha.20.tgz",
+      "integrity": "sha512-RbnDgKxA/odwB1R4gF7eUUj+rdSrq6ROQJsnMw7MIsGzlbSYvJeZN8YY4XqU0G6sKJvXI6bSzk7w/G94jNwzhw==",
+      "license": "MIT"
+    },
+    "node_modules/@rrweb/utils": {
+      "version": "2.0.0-alpha.20",
+      "resolved": "https://registry.npmjs.org/@rrweb/utils/-/utils-2.0.0-alpha.20.tgz",
+      "integrity": "sha512-MTQOmhPRe39C0fYaCnnVYOufQsyGzwNXpUStKiyFSfGLUJrzuwhbRoUAKR5w6W2j5XuA0bIz3ZDIBztkquOhLw==",
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/svelte": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@tsconfig/svelte/-/svelte-1.0.13.tgz",
+      "integrity": "sha512-5lYJP45Xllo4yE/RUBccBT32eBlRDbqN8r1/MIvQbKxW3aFqaYPCNgm8D5V20X4ShHcwvYWNlKg3liDh1MlBoA==",
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1259,6 +1279,12 @@
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
+    },
+    "node_modules/@types/css-font-loading-module": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@types/css-font-loading-module/-/css-font-loading-module-0.0.7.tgz",
+      "integrity": "sha512-nl09VhutdjINdWyXxHWN/w9zlNCfr60JUqJbd24YXUuCwgeL0TpFSdElCwb6cxfB6ybE19Gjj4g0jsgkXxKv1Q==",
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1315,6 +1341,12 @@
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
+    },
+    "node_modules/@xstate/fsm": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@xstate/fsm/-/fsm-1.6.5.tgz",
+      "integrity": "sha512-b5o1I6aLNeYlU/3CPlj/Z91ybk1gUsKT+5NAJI+2W4UjvS5KLG28K9v5UvNoFVjHV8PajVZ00RH3vnjyQO7ZAw==",
+      "license": "MIT"
     },
     "node_modules/any-promise": {
       "version": "1.3.0",
@@ -1379,6 +1411,15 @@
       },
       "peerDependencies": {
         "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
     "node_modules/baseline-browser-mapping": {
@@ -1958,6 +1999,12 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -1981,7 +2028,6 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2044,7 +2090,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -2084,7 +2129,6 @@
       "version": "8.5.8",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
       "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -2431,6 +2475,50 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rrdom": {
+      "version": "2.0.0-alpha.20",
+      "resolved": "https://registry.npmjs.org/rrdom/-/rrdom-2.0.0-alpha.20.tgz",
+      "integrity": "sha512-hoqjS4662LtBp82qEz9GrqU36UpEmCvTA2Hns3qdF7cklLFFy3G+0Th8hLytJENleHHWxsB5nWJ3eXz5mSRxdQ==",
+      "license": "MIT",
+      "dependencies": {
+        "rrweb-snapshot": "^2.0.0-alpha.20"
+      }
+    },
+    "node_modules/rrweb": {
+      "version": "2.0.0-alpha.20",
+      "resolved": "https://registry.npmjs.org/rrweb/-/rrweb-2.0.0-alpha.20.tgz",
+      "integrity": "sha512-CZKDlm+j1VA50Ko3gnMbpvguCAleljsTNXPnVk9aeNP8o6T6kolRbISHyDZpqZ4G+bdDLlQOignPP3jEsXs8Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@rrweb/types": "^2.0.0-alpha.20",
+        "@rrweb/utils": "^2.0.0-alpha.20",
+        "@types/css-font-loading-module": "0.0.7",
+        "@xstate/fsm": "^1.4.0",
+        "base64-arraybuffer": "^1.0.1",
+        "mitt": "^3.0.0",
+        "rrdom": "^2.0.0-alpha.20",
+        "rrweb-snapshot": "^2.0.0-alpha.20"
+      }
+    },
+    "node_modules/rrweb-player": {
+      "version": "1.0.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/rrweb-player/-/rrweb-player-1.0.0-alpha.4.tgz",
+      "integrity": "sha512-Wlmn9GZ5Fdqa37vd3TzsYdLl/JWEvXNUrLCrYpnOwEgmY409HwVIvvA5aIo7k582LoKgdRCsB87N+f0oWAR0Kg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsconfig/svelte": "^1.0.0",
+        "rrweb": "^2.0.0-alpha.4"
+      }
+    },
+    "node_modules/rrweb-snapshot": {
+      "version": "2.0.0-alpha.20",
+      "resolved": "https://registry.npmjs.org/rrweb-snapshot/-/rrweb-snapshot-2.0.0-alpha.20.tgz",
+      "integrity": "sha512-YTNf9YVeaGRo/jxY3FKBge2c/Ojd/KTHmuWloUSB+oyPXuY73ZeeG873qMMmhIpqEn7hn7aBF1eWEQmP7wjf8A==",
+      "license": "MIT",
+      "dependencies": {
+        "postcss": "^8.4.38"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -2478,7 +2566,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"

--- a/client/package.json
+++ b/client/package.json
@@ -12,7 +12,9 @@
     "lucide-react": "^0.460.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^6.28.0"
+    "react-router-dom": "^6.28.0",
+    "rrweb": "^2.0.0-alpha.20",
+    "rrweb-player": "^1.0.0-alpha.4"
   },
   "devDependencies": {
     "@types/react": "^18.3.12",

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -11,6 +11,8 @@ import { Properties } from '@/pages/Properties';
 import { UsersPage } from '@/pages/Users';
 import { Compliance } from '@/pages/Compliance';
 import { AuditLog } from '@/pages/AuditLog';
+import { QaBundles } from '@/pages/QaBundles';
+import { QaBundleDetail } from '@/pages/QaBundleDetail';
 import { Recertifications } from '@/pages/Recertifications';
 import { LedgerOverview, LedgerDetail } from '@/pages/Ledger';
 import { Evictions } from '@/pages/Evictions';
@@ -47,6 +49,8 @@ export default function App() {
               <Route path="recertifications" element={<Recertifications />} />
               <Route path="compliance" element={<Compliance />} />
               <Route path="audit-log" element={<AuditLog />} />
+              <Route path="qa-bundles" element={<QaBundles />} />
+              <Route path="qa-bundles/:stem" element={<QaBundleDetail />} />
               <Route path="*" element={<Navigate to="/" replace />} />
             </Route>
           </Route>

--- a/client/src/components/Sidebar.tsx
+++ b/client/src/components/Sidebar.tsx
@@ -15,6 +15,7 @@ import {
   LogOut,
   Shield,
   ScrollText,
+  Camera,
   type LucideIcon,
 } from 'lucide-react';
 import { useAuth } from '@/hooks/useAuth';
@@ -43,6 +44,7 @@ const NAV_ITEMS: NavItem[] = [
   { label: 'Recertifications', path: '/recertifications', icon: CalendarClock, minRole: 'senior_manager' },
   { label: 'Compliance', path: '/compliance', icon: Shield, minRole: 'regional_manager' },
   { label: 'Audit Log', path: '/audit-log', icon: ScrollText, minRole: 'regional_manager' },
+  { label: 'QA Bundles', path: '/qa-bundles', icon: Camera, minRole: 'regional_manager' },
 ];
 
 export function Sidebar() {

--- a/client/src/pages/QaBundleDetail.tsx
+++ b/client/src/pages/QaBundleDetail.tsx
@@ -1,0 +1,418 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { Camera, ArrowLeft, Copy, Check, ExternalLink } from 'lucide-react';
+import { useApiQuery } from '@/hooks/useApiQuery';
+import { useAuth } from '@/hooks/useAuth';
+import { PageHeader } from '@/components/PageHeader';
+import { hasMinRole } from '@/types';
+import type { QaBundleSummary } from './QaBundles';
+
+interface BundleResponse {
+  bundle: QaBundleSummary;
+}
+
+interface QaBufferFetch {
+  method?: string;
+  url?: string;
+  status?: number;
+  durationMs?: number;
+  startedAt?: string;
+  [k: string]: unknown;
+}
+
+interface QaBufferError {
+  message?: string;
+  stack?: string;
+  type?: string;
+  at?: string;
+  [k: string]: unknown;
+}
+
+interface Sidecar {
+  url?: string;
+  viewport?: { width?: number; height?: number; dpr?: number };
+  auth?: { claims?: Record<string, unknown> | null; [k: string]: unknown };
+  flags?: Record<string, unknown>;
+  storage?: Record<string, unknown>;
+  qaBuffer?: {
+    fetch?: QaBufferFetch[];
+    errors?: QaBufferError[];
+    [k: string]: unknown;
+  };
+  [k: string]: unknown;
+}
+
+function clipboardBlock(b: QaBundleSummary): string {
+  const lines: string[] = [];
+  if (b.urls.png) lines.push(`Screenshot: ${b.urls.png}`);
+  lines.push(`Debug: ${b.urls.json}`);
+  if (b.urls.replay) lines.push(`Replay: ${b.urls.replay}`);
+  return lines.join('\n');
+}
+
+function Section({
+  title,
+  children,
+  defaultOpen = false,
+}: {
+  title: string;
+  children: React.ReactNode;
+  defaultOpen?: boolean;
+}) {
+  return (
+    <details
+      open={defaultOpen}
+      className="rounded-lg border border-gray-200 bg-white"
+    >
+      <summary className="cursor-pointer px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50">
+        {title}
+      </summary>
+      <div className="border-t border-gray-100 px-4 py-3 text-sm">{children}</div>
+    </details>
+  );
+}
+
+function PreJson({ value }: { value: unknown }) {
+  return (
+    <pre className="overflow-x-auto rounded-md bg-gray-50 p-3 text-xs leading-relaxed text-gray-800">
+      {JSON.stringify(value, null, 2)}
+    </pre>
+  );
+}
+
+function FetchTable({ rows }: { rows: QaBufferFetch[] }) {
+  if (rows.length === 0) return <p className="text-xs text-gray-500">No fetch entries.</p>;
+  return (
+    <div className="overflow-x-auto rounded-md border border-gray-200">
+      <table className="min-w-full text-xs">
+        <thead className="bg-gray-50 text-left text-gray-600">
+          <tr>
+            <th className="px-3 py-2 font-medium">Method</th>
+            <th className="px-3 py-2 font-medium">Status</th>
+            <th className="px-3 py-2 font-medium">URL</th>
+            <th className="px-3 py-2 font-medium">Duration</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-gray-100 bg-white">
+          {rows.map((r, i) => {
+            const status = r.status ?? 0;
+            const statusClass =
+              status >= 500
+                ? 'text-red-700'
+                : status >= 400
+                  ? 'text-amber-700'
+                  : 'text-gray-700';
+            return (
+              <tr key={i}>
+                <td className="px-3 py-1.5 font-mono">{r.method ?? '—'}</td>
+                <td className={`px-3 py-1.5 font-mono ${statusClass}`}>{status || '—'}</td>
+                <td className="px-3 py-1.5 break-all text-gray-700">{r.url ?? '—'}</td>
+                <td className="px-3 py-1.5 font-mono text-gray-500">
+                  {r.durationMs != null ? `${r.durationMs}ms` : '—'}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function ErrorsList({ rows }: { rows: QaBufferError[] }) {
+  if (rows.length === 0)
+    return <p className="text-xs text-gray-500">No errors captured.</p>;
+  return (
+    <ul className="space-y-2">
+      {rows.map((e, i) => (
+        <li
+          key={i}
+          className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-800"
+        >
+          <div className="font-mono font-medium">
+            {e.type ?? 'error'}: {e.message ?? '(no message)'}
+          </div>
+          {e.at && <div className="mt-0.5 text-red-700">at {e.at}</div>}
+          {e.stack && (
+            <pre className="mt-2 overflow-x-auto whitespace-pre-wrap break-words text-red-700">
+              {String(e.stack).slice(0, 1200)}
+            </pre>
+          )}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function ReplayPanel({ url }: { url: string }) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+    let disposed = false;
+    let cleanup: (() => void) | null = null;
+
+    (async () => {
+      try {
+        const [{ default: RrwebPlayer }, eventsRes] = await Promise.all([
+          import('rrweb-player'),
+          // CSS lives next to the JS bundle — import it for side effects.
+          import('rrweb-player/dist/style.css'),
+          fetch(url),
+        ]).then(async ([mod, _css, res]) => {
+          if (!res.ok) throw new Error(`Replay fetch failed (HTTP ${res.status})`);
+          const events = await res.json();
+          return [mod, events] as const;
+        });
+        if (disposed || !containerRef.current) return;
+        const events = eventsRes as unknown[];
+        if (!Array.isArray(events) || events.length < 2) {
+          setErr('Replay file is empty or malformed (rrweb needs ≥2 events).');
+          return;
+        }
+        const instance = new (RrwebPlayer as unknown as new (opts: {
+          target: HTMLElement;
+          props: { events: unknown[]; autoPlay: boolean; width?: number; height?: number };
+        }) => unknown)({
+          target: containerRef.current,
+          props: { events, autoPlay: false, width: 800, height: 480 },
+        });
+        cleanup = () => {
+          // rrweb-player has no public destroy; clear the DOM.
+          if (containerRef.current) containerRef.current.innerHTML = '';
+          void instance;
+        };
+      } catch (e) {
+        if (!disposed) setErr(e instanceof Error ? e.message : 'Replay failed to load');
+      }
+    })();
+
+    return () => {
+      disposed = true;
+      if (cleanup) cleanup();
+    };
+  }, [url]);
+
+  return (
+    <div>
+      {err && (
+        <div className="mb-2 rounded-lg bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-700">
+          {err}
+        </div>
+      )}
+      <div ref={containerRef} className="rounded-lg border border-gray-200 bg-white p-2" />
+    </div>
+  );
+}
+
+export function QaBundleDetail() {
+  const { user } = useAuth();
+  const { stem } = useParams<{ stem: string }>();
+  const gated = !!user && hasMinRole(user.role, 'regional_manager');
+
+  const { data, loading, error } = useApiQuery<BundleResponse>(
+    gated && stem ? `/api/qa/bundles/${encodeURIComponent(stem)}` : null,
+  );
+  const bundle = data?.bundle ?? null;
+
+  // Sidecar contents (separate fetch — public URL, no auth)
+  const [sidecar, setSidecar] = useState<Sidecar | null>(null);
+  const [sidecarErr, setSidecarErr] = useState<string | null>(null);
+  useEffect(() => {
+    if (!bundle) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch(bundle.urls.json);
+        if (!res.ok) throw new Error(`Sidecar fetch failed (HTTP ${res.status})`);
+        const json = (await res.json()) as Sidecar;
+        if (!cancelled) setSidecar(json);
+      } catch (e) {
+        if (!cancelled)
+          setSidecarErr(e instanceof Error ? e.message : 'Sidecar failed to load');
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [bundle]);
+
+  // Copy-URLs button
+  const [copied, setCopied] = useState(false);
+  const handleCopy = useCallback(async () => {
+    if (!bundle) return;
+    try {
+      await navigator.clipboard.writeText(clipboardBlock(bundle));
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // ignore — older browsers / non-secure contexts
+    }
+  }, [bundle]);
+
+  if (!user || !hasMinRole(user.role, 'regional_manager')) {
+    return (
+      <p className="text-sm text-red-600">
+        Access denied. Regional Manager or above required.
+      </p>
+    );
+  }
+
+  if (loading) {
+    return <p className="text-sm text-gray-500">Loading bundle…</p>;
+  }
+  if (error || !bundle) {
+    return (
+      <div className="space-y-3">
+        <Link
+          to="/qa-bundles"
+          className="inline-flex items-center gap-1 text-sm text-emerald-700 hover:text-emerald-800"
+        >
+          <ArrowLeft className="h-4 w-4" /> All bundles
+        </Link>
+        <div className="rounded-lg bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-700">
+          {error ?? 'Bundle not found.'}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <Link
+        to="/qa-bundles"
+        className="inline-flex items-center gap-1 text-sm text-emerald-700 hover:text-emerald-800"
+      >
+        <ArrowLeft className="h-4 w-4" /> All bundles
+      </Link>
+
+      <PageHeader
+        icon={Camera}
+        title={bundle.slug}
+        description={`Captured ${new Date(bundle.capturedAt).toLocaleString()}`}
+        action={
+          <button
+            onClick={handleCopy}
+            className="inline-flex items-center gap-1.5 rounded-lg border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50"
+          >
+            {copied ? (
+              <>
+                <Check className="h-4 w-4 text-emerald-600" /> Copied
+              </>
+            ) : (
+              <>
+                <Copy className="h-4 w-4" /> Copy URLs
+              </>
+            )}
+          </button>
+        }
+      />
+
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        {/* PNG */}
+        <div className="rounded-xl border border-gray-200 bg-white p-3">
+          <div className="mb-2 flex items-center justify-between">
+            <h2 className="text-sm font-medium text-gray-700">Screenshot</h2>
+            {bundle.urls.png && (
+              <a
+                href={bundle.urls.png}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex items-center gap-1 text-xs text-emerald-700 hover:text-emerald-800"
+              >
+                Open full size <ExternalLink className="h-3 w-3" />
+              </a>
+            )}
+          </div>
+          {bundle.urls.png ? (
+            <a href={bundle.urls.png} target="_blank" rel="noreferrer">
+              <img
+                src={bundle.urls.png}
+                alt={`${bundle.slug} screenshot`}
+                className="w-full rounded-md border border-gray-200"
+              />
+            </a>
+          ) : (
+            <p className="text-xs text-gray-500">
+              No screenshot in this bundle.
+            </p>
+          )}
+        </div>
+
+        {/* Sidecar */}
+        <div className="space-y-2">
+          {sidecarErr && (
+            <div className="rounded-lg bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-700">
+              {sidecarErr}
+            </div>
+          )}
+          {sidecar && (
+            <>
+              <Section title="Context" defaultOpen>
+                <dl className="grid grid-cols-[max-content_1fr] gap-x-4 gap-y-1 text-xs">
+                  <dt className="text-gray-500">URL</dt>
+                  <dd className="break-all font-mono text-gray-800">
+                    {sidecar.url ?? '—'}
+                  </dd>
+                  <dt className="text-gray-500">Viewport</dt>
+                  <dd className="font-mono text-gray-800">
+                    {sidecar.viewport
+                      ? `${sidecar.viewport.width}×${sidecar.viewport.height} @ ${sidecar.viewport.dpr}x`
+                      : '—'}
+                  </dd>
+                  <dt className="text-gray-500">User</dt>
+                  <dd className="break-all font-mono text-gray-800">
+                    {(sidecar.auth?.claims as { email?: string } | undefined)?.email ??
+                      (sidecar.auth?.claims as { sub?: string } | undefined)?.sub ??
+                      '—'}
+                  </dd>
+                </dl>
+              </Section>
+
+              <Section title="Auth claims">
+                <PreJson value={sidecar.auth?.claims ?? null} />
+              </Section>
+
+              <Section title="Feature flags">
+                <PreJson value={sidecar.flags ?? {}} />
+              </Section>
+
+              <Section title="Storage">
+                <PreJson value={sidecar.storage ?? {}} />
+              </Section>
+
+              <Section
+                title={`Fetch log (${sidecar.qaBuffer?.fetch?.length ?? 0})`}
+                defaultOpen
+              >
+                <FetchTable rows={sidecar.qaBuffer?.fetch ?? []} />
+              </Section>
+
+              <Section title={`Errors (${sidecar.qaBuffer?.errors?.length ?? 0})`}>
+                <ErrorsList rows={sidecar.qaBuffer?.errors ?? []} />
+              </Section>
+
+              <Section title="Raw sidecar JSON">
+                <PreJson value={sidecar} />
+              </Section>
+            </>
+          )}
+        </div>
+      </div>
+
+      {/* Replay */}
+      <div>
+        <h2 className="mb-2 text-sm font-medium text-gray-700">Session replay</h2>
+        {bundle.urls.replay ? (
+          <ReplayPanel url={bundle.urls.replay} />
+        ) : (
+          <div className="rounded-lg bg-amber-50 border border-amber-200 px-4 py-3 text-sm text-amber-800">
+            No replay in this bundle — rrweb wasn't initialised at capture
+            time (e.g. unauthenticated page), or the upload failed.
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/QaBundles.tsx
+++ b/client/src/pages/QaBundles.tsx
@@ -1,0 +1,112 @@
+import { Link } from 'react-router-dom';
+import { Camera } from 'lucide-react';
+import { useApiQuery } from '@/hooks/useApiQuery';
+import { useAuth } from '@/hooks/useAuth';
+import { DataTable, type Column } from '@/components/DataTable';
+import { PageHeader } from '@/components/PageHeader';
+import { hasMinRole } from '@/types';
+
+export interface QaBundleSummary {
+  stem: string;
+  slug: string;
+  capturedAt: string;
+  urls: {
+    png: string | null;
+    json: string;
+    replay: string | null;
+  };
+}
+
+interface QaBundlesResponse {
+  bundles: QaBundleSummary[];
+  hint?: string;
+}
+
+const columns: Column<QaBundleSummary>[] = [
+  {
+    key: 'capturedAt',
+    header: 'Captured',
+    render: (r) => new Date(r.capturedAt).toLocaleString(),
+    className: 'whitespace-nowrap',
+  },
+  {
+    key: 'slug',
+    header: 'Slug',
+    render: (r) => (
+      <span className="rounded bg-gray-100 px-2 py-0.5 text-xs font-mono">
+        {r.slug}
+      </span>
+    ),
+  },
+  {
+    key: 'replay',
+    header: 'Replay',
+    render: (r) =>
+      r.urls.replay ? (
+        <span className="rounded-full bg-emerald-100 px-2.5 py-0.5 text-xs font-medium text-emerald-800">
+          ✓
+        </span>
+      ) : (
+        <span className="text-gray-400">—</span>
+      ),
+  },
+  {
+    key: 'view',
+    header: '',
+    render: (r) => (
+      <Link
+        to={`/qa-bundles/${r.stem}`}
+        className="text-sm font-medium text-emerald-700 hover:text-emerald-800"
+      >
+        View →
+      </Link>
+    ),
+    className: 'whitespace-nowrap text-right',
+  },
+];
+
+export function QaBundles() {
+  const { user } = useAuth();
+  const gated = !!user && hasMinRole(user.role, 'regional_manager');
+
+  const { data, loading, error } = useApiQuery<QaBundlesResponse>(
+    gated ? '/api/qa/bundles' : null,
+  );
+
+  if (!user || !hasMinRole(user.role, 'regional_manager')) {
+    return (
+      <p className="text-sm text-red-600">
+        Access denied. Regional Manager or above required.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <PageHeader
+        icon={Camera}
+        title="QA Bundles"
+        description="Operator viewer for camera-button capture bundles (PNG + JSON sidecar + rrweb replay)."
+      />
+
+      {data?.hint && (
+        <div className="rounded-lg bg-amber-50 border border-amber-200 px-4 py-3 text-sm text-amber-800">
+          {data.hint}
+        </div>
+      )}
+
+      {error && (
+        <div className="rounded-lg bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-700">
+          Could not load bundles ({error}).
+        </div>
+      )}
+
+      <DataTable
+        columns={columns}
+        data={data?.bundles ?? []}
+        loading={loading}
+        emptyMessage="No QA bundles uploaded yet."
+      />
+    </div>
+  );
+}

--- a/client/src/vite-env.d.ts
+++ b/client/src/vite-env.d.ts
@@ -1,0 +1,3 @@
+/// <reference types="vite/client" />
+
+declare module '*.css';

--- a/src/__tests__/qa-bundles.test.ts
+++ b/src/__tests__/qa-bundles.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Unit tests for the qa-bundle grouping logic.
+ *
+ * Network is not touched — only the pure helpers exported by routes.ts.
+ */
+
+import {
+  parseStem,
+  splitName,
+  groupBundles,
+  QA_BUCKET,
+  type StorageObject,
+} from "../modules/qa/routes";
+
+const BASE = `https://example.supabase.co/storage/v1/object/public/${QA_BUCKET}`;
+
+describe("parseStem", () => {
+  it("parses a single-token slug", () => {
+    expect(parseStem("frank-home-20260522-143000")).toEqual({
+      slug: "home",
+      capturedAt: "2026-05-22T14:30:00",
+    });
+  });
+
+  it("parses a hyphenated slug", () => {
+    expect(parseStem("frank-dashboard-overview-20260522-143000")).toEqual({
+      slug: "dashboard-overview",
+      capturedAt: "2026-05-22T14:30:00",
+    });
+  });
+
+  it("rejects stems without the timestamp suffix", () => {
+    expect(parseStem("frank-home")).toBeNull();
+    expect(parseStem("frank-home-2026-05-22")).toBeNull();
+  });
+
+  it("rejects stems that don't start with frank-", () => {
+    // The regex anchors on `^frank-` — a foreign prefix means it's not ours.
+    expect(parseStem("not-a-frank-stem-20260522-143000")).toBeNull();
+  });
+});
+
+describe("splitName", () => {
+  it("classifies .replay.json before .json", () => {
+    expect(splitName("frank-home-20260522-143000.replay.json")).toEqual({
+      stem: "frank-home-20260522-143000",
+      kind: "replay",
+    });
+  });
+
+  it("classifies .json", () => {
+    expect(splitName("frank-home-20260522-143000.json")).toEqual({
+      stem: "frank-home-20260522-143000",
+      kind: "json",
+    });
+  });
+
+  it("classifies .png", () => {
+    expect(splitName("frank-home-20260522-143000.png")).toEqual({
+      stem: "frank-home-20260522-143000",
+      kind: "png",
+    });
+  });
+
+  it("returns null for unrelated names", () => {
+    expect(splitName("README.md")).toBeNull();
+    expect(splitName(".keep")).toBeNull();
+    expect(splitName("frank-home-20260522-143000.txt")).toBeNull();
+  });
+});
+
+describe("groupBundles", () => {
+  function items(...names: string[]): StorageObject[] {
+    return names.map((name) => ({ name }));
+  }
+
+  it("groups three artifacts that share a stem", () => {
+    const out = groupBundles(
+      items(
+        "frank-home-20260522-143000.png",
+        "frank-home-20260522-143000.json",
+        "frank-home-20260522-143000.replay.json"
+      ),
+      BASE
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0]).toEqual({
+      stem: "frank-home-20260522-143000",
+      slug: "home",
+      capturedAt: "2026-05-22T14:30:00",
+      urls: {
+        png: `${BASE}/frank-home-20260522-143000.png`,
+        json: `${BASE}/frank-home-20260522-143000.json`,
+        replay: `${BASE}/frank-home-20260522-143000.replay.json`,
+      },
+    });
+  });
+
+  it("handles a bundle with no replay (png + json only)", () => {
+    const out = groupBundles(
+      items(
+        "frank-home-20260522-143000.png",
+        "frank-home-20260522-143000.json"
+      ),
+      BASE
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0].urls.replay).toBeNull();
+    expect(out[0].urls.png).not.toBeNull();
+  });
+
+  it("drops bundles missing the JSON sidecar", () => {
+    // Capture failed before the sidecar upload — useless to operators.
+    const out = groupBundles(
+      items(
+        "frank-home-20260522-143000.png",
+        "frank-home-20260522-143000.replay.json"
+      ),
+      BASE
+    );
+    expect(out).toHaveLength(0);
+  });
+
+  it("drops bundles with a malformed stem", () => {
+    const out = groupBundles(
+      items("not-our-format.json", "frank-stem-without-timestamp.json"),
+      BASE
+    );
+    expect(out).toHaveLength(0);
+  });
+
+  it("ignores irrelevant files (e.g. .gitkeep)", () => {
+    const out = groupBundles(
+      items(
+        ".gitkeep",
+        "README.md",
+        "frank-home-20260522-143000.json",
+        "frank-home-20260522-143000.png"
+      ),
+      BASE
+    );
+    expect(out).toHaveLength(1);
+  });
+
+  it("sorts most-recent first", () => {
+    const out = groupBundles(
+      items(
+        "frank-a-20260522-120000.json",
+        "frank-a-20260522-120000.png",
+        "frank-b-20260522-130000.json",
+        "frank-b-20260522-130000.png",
+        "frank-c-20260521-235959.json",
+        "frank-c-20260521-235959.png"
+      ),
+      BASE
+    );
+    expect(out.map((b) => b.slug)).toEqual(["b", "a", "c"]);
+  });
+
+  it("composes URLs against the provided base", () => {
+    const out = groupBundles(
+      items(
+        "frank-home-20260522-143000.png",
+        "frank-home-20260522-143000.json"
+      ),
+      "https://other.example/bucket/path"
+    );
+    expect(out[0].urls.png).toBe(
+      "https://other.example/bucket/path/frank-home-20260522-143000.png"
+    );
+    expect(out[0].urls.json).toBe(
+      "https://other.example/bucket/path/frank-home-20260522-143000.json"
+    );
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,7 @@ import tenantRoutes from "./modules/tenant/routes";
 import messagesRoutes from "./modules/messages/routes";
 import tapeRoutes from "./modules/tape/routes";
 import { createTapeViewerRoutes } from "./modules/tape/routes-viewer";
+import { qaRouter } from "./modules/qa/routes";
 import { startScheduler } from "./scheduler";
 
 // Boot-time guardrails: in production, refuse to start without the secrets that
@@ -195,6 +196,9 @@ app.use("/api/moveouts", moveoutRoutes);
 
 // Tenant portal (auth'd, scoped to user's own applications)
 app.use("/api/tenant", tenantRoutes);
+
+// QA debug bundles (audit:view) — operator viewer for screenshots / sidecars / rrweb
+app.use("/api/qa", qaRouter());
 
 // Audit log
 app.get(

--- a/src/modules/qa/routes.ts
+++ b/src/modules/qa/routes.ts
@@ -1,0 +1,263 @@
+/**
+ * QA debug-bundle viewer — operator-side routes.
+ *
+ * The tenant app's ScreenshotButton (client-tenant/src/components/dev/ScreenshotButton.tsx)
+ * uploads three artifacts per capture to the public `frank-qa-screenshots` Supabase
+ * Storage bucket: `frank-{slug}-{YYYYMMDD-HHMMSS}.{png|json|replay.json}`. These
+ * endpoints list and resolve those bundles for the operator UI.
+ *
+ * Auth: `audit:view` — same gate as /api/audit, so any role that can read the
+ * audit log can read QA bundles.
+ *
+ * The grouping and stem-parsing logic is pure and exported for unit tests.
+ */
+
+import { Router, Request, Response } from "express";
+import { authenticate } from "../../middleware/auth";
+import { requirePermission } from "../../middleware/rbac";
+import { logger } from "../../utils/logger";
+
+export const QA_BUCKET = "frank-qa-screenshots";
+const MAX_BUNDLES = 50;
+const STORAGE_LIST_LIMIT = 200;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface StorageObject {
+  name: string;
+  created_at?: string | null;
+}
+
+export interface BundleSummary {
+  stem: string;
+  slug: string;
+  capturedAt: string; // ISO-8601 (no timezone — recorded as the capture client's local clock)
+  urls: {
+    png: string | null;
+    json: string;
+    replay: string | null;
+  };
+}
+
+interface ListBundlesResponse {
+  bundles: BundleSummary[];
+  hint?: string;
+}
+
+interface BundleResponse {
+  bundle: BundleSummary;
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers (exported for tests)
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse `frank-{slug}-{YYYYMMDD}-{HHMMSS}` into its parts. The slug may
+ * itself contain hyphens (e.g. `dashboard-overview`), so we anchor on the
+ * trailing `-{8 digits}-{6 digits}` timestamp signature.
+ */
+export function parseStem(
+  stem: string
+): { slug: string; capturedAt: string } | null {
+  const m = stem.match(/^frank-(.+)-(\d{8})-(\d{6})$/);
+  if (!m) return null;
+  const [, slug, date, time] = m;
+  const iso = `${date.slice(0, 4)}-${date.slice(4, 6)}-${date.slice(6, 8)}T${time.slice(0, 2)}:${time.slice(2, 4)}:${time.slice(4, 6)}`;
+  return { slug, capturedAt: iso };
+}
+
+interface SplitName {
+  stem: string;
+  kind: "png" | "json" | "replay";
+}
+
+/** Classify a storage object's filename. Returns null if it isn't one of ours. */
+export function splitName(name: string): SplitName | null {
+  if (name.endsWith(".replay.json")) {
+    return { stem: name.slice(0, -".replay.json".length), kind: "replay" };
+  }
+  if (name.endsWith(".json")) {
+    return { stem: name.slice(0, -".json".length), kind: "json" };
+  }
+  if (name.endsWith(".png")) {
+    return { stem: name.slice(0, -".png".length), kind: "png" };
+  }
+  return null;
+}
+
+/**
+ * Group raw storage listings into bundles. Drops any group missing the JSON
+ * sidecar (capture failed mid-flight, useless to the operator), and sorts by
+ * capturedAt desc. Caller decides how many to return.
+ */
+export function groupBundles(
+  items: StorageObject[],
+  publicUrlBase: string
+): BundleSummary[] {
+  const byStem = new Map<
+    string,
+    { png?: string; json?: string; replay?: string }
+  >();
+
+  for (const it of items) {
+    const split = splitName(it.name);
+    if (!split) continue;
+    const entry = byStem.get(split.stem) ?? {};
+    entry[split.kind] = `${publicUrlBase}/${it.name}`;
+    byStem.set(split.stem, entry);
+  }
+
+  const out: BundleSummary[] = [];
+  for (const [stem, files] of byStem.entries()) {
+    if (!files.json) continue; // sidecar is mandatory
+    const parsed = parseStem(stem);
+    if (!parsed) continue;
+    out.push({
+      stem,
+      slug: parsed.slug,
+      capturedAt: parsed.capturedAt,
+      urls: {
+        png: files.png ?? null,
+        json: files.json,
+        replay: files.replay ?? null,
+      },
+    });
+  }
+
+  out.sort((a, b) =>
+    a.capturedAt < b.capturedAt ? 1 : a.capturedAt > b.capturedAt ? -1 : 0
+  );
+
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Storage fetch (server → Supabase REST)
+// ---------------------------------------------------------------------------
+
+interface StorageEnv {
+  url: string;
+  key: string;
+  bucket: string;
+}
+
+function readStorageEnv(): StorageEnv | null {
+  const url = (process.env.SUPABASE_URL || "").replace(/\/$/, "");
+  const key =
+    process.env.SUPABASE_SERVICE_ROLE_KEY ||
+    process.env.SUPABASE_KEY ||
+    "";
+  if (!url || !key) return null;
+  return { url, key, bucket: QA_BUCKET };
+}
+
+async function listStorage(
+  env: StorageEnv
+): Promise<StorageObject[]> {
+  const res = await fetch(
+    `${env.url}/storage/v1/object/list/${env.bucket}`,
+    {
+      method: "POST",
+      headers: {
+        apikey: env.key,
+        Authorization: `Bearer ${env.key}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        limit: STORAGE_LIST_LIMIT,
+        sortBy: { column: "created_at", order: "desc" },
+      }),
+    }
+  );
+  if (!res.ok) {
+    const detail = await res.text().catch(() => "");
+    throw new Error(`Storage list failed (${res.status}): ${detail.slice(0, 200)}`);
+  }
+  const body = (await res.json()) as unknown;
+  if (!Array.isArray(body)) {
+    throw new Error("Storage list response was not an array");
+  }
+  return body as StorageObject[];
+}
+
+function publicUrlBase(env: StorageEnv): string {
+  return `${env.url}/storage/v1/object/public/${env.bucket}`;
+}
+
+// ---------------------------------------------------------------------------
+// Router
+// ---------------------------------------------------------------------------
+
+export function qaRouter(): Router {
+  const router = Router();
+
+  router.use(authenticate, requirePermission("audit:view"));
+
+  router.get("/bundles", async (_req: Request, res: Response) => {
+    const env = readStorageEnv();
+    if (!env) {
+      const body: ListBundlesResponse = {
+        bundles: [],
+        hint:
+          "Supabase Storage is not configured on this server — set SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY to enable the QA viewer.",
+      };
+      res.json(body);
+      return;
+    }
+    try {
+      const items = await listStorage(env);
+      const grouped = groupBundles(items, publicUrlBase(env));
+      const body: ListBundlesResponse = {
+        bundles: grouped.slice(0, MAX_BUNDLES),
+      };
+      res.json(body);
+    } catch (err) {
+      logger.error("QA bundle list failed", {
+        error: (err as Error).message,
+      });
+      res.status(500).json({ error: "Failed to list QA bundles" });
+    }
+  });
+
+  router.get("/bundles/:stem", async (req: Request, res: Response) => {
+    const env = readStorageEnv();
+    if (!env) {
+      res.status(503).json({
+        error:
+          "Supabase Storage is not configured on this server — set SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY.",
+      });
+      return;
+    }
+    const raw = req.params.stem;
+    const stem = Array.isArray(raw) ? raw[0] : raw;
+    if (typeof stem !== "string" || !parseStem(stem)) {
+      res.status(400).json({ error: "Malformed bundle stem" });
+      return;
+    }
+    try {
+      const items = await listStorage(env);
+      const match = items.filter((it) => {
+        const split = splitName(it.name);
+        return split && split.stem === stem;
+      });
+      const grouped = groupBundles(match, publicUrlBase(env));
+      if (grouped.length === 0) {
+        res.status(404).json({ error: "Bundle not found" });
+        return;
+      }
+      const body: BundleResponse = { bundle: grouped[0] };
+      res.json(body);
+    } catch (err) {
+      logger.error("QA bundle fetch failed", {
+        stem,
+        error: (err as Error).message,
+      });
+      res.status(500).json({ error: "Failed to fetch QA bundle" });
+    }
+  });
+
+  return router;
+}


### PR DESCRIPTION
## Summary
- Adds an in-app operator viewer at `/qa-bundles` (list) and `/qa-bundles/:stem` (detail) for the QA capture bundles uploaded by the tenant ScreenshotButton — PNG, JSON sidecar, and rrweb replay. Closes the write-only gap: the replay artifact is uploaded today but never read back.
- New API: `GET /api/qa/bundles` + `GET /api/qa/bundles/:stem` (auth: `audit:view`, same gate as `/api/audit`). Pure grouping logic is unit-tested (15 jest tests in `src/__tests__/qa-bundles.test.ts`).
- New operator pages mirror the `AuditLog` scaffold (PageHeader, DataTable, `hasMinRole('regional_manager')`). rrweb-player is dynamically imported, so it splits into a separate 38KB-gzip chunk; main operator bundle is unchanged.

## What you get
- **List view:** capture time, slug, replay-availability badge, View link.
- **Detail view:** PNG with click-through, expandable sidecar sections (URL, viewport, auth claims, flags, storage, fetch log table, errors list, raw JSON), and a scrubbable rrweb-player below.
- **Copy URLs** button in the detail header reproduces the same clipboard format that the tenant's capture FAB uses.

## Behaviour when Supabase Storage isn't configured
The API returns `{ bundles: [], hint: "..." }` instead of crashing — devs without `SUPABASE_URL` / `SUPABASE_SERVICE_ROLE_KEY` get a banner explaining how to enable the viewer rather than a 500. Service role key is documented as server-only in `.env.example`.

## Out of scope (follow-ups)
- **Vitest spec for the new pages.** `client/` has zero test infrastructure and no CI gate today; adding both is a separate PR. The non-trivial grouping logic that *can* break silently is already covered by the api-side tests.
- Sentry sink for client + API errors, React ErrorBoundary auto-flush, request-ID middleware threading into `qaBuffer.fetch[]`, deeper `/health` probes, bucket lockdown (public-read → RLS + signed URLs), bundle delete tooling.

## Test plan
- [ ] `npm test -- --ci` — full api jest suite green (911 passing locally, including the 15 new qa-bundles tests).
- [ ] `npx tsc --noEmit` — green at repo root.
- [ ] `cd client && npx tsc --noEmit && npm run build` — green; confirm the lazy `rrweb-player` chunk appears in the build output.
- [ ] Click the camera FAB on `client-tenant` to upload a bundle, then visit `/qa-bundles` in the operator app — new bundle is row 1, PNG renders, JSON sections expand, rrweb player plays back the session.
- [ ] Repeat on a route where rrweb wasn't initialised (e.g. unauthenticated page) — confirm the "No replay" amber banner shows and the page does not crash.
- [ ] Confirm a non-`regional_manager` user gets a 403 from `/api/qa/bundles` (server-side role gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)