### PR TITLE
feat(discover): wire PropertyList to live /api/properties (gpmglv wedge #8)

### DIFF
--- a/client-tenant/src/api/properties.ts
+++ b/client-tenant/src/api/properties.ts
@@ -1,6 +1,89 @@
 import { api } from './client';
 import { UNIT_PLACEHOLDER } from '@/utils/unitPlaceholder';
 
+// ─── Wedge #8 — live `GET /api/properties` listing for /discover ──────────
+//
+// The server contract (`src/modules/properties/routes.ts:78-131`) zod-validates
+// `amiTier`, `bedroom`, `availability` and returns `{ properties, total }` with
+// a per-property availability rollup + rent range baked in. We don't redefine
+// those semantics client-side — we just translate the chip state into the
+// exact param names the server validates.
+//
+// `property:view` is admin-gated, so unauthed /discover users will see the
+// 401 → catch path and the PropertyList falls back to GPMG_FIXTURES. That's
+// the intentional contract: the live wire works for authed leasing agents
+// (and the gpmglv demo) without breaking the public browse surface.
+
+export type ApiAmiTier = '30' | '50' | '60' | '80';
+export type ApiBedroomFilter = 'studio' | '1' | '2' | '3';
+export type ApiAvailabilityFilter = 'available_now';
+
+export interface ApiPropertyAvailability {
+  availableCount: number;
+  leasedCount: number;
+  totalUnits: number;
+  bedroomBreakdown: {
+    studio: number;
+    br1: number;
+    br2: number;
+    br3: number;
+  };
+}
+
+export interface ApiRentBucket {
+  low: number;
+  high: number;
+}
+
+export interface ApiRentRange {
+  studio: ApiRentBucket | null;
+  br1: ApiRentBucket | null;
+  br2: ApiRentBucket | null;
+  br3: ApiRentBucket | null;
+}
+
+export interface ApiPropertyListing {
+  id: string;
+  name: string;
+  addressLine1: string;
+  addressLine2: string | null;
+  city: string;
+  state: string;
+  zip: string;
+  propertyType: 'senior' | 'family' | 'mixed_use';
+  amiTier: string | null;
+  availability: ApiPropertyAvailability;
+  rentRange: ApiRentRange;
+}
+
+export interface PropertiesListResponse {
+  properties: ApiPropertyListing[];
+  total: number;
+}
+
+export interface PropertiesListFilters {
+  amiTier?: ApiAmiTier;
+  bedroom?: ApiBedroomFilter;
+  availability?: ApiAvailabilityFilter;
+}
+
+/**
+ * Live properties listing. Uses the SAME param names the server's zod schema
+ * validates so any drift fails loudly (400 with `{ error, allowed }`) rather
+ * than silently fetching the unfiltered list. Throws on any non-2xx so the
+ * caller can fall back to the deterministic fixture render.
+ */
+export async function fetchPropertiesList(
+  filters: PropertiesListFilters = {},
+): Promise<PropertiesListResponse> {
+  const params = new URLSearchParams();
+  if (filters.amiTier) params.set('amiTier', filters.amiTier);
+  if (filters.bedroom) params.set('bedroom', filters.bedroom);
+  if (filters.availability) params.set('availability', filters.availability);
+  const qs = params.toString();
+  return api.get<PropertiesListResponse>(`/properties${qs ? `?${qs}` : ''}`);
+}
+
 export interface PropertyDetail {
   slug: string;
   name: string;

--- a/client-tenant/src/pages/discover/PropertyList.tsx
+++ b/client-tenant/src/pages/discover/PropertyList.tsx
@@ -1,8 +1,15 @@
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { fetchUnits } from '@/api/units';
 import { getToken } from '@/api/client';
+import {
+  fetchPropertiesList,
+  type ApiPropertyListing,
+  type ApiAmiTier,
+  type ApiBedroomFilter,
+  type ApiAvailabilityFilter,
+} from '@/api/properties';
 import {
   GPMG_FIXTURES,
   slugify,
@@ -17,12 +24,14 @@ import {
   getPropertyAvailability,
   propertyMatchesAmiTier,
   type BedroomBucket,
+  type PropertyAvailability,
 } from '@/utils/availability';
 import {
   propertyRentRange,
   propertyAmiTier,
   formatRentBucket,
   populatedBuckets,
+  type PropertyRentRange,
 } from '@/utils/pricing';
 
 type TypeFilter = 'all' | GPMGType;
@@ -95,6 +104,118 @@ function bedroomBucketFromFilter(filter: BedroomFilter): BedroomBucket | null {
   }
 }
 
+/**
+ * Server uses the same kebab/lowercase chip values as the URL chips, so
+ * `BedroomFilter` maps 1:1 onto `ApiBedroomFilter` except for the synthetic
+ * 'all' slot which means "omit the param entirely".
+ */
+function apiBedroomFromFilter(filter: BedroomFilter): ApiBedroomFilter | undefined {
+  return filter === 'all' ? undefined : filter;
+}
+
+/**
+ * Normalized tile shape — the rendering layer reads from this regardless of
+ * data source. When the live `/api/properties` call succeeds, we hydrate from
+ * the API response (using its `availability` rollup + `rentRange`). When the
+ * call errors (e.g. unauthed public visitor, network outage, server 500), we
+ * fall back to the GPMG_FIXTURES + `getPropertyAvailability` deterministic
+ * render — the gpmglv-demo offline guarantee.
+ *
+ * Why a normalized shape instead of branching at the JSX level? Because the
+ * filter-chip semantics need to operate on whichever source is live without
+ * the UI knowing or caring, AND because the existing PropertyTile reads from
+ * `GPMGProperty` today; introducing branches all the way down would multiply
+ * the diff. One adapter at the top, one shape downstream.
+ */
+interface TileSource {
+  name: string;
+  slug: string;
+  addr: string;
+  city: string;
+  zip: string;
+  type: GPMGType;
+  /** Display unit count for the "N units" subhead. */
+  unitsLabel: string;
+  /** From-$X estimate for the "From $X/mo" line. */
+  rentEstimateDollars: number;
+  /** Per-property availability rollup — same shape as `getPropertyAvailability`. */
+  availability: PropertyAvailability;
+  /** Per-bedroom rent range — same shape `populatedBuckets()` consumes. */
+  rentRange: PropertyRentRange;
+  /** Normalized AMI tier label, e.g. "60". null for market-rate. */
+  amiTier: string | null;
+}
+
+/**
+ * Hydrate a TileSource from the live API response. The server's `propertyType`
+ * narrows down to senior/family/mixed_use; we surface 'mixed_use' as 'family'
+ * for the chip + tile labels (the chip set is just senior|family today).
+ */
+function tileFromApi(p: ApiPropertyListing): TileSource {
+  const slug = slugify(p.name);
+  const type: GPMGType = p.propertyType === 'senior' ? 'senior' : 'family';
+  // Server returns the canonical label verbatim (e.g. "60% AMI" — see
+  // `normalizeAmiTier()` in src/modules/properties/service.ts). The chip i18n
+  // template ({{tier}}) renders this as-is, matching how the fixture path
+  // hydrates via `propertyAmiTier()`.
+  const amiTier = p.amiTier;
+  return {
+    name: p.name,
+    slug,
+    addr: p.addressLine1,
+    city: p.city,
+    zip: p.zip,
+    type,
+    unitsLabel:
+      p.availability.totalUnits > 0 ? `${p.availability.totalUnits} units` : '',
+    rentEstimateDollars: type === 'senior' ? 747 : 920,
+    availability: {
+      availableCount: p.availability.availableCount,
+      leasedCount: p.availability.leasedCount,
+      heldCount: 0,
+      totalUnits: p.availability.totalUnits,
+      bedroomBreakdown: { ...p.availability.bedroomBreakdown },
+    },
+    rentRange: {
+      studio: p.rentRange.studio,
+      br1: p.rentRange.br1,
+      br2: p.rentRange.br2,
+      br3: p.rentRange.br3,
+    },
+    amiTier,
+  };
+}
+
+/**
+ * Hydrate a TileSource from the deterministic GPMG fixture. Mirrors the
+ * pre-wedge-8 render path so the gpmglv demo keeps working when the API is
+ * unreachable.
+ */
+function tileFromFixture(p: GPMGProperty): TileSource {
+  const slug = slugify(p.name);
+  const availability = getPropertyAvailability(p.name);
+  const rentRange = propertyRentRange(p.name);
+  const amiTierLabel = propertyAmiTier(p.name); // e.g. "60% AMI"
+  const showCount = availability.totalUnits > 0;
+  return {
+    name: p.name,
+    slug,
+    addr: p.addr,
+    city: p.city,
+    zip: p.zip,
+    type: p.type,
+    unitsLabel: showCount
+      ? `${availability.totalUnits} units`
+      : p.units !== null
+      ? `${p.units} units`
+      : '',
+    rentEstimateDollars: rentEstimate(p),
+    availability,
+    rentRange,
+    amiTier: amiTierLabel,
+  };
+}
+
 export function PropertyList() {
   const { t } = useTranslation('discover');
   const [params, setParams] = useSearchParams();
@@ -143,24 +264,86 @@ export function PropertyList() {
     };
   }, []);
 
-  const filtered = useMemo(() => {
+  // ── Wedge #8 — live `/api/properties` data layer ────────────────────────
+  //
+  // Two-source rendering: when the live call succeeds, tiles render from the
+  // API response (so availability counts + rent ranges reflect what the DB
+  // actually has, not the seed mirror). When the call errors (401 for an
+  // unauthed visitor, network outage, server 500), we silently fall back to
+  // the GPMG_FIXTURES + `getPropertyAvailability` deterministic render —
+  // identical to the pre-wedge-8 behaviour. The gpmglv-demo offline
+  // guarantee is load-bearing for the runbook walkthrough.
+  //
+  // The chip values map 1:1 onto the server's zod-validated param names
+  // (`amiTier`, `bedroom`, `availability`) so a typo would fail loudly with a
+  // 400 — no silent "unfiltered list" surprise.
+  const [apiProperties, setApiProperties] = useState<ApiPropertyListing[] | null>(
+    null,
+  );
+
+  useEffect(() => {
+    let alive = true;
+    const filters: {
+      amiTier?: ApiAmiTier;
+      bedroom?: ApiBedroomFilter;
+      availability?: ApiAvailabilityFilter;
+    } = {};
+    if (amiTier) filters.amiTier = amiTier;
+    const apiBedroom = apiBedroomFromFilter(bedroomFilter);
+    if (apiBedroom) filters.bedroom = apiBedroom;
+    if (availableNow) filters.availability = 'available_now';
+
+    fetchPropertiesList(filters)
+      .then((res) => {
+        if (alive) setApiProperties(res.properties);
+      })
+      .catch(() => {
+        // Tolerate — fall back to the deterministic fixture render below.
+        // The catch path is the unauthed-public default today since
+        // `property:view` is admin-gated; the offline render carries the
+        // demo regardless.
+        if (alive) setApiProperties(null);
+      });
+    return () => {
+      alive = false;
+    };
+  }, [amiTier, bedroomFilter, availableNow]);
+
+  // Server doesn't have `?type` or `?city` params today (those are not part
+  // of the public discover contract; see the deferred wedges in
+  // `make-a-plan-of-zany-book.md`). When the API succeeds we still apply the
+  // Type + City chips client-side over the API response — that keeps the
+  // visible behaviour identical regardless of source. When the API fails we
+  // run the full filter set over GPMG_FIXTURES as before.
+  const tiles = useMemo<TileSource[]>(() => {
     const bucket = bedroomBucketFromFilter(bedroomFilter);
+    if (apiProperties !== null) {
+      return apiProperties
+        .map(tileFromApi)
+        .filter((t) => {
+          if (typeFilter !== 'all' && t.type !== typeFilter) return false;
+          if (cityFilter !== 'all' && t.city !== cityFilter) return false;
+          // Bedroom / availability already filtered server-side; type/city
+          // narrowing happens here. The server's amiTier filter narrowed
+          // there too, so we don't double-apply it.
+          return true;
+        });
+    }
+    // Fallback: deterministic fixture render. Identical to pre-wedge-8 logic.
     return GPMG_FIXTURES.filter((p) => {
       if (typeFilter !== 'all' && p.type !== typeFilter) return false;
       if (cityFilter !== 'all' && p.city !== cityFilter) return false;
       if (amiTier && !propertyMatchesAmiTier(p, amiTier)) return false;
-
-      // Bedroom / availability filters compare against the deterministic
-      // availability rollup (mirrors the seed). Studio/1BR/2BR/3BR show only
-      // properties with at least one available unit of that size.
       if (bucket || availableNow) {
         const avail = getPropertyAvailability(p.name);
         if (availableNow && avail.availableCount === 0) return false;
         if (bucket && avail.bedroomBreakdown[bucket] === 0) return false;
       }
       return true;
-    });
-  }, [typeFilter, cityFilter, bedroomFilter, availableNow, amiTier]);
+    }).map(tileFromFixture);
+  }, [apiProperties, typeFilter, cityFilter, bedroomFilter, availableNow, amiTier]);
+
+  const filtered = tiles;
 
   return (
     <div
@@ -385,22 +568,14 @@ function AvailabilityBadge({ availableCount }: { availableCount: number }) {
   );
 }
 
-function PropertyTile({ prop }: { prop: GPMGProperty }) {
+function PropertyTile({ prop }: { prop: TileSource }) {
   const { t } = useTranslation('discover');
-  const slug = slugify(prop.name);
-  const est = rentEstimate(prop);
-  const availability = getPropertyAvailability(prop.name);
-  // For DL2 (units=null in fixture, but seed.ts seeds 48), we still want a
-  // count. We trust the rollup even when fixture `units` is null — the
-  // sentinel test asserts the rollup totals reflect the seed truth.
-  const showCount = availability.totalUnits > 0;
+  const { slug, availability, rentRange, amiTier } = prop;
 
   // Wedge #9 — per-bedroom rent ranges + AMI tier. Only populated buckets
   // render (no "Studio $0" placeholders) and the chip only appears for
   // properties with a real set-aside (all 17 GPMG fixtures qualify today).
-  const rentRange = propertyRentRange(prop.name);
   const buckets = populatedBuckets(rentRange);
-  const amiTier = propertyAmiTier(prop.name);
 
   return (
     <li>
@@ -446,13 +621,7 @@ function PropertyTile({ prop }: { prop: GPMGProperty }) {
               className="flex items-center justify-between"
               style={{ marginTop: 10, gap: 8 }}
             >
-              <span style={{ fontSize: 12, color: HF.ink3 }}>
-                {showCount
-                  ? `${availability.totalUnits} units`
-                  : prop.units !== null
-                  ? `${prop.units} units`
-                  : ''}
-              </span>
+              <span style={{ fontSize: 12, color: HF.ink3 }}>{prop.unitsLabel}</span>
               <div className="flex items-center" style={{ gap: 6 }}>
                 {amiTier && (
                   <span
@@ -507,7 +676,7 @@ function PropertyTile({ prop }: { prop: GPMGProperty }) {
                   color: HF.ink,
                 }}
               >
-                From ${est}/mo
+                From ${prop.rentEstimateDollars}/mo
               </span>
               <div className="flex items-center" style={{ gap: 8 }}>
                 <AvailabilityBadge availableCount={availability.availableCount} />

--- a/client-tenant/src/pages/discover/__tests__/PropertyList.test.tsx
+++ b/client-tenant/src/pages/discover/__tests__/PropertyList.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
-import { describe, it, expect, beforeEach } from 'vitest';
-import { render, screen, within, fireEvent } from '@testing-library/react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, within, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { PropertyList } from '../PropertyList';
 
@@ -187,5 +187,199 @@ describe('PropertyList (GPMG fixtures)', () => {
     expect(aldeneRow.textContent).toMatch(/\$995/);
     expect(aldeneRow.textContent).not.toMatch(/2BR/);
     expect(aldeneRow.textContent).not.toMatch(/3BR/);
+  });
+});
+
+// ── Wedge #8 (live API) ─────────────────────────────────────────────────────
+//
+// PropertyList now calls `GET /api/properties?…` and hydrates tiles from the
+// response when it succeeds. The fallback path (errors / unauthed visitors)
+// is the same deterministic GPMG_FIXTURES + getPropertyAvailability render
+// the discover surface used pre-wedge-8 — that path is covered by the suite
+// above (those tests do not mock fetch; the call rejects in jsdom and we
+// silently fall back).
+//
+// The contract under test below is the wire shape: the right param names
+// land on the right requests, and a successful response drives the grid
+// from the API row order.
+
+interface CapturedRequest {
+  url: string;
+  params: URLSearchParams;
+}
+
+function mockPropertiesEndpoint(
+  responder: (params: URLSearchParams) => {
+    status: number;
+    body: unknown;
+  } | { reject: true },
+): { captured: CapturedRequest[]; fetchMock: ReturnType<typeof vi.fn> } {
+  const captured: CapturedRequest[] = [];
+  const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    // The /discover page only consumes /api/properties. Anything else
+    // (e.g. the auth-warm fetchUnits call) we resolve to a benign 200 so
+    // it doesn't pollute the capture log or trigger noisy 404 fallbacks.
+    if (!url.includes('/api/properties') || url.includes('/api/applicants')) {
+      return new Response(JSON.stringify({}), { status: 200 });
+    }
+    const [, query = ''] = url.split('?');
+    const params = new URLSearchParams(query);
+    captured.push({ url, params });
+    const verdict = responder(params);
+    if ('reject' in verdict) throw new Error('network fail');
+    return new Response(JSON.stringify(verdict.body), {
+      status: verdict.status,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  });
+  vi.stubGlobal('fetch', fetchMock);
+  return { captured, fetchMock };
+}
+
+function makeApiProperty(overrides: Partial<{
+  id: string;
+  name: string;
+  city: string;
+  propertyType: 'senior' | 'family' | 'mixed_use';
+  amiTier: string | null;
+  availableCount: number;
+  totalUnits: number;
+  bedroomBreakdown: { studio: number; br1: number; br2: number; br3: number };
+}> = {}) {
+  return {
+    id: overrides.id ?? 'p-1',
+    name: overrides.name ?? 'Live Apartment One',
+    addressLine1: '100 Main St',
+    addressLine2: null,
+    city: overrides.city ?? 'Las Vegas',
+    state: 'NV',
+    zip: '89101',
+    propertyType: overrides.propertyType ?? 'family',
+    amiTier: overrides.amiTier ?? '60% AMI',
+    availability: {
+      availableCount: overrides.availableCount ?? 5,
+      leasedCount: 2,
+      totalUnits: overrides.totalUnits ?? 20,
+      bedroomBreakdown:
+        overrides.bedroomBreakdown ?? { studio: 0, br1: 2, br2: 3, br3: 0 },
+    },
+    rentRange: {
+      studio: null,
+      br1: { low: 900, high: 1100 },
+      br2: { low: 1200, high: 1400 },
+      br3: null,
+    },
+  };
+}
+
+describe('PropertyList (live /api/properties)', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('?bedroom=2 + ?amiTier=60 → fetch URL carries both server-validated params', async () => {
+    const { captured } = mockPropertiesEndpoint(() => ({
+      status: 200,
+      body: { properties: [makeApiProperty()], total: 1 },
+    }));
+    renderList('/discover?bedroom=2&amiTier=60');
+    await waitFor(() => expect(captured.length).toBeGreaterThan(0));
+    const last = captured[captured.length - 1]!;
+    expect(last.params.get('bedroom')).toBe('2');
+    expect(last.params.get('amiTier')).toBe('60');
+    // Tile renders from the API response name, not GPMG_FIXTURES.
+    expect(await screen.findByText('Live Apartment One')).toBeInTheDocument();
+  });
+
+  it('?availability=available_now + ?bedroom=studio → fetch URL carries both server params', async () => {
+    const { captured } = mockPropertiesEndpoint(() => ({
+      status: 200,
+      body: {
+        properties: [
+          makeApiProperty({
+            id: 'p-2',
+            name: 'Studio Tower',
+            propertyType: 'senior',
+            bedroomBreakdown: { studio: 4, br1: 0, br2: 0, br3: 0 },
+            availableCount: 4,
+            totalUnits: 12,
+          }),
+        ],
+        total: 1,
+      },
+    }));
+    renderList('/discover?availability=available_now&bedroom=studio');
+    await waitFor(() => expect(captured.length).toBeGreaterThan(0));
+    const last = captured[captured.length - 1]!;
+    expect(last.params.get('availability')).toBe('available_now');
+    expect(last.params.get('bedroom')).toBe('studio');
+    expect(await screen.findByText('Studio Tower')).toBeInTheDocument();
+  });
+
+  it('API returns empty properties array → empty-state count copy renders', async () => {
+    mockPropertiesEndpoint(() => ({
+      status: 200,
+      body: { properties: [], total: 0 },
+    }));
+    renderList('/discover?bedroom=3&amiTier=80');
+    // Wait for the API result to apply (count drops to 0). The pre-existing
+    // copy is the result-count footer — same as the unauthed empty result.
+    await waitFor(() => {
+      expect(screen.getByTestId('result-count').textContent).toBe(
+        '0 communities',
+      );
+    });
+    expect(tileCount()).toBe(0);
+  });
+
+  it('fetch rejects → fallback render keeps all 17 deterministic fixture tiles', async () => {
+    // Server 500 / network failure / 401 unauthed all surface as a thrown
+    // error in api/client.ts. The discover surface must keep showing the
+    // 17-property deterministic catalog so the gpmglv demo walkthrough
+    // still works when the API is unreachable.
+    mockPropertiesEndpoint(() => ({ reject: true }));
+    renderList();
+    // Initial render hydrates from GPMG_FIXTURES because apiProperties starts
+    // null. After the rejected fetch settles, apiProperties stays null and
+    // the fixture render persists.
+    expect(tileCount()).toBe(17);
+    // Give the rejected promise a microtask to settle, then re-assert.
+    await waitFor(() => expect(tileCount()).toBe(17));
+  });
+
+  it('API success rewires availability count from the response (no client-side seed mirror)', async () => {
+    // The wire is load-bearing: the contract is "use the server's rollup,
+    // do not re-derive from PROPERTY_UNIT_MIX". If the API says 0 available
+    // for a property the tile must reflect that — even if the deterministic
+    // seed mirror would have said 7.
+    mockPropertiesEndpoint(() => ({
+      status: 200,
+      body: {
+        properties: [
+          makeApiProperty({
+            id: 'p-3',
+            name: 'Empty House',
+            availableCount: 0,
+            totalUnits: 10,
+            bedroomBreakdown: { studio: 0, br1: 0, br2: 0, br3: 0 },
+          }),
+        ],
+        total: 1,
+      },
+    }));
+    renderList();
+    const grid = await screen.findByTestId('property-grid');
+    await waitFor(() => {
+      // Single tile from the API.
+      expect(within(grid).queryAllByRole('link')).toHaveLength(1);
+    });
+    const badge = within(grid).getByTestId('availability-badge');
+    expect(badge.getAttribute('data-state')).toBe('fully-leased');
   });
 });

--- a/docs/intel/gpmglv-gap-backlog.md
+++ b/docs/intel/gpmglv-gap-backlog.md
@@ -1,7 +1,7 @@
 # GPMGLV Gap Backlog — Competitive Build Tracker
 
 _Active backlog. Source: [`gpmglv-audit.md`](gpmglv-audit.md) + [`gpmglv-bp-03b-positioning.md`](gpmglv-bp-03b-positioning.md)._
-_Last updated: 2026-05-22._
+_Last updated: 2026-05-22 (wedge #8)._
 
 Every row is a wedge — a feature Frank-Pilot can ship where the evidence-based audit shows GPMGLV (and the "custom Next.js marketing site" tier of affordable-housing operator) has no answer. Pull tickets through this table to keep work grounded in actual competitor weakness, not opinions.
 
@@ -14,6 +14,7 @@ Every row is a wedge — a feature Frank-Pilot can ship where the evidence-based
 | #6 | i18n EN/ES parity + CI guard | PR #91 | All apply steps |
 | #7 | Mobile-first apply UX | PR #79 + #92 | Sticky CTA behind `MOBILE_APPLY_ENABLED` |
 | #14 | Sitemap + robots served as static assets | PR #95 | `vercel.json` negative-lookahead rewrite |
+| #8 | Live unit availability + filter | PR (this branch) | `PropertyList.tsx` → live `GET /api/properties` with `amiTier` / `bedroom` / `availability` params; deterministic GPMG fallback on error |
 
 The ranked table below reflects these shipped statuses inline.
 
@@ -35,7 +36,7 @@ The ranked table below reflects these shipped statuses inline.
 | 5 | **Position-aware waitlist** | Submit-and-wait black hole; no position field (audit §Waitlist) | Lane E waitlist banner | shipped 2026-05-22 (PR TBD) — position display surfaced via `StepConfirm` CTA | M | 4 | ★★★ |
 | 6 | **EN-ES from day one** | English-only, no language switcher (audit §Per-Page Dumps) | `src/i18n/{en,es}/` scaffold | shipped 2026-05-22 (PR #91) | M | 3 | ★★★ |
 | 7 | **Mobile-first apply UX** | gpmglv site is responsive but apply = #contact = no flow to optimize | `MOBILE_APPLY_ENABLED` flag | shipped 2026-05-22 (PR #79 + #92) | M–L | 3 | ★★ |
-| 8 | **Live unit availability + filter** | 17 property cards, zero rent, zero availability dates (audit §Property Listing) | `client-tenant/src/pages/discover/PropertyList.tsx` | partial — cards exist, filters TBD | M | 3 | ★★ |
+| 8 | **Live unit availability + filter** | 17 property cards, zero rent, zero availability dates (audit §Property Listing) | `client-tenant/src/pages/discover/PropertyList.tsx` | shipped 2026-05-22 — live `/api/properties` wire with server-validated `amiTier` / `bedroom` / `availability` params; deterministic 17-fixture fallback on error | M | 3 | ★★ |
 | 9 | **Honest pricing / AMI disclosure on listings** | Zero rent figures public (audit §Property Listing) | `discover/PropertyList.tsx` + `UnitCard.tsx` | partial | S | 2 | ★★ |
 | 10 | **Real applicant accounts (auth)** | No login on tenant side (audit §Tenant Login) | wizard + magic-link infra | shipped (foundational) | n/a | 2 | ★★ |
 | 11 | **Eligibility-aware lead routing** | Generic "Community + Message" form, no structured signal (audit §Per-Page Dumps `/contact-us`) | W0 output → property filter | folds into #2 | n/a | n/a | — |


### PR DESCRIPTION
## Summary

Wedge #8 from `docs/intel/gpmglv-gap-backlog.md` — the discover surface now consumes the real `GET /api/properties` endpoint:

- New `fetchPropertiesList` helper in `client-tenant/src/api/properties.ts` translates the existing filter chip state into the server's zod-validated query params (`amiTier`, `bedroom`, `availability`) — no semantic redefinition, so any drift fails loud with a `400 { error, allowed }`.
- `PropertyList.tsx` adapts both data sources (live API response + GPMG_FIXTURES) into one `TileSource` shape so `PropertyTile` reads a single contract — no JSX branching on data origin.
- On any error (unauthed `property:view` gate, 5xx, network) the existing `GPMG_FIXTURES + getPropertyAvailability` deterministic render takes over. **The offline guarantee that powers the gpmglv demo walkthrough is intact.**
- Type / City client-side narrowing still works on top of the API response, since the server doesn't expose those filters.
- 5 new MSW-style tests via `vi.stubGlobal('fetch', …)` cover the wire-param assertions, empty-state, fetch-rejection fallback, and a `availableCount=0` case proving we use the server rollup, not the client seed mirror.

## Scope guarantees

- Untouched (per spec): `client-tenant/src/utils/availability.ts`, `PROPERTY_UNIT_MIX`, the `AvailabilityDriftSentinel` test, `PropertyDetail.tsx`.
- `data-testid` strings on every chip / tile / row preserved — the apply-smoke regression keeps its hooks.

## Test plan

- [x] `npx vitest run` — **207 passed (33 files)**, includes the 5 new wedge #8 cases.
- [x] `node client-tenant/scripts/check-i18n-parity.mjs` — clean (no new strings).
- [x] All 14 pre-existing PropertyList tests pass unmodified (offline fallback path).
- [ ] CI: `test (18)` / `test (20)` / `test (22)` / `smoke-apply` (4 required gates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)