### PR TITLE
feat(properties): make GET listing public (gpmglv wedge #8 reach)

### DIFF
--- a/docs/intel/gpmglv-gap-backlog.md
+++ b/docs/intel/gpmglv-gap-backlog.md
@@ -14,7 +14,7 @@ Every row is a wedge — a feature Frank-Pilot can ship where the evidence-based
 | #6 | i18n EN/ES parity + CI guard | PR #91 | All apply steps |
 | #7 | Mobile-first apply UX | PR #79 + #92 | Sticky CTA behind `MOBILE_APPLY_ENABLED` |
 | #14 | Sitemap + robots served as static assets | PR #95 | `vercel.json` negative-lookahead rewrite |
-| #8 | Live unit availability + filter | PR (this branch) | `PropertyList.tsx` → live `GET /api/properties` with `amiTier` / `bedroom` / `availability` params; deterministic GPMG fallback on error |
+| #8 | Live unit availability + filter | PR #105 + this branch | `PropertyList.tsx` → live `GET /api/properties` with `amiTier` / `bedroom` / `availability` params; GET listing is now **public** so anonymous gpmglv-demo visitors see live data (create/update/delete remain auth-gated); deterministic GPMG fallback on error |
 
 The ranked table below reflects these shipped statuses inline.
 
@@ -36,7 +36,7 @@ The ranked table below reflects these shipped statuses inline.
 | 5 | **Position-aware waitlist** | Submit-and-wait black hole; no position field (audit §Waitlist) | Lane E waitlist banner | shipped 2026-05-22 (PR TBD) — position display surfaced via `StepConfirm` CTA | M | 4 | ★★★ |
 | 6 | **EN-ES from day one** | English-only, no language switcher (audit §Per-Page Dumps) | `src/i18n/{en,es}/` scaffold | shipped 2026-05-22 (PR #91) | M | 3 | ★★★ |
 | 7 | **Mobile-first apply UX** | gpmglv site is responsive but apply = #contact = no flow to optimize | `MOBILE_APPLY_ENABLED` flag | shipped 2026-05-22 (PR #79 + #92) | M–L | 3 | ★★ |
-| 8 | **Live unit availability + filter** | 17 property cards, zero rent, zero availability dates (audit §Property Listing) | `client-tenant/src/pages/discover/PropertyList.tsx` | shipped 2026-05-22 — live `/api/properties` wire with server-validated `amiTier` / `bedroom` / `availability` params; deterministic 17-fixture fallback on error | M | 3 | ★★ |
+| 8 | **Live unit availability + filter** | 17 property cards, zero rent, zero availability dates (audit §Property Listing) | `client-tenant/src/pages/discover/PropertyList.tsx` | shipped 2026-05-22 — live `/api/properties` wire (PR #105) + GET listing made public so anonymous /discover visitors get live data (this PR); create/update/delete remain auth-gated; deterministic 17-fixture fallback on error | M | 3 | ★★ |
 | 9 | **Honest pricing / AMI disclosure on listings** | Zero rent figures public (audit §Property Listing) | `discover/PropertyList.tsx` + `UnitCard.tsx` | partial | S | 2 | ★★ |
 | 10 | **Real applicant accounts (auth)** | No login on tenant side (audit §Tenant Login) | wizard + magic-link infra | shipped (foundational) | n/a | 2 | ★★ |
 | 11 | **Eligibility-aware lead routing** | Generic "Community + Message" form, no structured signal (audit §Per-Page Dumps `/contact-us`) | W0 output → property filter | folds into #2 | n/a | n/a | — |

--- a/docs/intel/gpmglv-gap-backlog.md
+++ b/docs/intel/gpmglv-gap-backlog.md
@@ -10,11 +10,11 @@ Every row is a wedge — a feature Frank-Pilot can ship where the evidence-based
 | Wedge | Title | Shipped via | Demo surface |
 |---|---|---|---|
 | #2 | W0 AMI prefill (Welcome → Apply → Review) | PR #94 | `StepIntent`, `StepReview` |
-| #5 | Position-aware waitlist — position display surfaced | PR #TBD (feat/wedge-5-position-cta) | `StepConfirm` → `/waitlist/position/:slug` CTA |
+| #5 | Position-aware waitlist — position display surfaced | PR #104 | `StepConfirm` → `/waitlist/position/:slug` CTA (CTA dormant until wizard adds waitlist-join branch — see memory) |
 | #6 | i18n EN/ES parity + CI guard | PR #91 | All apply steps |
 | #7 | Mobile-first apply UX | PR #79 + #92 | Sticky CTA behind `MOBILE_APPLY_ENABLED` |
 | #14 | Sitemap + robots served as static assets | PR #95 | `vercel.json` negative-lookahead rewrite |
-| #8 | Live unit availability + filter | PR #105 + this branch | `PropertyList.tsx` → live `GET /api/properties` with `amiTier` / `bedroom` / `availability` params; GET listing is now **public** so anonymous gpmglv-demo visitors see live data (create/update/delete remain auth-gated); deterministic GPMG fallback on error |
+| #8 | Live unit availability + filter | PR #105 + PR #119 | `PropertyList.tsx` → live `GET /api/properties` with `amiTier` / `bedroom` / `availability` params; GET listing is **public** so anonymous gpmglv-demo visitors see live data (create/update/delete remain auth-gated); deterministic GPMG fallback on error |
 
 The ranked table below reflects these shipped statuses inline.
 
@@ -33,7 +33,7 @@ The ranked table below reflects these shipped statuses inline.
 | 2 | **AMI pre-qualifier (W0)** | "Income-qualified" mentioned, zero AMI tables disclosed (audit §HUD) | `client-tenant/src/lib/ami.ts` + `components/AmiCalculator.tsx` | shipped 2026-05-22 (PR #94) | S–M | 5 | ★★★★★ |
 | 3 | **"Apply button does nothing" demo flip** | property page CTA = `#contact` anchor scroll-jump (audit §Per-Page Dumps) | demo script + landing page mount | none (asset, not feature) | S | 5 | ★★★★★ |
 | 4 | **Unit-claim FTU / "carrot" UX** | No unit-level state anywhere on gpmglv | unit-claim slice (PR #5 merged 2026-05-14, commit 58c1036) | shipped, low visibility | S (amplify) | 4 | ★★★★ |
-| 5 | **Position-aware waitlist** | Submit-and-wait black hole; no position field (audit §Waitlist) | Lane E waitlist banner | shipped 2026-05-22 (PR TBD) — position display surfaced via `StepConfirm` CTA | M | 4 | ★★★ |
+| 5 | **Position-aware waitlist** | Submit-and-wait black hole; no position field (audit §Waitlist) | Lane E waitlist banner | shipped 2026-05-22 (PR #104) — position display surfaced via `StepConfirm` CTA; CTA dormant until wizard adds waitlist-join branch | M | 4 | ★★★ |
 | 6 | **EN-ES from day one** | English-only, no language switcher (audit §Per-Page Dumps) | `src/i18n/{en,es}/` scaffold | shipped 2026-05-22 (PR #91) | M | 3 | ★★★ |
 | 7 | **Mobile-first apply UX** | gpmglv site is responsive but apply = #contact = no flow to optimize | `MOBILE_APPLY_ENABLED` flag | shipped 2026-05-22 (PR #79 + #92) | M–L | 3 | ★★ |
 | 8 | **Live unit availability + filter** | 17 property cards, zero rent, zero availability dates (audit §Property Listing) | `client-tenant/src/pages/discover/PropertyList.tsx` | shipped 2026-05-22 — live `/api/properties` wire (PR #105) + GET listing made public so anonymous /discover visitors get live data (this PR); create/update/delete remain auth-gated; deterministic 17-fixture fallback on error | M | 3 | ★★ |

--- a/src/__tests__/property-routes.test.ts
+++ b/src/__tests__/property-routes.test.ts
@@ -127,17 +127,19 @@ const app = buildApp();
 describe("GET /properties", () => {
   beforeEach(() => jest.clearAllMocks());
 
-  it("returns 401 when no Authorization header is provided", async () => {
+  it("returns 200 anonymously — listing is a public marketing surface", async () => {
+    mockListWithAvailability.mockResolvedValue([]);
     const res = await request(app).get("/properties");
-    expect(res.status).toBe(401);
-    expect(res.body.error).toMatch(/authentication required/i);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ properties: [], total: 0 });
   });
 
-  it("returns 401 when token is invalid", async () => {
+  it("returns 200 with a malformed Authorization header (anonymous treated same as authed for listing)", async () => {
+    mockListWithAvailability.mockResolvedValue([]);
     const res = await request(app)
       .get("/properties")
       .set("Authorization", "Bearer bad.token.here");
-    expect(res.status).toBe(401);
+    expect(res.status).toBe(200);
   });
 
   it("returns 200 for leasing_agent (property:view open to all roles)", async () => {

--- a/src/__tests__/property-routes.test.ts
+++ b/src/__tests__/property-routes.test.ts
@@ -122,6 +122,15 @@ function buildApp() {
 
 const app = buildApp();
 
+// `mockResolvedValueOnce` adds to a queue that survives `jest.clearAllMocks()`
+// (which only clears `.mock.calls/.instances/.results`). The GET /properties
+// listing is public, so its tests prime the queue but the route never consumes
+// — without this top-level reset the leftovers leak into POST/PATCH tests and
+// `authenticate` reads the wrong row, flipping role checks.
+beforeEach(() => {
+  mockQuery.mockReset();
+});
+
 // ── GET /properties — list all properties ─────────────────────────────────
 
 describe("GET /properties", () => {

--- a/src/modules/properties/routes.ts
+++ b/src/modules/properties/routes.ts
@@ -73,12 +73,13 @@ const UpdatePropertySchema = z.object({
  * Invalid values return 400 with `{ error, allowed }` so a typo (e.g.
  * `?amiTier=70`) is a loud failure rather than a silent "full list" surprise.
  *
- * Permission: property:view (all roles including leasing_agent)
+ * Public read: property listings are marketing surfaces (the gpmglv tier of
+ * affordable-housing operator publishes the same data on its homepage) and
+ * /discover renders this anonymously. Create / update / delete on this
+ * router remain gated by `authenticate` + role-scoped permissions.
  */
 router.get(
   "/",
-  authenticate,
-  requirePermission("property:view"),
   async (req: AuthRequest, res) => {
     try {
       // Zod-validate query params with a 400 contract that matches PR #69's


### PR DESCRIPTION
## Why

PR #105 wired PropertyList.tsx to live \`GET /api/properties\` but that endpoint required \`authenticate + property:view\`. Anonymous /discover visitors — the entire gpmglv-demo audience — always hit 401 and fell through to the GPMG_FIXTURES deterministic render. The wedge wiring shipped; the wedge **intent** (live data on the public discover surface) did not.

## What

Drops \`authenticate + requirePermission("property:view")\` from the GET listing handler only. **Create / update / delete and the \`:propertyId/*\` read routes keep their existing role-scoped gates.**

Property listings are public marketing data: gpmglv.com (and every other affordable-housing operator in this audit tier) publishes the same set of fields — name, address, type, availability, unit mix — on its anonymous homepage. The auth gate was over-protective for a public marketing surface.

## Changes

- \`src/modules/properties/routes.ts\` — drop \`authenticate\` and \`requirePermission\` from the list handler; route comment now explains the public-read contract.
- \`src/__tests__/property-routes.test.ts\` — the two 401-asserting tests flip to 200 ("anonymous treated same as authed for listing"). All other GET/POST/PATCH tests are untouched and continue to exercise the same authed paths that still gate writes.
- \`docs/intel/gpmglv-gap-backlog.md\` — wedge #8 row updated to reflect anonymous-reachable live data.

## Verification

\`\`\`bash
# Pre-merge (current main)
curl -sS -w "\nHTTP %{http_code}\n" "https://frank-pilot-tenant.vercel.app/api/properties?amiTier=60&bedroom=2"
# → {"error":"Authentication required"} HTTP 401

# Post-merge expectation (Railway auto-redeploys on push-to-main)
curl -sS -w "\nHTTP %{http_code}\n" "https://frank-pilot-tenant.vercel.app/api/properties?amiTier=60&bedroom=2"
# → {"properties":[…], "total": N} HTTP 200
\`\`\`

## Test plan

- [x] Jest property-routes tests updated (anonymous → 200, malformed-bearer → 200, authed paths unchanged)
- [ ] CI: \`api (tsc + jest)\`, \`client-tenant\`, \`check-i18n\`, \`smoke-apply\` all green
- [ ] Post-merge: anonymous curl on \`/api/properties\` returns 200 against Railway prod
- [ ] Post-deploy: \`frank-pilot-tenant.vercel.app/discover\` shows live tiles in network tab (not the deterministic fixture)

Closes wedge #8 reach gap (anonymous discover audience).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>