### PR TITLE
feat(bp-02): Phase 2 Step 1 — viewer service list() + verify smoke + rollback runbook

### DIFF
--- a/.github/workflows/prod-smoke.yml
+++ b/.github/workflows/prod-smoke.yml
@@ -73,3 +73,50 @@ jobs:
             /tmp/smoke-logs
           if-no-files-found: warn
           retention-days: 7
+
+  compliance-tape-verify:
+    name: compliance-tape-verify
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Independent of the Playwright smoke — chain-integrity health does not
+    # depend on UI handoff health. Both jobs surface as separate checks.
+    steps:
+      - name: Gate on secrets
+        id: gate
+        env:
+          TOKEN: ${{ secrets.SMOKE_AUDIT_TOKEN }}
+          APPLICANT_ID: ${{ secrets.SMOKE_APPLICANT_ID }}
+        run: |
+          if [ -z "$TOKEN" ] || [ -z "$APPLICANT_ID" ]; then
+            echo "::notice::SMOKE_AUDIT_TOKEN and/or SMOKE_APPLICANT_ID not set — skipping. Set repo secrets to enable. Token must have audit:view scope; rotate quarterly. See docs/runbooks/bp02-rollback.md."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Verify chain integrity
+        if: steps.gate.outputs.skip == 'false'
+        env:
+          TOKEN: ${{ secrets.SMOKE_AUDIT_TOKEN }}
+          APPLICANT_ID: ${{ secrets.SMOKE_APPLICANT_ID }}
+          API_BASE: https://api-production-ed89.up.railway.app
+        run: |
+          set -euo pipefail
+          status=$(curl -sS -o /tmp/verify.json -w "%{http_code}" \
+            -H "Authorization: Bearer $TOKEN" \
+            "$API_BASE/api/compliance-tape/verify?applicantId=$APPLICANT_ID")
+          echo "HTTP $status"
+          cat /tmp/verify.json
+          echo ""
+          if [ "$status" != "200" ]; then
+            echo "::error::compliance-tape/verify returned HTTP $status"
+            exit 1
+          fi
+          ok=$(jq -r '.ok' < /tmp/verify.json)
+          if [ "$ok" != "true" ]; then
+            broke_at=$(jq -r '.brokeAt // "n/a"' < /tmp/verify.json)
+            reason=$(jq -r '.reason // "no reason given"' < /tmp/verify.json)
+            echo "::error::chain break detected at sequence $broke_at: $reason"
+            exit 1
+          fi
+          echo "compliance-tape chain ok"

--- a/docs/runbooks/bp02-rollback.md
+++ b/docs/runbooks/bp02-rollback.md
@@ -1,0 +1,182 @@
+# BP-02 Compliance Tape — Rollback Runbook
+
+This document is the canonical rollback procedure for the BP-02 compliance
+tape (`compliance_tape` table + dual-write at 5 sites, gated on the
+`COMPLIANCE_TAPE_V2_ENABLED` environment variable). Reach for it only when
+the conditions in **When to use** are met. Every step requires two-engineer
+witness sign-off.
+
+---
+
+## When to use
+
+Activate this runbook only if any of:
+
+- `verify-cron` emits `BP-02 chain break detected` warnings for **three
+  consecutive ticks** (15 minutes) without a remediating PR in flight.
+- `prod-smoke.yml` `compliance-tape-verify` job fails **twice consecutively**
+  on the scheduled 6h cadence.
+- Application latency or error rate spikes measurably and the spike correlates
+  with `compliance_tape` write volume on Railway dashboards.
+- Two-engineer review concludes that compliance data integrity is at risk and
+  forward repair is not feasible inside the cutover window.
+
+If none of these apply, do **not** rollback. Forward-fix in a follow-up PR.
+
+---
+
+## Sign-off (two-engineer witness required)
+
+Before running any step below the diagnose phase, both engineers must record
+the decision below. Save the filled-in copy to the incident channel.
+
+```
+Engineer 1:                       Engineer 2:
+Name: ______                      Name: ______
+Time: ______ UTC                  Time: ______ UTC
+Decision: rollback / abort        Decision: rollback / abort
+```
+
+---
+
+## Step 1 — Halt new tape writes (flag → false)
+
+This step is safe and reversible. Run it first regardless of which downstream
+path you ultimately take.
+
+Railway dashboard → service → **Variables**:
+- Set `COMPLIANCE_TAPE_V2_ENABLED=false`
+- Click **Redeploy**
+- Wait for the new container to come up (verify via `GET /health`, expect
+  `status:ok`)
+- Confirm no new rows arriving:
+
+```sql
+SELECT COUNT(*) FROM compliance_tape
+ WHERE created_at > NOW() - INTERVAL '5 minutes';
+```
+
+The count should plateau within 60 seconds of the redeploy. The legacy NDJSON
+tape continues to receive events untouched. Reads through
+`/api/compliance-tape/*` continue to work against historic data — no data
+loss yet.
+
+---
+
+## Step 2 — Diagnose
+
+Pause here. Convene the two-engineer witness review. Do **not** drop tables
+or restore snapshots without sign-off.
+
+Capture:
+- Winston log lines with `BP-02 chain break detected` from the last 24h
+  (Railway logs → search).
+- The `compliance_tape` row count vs the NDJSON event count for the same
+  window. They should be roughly equal (small drift from in-flight requests
+  is fine; a large gap is itself diagnostic).
+- A targeted verify call on each affected applicant:
+
+```bash
+curl -fsS \
+  -H "Authorization: Bearer $JWT" \
+  "$API/api/compliance-tape/verify?applicantId=<id>" | jq
+```
+
+Decision: is the corruption **bounded** (specific `applicant_id`s) or
+**systemic** (every chain breaks)?
+
+---
+
+## Step 3 — Quarantine (preferred)
+
+If corruption is bounded to one or more `applicant_id`s, leave the table
+intact for forensic review.
+
+- Document the affected `applicant_id`s in the incident log.
+- File a follow-up PR for the forward fix (typically: identify the bad
+  payload, fix the maker, re-stamp from a corrected baseline).
+- Skip Step 4 and Step 5.
+
+The `verify-cron` will continue to WARN on the affected applicants until the
+forward fix lands — silence it for those ids in the log filter if the noise
+is hiding new breaks.
+
+---
+
+## Step 4 — Full table teardown (last resort)
+
+Only proceed if **all** of:
+1. corruption is systemic (every applicant chain breaks), **and**
+2. Step 3 quarantine is impractical, **and**
+3. both engineers have explicitly signed off above.
+
+Run the SQL block below from a `railway run psql` shell on prod. Capture the
+output to the incident channel.
+
+```sql
+-- 1. Drop the append-only triggers so DELETE/DROP can run. Without this
+--    the next statement raises 'compliance_tape is append-only'.
+DROP TRIGGER IF EXISTS compliance_tape_no_update ON compliance_tape;
+DROP TRIGGER IF EXISTS compliance_tape_no_truncate ON compliance_tape;
+
+-- 2. Then either:
+--    a) Soft-empty (preferred — preserves indexes + grants):
+DELETE FROM compliance_tape;
+--    b) Or drop entirely (only if (a) leaves bad indexes behind):
+-- DROP TABLE compliance_tape CASCADE;
+```
+
+After teardown:
+- If you ran (b): re-apply `src/db/migrations/2026-05-23-compliance-tape.sql`
+  and `src/db/migrations/2026-05-24-compliance-tape-idem-index.sql`:
+  ```bash
+  railway run npm run migrate
+  ```
+- Leave `COMPLIANCE_TAPE_V2_ENABLED=false` until the root cause is fixed in
+  code and a follow-up PR re-enables the flag in a staged rollout.
+
+---
+
+## Step 5 — Snapshot restore (only if Step 4 corrupts adjacent data)
+
+If Step 4's `DROP TABLE … CASCADE` removed something it shouldn't have, or
+the rollback itself introduced corruption: Railway dashboard → Database →
+**Snapshots** → restore the latest pre-incident snapshot.
+
+This rewinds **every** table in the database, not just `compliance_tape`.
+Coordinate with anyone holding open transactions. Expect a brief read-only
+window. Re-deploy the application after the restore completes so the
+connection pool picks up a fresh handle.
+
+---
+
+## Step 6 — Postmortem
+
+Within 24h of the rollback completing, file the incident in the Backlog
+Tracker with:
+- Trigger condition (which alert fired, what was the rate).
+- Time-to-detection and time-to-mitigation.
+- Root cause (best-guess if still under investigation; mark as such).
+- Action items to prevent recurrence (typically: extra invariant in
+  `service.ts`, new test in `__tests__/`, alert tuning).
+
+Schedule the forward-fix PR. Do not re-flip `COMPLIANCE_TAPE_V2_ENABLED=true`
+until the forward fix has shipped, soaked on staging for 24h, and the
+postmortem action items are at least scheduled.
+
+---
+
+## Rehearsal
+
+Before the first prod flag flip (Phase 2 Step 3), rehearse this runbook
+end-to-end on an isolated Railway Postgres branch:
+1. Create a branch off prod.
+2. Apply both migrations.
+3. Stamp ~10 rows via the dual-write site by enabling the flag temporarily on
+   the branch.
+4. Execute Step 1 → Step 4(a) → re-apply migrations.
+5. Confirm an empty `compliance_tape` with intact indexes and triggers.
+6. Tear down the branch.
+
+The rehearsal protects against the failure mode where the rollback procedure
+itself is broken — discovering that during a real incident is unacceptable.

--- a/src/modules/tape/service.ts
+++ b/src/modules/tape/service.ts
@@ -78,6 +78,16 @@ export interface TapeService {
    * SHA-256 of the last entry so the printout is self-verifying.
    */
   exportPdf(scope: TapeScope): Promise<Buffer>;
+
+  /**
+   * Read entries in scope, oldest first.  Passthrough to repo.list — exposed
+   * on the service so callers (BP-19 viewer routes, verify-cron) don't have
+   * to hold a reference to the repository directly.
+   */
+  list(
+    scope: TapeScope,
+    opts?: { limit?: number; afterSequence?: number }
+  ): Promise<TapeEntry[]>;
 }
 
 // ---------------------------------------------------------------------------
@@ -356,5 +366,15 @@ export function createTapeService(repo: TapeRepository): TapeService {
     });
   }
 
-  return { stamp, verify, exportPdf };
+  // -------------------------------------------------------------------------
+  // list
+  // -------------------------------------------------------------------------
+  async function list(
+    scope: TapeScope,
+    opts?: { limit?: number; afterSequence?: number }
+  ): Promise<TapeEntry[]> {
+    return repo.list(scope, opts);
+  }
+
+  return { stamp, verify, exportPdf, list };
 }

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -2,11 +2,14 @@ import cron from "node-cron";
 import { RecertificationService } from "./modules/recertification/service";
 import { LedgerService } from "./modules/ledger/service";
 import { LeaseRenewalService } from "./modules/renewal/service";
+import { createTapeService } from "./modules/tape/service";
+import { PgTapeRepository } from "./modules/tape/repository";
 import { logger } from "./utils/logger";
 
 const recertService = new RecertificationService();
 const ledgerService = new LedgerService();
 const renewalService = new LeaseRenewalService();
+const tapeService = createTapeService(new PgTapeRepository());
 
 /**
  * Start daily scheduled jobs.
@@ -100,5 +103,45 @@ export function startScheduler() {
     }
   });
 
-  logger.info("Scheduler started: rent postings (1st @ 6AM) + late fees (7AM) + renewals (7:30AM) + recert reminders (8AM) + TRACS checks (9AM)");
+  // Every 5 minutes — BP-02 compliance-tape chain-integrity sweep.
+  // Samples up to 20 applicants that received a tape stamp in the last hour
+  // and runs verify() on each. WARN per broken chain is the in-app alert
+  // signal; the prod-smoke compliance-tape-verify job is the external one.
+  cron.schedule("*/5 * * * *", async () => {
+    try {
+      const { query } = await import("./config/database");
+      const { rows } = await query(
+        `SELECT DISTINCT applicant_id
+           FROM compliance_tape
+          WHERE created_at > NOW() - INTERVAL '1 hour'
+            AND applicant_id IS NOT NULL
+          LIMIT 20`
+      );
+      let warnings = 0;
+      for (const r of rows) {
+        const result = await tapeService.verify({
+          type: "applicant",
+          applicantId: r.applicant_id as string,
+        });
+        if (!result.ok) {
+          warnings++;
+          logger.warn("BP-02 chain break detected", {
+            applicantId: r.applicant_id,
+            brokeAt: result.brokeAt,
+            reason: result.reason,
+          });
+        }
+      }
+      logger.info("BP-02 verify-cron tick", {
+        sampledApplicants: rows.length,
+        warnings,
+      });
+    } catch (err) {
+      logger.error("BP-02 verify-cron failed", {
+        error: (err as Error).message,
+      });
+    }
+  });
+
+  logger.info("Scheduler started: rent postings (1st @ 6AM) + late fees (7AM) + renewals (7:30AM) + recert reminders (8AM) + TRACS checks (9AM) + BP-02 verify-cron (every 5min)");
 }


### PR DESCRIPTION
## Summary

Phase 2 **Step 1** of the BP-02 compliance tape cutover (plan: `~/.claude/plans/seems-like-you-are-calm-milner.md`). Lands the operator-side scaffolding so the staging soak in Step 2 has somewhere to land. No production behavior change in this PR.

**Four pieces:**

- **`src/modules/tape/service.ts`** — extend `TapeService` interface with `list(scope, opts)`, a passthrough to `repo.list`. Lets viewer routes + the verify-cron call through the service instead of holding a repo reference. ~22 lines.

- **`src/scheduler.ts`** — module-scope `tapeService` + every-5-min `verify-cron` block. Samples up to 20 distinct applicant_ids that received a tape stamp in the last hour, runs `tapeService.verify()` on each, logs WARN per `!result.ok` with `brokeAt` + `reason`, logs INFO heartbeat with `sampledApplicants` + `warnings` count. Bounded query keeps load flat regardless of tape volume. ~44 lines.

- **`.github/workflows/prod-smoke.yml`** — new `compliance-tape-verify` job. **Gated** on `SMOKE_AUDIT_TOKEN` + `SMOKE_APPLICANT_ID` repo secrets — skips with a `::notice::` when either is missing, so this PR is safe to merge before the secrets exist or the stub swap lands. When wired, curls `/api/compliance-tape/verify?applicantId=$APPLICANT_ID` and asserts HTTP 200 + `.ok === true` on the existing 6h schedule.

- **`docs/runbooks/bp02-rollback.md`** — canonical 6-step rollback procedure. Two-engineer witness required before any destructive step. Includes a **rehearsal** section so the runbook is proven against an isolated Railway Postgres branch before the first prod flag flip.

---

## Deferred to follow-up PR

One piece of the approved Step 1 plan is still deferred due to a file-lock conflict with **concurrent BP-08 work** active right now on `src/index.ts`:

- **`src/index.ts:113-129`** — swap the stub `TapeService` (returns 503) for `createTapeService(new PgTapeRepository())`. Currently locked by `cc-15585` (\"bp-08 server slice impl\") — no BP-08 PR open yet, so I can't predict ETA.

**Implication:** Step 2 (24h staging flag flip + soak) is **blocked** on that follow-up landing first — without it, the BP-19 viewer renders 503 against `/api/compliance-tape/*` and the `compliance-tape-verify` smoke job (if secrets are set) would 503-fail.

**Recovery path:** once cc-15585's BP-08 PR opens and merges (or releases src/index.ts), I'll cut a tiny follow-up PR (~5 lines: imports + replace the stub block). The exact diff is pre-staged in the original Step 1 plan.

---

## Rollback runbook (mirrored from `docs/runbooks/bp02-rollback.md` for inline review)

### When to use

- `verify-cron` emits `BP-02 chain break detected` for **3 consecutive ticks** (15 minutes) without a remediating PR in flight, OR
- `prod-smoke.yml` `compliance-tape-verify` job fails **twice consecutively** on the 6h cadence, OR
- latency/error spike correlates with `compliance_tape` write volume on Railway, OR
- two-engineer review concludes integrity is at risk and forward-fix is infeasible inside the cutover window.

If none → do **not** rollback. Forward-fix in a follow-up PR.

### Steps (each requires two-engineer witness sign-off recorded in the incident channel before proceeding)

1. **Halt new tape writes (flag → false)** — Railway → service → Variables → `COMPLIANCE_TAPE_V2_ENABLED=false` → Redeploy → confirm via `SELECT COUNT(*) FROM compliance_tape WHERE created_at > NOW() - INTERVAL '5 minutes'` plateaus within 60s. NDJSON path continues uninterrupted. Reversible; safe to run unilaterally.

2. **Diagnose** — pause + convene witness review. Capture last-24h winston `chain break detected` lines, compliance_tape row count vs NDJSON event count for the same window, targeted verify on each affected applicant. Decision: bounded (specific `applicant_id`s) or systemic (every chain breaks)?

3. **Quarantine (preferred — bounded corruption)** — leave the table intact for forensic review, document affected ids, file follow-up forward-fix PR, skip steps 4 & 5. Silence verify-cron for affected ids in log filter if noise hides new breaks.

4. **Full table teardown (last resort — systemic + step 3 impractical + both engineers signed off)** — drop append-only triggers, then `DELETE FROM compliance_tape` (preferred — preserves indexes/grants) or `DROP TABLE compliance_tape CASCADE` (only if (a) leaves bad indexes). If (b): re-apply both migrations via `railway run npm run migrate`. Leave flag at `false` until root cause is fixed in code.

5. **Snapshot restore (only if step 4 corrupts adjacent data)** — Railway → Database → Snapshots → restore latest pre-incident snapshot. Rewinds **every** table — coordinate with anyone holding open transactions. Re-deploy app after restore.

6. **Postmortem** — within 24h, file in Backlog Tracker: trigger, time-to-detection, time-to-mitigation, root cause (best-guess if still under investigation), action items (typically extra invariant in `service.ts` + new test + alert tuning). Schedule forward-fix PR. Do not re-enable flag until forward fix has shipped + 24h staging soak + postmortem action items at least scheduled.

### Rehearsal

Before first prod flag flip (Step 3), rehearse end-to-end on an isolated Railway Postgres branch: branch off prod → apply both migrations → stamp ~10 rows via dual-write site with flag temporarily true on the branch → execute Step 1 → Step 4(a) → re-apply migrations → confirm empty `compliance_tape` with intact indexes + triggers → tear down branch. Protects against rollback procedure itself being broken.

---

## Human action items (Alex)

1. **Rollback rehearsal** on isolated Railway Postgres branch — block at least 60 min, follow `docs/runbooks/bp02-rollback.md` § Rehearsal end-to-end before the first prod flag flip (Step 3).
2. **Verify prod Postgres snapshot age** — Railway → Database → Snapshots → confirm latest snapshot is < 4h old before merging Step 2's flag-flip PR (master plan pre-demo gate #2).
3. **Repo secrets — defer**: do **not** set `SMOKE_AUDIT_TOKEN` and `SMOKE_APPLICANT_ID` yet. The stub at `src/index.ts:113-129` still returns 503 for `/api/compliance-tape/verify`, so wiring the secrets now would make the smoke job fail. Add them in the follow-up PR that swaps the stub.

## Test plan

- [ ] CI green (lint + tape jest suite — 32 tests, run locally green)
- [ ] `gh workflow run prod-smoke.yml` from the PR — `prod-smoke` job stays green (Playwright handoff still passes); `compliance-tape-verify` job emits the `::notice::` skip (no secrets set yet) and reports neutral, not failure
- [ ] Reviewer reads through `docs/runbooks/bp02-rollback.md` end-to-end and confirms the destructive-SQL block is callable from `railway run psql`
- [ ] After merge: `railway logs --service=prod` shows the first `BP-02 verify-cron tick` log line within the first 5-minute window post-deploy (will be `sampledApplicants: 0, warnings: 0` until flag is flipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)