### PR TITLE
chore(backlog): flip wedge #9 + #15 to shipped + fix post-deploy-verify

### DIFF
--- a/docs/intel/gpmglv-gap-backlog.md
+++ b/docs/intel/gpmglv-gap-backlog.md
@@ -1,7 +1,7 @@
 # GPMGLV Gap Backlog — Competitive Build Tracker
 
 _Active backlog. Source: [`gpmglv-audit.md`](gpmglv-audit.md) + [`gpmglv-bp-03b-positioning.md`](gpmglv-bp-03b-positioning.md)._
-_Last updated: 2026-05-22 (wedge #8)._
+_Last updated: 2026-05-22 (wedge #8, #9, #15)._
 
 Every row is a wedge — a feature Frank-Pilot can ship where the evidence-based audit shows GPMGLV (and the "custom Next.js marketing site" tier of affordable-housing operator) has no answer. Pull tickets through this table to keep work grounded in actual competitor weakness, not opinions.
 
@@ -15,6 +15,8 @@ Every row is a wedge — a feature Frank-Pilot can ship where the evidence-based
 | #7 | Mobile-first apply UX | PR #79 + #92 | Sticky CTA behind `MOBILE_APPLY_ENABLED` |
 | #14 | Sitemap + robots served as static assets | PR #95 | `vercel.json` negative-lookahead rewrite |
 | #8 | Live unit availability + filter | PR #105 + PR #119 | `PropertyList.tsx` → live `GET /api/properties` with `amiTier` / `bedroom` / `availability` params; GET listing is **public** so anonymous gpmglv-demo visitors see live data (create/update/delete remain auth-gated); deterministic GPMG fallback on error |
+| #9 | Honest pricing / AMI disclosure on listings | inline (no separate PR) | `PropertyList.tsx` tile rent buckets (`formatRentBucket()`) + AMI tier chip (`t('amiTier.label')`) + `UnitCard.tsx` unit detail |
+| #15 | Cookie banner / GDPR posture | inline (no separate PR) | `state/consent.ts` (localStorage `fp.consent.v1`, useConsent hook) + `components/CookieBanner.tsx` (bottom-fixed, Esc→rejectAll, i18n `legal.*`) |
 
 The ranked table below reflects these shipped statuses inline.
 
@@ -37,13 +39,13 @@ The ranked table below reflects these shipped statuses inline.
 | 6 | **EN-ES from day one** | English-only, no language switcher (audit §Per-Page Dumps) | `src/i18n/{en,es}/` scaffold | shipped 2026-05-22 (PR #91) | M | 3 | ★★★ |
 | 7 | **Mobile-first apply UX** | gpmglv site is responsive but apply = #contact = no flow to optimize | `MOBILE_APPLY_ENABLED` flag | shipped 2026-05-22 (PR #79 + #92) | M–L | 3 | ★★ |
 | 8 | **Live unit availability + filter** | 17 property cards, zero rent, zero availability dates (audit §Property Listing) | `client-tenant/src/pages/discover/PropertyList.tsx` | shipped 2026-05-22 — live `/api/properties` wire (PR #105) + GET listing made public so anonymous /discover visitors get live data (this PR); create/update/delete remain auth-gated; deterministic 17-fixture fallback on error | M | 3 | ★★ |
-| 9 | **Honest pricing / AMI disclosure on listings** | Zero rent figures public (audit §Property Listing) | `discover/PropertyList.tsx` + `UnitCard.tsx` | partial | S | 2 | ★★ |
+| 9 | **Honest pricing / AMI disclosure on listings** | Zero rent figures public (audit §Property Listing) | `discover/PropertyList.tsx` + `UnitCard.tsx` | shipped 2026-05-22 | S | 2 | ★★ |
 | 10 | **Real applicant accounts (auth)** | No login on tenant side (audit §Tenant Login) | wizard + magic-link infra | shipped (foundational) | n/a | 2 | ★★ |
 | 11 | **Eligibility-aware lead routing** | Generic "Community + Message" form, no structured signal (audit §Per-Page Dumps `/contact-us`) | W0 output → property filter | folds into #2 | n/a | n/a | — |
 | 12 | **Resident portal: rent pay / docs / lease** | gpmglv `/portal` = maintenance + message + lookup only (audit §Tenant Login) | NEW | none (stage 2, post-move-in) | L | 2 | ★ |
 | 13 | **Anti-spam (Turnstile / rate-limit)** | Waitlist + contact forms have no visible captcha (audit §Per-Page Dumps) | server-side rate limit + Turnstile/hCaptcha | none | S–M | 1 | ★ |
 | 14 | **SEO / sitemap / JSON-LD** | `robots.txt` 404, `sitemap.xml` 404 (audit §Robots/Sitemap) | infra | partial — sitemap+robots static-serve fixed 2026-05-22 (PR #95) | S | 1 | ★ |
-| 15 | **Cookie banner / GDPR posture** | No `Set-Cookie` observed, thin privacy policy (audit §Cookies) | NEW | none | S | 1 | ★ |
+| 15 | **Cookie banner / GDPR posture** | No `Set-Cookie` observed, thin privacy policy (audit §Cookies) | NEW | shipped 2026-05-22 | S | 1 | ★ |
 
 ## Top-5 detail
 
@@ -85,7 +87,7 @@ The ranked table below reflects these shipped statuses inline.
 
 Carry-over from positioning brief — these gaps are real but not the wedge:
 - Resident portal post-move-in features (rent pay, lease, docs) — stage 2, not the apply→tenant ramp.
-- Cookie banner / GDPR — table stakes once auth ships, not a positioning lever.
+- Cookie banner / GDPR — shipped 2026-05-22 (#15); was table stakes, not a positioning lever.
 - SEO infrastructure — easy win but not a product differentiator. Backlog as #14.
 
 ## Update protocol

--- a/scripts/post-deploy-verify.mjs
+++ b/scripts/post-deploy-verify.mjs
@@ -6,7 +6,7 @@
 //   2) POST /api/applicants/register returns 202 + ok:true (not 405).
 //   3) Magic-link path is reachable (either devLink in response when
 //      DEMO_LINK_IN_RESPONSE=true, or the route just doesn't 5xx).
-//   4) GET /api/tape/page-view (public BP-03b beacon) returns 200/204.
+//   4) POST /api/tape/welcome-view (BP-03b HUD_928_1 beacon) returns 204.
 //
 // Optional Vercel SPA static-asset checks (front-end domain):
 //   --site=https://frank-pilot-tenant.vercel.app
@@ -78,7 +78,7 @@ async function checkRegister() {
     record(
       "02-register-post",
       ok,
-      `${r.status} ok=${body.ok ?? "?"} userId=${body.userId ? "✓" : "✗"}`,
+      `${r.status} ok=${body.ok ?? "?"} message=${body.message ? "✓" : "✗"}`,
     );
     return body;
   } catch (e) {
@@ -92,27 +92,30 @@ function checkMagicLinkSurface(registerBody) {
     record("03-magic-link-surface", false, "skipped — no register body");
     return;
   }
-  // Either dev/demo mode surfaces devLink, or it doesn't — both are valid in
-  // prod. The fail case is a 5xx on register (already caught above) or a
-  // payload that drops `ok` / `userId`.
-  const hasUserId = typeof registerBody.userId === "string";
+  // W6: /register never returns userId (timing-side-channel mitigation for
+  // email enumeration). The uniform response is { ok: true, message: "..." }.
+  // Dev/demo mode additionally surfaces devLink. The fail case is a 5xx on
+  // register (already caught above) or a payload that drops `ok`.
   const hasOk = registerBody.ok === true;
+  const hasMessage = typeof registerBody.message === "string";
   record(
     "03-magic-link-surface",
-    hasUserId && hasOk,
-    `userId=${hasUserId ? "✓" : "✗"} devLink=${
+    hasOk && hasMessage,
+    `ok=${hasOk ? "✓" : "✗"} message=${hasMessage ? "✓" : "✗"} devLink=${
       registerBody.devLink ? "present" : "absent (prod-safe)"
     }`,
   );
 }
 
 async function checkTapeBeacon() {
-  const url = `${API}/api/tape/page-view`;
+  // Route is /api/tape/welcome-view (fires HUD_928_1_FAIR_HOUSING_POSTED).
+  // Schema requires session_id (min 8 chars); state and property_slug are optional.
+  const url = `${API}/api/tape/welcome-view`;
   try {
     const r = await fetch(url, {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ formId: "HUD-928.1", page: 1, ts: Date.now() }),
+      body: JSON.stringify({ session_id: `verify-${Date.now()}` }),
     });
     const ok = r.status === 200 || r.status === 202 || r.status === 204;
     record("04-tape-beacon", ok, `status=${r.status}`);
@@ -160,17 +163,12 @@ async function checkDualWriteParity() {
     return;
   }
   const sessionId = `verify-${Date.now()}`;
-  const url = `${API}/api/tape/page-view`;
+  const url = `${API}/api/tape/welcome-view`;
   try {
     const r = await fetch(url, {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({
-        session_id: sessionId,
-        formId: "HUD-928.1",
-        page: 1,
-        ts: Date.now(),
-      }),
+      body: JSON.stringify({ session_id: sessionId }),
     });
     if (!r.ok && r.status !== 202 && r.status !== 204) {
       record("06-dual-write-parity", false, `beacon POST returned ${r.status}`);


### PR DESCRIPTION
## Summary

- **Wedge #9** (honest pricing / AMI disclosure): `formatRentBucket()` + AMI tier chip render on `PropertyList.tsx` tiles and `UnitCard.tsx` unit detail. Status was `partial` — flipped to `shipped 2026-05-22`.
- **Wedge #15** (cookie banner / GDPR): full consent stack in `state/consent.ts` + `CookieBanner.tsx` (bottom-fixed, Esc→rejectAll, i18n `legal.*`) mounted in `App.tsx`. Status was `none` — flipped to `shipped 2026-05-22`.
- **`scripts/post-deploy-verify.mjs`**: fixed two false-alarm FAILs → now 6/6 PASS:
  1. `04-tape-beacon`: `/api/tape/page-view` → `/api/tape/welcome-view` (actual route); body schema corrected to `{ session_id }`.
  2. `02-register-post` / `03-magic-link-surface`: removed `userId` expectation — W6 security audit intentionally omits it (timing-side-channel mitigation); now checks `ok + message` per the W6-compliant uniform response shape.

## Test plan

- [x] `node scripts/post-deploy-verify.mjs https://api-production-ed89.up.railway.app --site=https://frank-pilot-tenant.vercel.app` → 6/6 PASS confirmed against prod
- [x] Backlog rows #9 and #15 updated in ranked table + added to "Recently shipped" table
- [x] "Explicitly NOT priorities" note for cookie banner updated to reflect shipped status

🤖 Generated with [Claude Code](https://claude.com/claude-code)