### PR TITLE
feat(apply): activate wedge #5 — zero-units → waitlist-join branch

### DIFF
--- a/client-tenant/src/i18n/en/apply.json
+++ b/client-tenant/src/i18n/en/apply.json
@@ -96,6 +96,9 @@
     "fallbackBanner": "No exact matches. Here are the closest options — your preferences are noted on each card.",
     "adjust": "Adjust your search",
     "editPrefs": "← Edit preferences",
+    "waitlistCta": "Join the waitlist instead",
+    "waitlistLoading": "Joining waitlist…",
+    "waitlistError": "Could not join the waitlist",
     "claimError": "Could not claim this unit",
     "loadError": "Could not load units",
     "mismatch": {

--- a/client-tenant/src/i18n/es/apply.json
+++ b/client-tenant/src/i18n/es/apply.json
@@ -96,6 +96,9 @@
     "fallbackBanner": "Sin coincidencias exactas. Estas son las opciones más cercanas — tus preferencias aparecen en cada tarjeta.",
     "adjust": "Ajustar tu búsqueda",
     "editPrefs": "← Editar preferencias",
+    "waitlistCta": "Únete a la lista de espera",
+    "waitlistLoading": "Uniéndose a la lista de espera…",
+    "waitlistError": "No se pudo unirse a la lista de espera",
     "claimError": "No se pudo reservar esta unidad",
     "loadError": "No se pudieron cargar las unidades",
     "mismatch": {

--- a/client-tenant/src/pages/Apply.tsx
+++ b/client-tenant/src/pages/Apply.tsx
@@ -177,6 +177,18 @@ export function Apply() {
   // persisted to sessionStorage under key `frank_apply_state`.
   const wiz = useWizState();
 
+  // Wedge #5 — seed propertySlug from the ?propertyId= query param (set by
+  // PropertyDetail when bouncing the user to /apply). Falls back to wiz state
+  // (persisted) so a reload on the confirm step doesn't lose the CTA.
+  useEffect(() => {
+    const slugFromUrl = search.get('propertyId');
+    if (slugFromUrl && !wiz.propertySlug) {
+      wiz.setPropertySlug(slugFromUrl);
+    }
+    // Run only on mount — URL param is consumed once, wiz state owns it after.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   // Issue #8 — gate render on intent-step deep links until hydration completes.
   // Without this, landing on `?step=intent` paints the empty quiz form for a
   // tick before /auth/me + /applicants/me/applications resolve and backfill
@@ -268,6 +280,9 @@ export function Apply() {
     dateOfBirth, setDateOfBirth, addressLine1, setAddressLine1, city, setCity, state, setState, zip, setZip,
     employerName, setEmployerName, annualIncome, setAnnualIncome, householdSize, setHouseholdSize, moveInDate, setMoveInDate,
     done, setDone,
+    // Wedge #5 — waitlist outcome
+    outcome: wiz.outcome, setOutcome: wiz.setOutcome,
+    propertySlug: wiz.propertySlug, setPropertySlug: wiz.setPropertySlug,
     // Contract 2 — wizard
     adults: wiz.adults, setAdults: wiz.setAdults,
     paymentTotal: wiz.paymentTotal,
@@ -312,7 +327,13 @@ export function Apply() {
       )}
       {step === 2 && <Step2Details />}
       {step === 'confirm' && (
-        <Suspense fallback={null}><StepConfirm /></Suspense>
+        <Suspense fallback={null}>
+          <StepConfirm
+            outcome={value.outcome}
+            propertySlug={value.propertySlug}
+            bedrooms={value.intentBedrooms}
+          />
+        </Suspense>
       )}
     </>
   );

--- a/client-tenant/src/pages/apply/ApplyContext.tsx
+++ b/client-tenant/src/pages/apply/ApplyContext.tsx
@@ -43,6 +43,9 @@ interface WizPersisted {
   // /auth/callback route hop (Apply unmounts during verify).
   intentBedrooms: number | null;
   intentHouseholdSize: number;
+  // Wedge #5 — persist waitlist outcome so StepConfirm CTA survives a reload.
+  outcome: 'claimed' | 'waitlisted' | null;
+  propertySlug: string | null;
 }
 
 const DEFAULTS: WizPersisted = {
@@ -54,6 +57,8 @@ const DEFAULTS: WizPersisted = {
   qualifyingHouseholdSize: null,
   intentBedrooms: null,
   intentHouseholdSize: 1,
+  outcome: null,
+  propertySlug: null,
 };
 
 const TIER_SET: ReadonlySet<AmiTier> = new Set(['30', '50', '60', '80']);
@@ -88,6 +93,9 @@ function readPersisted(): WizPersisted {
         typeof parsed.intentHouseholdSize === 'number' && parsed.intentHouseholdSize >= 1
           ? parsed.intentHouseholdSize
           : DEFAULTS.intentHouseholdSize,
+      outcome:
+        parsed.outcome === 'claimed' || parsed.outcome === 'waitlisted' ? parsed.outcome : null,
+      propertySlug: typeof parsed.propertySlug === 'string' ? parsed.propertySlug : null,
     };
   } catch {
     return { ...DEFAULTS };
@@ -164,6 +172,10 @@ export interface ApplyState {
 
   done: boolean; setDone: (b: boolean) => void;
 
+  // Wedge #5 — waitlist outcome, persisted so StepConfirm CTA survives a reload.
+  outcome: 'claimed' | 'waitlisted' | null; setOutcome: (v: 'claimed' | 'waitlisted' | null) => void;
+  propertySlug: string | null; setPropertySlug: (v: string | null) => void;
+
   // FROZEN CONTRACT 2 — payment wizard
   adults: number; setAdults: (n: number) => void;
   paymentTotal: string; // computed from adults; not settable directly
@@ -205,6 +217,8 @@ export function useWizState() {
   const [intentHouseholdSize, setIntentHouseholdSizeRaw] = useState<number>(
     initial.intentHouseholdSize,
   );
+  const [outcome, setOutcomeRaw] = useState<'claimed' | 'waitlisted' | null>(initial.outcome);
+  const [propertySlug, setPropertySlugRaw] = useState<string | null>(initial.propertySlug);
 
   useEffect(() => {
     writePersisted({
@@ -216,6 +230,8 @@ export function useWizState() {
       qualifyingHouseholdSize,
       intentBedrooms,
       intentHouseholdSize,
+      outcome,
+      propertySlug,
     });
   }, [
     adults,
@@ -226,6 +242,8 @@ export function useWizState() {
     qualifyingHouseholdSize,
     intentBedrooms,
     intentHouseholdSize,
+    outcome,
+    propertySlug,
   ]);
 
   return {
@@ -246,5 +264,9 @@ export function useWizState() {
     setIntentBedrooms: setIntentBedroomsRaw,
     intentHouseholdSize,
     setIntentHouseholdSize: setIntentHouseholdSizeRaw,
+    outcome,
+    setOutcome: setOutcomeRaw,
+    propertySlug,
+    setPropertySlug: setPropertySlugRaw,
   };
 }

--- a/client-tenant/src/pages/apply/__tests__/StepPick.test.tsx
+++ b/client-tenant/src/pages/apply/__tests__/StepPick.test.tsx
@@ -1,7 +1,13 @@
-import { describe, it, expect } from 'vitest';
-import { screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { screen, waitFor, fireEvent } from '@testing-library/react';
 import { StepPick } from '../steps/StepPick';
 import { renderWithApply, makeState, mockFetch } from './helpers';
+
+vi.mock('@/api/properties', () => ({
+  joinWaitlist: vi.fn(),
+}));
+
+import * as propertiesApi from '@/api/properties';
 
 describe('StepPick', () => {
   it('renders the title and a loading state when units fetch is in flight', async () => {
@@ -18,6 +24,50 @@ describe('StepPick', () => {
     expect(screen.getByRole('heading', { name: /pick your unit/i })).toBeInTheDocument();
     await waitFor(() => {
       expect(screen.queryByText(/loading units/i)).not.toBeInTheDocument();
+    });
+  });
+
+  it('shows waitlist CTA when zero units, joinWaitlist call sets outcome', async () => {
+    mockFetch({
+      '/applicants/units': { units: [] },
+    });
+    vi.mocked(propertiesApi.joinWaitlist).mockResolvedValue({
+      position: 5,
+      totalQueue: 50,
+      movement: null,
+      estimatedWindow: '3–6 months',
+      expectedNotificationWindow: '3–6 months',
+      enrolled: true,
+    });
+
+    const setOutcome = vi.fn();
+    const setPropertySlug = vi.fn();
+    const setStep = vi.fn();
+
+    const state = makeState({
+      step: 'pick',
+      intentBedrooms: 2,
+      intentMoveInDate: '2026-06-01',
+      intentBudgetMax: 2000,
+      propertySlug: 'donna-louise-2',
+      setOutcome,
+      setPropertySlug,
+      setStep,
+    });
+
+    renderWithApply(<StepPick />, { state });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('join-waitlist-cta')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('join-waitlist-cta'));
+
+    await waitFor(() => {
+      expect(propertiesApi.joinWaitlist).toHaveBeenCalledWith('donna-louise-2', 2);
+      expect(setPropertySlug).toHaveBeenCalledWith('donna-louise-2');
+      expect(setOutcome).toHaveBeenCalledWith('waitlisted');
+      expect(setStep).toHaveBeenCalledWith('confirm');
     });
   });
 });

--- a/client-tenant/src/pages/apply/__tests__/helpers.tsx
+++ b/client-tenant/src/pages/apply/__tests__/helpers.tsx
@@ -47,6 +47,9 @@ export function makeState(overrides: Partial<ApplyState> = {}): ApplyState {
     employerName: '', setEmployerName: noop, annualIncome: '', setAnnualIncome: noop,
     householdSize: '1', setHouseholdSize: noop, moveInDate: '', setMoveInDate: noop,
     done: false, setDone: noop,
+    // Wedge #5 — waitlist outcome
+    outcome: null, setOutcome: noop,
+    propertySlug: null, setPropertySlug: noop,
     // Contract 2 — wizard slice
     adults: 1, setAdults: noop,
     paymentTotal: '$71.90',

--- a/client-tenant/src/pages/apply/steps/StepPick.tsx
+++ b/client-tenant/src/pages/apply/steps/StepPick.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { Loader2 } from 'lucide-react';
 import { fetchUnits, claimUnit, type Unit } from '@/api/units';
+import { joinWaitlist } from '@/api/properties';
 import { UnitCard, type UnitMismatch } from '@/components/UnitCard';
 import { useApply } from '../ApplyContext';
 import { useTranslation } from 'react-i18next';
@@ -95,6 +96,8 @@ export function StepPick() {
   const { t, i18n } = useTranslation('apply');
   const [isFallback, setIsFallback] = useState(false);
   const [intentSnapshot, setIntentSnapshot] = useState<IntentSnapshot | null>(null);
+  const [waitlistJoining, setWaitlistJoining] = useState(false);
+  const [waitlistError, setWaitlistError] = useState<string | null>(null);
 
   useEffect(() => {
     if (s.intentBedrooms === null || !s.intentMoveInDate) {
@@ -171,6 +174,23 @@ export function StepPick() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [s.intentBedrooms, s.intentBudgetMax, s.intentMoveInDate, s.qualifyingAmiTier]);
 
+  async function handleJoinWaitlist() {
+    const slug = s.propertySlug ?? 'donna-louise-2';
+    const bedrooms = s.intentBedrooms ?? 1;
+    setWaitlistJoining(true);
+    setWaitlistError(null);
+    try {
+      await joinWaitlist(slug, bedrooms);
+      s.setPropertySlug(slug);
+      s.setOutcome('waitlisted');
+      s.setStep('confirm');
+    } catch (err) {
+      setWaitlistError(err instanceof Error ? err.message : (t('pick.waitlistError') as string));
+    } finally {
+      setWaitlistJoining(false);
+    }
+  }
+
   async function handleClaim(unitId: string) {
     s.setClaimingUnitId(unitId);
     s.setError(null);
@@ -223,6 +243,22 @@ export function StepPick() {
           >
             {t('pick.adjust')}
           </button>
+          <div className="mt-3 flex flex-col gap-2">
+            <button
+              onClick={handleJoinWaitlist}
+              disabled={waitlistJoining}
+              className="font-medium underline"
+              style={{ color: HF.accent, textAlign: 'left' }}
+              data-testid="join-waitlist-cta"
+            >
+              {waitlistJoining
+                ? (t('pick.waitlistLoading') as string)
+                : (t('pick.waitlistCta') as string)}
+            </button>
+            {waitlistError && (
+              <span style={{ color: HF.err, fontSize: 12 }}>{waitlistError}</span>
+            )}
+          </div>
         </div>
       ) : (
         <>

--- a/docs/intel/gpmglv-gap-backlog.md
+++ b/docs/intel/gpmglv-gap-backlog.md
@@ -10,7 +10,7 @@ Every row is a wedge — a feature Frank-Pilot can ship where the evidence-based
 | Wedge | Title | Shipped via | Demo surface |
 |---|---|---|---|
 | #2 | W0 AMI prefill (Welcome → Apply → Review) | PR #94 | `StepIntent`, `StepReview` |
-| #5 | Position-aware waitlist — position display surfaced | PR #104 | `StepConfirm` → `/waitlist/position/:slug` CTA (CTA dormant until wizard adds waitlist-join branch — see memory) |
+| #5 | Position-aware waitlist — position display surfaced + waitlist-join branch activated | PR #104 + wedge #5 branch | `StepConfirm` → `/waitlist/position/:slug` CTA (activated 2026-05-22 via wizard zero-units → waitlist branch) |
 | #6 | i18n EN/ES parity + CI guard | PR #91 | All apply steps |
 | #7 | Mobile-first apply UX | PR #79 + #92 | Sticky CTA behind `MOBILE_APPLY_ENABLED` |
 | #14 | Sitemap + robots served as static assets | PR #95 | `vercel.json` negative-lookahead rewrite |
@@ -33,7 +33,7 @@ The ranked table below reflects these shipped statuses inline.
 | 2 | **AMI pre-qualifier (W0)** | "Income-qualified" mentioned, zero AMI tables disclosed (audit §HUD) | `client-tenant/src/lib/ami.ts` + `components/AmiCalculator.tsx` | shipped 2026-05-22 (PR #94) | S–M | 5 | ★★★★★ |
 | 3 | **"Apply button does nothing" demo flip** | property page CTA = `#contact` anchor scroll-jump (audit §Per-Page Dumps) | demo script + landing page mount | none (asset, not feature) | S | 5 | ★★★★★ |
 | 4 | **Unit-claim FTU / "carrot" UX** | No unit-level state anywhere on gpmglv | unit-claim slice (PR #5 merged 2026-05-14, commit 58c1036) | shipped, low visibility | S (amplify) | 4 | ★★★★ |
-| 5 | **Position-aware waitlist** | Submit-and-wait black hole; no position field (audit §Waitlist) | Lane E waitlist banner | shipped 2026-05-22 (PR #104) — position display surfaced via `StepConfirm` CTA; CTA dormant until wizard adds waitlist-join branch | M | 4 | ★★★ |
+| 5 | **Position-aware waitlist** | Submit-and-wait black hole; no position field (audit §Waitlist) | Lane E waitlist banner | shipped 2026-05-22 (PR #104) — position display surfaced via `StepConfirm` CTA (activated 2026-05-22 via wizard zero-units → waitlist branch) | M | 4 | ★★★ |
 | 6 | **EN-ES from day one** | English-only, no language switcher (audit §Per-Page Dumps) | `src/i18n/{en,es}/` scaffold | shipped 2026-05-22 (PR #91) | M | 3 | ★★★ |
 | 7 | **Mobile-first apply UX** | gpmglv site is responsive but apply = #contact = no flow to optimize | `MOBILE_APPLY_ENABLED` flag | shipped 2026-05-22 (PR #79 + #92) | M–L | 3 | ★★ |
 | 8 | **Live unit availability + filter** | 17 property cards, zero rent, zero availability dates (audit §Property Listing) | `client-tenant/src/pages/discover/PropertyList.tsx` | shipped 2026-05-22 — live `/api/properties` wire (PR #105) + GET listing made public so anonymous /discover visitors get live data (this PR); create/update/delete remain auth-gated; deterministic 17-fixture fallback on error | M | 3 | ★★ |


### PR DESCRIPTION
## Summary

- **Fixes dormant CTA**: PR #104 wired the `StepConfirm` "Check your position →" CTA for `outcome === 'waitlisted'`, but no upstream step ever set that outcome. This PR adds that branch.
- **Zero-units path**: When `StepPick` finds no available units after progressive relaxation, a second CTA "Join the waitlist instead" now appears next to the existing "Adjust your search" button. Clicking it calls `joinWaitlist(slug, bedrooms)`, then sets `outcome = 'waitlisted'` and advances to `StepConfirm`, where the dormant CTA activates.
- **Context persistence**: `outcome` and `propertySlug` are persisted to `sessionStorage` so the CTA survives a page reload on the confirm step.

## Ambiguity note

The apply wizard has no native `slug` concept (it uses `property_id` / UUIDs). `PropertyDetail.tsx` passes `propertyId: slug` in the `/apply?propertyId=` query param; `Apply.tsx` now reads that on mount as the initial `propertySlug`. When the param is absent (e.g., direct `/apply` entry), the handler falls back to `'donna-louise-2'` (the only fixture in the system). A real-slug wire-up from the units API is a follow-up if needed.

## Backlog

Wedge #5 in `docs/intel/gpmglv-gap-backlog.md` updated — "(CTA dormant…)" parenthetical removed.

## Test plan

- [x] `npx tsc --noEmit` — only pre-existing missing-type-defs errors (no new errors)
- [x] `vitest run` — 208 tests pass (all 33 test files), including new regression test
- [x] `vite build` — succeeds, 1714 modules transformed
- [x] `node scripts/check-i18n-parity.mjs` — EN-ES parity clean, 0 missing keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)