### PR TITLE
feat(claim): 24h countdown on ClaimedUnitHeader (wedge #4 amp)

### DIFF
--- a/client-tenant/src/components/ClaimedUnitHeader.tsx
+++ b/client-tenant/src/components/ClaimedUnitHeader.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Clock } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import type { Unit } from '@/api/units';
 import { getUnitPhoto } from '@/utils/unitPlaceholder';
 import { HF } from '@/styles/tokens';
@@ -14,25 +15,27 @@ function formatRent(rent: string | number): string {
   return `$${Math.round(n).toLocaleString()}/mo`;
 }
 
-function formatCountdown(ms: number): string {
-  if (ms <= 0) return '00:00:00';
-  const total = Math.floor(ms / 1000);
-  const h = String(Math.floor(total / 3600)).padStart(2, '0');
-  const m = String(Math.floor((total % 3600) / 60)).padStart(2, '0');
-  const s = String(total % 60).padStart(2, '0');
-  return `${h}:${m}:${s}`;
-}
-
 export function ClaimedUnitHeader({ unit, expiresAt }: Props) {
+  const { t } = useTranslation('apply');
   const [now, setNow] = useState(() => Date.now());
 
   useEffect(() => {
-    const interval = setInterval(() => setNow(Date.now()), 1000);
+    const interval = setInterval(() => setNow(Date.now()), 60_000);
     return () => clearInterval(interval);
   }, []);
 
   const remaining = new Date(expiresAt).getTime() - now;
   const photo = getUnitPhoto(unit.photo_url);
+  const isExpired = remaining <= 0;
+
+  const countdownLabel = isExpired
+    ? t('claim.expired')
+    : (() => {
+        const totalMinutes = Math.floor(remaining / 60_000);
+        const hours = Math.floor(totalMinutes / 60);
+        const minutes = totalMinutes % 60;
+        return t('claim.expiresIn', { hours, minutes });
+      })();
 
   return (
     <div
@@ -63,16 +66,20 @@ export function ClaimedUnitHeader({ unit, expiresAt }: Props) {
         <div className="flex flex-col items-end">
           <div
             className="inline-flex items-center gap-1 text-xs"
-            style={{ color: HF.accentInk }}
+            style={{ color: isExpired ? HF.ink3 : HF.accentInk }}
           >
-            <Clock className="h-3 w-3" />
-            <span className="font-mono font-medium" style={{ fontFamily: HF.mono }}>
-              {formatCountdown(remaining)}
+            {!isExpired && <Clock className="h-3 w-3" />}
+            <span
+              data-testid="claim-countdown"
+              className="font-medium"
+              style={{ fontFamily: isExpired ? HF.body : HF.mono }}
+            >
+              {countdownLabel}
             </span>
           </div>
           <div
             className="text-[10px] uppercase tracking-wide"
-            style={{ color: HF.accent }}
+            style={{ color: isExpired ? HF.ink3 : HF.accent }}
           >
             held
           </div>

--- a/client-tenant/src/components/__tests__/ClaimedUnitHeader.test.tsx
+++ b/client-tenant/src/components/__tests__/ClaimedUnitHeader.test.tsx
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ClaimedUnitHeader } from '../ClaimedUnitHeader';
+import type { Unit } from '@/api/units';
+
+const unit: Unit = {
+  id: 'unit-abc123',
+  property_id: 'prop-1',
+  unit_number: '101',
+  bedrooms: 1,
+  bathrooms: '1',
+  sqft: 650,
+  monthly_rent: '1200',
+  photo_url: null,
+  available_from: null,
+  property_name: 'Sunrise Apartments',
+  property_city: 'Las Vegas',
+  property_state: 'NV',
+};
+
+describe('ClaimedUnitHeader', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders "expires in 23h 30m" when 23.5h remain', () => {
+    const now = Date.now();
+    vi.setSystemTime(now);
+    const remainingMs = (23 * 60 + 30) * 60 * 1000; // 23h 30m in ms
+    const expiresAt = new Date(now + remainingMs).toISOString();
+
+    render(<ClaimedUnitHeader unit={unit} expiresAt={expiresAt} />);
+
+    expect(screen.getByTestId('claim-countdown')).toHaveTextContent(
+      'expires in 23h 30m',
+    );
+  });
+
+  it('renders "expired" when expiresAt is in the past', () => {
+    const now = Date.now();
+    vi.setSystemTime(now);
+    const expiresAt = new Date(now - 60_000).toISOString(); // 1 min ago
+
+    render(<ClaimedUnitHeader unit={unit} expiresAt={expiresAt} />);
+
+    expect(screen.getByTestId('claim-countdown')).toHaveTextContent('expired');
+  });
+
+  it('renders the unit property name and unit number', () => {
+    const expiresAt = new Date(Date.now() + 24 * 3600 * 1000).toISOString();
+    render(<ClaimedUnitHeader unit={unit} expiresAt={expiresAt} />);
+
+    expect(screen.getByText(/sunrise apartments/i)).toBeInTheDocument();
+    expect(screen.getByText(/unit 101/i)).toBeInTheDocument();
+  });
+
+  it('renders the monthly rent formatted correctly', () => {
+    const expiresAt = new Date(Date.now() + 24 * 3600 * 1000).toISOString();
+    render(<ClaimedUnitHeader unit={unit} expiresAt={expiresAt} />);
+
+    expect(screen.getByText('$1,200/mo')).toBeInTheDocument();
+  });
+
+  it('renders "expires in 0h 1m" when 1 minute remains', () => {
+    const now = Date.now();
+    vi.setSystemTime(now);
+    const expiresAt = new Date(now + 90_000).toISOString(); // 1m 30s → floors to 1m
+
+    render(<ClaimedUnitHeader unit={unit} expiresAt={expiresAt} />);
+
+    expect(screen.getByTestId('claim-countdown')).toHaveTextContent(
+      'expires in 0h 1m',
+    );
+  });
+});

--- a/client-tenant/src/i18n/en/apply.json
+++ b/client-tenant/src/i18n/en/apply.json
@@ -116,7 +116,9 @@
     "continue": "Continue your application",
     "pickDifferent": "Pick a different unit",
     "noActive": "No active claim — let's pick a unit.",
-    "startOver": "Start over"
+    "startOver": "Start over",
+    "expiresIn": "expires in {{hours}}h {{minutes}}m",
+    "expired": "expired"
   },
   "details": {
     "title": "Application details",

--- a/client-tenant/src/i18n/es/apply.json
+++ b/client-tenant/src/i18n/es/apply.json
@@ -116,7 +116,9 @@
     "continue": "Continuar tu solicitud",
     "pickDifferent": "Elegir otra unidad",
     "noActive": "Sin reserva activa — vamos a elegir una unidad.",
-    "startOver": "Empezar de nuevo"
+    "startOver": "Empezar de nuevo",
+    "expiresIn": "vence en {{hours}}h {{minutes}}m",
+    "expired": "vencida"
   },
   "details": {
     "title": "Detalles de la solicitud",


### PR DESCRIPTION
## Summary
- Reworks `ClaimedUnitHeader` countdown display from `HH:MM:SS` to human-friendly `expires in {hours}h {minutes}m` format with 60s interval cadence (was 1s)
- Adds `claim.expiresIn` and `claim.expired` i18n keys to `en/apply.json` and `es/apply.json` (parity clean, CI check passes)
- Shows muted `expired` text (no clock icon) when `expiresAt` is in the past
- Adds `ClaimedUnitHeader.test.tsx` with `vi.useFakeTimers()` covering: 23h 30m remaining, past expiry, 0h 1m edge case

## Test plan
- [x] `pnpm vitest run` — 213 tests pass (34 files)
- [x] `npx tsc --noEmit` — no type errors
- [x] `npm run check:i18n` — EN-ES parity clean
- [ ] Visual: confirm countdown reads `expires in Xh Ym` on the claimed-unit sticky header during the apply flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)