### PR TITLE
feat(privacy): gate analytics init on consent (wedge #15 deferred)

### DIFF
--- a/client-tenant/.env.example
+++ b/client-tenant/.env.example
@@ -30,6 +30,13 @@ VITE_SUPABASE_PUBLISHABLE_KEY=
 # main bundle untouched.
 VITE_QA_SESSION_REPLAY_ENABLED=
 
+# Analytics vendor (wedge #15 — analytics is consent-gated).
+# Supported values: 'none' (default, no-op) | 'plausible'
+# When set to 'plausible', analytics will initialise only for users who have
+# accepted the analytics consent category.  Add the real Plausible snippet
+# to src/lib/analytics.ts before flipping this in production.
+VITE_ANALYTICS_VENDOR=none
+
 # Cloudflare Turnstile site key (wedge #13 — anti-spam on public forms).
 # The dev key below renders the widget in pass-through mode and synchronously
 # yields a `test-token-dev` token so the Welcome → Claim smoke stays green

--- a/client-tenant/src/App.tsx
+++ b/client-tenant/src/App.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { Routes, Route, Navigate } from 'react-router-dom';
 import { AuthGuard } from '@/components/AuthGuard';
 import { Layout } from '@/components/Layout';
@@ -23,12 +24,23 @@ import { SiteFooter } from '@/components/SiteFooter';
 import { PrivacyPolicy } from '@/pages/legal/PrivacyPolicy';
 import { CookiesPolicy } from '@/pages/legal/CookiesPolicy';
 import { getToken } from '@/api/client';
+import { initAnalytics, watchConsentAndInit } from '@/lib/analytics';
 
 function RootRedirect() {
   return <Navigate to={getToken() ? '/dashboard' : '/login'} replace />;
 }
 
 export default function App() {
+  // gpmglv wedge #15 — gate analytics on consent.
+  // Run once on mount (covers users who already accepted before this load),
+  // then subscribe so a user who accepts mid-session gets tracked without a
+  // reload.
+  useEffect(() => {
+    initAnalytics();
+    const unsubscribe = watchConsentAndInit();
+    return unsubscribe;
+  }, []);
+
   return (
     <>
     <Routes>

--- a/client-tenant/src/lib/__tests__/analytics.test.ts
+++ b/client-tenant/src/lib/__tests__/analytics.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// We re-import the module fresh between tests so module-level state
+// (`initialised`) resets correctly.
+async function loadAnalytics() {
+  vi.resetModules();
+  return await import('../analytics');
+}
+
+// ── Consent store helpers ────────────────────────────────────────────────────
+// We mock the consent store so tests don't depend on localStorage.
+
+vi.mock('@/state/consent', () => {
+  let analyticsConsent: boolean | undefined = undefined;
+  const listeners = new Set<() => void>();
+
+  return {
+    getConsentSnapshot: () => ({ analytics: analyticsConsent }),
+    subscribe: (fn: () => void) => {
+      listeners.add(fn);
+      return () => listeners.delete(fn);
+    },
+    // test helpers (not exported by the real module, only used here)
+    __setAnalyticsConsent: (v: boolean | undefined) => {
+      analyticsConsent = v;
+      for (const l of listeners) l();
+    },
+  };
+});
+
+// Grab the test helper from the mocked module
+async function setAnalyticsConsent(v: boolean | undefined) {
+  const mod = await import('@/state/consent');
+  (mod as { __setAnalyticsConsent: (v: boolean | undefined) => void }).__setAnalyticsConsent(v);
+}
+
+describe('analytics — consent gate', () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+    vi.spyOn(console, 'info').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  describe('initAnalytics()', () => {
+    it('is a no-op when analytics consent is undefined (unset)', async () => {
+      await setAnalyticsConsent(undefined);
+      vi.stubEnv('VITE_ANALYTICS_VENDOR', 'plausible');
+      const { initAnalytics } = await loadAnalytics();
+
+      initAnalytics();
+
+      expect(console.info).not.toHaveBeenCalled();
+    });
+
+    it('is a no-op when analytics consent is false (rejected)', async () => {
+      await setAnalyticsConsent(false);
+      vi.stubEnv('VITE_ANALYTICS_VENDOR', 'plausible');
+      const { initAnalytics } = await loadAnalytics();
+
+      initAnalytics();
+
+      expect(console.info).not.toHaveBeenCalled();
+    });
+
+    it('initialises the plausible stub when consent is true and vendor = plausible', async () => {
+      await setAnalyticsConsent(true);
+      vi.stubEnv('VITE_ANALYTICS_VENDOR', 'plausible');
+      const { initAnalytics } = await loadAnalytics();
+
+      initAnalytics();
+
+      expect(console.info).toHaveBeenCalledWith('[analytics] plausible would init now');
+    });
+
+    it('is a no-op when vendor = none even if consent is true', async () => {
+      await setAnalyticsConsent(true);
+      vi.stubEnv('VITE_ANALYTICS_VENDOR', 'none');
+      const { initAnalytics } = await loadAnalytics();
+
+      initAnalytics();
+
+      expect(console.info).not.toHaveBeenCalled();
+    });
+
+    it('does not init twice if called multiple times', async () => {
+      await setAnalyticsConsent(true);
+      vi.stubEnv('VITE_ANALYTICS_VENDOR', 'plausible');
+      const { initAnalytics } = await loadAnalytics();
+
+      initAnalytics();
+      initAnalytics();
+
+      expect(console.info).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('trackEvent()', () => {
+    it('is a no-op before init (no consent)', async () => {
+      await setAnalyticsConsent(undefined);
+      vi.stubEnv('VITE_ANALYTICS_VENDOR', 'plausible');
+      const { trackEvent } = await loadAnalytics();
+
+      trackEvent('page_view', { path: '/apply' });
+
+      expect(console.info).not.toHaveBeenCalled();
+    });
+
+    it('logs event info after init with plausible', async () => {
+      await setAnalyticsConsent(true);
+      vi.stubEnv('VITE_ANALYTICS_VENDOR', 'plausible');
+      const { initAnalytics, trackEvent } = await loadAnalytics();
+
+      initAnalytics();
+      vi.mocked(console.info).mockClear(); // clear the init log
+
+      trackEvent('page_view', { path: '/dashboard' });
+
+      expect(console.info).toHaveBeenCalledWith(
+        '[analytics] trackEvent',
+        'page_view',
+        { path: '/dashboard' },
+      );
+    });
+  });
+
+  describe('watchConsentAndInit()', () => {
+    it('calls initAnalytics when consent changes to accepted', async () => {
+      await setAnalyticsConsent(undefined);
+      vi.stubEnv('VITE_ANALYTICS_VENDOR', 'plausible');
+      const { watchConsentAndInit } = await loadAnalytics();
+
+      const unsubscribe = watchConsentAndInit();
+
+      // Simulate user accepting analytics consent
+      await setAnalyticsConsent(true);
+
+      expect(console.info).toHaveBeenCalledWith('[analytics] plausible would init now');
+
+      unsubscribe();
+    });
+
+    it('returns an unsubscribe function that stops future calls', async () => {
+      await setAnalyticsConsent(undefined);
+      vi.stubEnv('VITE_ANALYTICS_VENDOR', 'plausible');
+      const { watchConsentAndInit } = await loadAnalytics();
+
+      const unsubscribe = watchConsentAndInit();
+      unsubscribe();
+
+      // Even though consent is now accepted, unsubscribed so no init
+      await setAnalyticsConsent(true);
+
+      expect(console.info).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/client-tenant/src/lib/analytics.ts
+++ b/client-tenant/src/lib/analytics.ts
@@ -1,0 +1,85 @@
+/**
+ * Analytics initialisation gate (gpmglv wedge #15 — deferred work).
+ *
+ * Analytics is consent-gated: `initAnalytics()` is a no-op unless the user
+ * has accepted the `analytics` consent category.  Calling it on every consent
+ * change (via the `useEffect` in App.tsx) means a user who accepts after page
+ * load gets instrumented without a reload.
+ *
+ * Vendor selection is controlled by `VITE_ANALYTICS_VENDOR`.  Currently only
+ * `'plausible'` and `'none'` (default) are handled.  Add new cases here when
+ * a tracker is adopted — consent gating stays in place automatically.
+ */
+
+import { getConsentSnapshot, subscribe } from '@/state/consent';
+
+type Vendor = 'plausible' | 'none';
+
+let initialised = false;
+
+function resolveVendor(): Vendor {
+  const raw = (import.meta.env.VITE_ANALYTICS_VENDOR ?? 'none').trim();
+  if (raw === 'plausible') return 'plausible';
+  return 'none';
+}
+
+/**
+ * Initialise the analytics vendor, but only when the user has accepted the
+ * `analytics` consent category.  Safe to call multiple times — subsequent
+ * calls after a successful init are no-ops.
+ */
+export function initAnalytics(): void {
+  const consent = getConsentSnapshot();
+  if (consent.analytics !== true) return;
+  if (initialised) return;
+
+  const vendor = resolveVendor();
+  switch (vendor) {
+    case 'plausible':
+      // When a real Plausible snippet is added, replace this stub with the
+      // actual script-injection / `window.plausible` setup.
+      console.info('[analytics] plausible would init now');
+      initialised = true;
+      break;
+    case 'none':
+    default:
+      // No vendor configured — intentional no-op.
+      break;
+  }
+}
+
+/**
+ * Track a named event with optional properties.
+ *
+ * No-ops silently if analytics was never initialised (vendor = 'none', or
+ * the user has not accepted analytics).
+ */
+export function trackEvent(
+  name: string,
+  props?: Record<string, string | number | boolean>,
+): void {
+  if (!initialised) return;
+
+  const vendor = resolveVendor();
+  switch (vendor) {
+    case 'plausible':
+      // Replace with `window.plausible(name, { props })` once the real
+      // snippet is injected.
+      console.info('[analytics] trackEvent', name, props);
+      break;
+    default:
+      break;
+  }
+}
+
+/**
+ * Subscribe to consent changes so analytics is initialised as soon as the
+ * user accepts, without requiring a page reload.  Returns an unsubscribe fn.
+ *
+ * Called once from App.tsx; exported for testing.
+ */
+export function watchConsentAndInit(): () => void {
+  return subscribe(() => {
+    initAnalytics();
+  });
+}

--- a/client-tenant/src/state/consent.ts
+++ b/client-tenant/src/state/consent.ts
@@ -107,7 +107,13 @@ function emit(): void {
   for (const l of listeners) l();
 }
 
-function subscribe(listener: () => void): () => void {
+/**
+ * Subscribe to consent state changes.  Exported so non-hook code (e.g.
+ * `lib/analytics.ts` for the wedge #15 analytics gate) can react to the
+ * user accepting/rejecting categories mid-session without subscribing via
+ * React.  Returns an unsubscribe function.
+ */
+export function subscribe(listener: () => void): () => void {
   listeners.add(listener);
   return () => {
     listeners.delete(listener);

--- a/docs/intel/gpmglv-gap-backlog.md
+++ b/docs/intel/gpmglv-gap-backlog.md
@@ -16,7 +16,7 @@ Every row is a wedge — a feature Frank-Pilot can ship where the evidence-based
 | #14 | Sitemap + robots served as static assets | PR #95 | `vercel.json` negative-lookahead rewrite |
 | #8 | Live unit availability + filter | PR #105 + PR #119 | `PropertyList.tsx` → live `GET /api/properties` with `amiTier` / `bedroom` / `availability` params; GET listing is **public** so anonymous gpmglv-demo visitors see live data (create/update/delete remain auth-gated); deterministic GPMG fallback on error |
 | #9 | Honest pricing / AMI disclosure on listings | inline (no separate PR) | `PropertyList.tsx` tile rent buckets (`formatRentBucket()`) + AMI tier chip (`t('amiTier.label')`) + `UnitCard.tsx` unit detail |
-| #15 | Cookie banner / GDPR posture | inline (no separate PR) | `state/consent.ts` (localStorage `fp.consent.v1`, useConsent hook) + `components/CookieBanner.tsx` (bottom-fixed, Esc→rejectAll, i18n `legal.*`) |
+| #15 | Cookie banner / GDPR posture + analytics gate | inline (no separate PR) + feat/wedge-15-analytics-consent | `state/consent.ts` (localStorage `fp.consent.v1`, useConsent hook) + `components/CookieBanner.tsx` (bottom-fixed, Esc→rejectAll, i18n `legal.*`) + `lib/analytics.ts` (consent-gated vendor init, `VITE_ANALYTICS_VENDOR` flag) |
 
 The ranked table below reflects these shipped statuses inline.
 
@@ -45,7 +45,7 @@ The ranked table below reflects these shipped statuses inline.
 | 12 | **Resident portal: rent pay / docs / lease** | gpmglv `/portal` = maintenance + message + lookup only (audit §Tenant Login) | NEW | none (stage 2, post-move-in) | L | 2 | ★ |
 | 13 | **Anti-spam (Turnstile / rate-limit)** | Waitlist + contact forms have no visible captcha (audit §Per-Page Dumps) | server-side rate limit + Turnstile/hCaptcha | none | S–M | 1 | ★ |
 | 14 | **SEO / sitemap / JSON-LD** | `robots.txt` 404, `sitemap.xml` 404 (audit §Robots/Sitemap) | infra | partial — sitemap+robots static-serve fixed 2026-05-22 (PR #95) | S | 1 | ★ |
-| 15 | **Cookie banner / GDPR posture** | No `Set-Cookie` observed, thin privacy policy (audit §Cookies) | NEW | shipped 2026-05-22 | S | 1 | ★ |
+| 15 | **Cookie banner / GDPR posture** | No `Set-Cookie` observed, thin privacy policy (audit §Cookies) | NEW | shipped 2026-05-22; analytics gate shipped feat/wedge-15-analytics-consent | S | 1 | ★ |
 
 ## Top-5 detail
 


### PR DESCRIPTION
## Summary

- Adds `client-tenant/src/lib/analytics.ts`: consent-gated analytics initialisation. `initAnalytics()` is a no-op unless `consent.analytics === true` (set via the existing cookie banner / `fp.consent.v1` store). Vendor is selected via **`VITE_ANALYTICS_VENDOR`** — set to `'plausible'` to activate the Plausible stub, `'none'` (default) for no-op.
- `trackEvent(name, props)` silently no-ops if analytics was never initialised, so call-sites can be wired ahead of a real tracker being picked.
- `App.tsx` wires a mount-time `useEffect` that calls `initAnalytics()` once (covers users who already accepted) and subscribes via `watchConsentAndInit()` so a user who accepts the banner mid-session gets tracked without a page reload.
- `client-tenant/.env.example` documents `VITE_ANALYTICS_VENDOR=none` — flip path for the team.
- `docs/intel/gpmglv-gap-backlog.md` row #15 updated to reflect the deferred analytics gate is now shipped.
- Unit tests in `src/lib/__tests__/analytics.test.ts` cover: no-op when consent is undefined/false, init fires when consent is true, double-init guard, `trackEvent` before/after init, `watchConsentAndInit` subscribe/unsubscribe.

## Flip path

To enable Plausible (or any future vendor):
1. Set `VITE_ANALYTICS_VENDOR=plausible` on Vercel.
2. Replace the `console.info` stub in `analytics.ts` with the real Plausible snippet injection.
3. No other changes needed — consent gating stays in place automatically.

## Test plan

- [ ] `pnpm vitest run` passes (new analytics tests green, existing 207 tests unaffected)
- [ ] With `VITE_ANALYTICS_VENDOR=none` (default), no `[analytics]` logs appear in console regardless of consent state
- [ ] With `VITE_ANALYTICS_VENDOR=plausible` and consent accepted, `[analytics] plausible would init now` logs once on mount
- [ ] Accepting the cookie banner mid-session triggers init without reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)