### PR TITLE
sec: follow-up to #99 + #101 — NODE_ENV-gated CORS + jwt/cvv redaction

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,9 +10,12 @@ DB_PASSWORD=changeme
 PORT=3000
 NODE_ENV=development
 
-# CORS — required. Comma-separated list of allowed origins. In prod set via Railway env.
-# Example: CORS_ORIGIN=https://frank-pilot-tenant.vercel.app,https://staff.example.com
-# Backend exits at startup if this is unset (HIGH-2, SECURITY-AUDIT-2026-05-21).
+# CORS — required in production AND staging. Comma-separated list of allowed
+# origins. Set via Railway env. Example:
+#   CORS_ORIGIN=https://frank-pilot-tenant.vercel.app,https://staff.example.com
+# In production the backend exits at startup if this is unset (HIGH-2,
+# SECURITY-AUDIT-2026-05-21). In dev/test the backend falls back to localhost
+# (5174 + 3000) — see src/utils/cors-origin.ts.
 CORS_ORIGIN=http://localhost:5174
 
 # JWT

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import express from "express";
 import cors from "cors";
 import helmet from "helmet";
 import { logger } from "./utils/logger";
+import { resolveCorsOrigin } from "./utils/cors-origin";
 import { authenticate, login, AuthRequest } from "./middleware/auth";
 import { requirePermission } from "./middleware/rbac";
 import { queryAuditLog } from "./middleware/audit";
@@ -55,13 +56,18 @@ const PORT = parseInt(process.env.PORT || "3000");
 
 // Security middleware
 app.use(helmet());
-// HIGH-2 (SECURITY-AUDIT-2026-05-21): fail closed on CORS — refuse to boot
-// without an explicit allow-list. Wildcard fallback removed.
-const corsOrigin = process.env.CORS_ORIGIN;
-if (!corsOrigin) {
-  throw new Error("CORS_ORIGIN is required (no wildcard fallback)");
+// HIGH-2 (SECURITY-AUDIT-2026-05-21): fail closed on CORS — production
+// refuses to boot without an explicit allow-list (mirrors the JWT_SECRET /
+// ENCRYPTION_KEY gate above). Dev/test fall back to localhost so `npm start`
+// works out of the box. See src/utils/cors-origin.ts + unit tests.
+let corsOrigins: string[];
+try {
+  corsOrigins = resolveCorsOrigin(process.env);
+} catch (err) {
+  console.error((err as Error).message);
+  process.exit(1);
 }
-app.use(cors({ origin: corsOrigin.split(",").map((s) => s.trim()) }));
+app.use(cors({ origin: corsOrigins }));
 app.use(express.json({ limit: "1mb" }));
 
 // Request logging (PII-safe)

--- a/src/utils/__tests__/cors-origin.test.ts
+++ b/src/utils/__tests__/cors-origin.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Tests for resolveCorsOrigin (#99 follow-up).
+ *
+ * The original PR #99 fix threw unconditionally on missing CORS_ORIGIN —
+ * crashing `npm start` in local dev. This helper restores dev ergonomics
+ * while keeping production fail-closed.
+ */
+
+import { resolveCorsOrigin } from "../cors-origin";
+
+describe("resolveCorsOrigin", () => {
+  it("throws in production when CORS_ORIGIN is unset", () => {
+    expect(() =>
+      resolveCorsOrigin({ NODE_ENV: "production" } as NodeJS.ProcessEnv)
+    ).toThrow(/CORS_ORIGIN is required in production/);
+  });
+
+  it("throws in production when CORS_ORIGIN is empty/whitespace", () => {
+    expect(() =>
+      resolveCorsOrigin({
+        NODE_ENV: "production",
+        CORS_ORIGIN: "   ",
+      } as NodeJS.ProcessEnv)
+    ).toThrow(/CORS_ORIGIN is required in production/);
+  });
+
+  it("returns localhost defaults in dev when CORS_ORIGIN is unset", () => {
+    const result = resolveCorsOrigin({
+      NODE_ENV: "development",
+    } as NodeJS.ProcessEnv);
+    expect(result).toEqual([
+      "http://localhost:5174",
+      "http://localhost:3000",
+    ]);
+  });
+
+  it("returns localhost defaults in test when CORS_ORIGIN is unset", () => {
+    const result = resolveCorsOrigin({
+      NODE_ENV: "test",
+    } as NodeJS.ProcessEnv);
+    expect(result).toEqual([
+      "http://localhost:5174",
+      "http://localhost:3000",
+    ]);
+  });
+
+  it("parses explicit single CORS_ORIGIN value", () => {
+    const result = resolveCorsOrigin({
+      NODE_ENV: "production",
+      CORS_ORIGIN: "https://frank-pilot-tenant.vercel.app",
+    } as NodeJS.ProcessEnv);
+    expect(result).toEqual(["https://frank-pilot-tenant.vercel.app"]);
+  });
+
+  it("parses explicit comma-separated CORS_ORIGIN list", () => {
+    const result = resolveCorsOrigin({
+      NODE_ENV: "production",
+      CORS_ORIGIN: "https://frank-pilot-tenant.vercel.app, https://staff.example.com",
+    } as NodeJS.ProcessEnv);
+    expect(result).toEqual([
+      "https://frank-pilot-tenant.vercel.app",
+      "https://staff.example.com",
+    ]);
+  });
+
+  it("respects explicit CORS_ORIGIN even in dev", () => {
+    const result = resolveCorsOrigin({
+      NODE_ENV: "development",
+      CORS_ORIGIN: "http://localhost:9999",
+    } as NodeJS.ProcessEnv);
+    expect(result).toEqual(["http://localhost:9999"]);
+  });
+});

--- a/src/utils/__tests__/logger.test.ts
+++ b/src/utils/__tests__/logger.test.ts
@@ -175,6 +175,62 @@ describe("logger PII redaction (LOW-1)", () => {
     expect(capture.lines[0].requestId).toBe("req-1");
   });
 
+  it("redacts jwt and cvv keys (Opus REQUEST_CHANGES on PR #101)", async () => {
+    const { logger, capture } = buildTestLogger();
+
+    await logAndWait(logger, capture, () =>
+      logger.info("payment event", {
+        jwt: "eyJhbGciOiJIUzI1NiJ9.payload.sig",
+        cvv: "123",
+        amount: 50,
+      })
+    );
+
+    expect(capture.lines).toHaveLength(1);
+    expect(capture.lines[0].jwt).toBe("[REDACTED]");
+    expect(capture.lines[0].cvv).toBe("[REDACTED]");
+    expect(capture.lines[0].amount).toBe(50);
+  });
+
+  it("matches PII keys case-insensitively (Email, SSN, DOB uppercase)", async () => {
+    const { logger, capture } = buildTestLogger();
+
+    await logAndWait(logger, capture, () =>
+      logger.info("mixed-case event", {
+        Email: "Alex@Example.com",
+        SSN: "111-22-3333",
+        DOB: "1990-01-01",
+        UserID: "u-1",
+      })
+    );
+
+    expect(capture.lines).toHaveLength(1);
+    expect(capture.lines[0].Email).toBe("[REDACTED]");
+    expect(capture.lines[0].SSN).toBe("[REDACTED]");
+    expect(capture.lines[0].DOB).toBe("[REDACTED]");
+    expect(capture.lines[0].UserID).toBe("u-1");
+  });
+
+  it("recurses into 3-level-deep nested metadata", async () => {
+    const { logger, capture } = buildTestLogger();
+
+    await logAndWait(logger, capture, () =>
+      logger.info("deep event", {
+        outer: {
+          middle: {
+            inner: { email: "deep@example.com", id: "x-1" },
+          },
+        },
+      })
+    );
+
+    expect(capture.lines).toHaveLength(1);
+    const middle = (capture.lines[0].outer as Record<string, unknown>).middle as Record<string, unknown>;
+    const inner = middle.inner as Record<string, unknown>;
+    expect(inner.email).toBe("[REDACTED]");
+    expect(inner.id).toBe("x-1");
+  });
+
   it("does NOT walk array elements (documents known gap from pii-filter.ts:56)", async () => {
     // sanitizeObject deliberately skips arrays (`!Array.isArray(value)`).
     // This test pins that behavior so a future fix is a conscious change,

--- a/src/utils/cors-origin.ts
+++ b/src/utils/cors-origin.ts
@@ -1,0 +1,24 @@
+/**
+ * Boot-time CORS allow-list resolution.
+ *
+ * #99 follow-up (HIGH-2, SECURITY-AUDIT-2026-05-21): the original fix threw
+ * unconditionally when CORS_ORIGIN was unset, crashing `npm start` in local
+ * dev. Mirror the NODE_ENV gate used for JWT_SECRET / ENCRYPTION_KEY in
+ * src/index.ts: fail-closed in production, fall back to localhost in dev/test.
+ *
+ * Staging must set CORS_ORIGIN explicitly via Railway env — see .env.example.
+ */
+export function resolveCorsOrigin(env: NodeJS.ProcessEnv): string[] {
+  const raw = env.CORS_ORIGIN?.trim();
+  if (raw) {
+    return raw
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean);
+  }
+  if (env.NODE_ENV === "production") {
+    throw new Error("CORS_ORIGIN is required in production (no wildcard fallback)");
+  }
+  // Dev/test default: Vite dev server (5174) + API self-origin (3000).
+  return ["http://localhost:5174", "http://localhost:3000"];
+}

--- a/src/utils/pii-filter.ts
+++ b/src/utils/pii-filter.ts
@@ -24,6 +24,11 @@ const PII_KEYS = [
   "password",
   "secret",
   "token",
+  // Opus review on PR #101: `token` does not substring-match `jwt`, and the
+  // creditCard family does not cover `cvv`. A metadata key literally named
+  // `jwt` or `cvv` would have leaked. Add both explicitly.
+  "jwt",
+  "cvv",
   "date_of_birth",
   "dateOfBirth",
   "dob",


### PR DESCRIPTION
## Summary

Both #99 (HIGH-2) and #101 (LOW-1) merged before the Opus review's REQUEST_CHANGES landed. This consolidates the follow-up.

### #99 follow-up: NODE_ENV-gate CORS fail-closed
- `src/index.ts:60-63` had an unconditional `throw new Error("CORS_ORIGIN is required...")`. That crashes `npm start` in local dev without CORS_ORIGIN.
- Mirror the JWT_SECRET / ENCRYPTION_KEY gate (`src/index.ts:43-51`): **prod exits, dev/test fall back to localhost** (5174 + 3000).
- Extracted into `src/utils/cors-origin.ts` so the boot-time logic is unit-testable (7 cases).
- `.env.example` updated to clarify staging also needs CORS_ORIGIN; documents the dev/test localhost fallback.

### #101 follow-up: jwt + cvv + nesting + case-insens tests
- `{ jwt: ... }` did not substring-match `token`; `{ cvv: ... }` was not covered by the creditCard family. Both metadata shapes were leaking. Added explicitly to `PII_KEYS`.
- Added 3 tests: jwt/cvv redaction (the Opus blocker), case-insensitive matching (Email/SSN/DOB), and 3-level-deep recursion.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `jest src/utils/__tests__/logger.test.ts src/utils/__tests__/cors-origin.test.ts` — 18/18 pass (11 logger + 7 cors-origin)
- [ ] CI: api (tsc+jest), client-tenant build, check-i18n, smoke-apply — should all stay green
- [ ] Local smoke: `npm start` with CORS_ORIGIN unset → boots cleanly on localhost (regression check for the dev crash)
- [ ] Local smoke: `NODE_ENV=production npm start` with CORS_ORIGIN unset → exits with clear message

## Refs
- SECURITY-AUDIT-2026-05-21 (HIGH-2, LOW-1)
- PR #99 (CORS fail-closed) — merged 8603702 ← addressed here
- PR #101 (PII log redaction) — merged 7ac96e8 ← addressed here