### PR TITLE
test(e2e): Playwright apply/discover harness + qa-drain fixtures

### DIFF
--- a/client-tenant/.gitignore
+++ b/client-tenant/.gitignore
@@ -6,3 +6,8 @@ dist-ssr
 .DS_Store
 tsconfig.tsbuildinfo
 .vercel
+# Playwright (e2e/ — see e2e/README.md)
+test-results/
+playwright-report/
+.playwright/
+playwright/.cache/

--- a/client-tenant/e2e/README.md
+++ b/client-tenant/e2e/README.md
@@ -1,0 +1,117 @@
+# Frank-Pilot tenant portal — Playwright harness
+
+Autonomous Playwright-driven validation for the tenant portal. Lets you
+write small per-feature `*.spec.ts` files and get the same debug bundle the
+in-app camera button produces (PNG + qaBuffer JSON + rrweb replay) attached
+to any failing test.
+
+## Quick start
+
+```bash
+# 1) One-time install (downloads chromium ~150 MB)
+cd client-tenant
+npm install
+npm run e2e:install
+
+# 2) Run the suite
+npm run e2e
+
+# 3) Interactive runner (great for writing new scenarios)
+npm run e2e:ui
+```
+
+`npm run e2e` invokes Playwright's webServer hook, which boots the full
+stack via `npm run e2e:up` at the repo root. The hook is idempotent:
+if Postgres / API / Vite are already running, it reuses them.
+
+## Stack boot
+
+`scripts/e2e-up.mjs` (repo root) does the following:
+
+1. **Postgres** — reuses whatever is already listening on `:5432` (Homebrew /
+   Postgres.app / Docker — any source works). Falls back to
+   `docker compose up -d postgres` only if nothing is up. If neither
+   Postgres nor Docker is present, the script exits with a clear message.
+2. **Migrations** — schema is created from `src/db/schema.ts` on first run.
+   On subsequent runs the schema is detected as initialized and only the
+   delta migrations under `src/db/migrations/*.sql` are re-applied
+   (idempotent — they use `CREATE … IF NOT EXISTS`).
+3. **Seed** — `npm run seed` (always — fast, and ensures `applicantA@cdpc.test`
+   plus the 17-property GPMG catalog exist).
+4. **API** on `:3002` (`PORT=3002 NODE_ENV=development`).
+5. **Vite** on `:5175` (defaults out of the way of the normal `npm run dev`
+   on `:5174`; bind `--host 127.0.0.1` so the health probe doesn't trip
+   over macOS's IPv6-only `localhost`).
+6. Polls `/health` on the API and `/` on Vite before printing `READY`.
+
+It exits when its child processes die. Hit `Ctrl-C` to tear everything
+down (Postgres stays up — that's expected; it's long-lived).
+
+**Auto-discovered DB connection.** When `DATABASE_URL` / `DB_USER` /
+`.env` are all absent, the orchestrator points migrate + seed at
+`localhost:5432`, database `frank_pilot`, user = current OS user. Override
+any of those via the usual env vars to talk to a remote DB.
+
+## Fixtures
+
+Three pre-authenticated `Page` handles from `e2e/fixtures.ts`:
+
+| Fixture | Identity | Lands on |
+|---|---|---|
+| `applicantPage` | fresh `qa+${Date.now()}@example.com`, registered + magic-link verified | `/apply?step=intent` |
+| `seededApplicantPage` | `applicantA@cdpc.test`, past intent + claim | `/apply?step=checklist` |
+| `agentPage` | `agent@cdpc.test` (staff) | `/dashboard` |
+
+Use them like this:
+
+```ts
+import { test, expect } from "../fixtures";
+
+test("bedroom filter narrows results", async ({ seededApplicantPage: page }) => {
+  await page.goto("/discover");
+  await page.getByTestId("chip-bedroom-2").click(); // chips use 'all'|'studio'|'1'|'2'|'3'
+  await expect(page.getByTestId("result-count")).toContainText(/communit/);
+});
+```
+
+## QA debug bundle on failure
+
+`e2e/qaDrain.ts` is wired via `test.afterEach` in `fixtures.ts`. On any
+non-passing test it grabs three files from the page and attaches them
+to the Playwright HTML report (and writes them to `testInfo.outputDir`):
+
+- **`*.json`** — last 25 fetches + JS errors + unhandled rejections (`qaBuffer`).
+- **`*.replay.json`** — rrweb session-replay events, fully masked (inputs, `rr-mask`, `rr-block`, `[data-screenshot-exclude="1"]`).
+- **`*.png`** — `html-to-image` snapshot of `document.body`.
+
+Same shape as the camera-button bundle in `ScreenshotButton.tsx`. Open
+`playwright-report/index.html` after a run to inspect them inline.
+
+## Writing a new scenario
+
+1. Drop a file under `e2e/scenarios/<feature>.spec.ts`.
+2. Import `test, expect` from `../fixtures`.
+3. Pick the lightest fixture that gives you the auth state you need.
+4. Prefer `getByTestId` over text/role selectors — survives i18n + design churn.
+
+## Adding a seeded fixture
+
+`applicantA@cdpc.test` lives in `src/db/seed.ts`. Mirror that block to add
+a `tenant`, `admin`, etc. — keep them additive so the smoke-apply CI gate
+(`scripts/qa-apply-handoff.mjs`) stays untouched.
+
+## Caveats
+
+- **Single worker.** Tests share one DB; parallel writes race. Don't set `fullyParallel: true` until each test acquires its own application via API setup.
+- **Single browser.** Chromium only. Mobile / WebKit projects are a follow-up.
+- **DEV gating.** `window.__qa_drain` and the in-page magic-link `devLink` are gated by `import.meta.env.DEV` / `NODE_ENV === "development"`. Production bundles do not expose them.
+- **No Supabase upload.** The drain writes to local disk only — never uploads to the `frank-qa-screenshots` bucket.
+- **Token lift.** Auth lives in `localStorage` (`frank_tenant_token`). `signInViaDevMagicLink` lifts it onto the BrowserContext's `extraHTTPHeaders` so `page.request.*` calls authenticate the same way the SPA's `fetch` does.
+- **Port choice.** Vite defaults to `:5175` to coexist with a normal `npm run dev` on `:5174`. Bump via `VITE_PORT=5174 npm run e2e:up` (and set `E2E_BASE_URL` to match) if you want to reuse the existing dev server.
+
+## Follow-ups (not in this PR)
+
+- `messaging.spec.ts` — needs a seeded application in `onboarded` status; mirror the seed-demo `Tomasz Kowalski` pattern under a stable email.
+- Visual regression via `toHaveScreenshot()`.
+- A `playwright-features` CI job that runs this suite on PRs.
+- Migrating `scripts/qa-apply-handoff.mjs` into a `.spec.ts` under this harness.

--- a/client-tenant/e2e/fixtures.ts
+++ b/client-tenant/e2e/fixtures.ts
@@ -1,0 +1,102 @@
+// Playwright fixtures for the Frank-Pilot tenant portal.
+//
+// Provides three pre-authenticated Page handles:
+//   applicantPage         — fresh register + dev magic-link, parked at intent
+//   seededApplicantPage   — applicantA@cdpc.test (already past claim), at checklist
+//   agentPage             — agent@cdpc.test (staff), at /dashboard
+//
+// Also wires `afterEach` to drain the QA debug bundle (PNG + qaBuffer + rrweb)
+// on any non-passing test — same shape as the camera button, but local disk only.
+
+import { test as base, expect, type Page } from "@playwright/test";
+import { drainQaBundle } from "./qaDrain";
+
+type Fixtures = {
+  applicantPage: Page;
+  seededApplicantPage: Page;
+  agentPage: Page;
+};
+
+async function signInViaDevMagicLink(page: Page, email: string): Promise<void> {
+  // Dev backends return `devLink` in the magic-link response. We hit the API
+  // directly via the page's request context so the cookie/origin matches the
+  // browser session that will consume the link.
+  const res = await page.request.post("/api/auth/magic-link/request", {
+    data: { email },
+  });
+  expect(res.ok(), `magic-link/request failed (${res.status()})`).toBeTruthy();
+  const body = (await res.json()) as { devLink?: string };
+  if (!body.devLink) {
+    throw new Error(
+      `dev magic-link missing for ${email}; ensure NODE_ENV=development on the API.`
+    );
+  }
+  const url = new URL(body.devLink);
+  await page.goto(`/auth/callback${url.search}`);
+  await page.waitForURL((u) => !u.pathname.startsWith("/auth/callback"), {
+    timeout: 15_000,
+  });
+  // Auth token lives in localStorage (see client-tenant/src/api/client.ts).
+  // Lift it onto the page's request context so `page.request.get(...)` calls
+  // are authenticated the same way the SPA's fetches are.
+  const token = await page.evaluate(() => localStorage.getItem("frank_tenant_token"));
+  if (token) {
+    // BrowserContext-level so it applies to page.request.* too (the SPA reads
+    // the token from localStorage, but page.request runs out-of-process and
+    // needs the header lifted onto it explicitly).
+    await page.context().setExtraHTTPHeaders({ Authorization: `Bearer ${token}` });
+  }
+}
+
+export const test = base.extend<Fixtures>({
+  applicantPage: async ({ page }, use) => {
+    const email = `qa+${Date.now()}@example.com`;
+    await page.goto("/apply");
+    await page.getByLabel(/email/i).first().fill(email);
+    await page.getByLabel(/first name/i).fill("QA");
+    await page.getByLabel(/last name/i).fill("Tester");
+    // Submit and wait for the dev banner (devLink rendered on StepVerify).
+    const reqWait = page.waitForResponse(
+      (r) => r.url().includes("/applicants/register") && r.request().method() === "POST"
+    );
+    await page.getByRole("button", { name: /continue|submit|sign up|create/i }).click();
+    const reg = await reqWait;
+    const regBody = (await reg.json().catch(() => ({}))) as { devLink?: string };
+    if (!regBody.devLink) {
+      throw new Error("applicantPage: dev magic-link absent from register response");
+    }
+    const url = new URL(regBody.devLink);
+    await page.goto(`/auth/callback${url.search}`);
+    await page.waitForURL(/\/apply\?step=intent/, { timeout: 15_000 });
+    await use(page);
+  },
+
+  seededApplicantPage: async ({ page }, use) => {
+    await signInViaDevMagicLink(page, "applicantA@cdpc.test");
+    // The seeded user is past intent + claim, so we deep-link straight to
+    // the checklist step. StepChecklist hydrates from /applicants/me/applications.
+    await page.goto("/apply?step=checklist");
+    await use(page);
+  },
+
+  agentPage: async ({ page }, use) => {
+    await signInViaDevMagicLink(page, "agent@cdpc.test");
+    await page.waitForURL(/\/dashboard/, { timeout: 15_000 }).catch(() => {
+      /* If routing differs (e.g. role-based redirect), let the test handle it. */
+    });
+    await use(page);
+  },
+});
+
+test.afterEach(async ({ page }, testInfo) => {
+  if (testInfo.status !== "passed" && testInfo.status !== "skipped") {
+    await drainQaBundle(page, testInfo).catch((err: unknown) => {
+      const msg = err instanceof Error ? err.message : String(err);
+      // Don't fail the test on a drain hiccup; the original failure stands.
+      // eslint-disable-next-line no-console
+      console.warn(`[qaDrain] ${msg}`);
+    });
+  }
+});
+
+export { expect };

--- a/client-tenant/e2e/qaDrain.ts
+++ b/client-tenant/e2e/qaDrain.ts
@@ -1,0 +1,130 @@
+// qaDrain — Playwright helper that captures the same debug bundle as the
+// in-app camera button (PNG + qaBuffer + rrweb replay) and attaches it to
+// the failing test's report.
+//
+// Why: the camera button works when a human is driving and can click. For
+// Playwright-driven runs we want the same payload triggered automatically
+// on any non-passing test. Local disk only — no Supabase upload.
+
+import type { Page, TestInfo } from "@playwright/test";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+// Shape installed by client-tenant/src/main.tsx in DEV.
+type WindowWithDrain = Window & {
+  __qa_drain?: {
+    getQaBuffer: () => unknown[];
+    clearQaBuffer: () => void;
+    getQaReplayEvents: () => unknown[];
+    clearQaReplay: () => void;
+    stopQaReplay: () => void;
+    installQaReplay: () => Promise<void>;
+    toPng?: (n: HTMLElement, o?: object) => Promise<string>;
+  };
+};
+
+async function safeEvaluate<T>(page: Page, fn: () => T | Promise<T>): Promise<T | null> {
+  try {
+    if (page.isClosed()) return null;
+    return await page.evaluate(fn);
+  } catch {
+    return null;
+  }
+}
+
+async function writeAttachment(
+  testInfo: TestInfo,
+  basename: string,
+  body: string | Buffer,
+  contentType: string
+): Promise<void> {
+  await fs.mkdir(testInfo.outputDir, { recursive: true });
+  const filePath = path.join(testInfo.outputDir, basename);
+  await fs.writeFile(filePath, body);
+  await testInfo.attach(basename, { path: filePath, contentType });
+}
+
+/**
+ * Attach a debug bundle to a Playwright TestInfo. Safe to call on success
+ * (no-op skipping the attachments) but typically wired via `test.afterEach`
+ * with a status guard.
+ */
+export async function drainQaBundle(page: Page, testInfo: TestInfo): Promise<void> {
+  if (page.isClosed()) return;
+
+  // 1. qaBuffer (fetch + JS error log)
+  const buffer = await safeEvaluate(page, () => {
+    const w = window as unknown as WindowWithDrain;
+    return w.__qa_drain ? w.__qa_drain.getQaBuffer() : null;
+  });
+
+  // 2. rrweb events — stop, snapshot, clear, re-install for next test
+  const replayEvents = await safeEvaluate(page, async () => {
+    const w = window as unknown as WindowWithDrain;
+    if (!w.__qa_drain) return null;
+    w.__qa_drain.stopQaReplay();
+    const events = w.__qa_drain.getQaReplayEvents();
+    w.__qa_drain.clearQaReplay();
+    void w.__qa_drain.installQaReplay();
+    return events;
+  });
+
+  // 3. PNG via html-to-image, mirroring ScreenshotButton (same
+  //    data-screenshot-exclude rule). main.tsx eagerly binds `toPng` to
+  //    `window.__qa_drain.toPng` in DEV so we never have to dynamic-import
+  //    a bare specifier from the page context.
+  const png = await safeEvaluate(page, async () => {
+    const w = window as unknown as WindowWithDrain;
+    if (!w.__qa_drain?.toPng) return null;
+    try {
+      return await w.__qa_drain.toPng(document.body, {
+        cacheBust: true,
+        backgroundColor: "#ffffff",
+        skipFonts: true,
+        filter: (n: Node) => {
+          if (!(n instanceof Element)) return true;
+          return n.getAttribute("data-screenshot-exclude") !== "1";
+        },
+      });
+    } catch {
+      return null;
+    }
+  });
+
+  const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const slug = testInfo.title.replace(/[^a-z0-9]+/gi, "-").toLowerCase().slice(0, 60);
+  const base = `frank-${slug}-${stamp}`;
+
+  if (buffer) {
+    await writeAttachment(
+      testInfo,
+      `${base}.json`,
+      JSON.stringify(
+        {
+          test: testInfo.title,
+          file: testInfo.file,
+          status: testInfo.status,
+          url: page.url(),
+          buffer,
+        },
+        null,
+        2
+      ),
+      "application/json"
+    );
+  }
+
+  if (replayEvents && Array.isArray(replayEvents) && replayEvents.length > 0) {
+    await writeAttachment(
+      testInfo,
+      `${base}.replay.json`,
+      JSON.stringify(replayEvents),
+      "application/json"
+    );
+  }
+
+  if (png && typeof png === "string" && png.startsWith("data:image/png;base64,")) {
+    const b64 = png.slice("data:image/png;base64,".length);
+    await writeAttachment(testInfo, `${base}.png`, Buffer.from(b64, "base64"), "image/png");
+  }
+}

--- a/client-tenant/e2e/scenarios/apply-checklist.spec.ts
+++ b/client-tenant/e2e/scenarios/apply-checklist.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from "../fixtures";
+
+// Seeded-applicant smoke. applicantA@cdpc.test is past register + verify +
+// intent + claim (see src/db/seed.ts). The fixture signs them in via the
+// dev magic-link bypass and deep-links to /apply?step=checklist.
+
+test.describe("Apply — checklist (seeded applicant)", () => {
+  test("seededApplicantPage lands on the checklist step with auth", async ({
+    seededApplicantPage: page,
+  }) => {
+    await expect(page).toHaveURL(/\/apply\?step=checklist/);
+    // /auth/me succeeded → applicant session present.
+    const me = await page.request.get("/api/auth/me");
+    expect(me.ok(), `/auth/me failed (${me.status()})`).toBeTruthy();
+    const meBody = (await me.json()) as { user?: { email?: string; role?: string } };
+    expect(meBody.user?.email).toBe("applicantA@cdpc.test");
+    expect(meBody.user?.role).toBe("applicant");
+  });
+
+  test("seeded application carries intent + claimed unit", async ({
+    seededApplicantPage: page,
+  }) => {
+    const apps = await page.request.get("/api/applicants/me/applications");
+    expect(apps.ok(), `/applicants/me/applications failed (${apps.status()})`).toBeTruthy();
+    const body = (await apps.json()) as {
+      applications?: Array<{
+        status?: string;
+        intent_bedrooms?: number | null;
+        intent_household_size?: number | null;
+        requested_rent_amount?: string | null;
+        property_name?: string | null;
+      }>;
+    };
+    const draft = body.applications?.[0];
+    expect(draft, "seeded applicant should have a draft application").toBeDefined();
+    expect(draft?.status).toBe("draft");
+    expect(draft?.intent_bedrooms).toBe(2);
+    expect(draft?.intent_household_size).toBe(2);
+    // B-201 of David J. Hoggard is held for this applicant at $1,194/mo.
+    expect(draft?.property_name).toMatch(/Hoggard/i);
+    expect(draft?.requested_rent_amount).toBe("1194.00");
+  });
+});

--- a/client-tenant/e2e/scenarios/discover.spec.ts
+++ b/client-tenant/e2e/scenarios/discover.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from "../fixtures";
+
+// Public /discover page — no auth needed. Exercises the bedroom-chip filter
+// from gpmglv wedge #8/#9 and the result-count counter.
+
+test.describe("Discover (public listings)", () => {
+  test("renders the GPMG catalog and the result counter", async ({ page }) => {
+    await page.goto("/discover");
+    await expect(page.getByTestId("property-grid")).toBeVisible();
+    await expect(page.getByTestId("result-count")).toContainText(/communit/i);
+  });
+
+  test("bedroom filter narrows the result count", async ({ page }) => {
+    await page.goto("/discover");
+    await page.getByTestId("result-count").waitFor();
+    const initial = await page.getByTestId("result-count").innerText();
+    const initialN = Number(initial.match(/^(\d+)/)?.[1] ?? "0");
+    expect(initialN).toBeGreaterThan(0);
+
+    // Bedroom chips use the raw key ('all'|'studio'|'1'|'2'|'3') as suffix.
+    await page.getByTestId("chip-bedroom-1").click();
+    await expect
+      .poll(async () => {
+        const text = await page.getByTestId("result-count").innerText();
+        return Number(text.match(/^(\d+)/)?.[1] ?? "0");
+      })
+      .toBeLessThanOrEqual(initialN);
+  });
+});

--- a/client-tenant/package-lock.json
+++ b/client-tenant/package-lock.json
@@ -22,6 +22,7 @@
       },
       "devDependencies": {
         "@axe-core/react": "^4.11.3",
+        "@playwright/test": "^1.60.0",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
@@ -1191,6 +1192,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -3646,6 +3663,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/client-tenant/package.json
+++ b/client-tenant/package.json
@@ -12,7 +12,10 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "test:a11y": "vitest run --grep a11y",
-    "check:i18n": "node scripts/check-i18n-parity.mjs"
+    "check:i18n": "node scripts/check-i18n-parity.mjs",
+    "e2e": "playwright test",
+    "e2e:ui": "playwright test --ui",
+    "e2e:install": "playwright install chromium"
   },
   "dependencies": {
     "@rrweb/record": "^2.0.0-alpha.20",
@@ -29,6 +32,7 @@
   },
   "devDependencies": {
     "@axe-core/react": "^4.11.3",
+    "@playwright/test": "^1.60.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",

--- a/client-tenant/playwright.config.ts
+++ b/client-tenant/playwright.config.ts
@@ -1,0 +1,45 @@
+import { defineConfig, devices } from "@playwright/test";
+
+// Single source of truth for the Playwright harness. Boots the full stack
+// via `npm run e2e:up` at the repo root (idempotent — reuses existing
+// dev servers via reuseExistingServer:true). See e2e/README.md.
+
+// Default to :5175 so the harness coexists with a normal `npm run dev`
+// on :5174 (vite.config has a hardcoded 5174). Override via E2E_BASE_URL
+// or VITE_PORT (read by scripts/e2e-up.mjs).
+const BASE_URL = process.env.E2E_BASE_URL ?? "http://127.0.0.1:5175";
+
+export default defineConfig({
+  testDir: "./e2e/scenarios",
+  testMatch: /.*\.spec\.ts/,
+  fullyParallel: false, // tests share one DB; serial avoids race conditions
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  reporter: process.env.CI
+    ? [["github"], ["html", { open: "never" }]]
+    : [["list"], ["html", { open: "never" }]],
+  use: {
+    baseURL: BASE_URL,
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+    actionTimeout: 10_000,
+    navigationTimeout: 30_000,
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    command: "npm run e2e:up",
+    cwd: "..",
+    url: BASE_URL,
+    reuseExistingServer: true,
+    timeout: 120_000,
+    stdout: "pipe",
+    stderr: "pipe",
+  },
+});

--- a/client-tenant/src/main.tsx
+++ b/client-tenant/src/main.tsx
@@ -4,9 +4,39 @@ import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 import './index.css';
 import './i18n';
-import { installQaBuffer } from './lib/qaBuffer';
+import { installQaBuffer, getQaBuffer, clearQaBuffer } from './lib/qaBuffer';
+import {
+  installQaReplay,
+  getQaReplayEvents,
+  clearQaReplay,
+  stopQaReplay,
+} from './lib/qaSessionReplay';
 
 installQaBuffer();
+
+// DEV-only window shim — lets the Playwright harness (e2e/qaDrain.ts) read
+// the same buffers the in-app camera button uses, without dynamic-importing
+// /src/lib/* paths (which works in dev but breaks once Vite bundles).
+if (import.meta.env.DEV) {
+  void installQaReplay();
+  // Eagerly bind html-to-image's toPng so qaDrain doesn't need to dynamic-
+  // import a bare specifier from the page context (vite resolves bare deps
+  // only when the import appears in the bundle graph).
+  void import('html-to-image').then((mod) => {
+    (window as unknown as { __qa_drain?: Record<string, unknown> }).__qa_drain = {
+      ...((window as unknown as { __qa_drain?: Record<string, unknown> }).__qa_drain ?? {}),
+      toPng: mod.toPng,
+    };
+  });
+  (window as unknown as { __qa_drain?: unknown }).__qa_drain = {
+    getQaBuffer,
+    clearQaBuffer,
+    getQaReplayEvents,
+    clearQaReplay,
+    stopQaReplay,
+    installQaReplay,
+  };
+}
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,13 +37,15 @@
         "@types/pg": "^8.11.10",
         "@types/supertest": "^7.2.0",
         "@types/uuid": "^10.0.0",
+        "concurrently": "^9.0.0",
         "fast-check": "^4.8.0",
         "jest": "^29.7.0",
         "playwright": "^1.60.0",
         "supertest": "^7.2.2",
         "ts-jest": "^29.4.11",
         "ts-node": "^10.9.2",
-        "typescript": "^5.6.0"
+        "typescript": "^5.6.0",
+        "wait-on": "^8.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -656,6 +658,60 @@
         "kuler": "^2.0.0"
       }
     },
+    "node_modules/@hapi/address": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-5.1.1.tgz",
+      "integrity": "sha512-A+po2d/dVoY7cYajycYI43ZbYMXukuopIsqCjh5QzsBCipDtdofHntljDlpccMjIfTy6UOkg+5KPriwYch2bXA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^11.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@hapi/formula": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-3.0.2.tgz",
+      "integrity": "sha512-hY5YPNXzw1He7s0iqkRQi+uMGh383CGdyyIGYtB+W5N3KHPXoqychklvHhKCC9M3Xtv0OCs/IHw+r4dcHtBYWw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@hapi/hoek": {
+      "version": "11.0.7",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.7.tgz",
+      "integrity": "sha512-HV5undWkKzcB4RZUusqOpcgxOaq6VOAH7zhhIr2g3G8NF/MlFO75SjOr2NfuSx0Mh40+1FqCkagKLJRykUWoFQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@hapi/pinpoint": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-2.0.1.tgz",
+      "integrity": "sha512-EKQmr16tM8s16vTT3cA5L0kZZcTMU5DUOZTuvpnY738m+jyP3JIUj+Mm1xc1rsLkGBQ/gVnfKYPwOmPg1tUR4Q==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@hapi/tlds": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@hapi/tlds/-/tlds-1.1.6.tgz",
+      "integrity": "sha512-xdi7A/4NZokvV0ewovme3aUO5kQhW9pQ2YD1hRqZGhhSi5rBv4usHYidVocXSi9eihYsznZxLtAiEYYUL6VBGw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@hapi/topo": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-6.0.2.tgz",
+      "integrity": "sha512-KR3rD5inZbGMrHmgPxsJ9dbi6zEK+C3ZwUwTa+eMwWLz7oijWUTWD2pMSNNYJAU6Qq+65NkxXjqHr/7LM2Xkqg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^11.0.2"
+      }
+    },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -1120,6 +1176,13 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
       "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@swc/helpers": {
@@ -2295,6 +2358,47 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "license": "MIT"
     },
+    "node_modules/concurrently": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.1.tgz",
+      "integrity": "sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "4.1.2",
+        "rxjs": "7.8.2",
+        "shell-quote": "1.8.3",
+        "supports-color": "8.1.1",
+        "tree-kill": "1.2.2",
+        "yargs": "17.7.2"
+      },
+      "bin": {
+        "conc": "dist/bin/concurrently.js",
+        "concurrently": "dist/bin/concurrently.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
     "node_modules/console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
@@ -2446,7 +2550,7 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
       "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4267,6 +4371,25 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/joi": {
+      "version": "18.2.1",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-18.2.1.tgz",
+      "integrity": "sha512-2/OKlogiESf2Nh3TFCrRjrr9z1DRHeW0I+KReF67+4J0Ns+8hBtHRmoWAZ2OFU6I5+TWLEe6sVlSdXPjHm5UbQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/address": "^5.1.1",
+        "@hapi/formula": "^3.0.2",
+        "@hapi/hoek": "^11.0.7",
+        "@hapi/pinpoint": "^2.0.1",
+        "@hapi/tlds": "^1.1.1",
+        "@hapi/topo": "^6.0.2",
+        "@standard-schema/spec": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/js-md5": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/js-md5/-/js-md5-0.8.3.tgz",
@@ -4440,6 +4563,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
@@ -5553,6 +5683,16 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -5685,6 +5825,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/shell-quote": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
+      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/side-channel": {
@@ -6160,6 +6313,16 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
     },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
     "node_modules/triple-beam": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
@@ -6490,6 +6653,26 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/wait-on": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-8.0.5.tgz",
+      "integrity": "sha512-J3WlS0txVHkhLRb2FsmRg3dkMTCV1+M6Xra3Ho7HzZDHpE7DCOnoSoCJsZotrmW3uRMhvIJGSKUKrh/MeF4iag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "axios": "^1.12.1",
+        "joi": "^18.0.1",
+        "lodash": "^4.17.21",
+        "minimist": "^1.2.8",
+        "rxjs": "^7.8.2"
+      },
+      "bin": {
+        "wait-on": "bin/wait-on"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/walker": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "migrate": "ts-node src/db/migrate.ts",
     "seed": "ts-node src/db/seed.ts",
     "seed:demo": "ts-node src/db/seed-demo.ts",
-    "test": "jest --passWithNoTests"
+    "test": "jest --passWithNoTests",
+    "e2e:up": "node scripts/e2e-up.mjs",
+    "e2e:up:once": "node scripts/e2e-up.mjs --once"
   },
   "dependencies": {
     "bcrypt": "^5.1.1",
@@ -43,9 +45,11 @@
     "@types/pg": "^8.11.10",
     "@types/supertest": "^7.2.0",
     "@types/uuid": "^10.0.0",
+    "concurrently": "^9.0.0",
     "fast-check": "^4.8.0",
     "jest": "^29.7.0",
     "playwright": "^1.60.0",
+    "wait-on": "^8.0.0",
     "supertest": "^7.2.2",
     "ts-jest": "^29.4.11",
     "ts-node": "^10.9.2",

--- a/scripts/e2e-up.mjs
+++ b/scripts/e2e-up.mjs
@@ -1,0 +1,286 @@
+#!/usr/bin/env node
+// e2e-up.mjs — boot the full stack for Playwright-driven feature tests.
+//
+// 1. Docker Postgres (idempotent — reuses an existing container if up).
+// 2. npm run migrate + npm run seed (always — fast and ensures the
+//    applicantA fixture user exists).
+// 3. API on :3002 (matches the vite proxy default).
+// 4. Vite dev server on :5174.
+// 5. Wait for /health (API) + Vite root before printing READY.
+//
+// Idempotent: if a port is already busy, reuses the existing process and
+// skips the spawn. Playwright's webServer.reuseExistingServer flag handles
+// the rest. Pass --once to exit after READY (Playwright will manage the
+// child stack itself in CI follow-ups).
+
+import { spawn, spawnSync } from "node:child_process";
+import { existsSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { userInfo } from "node:os";
+import net from "node:net";
+import http from "node:http";
+import process from "node:process";
+
+const ONCE = process.argv.includes("--once");
+const API_PORT = Number(process.env.API_PORT ?? 3002);
+// Default to 5175 so the harness coexists with a normal `npm run dev` (which
+// claims 5174). Bump via `VITE_PORT=5174 npm run e2e:up` if you actually want
+// to share the main dev server.
+const VITE_PORT = Number(process.env.VITE_PORT ?? 5175);
+const VITE_BASE = `http://127.0.0.1:${VITE_PORT}`;
+const API_BASE = `http://127.0.0.1:${API_PORT}`;
+
+// Auto-discover a local (non-docker) Postgres when neither DATABASE_URL nor
+// DB_USER is set and there's no committed env. Lets us reuse a Homebrew /
+// Postgres.app install without forcing developers to add a docker layer.
+const DB_ENV = {};
+if (!process.env.DATABASE_URL && !process.env.DB_USER && !existsSync(".env")) {
+  DB_ENV.DB_HOST = "localhost";
+  DB_ENV.DB_PORT = "5432";
+  DB_ENV.DB_NAME = process.env.DB_NAME ?? "frank_pilot";
+  DB_ENV.DB_USER = userInfo().username;
+}
+
+const children = [];
+let shuttingDown = false;
+
+function log(prefix, line) {
+  process.stdout.write(`[${prefix}] ${line}\n`);
+}
+
+function isPortBusy(port) {
+  // Probe by *connecting* rather than trying to bind. macOS lets a
+  // 127.0.0.1-only bind succeed when another process holds the wildcard
+  // address on the same port, so the bind-and-release trick gives false
+  // negatives. A successful connect is the truthful signal.
+  return new Promise((resolve) => {
+    const sock = new net.Socket();
+    const done = (busy) => {
+      sock.destroy();
+      resolve(busy);
+    };
+    sock.once("connect", () => done(true));
+    sock.once("error", () => done(false));
+    sock.setTimeout(800, () => done(false));
+    sock.connect(port, "127.0.0.1");
+  });
+}
+
+function httpOk(url, timeoutMs = 90_000) {
+  const deadline = Date.now() + timeoutMs;
+  return new Promise((resolve, reject) => {
+    const tick = () => {
+      const req = http.get(url, (res) => {
+        res.resume();
+        if (res.statusCode && res.statusCode < 500) resolve(true);
+        else retry();
+      });
+      req.on("error", retry);
+      req.setTimeout(1500, () => req.destroy(new Error("timeout")));
+    };
+    const retry = () => {
+      if (Date.now() > deadline) reject(new Error(`timeout waiting for ${url}`));
+      else setTimeout(tick, 400);
+    };
+    tick();
+  });
+}
+
+function spawnChild(name, cmd, args, opts = {}) {
+  const child = spawn(cmd, args, {
+    stdio: ["ignore", "pipe", "pipe"],
+    env: { ...process.env, ...(opts.env ?? {}) },
+    cwd: opts.cwd ?? process.cwd(),
+    detached: ONCE,
+  });
+  child.stdout.on("data", (b) => process.stdout.write(`[${name}] ${b}`));
+  child.stderr.on("data", (b) => process.stderr.write(`[${name}] ${b}`));
+  child.on("exit", (code, sig) => {
+    if (!shuttingDown) {
+      log(name, `exited code=${code} signal=${sig}`);
+      shutdown(code ?? 1);
+    }
+  });
+  children.push({ name, child });
+  return child;
+}
+
+function shutdown(code = 0) {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  for (const { child } of children) {
+    if (!child.killed) child.kill("SIGTERM");
+  }
+  setTimeout(() => process.exit(code), 200).unref();
+}
+process.on("SIGINT", () => shutdown(0));
+process.on("SIGTERM", () => shutdown(0));
+
+async function ensurePostgres() {
+  // Prefer whatever Postgres the developer already has on :5432 (local
+  // Homebrew pg, OrbStack, Docker — anything goes). Falls back to docker
+  // compose only if nothing is listening.
+  const pgUp = await isPortBusy(5432);
+  if (pgUp) {
+    log("e2e-up", "postgres reachable on :5432 — reusing");
+    return;
+  }
+  const dockerCheck = spawnSync("docker", ["--version"], { stdio: "ignore" });
+  if (dockerCheck.status !== 0) {
+    throw new Error(
+      "no postgres on :5432 and docker is not installed; start Postgres first."
+    );
+  }
+  const res = spawnSync("docker", ["compose", "up", "-d", "postgres"], {
+    stdio: "inherit",
+  });
+  if (res.status !== 0) {
+    throw new Error("docker compose up postgres failed (is Docker running?)");
+  }
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    if (await isPortBusy(5432)) return;
+    await new Promise((r2) => setTimeout(r2, 500));
+  }
+  throw new Error("postgres did not become ready within 30s");
+}
+
+function isSchemaInitialized() {
+  // schema.ts uses bare `CREATE TYPE user_role …`, which is not idempotent.
+  // Use psql to detect whether the type already exists, and skip migrate if so.
+  const env = { ...process.env, ...DB_ENV };
+  const r = spawnSync(
+    "psql",
+    [
+      "-h",
+      env.DB_HOST ?? "localhost",
+      "-p",
+      env.DB_PORT ?? "5432",
+      "-U",
+      env.DB_USER ?? userInfo().username,
+      "-d",
+      env.DB_NAME ?? "frank_pilot",
+      "-tAc",
+      "SELECT to_regtype('user_role') IS NOT NULL;",
+    ],
+    { encoding: "utf8" }
+  );
+  return r.status === 0 && r.stdout.trim() === "t";
+}
+
+function applyMigrationFiles() {
+  // The migration files under src/db/migrations are append-only deltas that
+  // each use `CREATE TABLE IF NOT EXISTS` / `ALTER TABLE … IF NOT EXISTS`,
+  // so they're safe to re-apply on every boot. Catches schema drift between
+  // a long-lived dev DB and newer migrations.
+  const dir = "src/db/migrations";
+  if (!existsSync(dir)) return;
+  const env = { ...process.env, ...DB_ENV };
+  const files = readdirSync(dir)
+    .filter((f) => f.endsWith(".sql"))
+    .sort();
+  for (const f of files) {
+    const r = spawnSync(
+      "psql",
+      [
+        "-h",
+        env.DB_HOST ?? "localhost",
+        "-p",
+        env.DB_PORT ?? "5432",
+        "-U",
+        env.DB_USER ?? userInfo().username,
+        "-d",
+        env.DB_NAME ?? "frank_pilot",
+        "-v",
+        "ON_ERROR_STOP=1",
+        "-q",
+        "-f",
+        join(dir, f),
+      ],
+      { stdio: ["ignore", "pipe", "pipe"], encoding: "utf8" }
+    );
+    if (r.status !== 0) {
+      const stderr = (r.stderr ?? "").trim();
+      // Suppress only the duplicate-column noise from `ADD COLUMN IF NOT
+      // EXISTS` not being supported on older Postgres — every other error
+      // bubbles up.
+      throw new Error(`migration ${f} failed:\n${stderr}`);
+    }
+  }
+}
+
+async function runMigrateAndSeed() {
+  if (isSchemaInitialized()) {
+    log("e2e-up", "schema already initialized — applying any missing migrations");
+    applyMigrationFiles();
+  } else {
+    const r = spawnSync("npm", ["run", "migrate"], {
+      stdio: "inherit",
+      env: { ...process.env, ...DB_ENV },
+    });
+    if (r.status !== 0) throw new Error("npm run migrate failed");
+  }
+  const s = spawnSync("npm", ["run", "seed"], {
+    stdio: "inherit",
+    env: { ...process.env, ...DB_ENV },
+  });
+  if (s.status !== 0) throw new Error("npm run seed failed");
+}
+
+async function main() {
+  log("e2e-up", `target ports: api=${API_PORT} vite=${VITE_PORT}`);
+
+  await ensurePostgres();
+  await runMigrateAndSeed();
+
+  const apiBusy = await isPortBusy(API_PORT);
+  const viteBusy = await isPortBusy(VITE_PORT);
+
+  if (apiBusy) {
+    log("e2e-up", `port ${API_PORT} already in use — reusing existing API`);
+  } else {
+    spawnChild("api", "npm", ["run", "dev"], {
+      env: { PORT: String(API_PORT), NODE_ENV: "development", ...DB_ENV },
+    });
+  }
+
+  if (viteBusy) {
+    log("e2e-up", `port ${VITE_PORT} already in use — reusing existing Vite`);
+  } else {
+    // `npm run dev -- --port N --host 127.0.0.1` so we can run alongside a
+    // normal dev server on 5174 without colliding, and so the health probe
+    // (which polls 127.0.0.1) hits the right interface — vite's default
+    // `localhost` host can resolve to ::1 only on macOS.
+    spawnChild(
+      "vite",
+      "npm",
+      ["run", "dev", "--", "--port", String(VITE_PORT), "--host", "127.0.0.1"],
+      {
+        cwd: "client-tenant",
+        env: { VITE_API_PROXY_TARGET: API_BASE },
+      }
+    );
+  }
+
+  await httpOk(`${API_BASE}/health`);
+  log("e2e-up", `api ready at ${API_BASE}/health`);
+  await httpOk(`${VITE_BASE}/`);
+  log("e2e-up", `vite ready at ${VITE_BASE}/`);
+
+  process.stdout.write(
+    `\nREADY — base=${VITE_BASE} api=${API_BASE} — see client-tenant/e2e/README.md\n\n`
+  );
+
+  if (ONCE) {
+    // Detach children so they survive this exit. Playwright connects to
+    // them via reuseExistingServer:true.
+    for (const { child } of children) child.unref();
+    children.length = 0;
+    process.exit(0);
+  }
+}
+
+main().catch((err) => {
+  console.error("[e2e-up] fatal:", err.message);
+  shutdown(1);
+});

--- a/src/db/seed.ts
+++ b/src/db/seed.ts
@@ -299,6 +299,117 @@ async function seed() {
     }
     console.log(`  Distribution check passed: ${distReport.map((r) => `${r.status}=${r.actual}%`).join(" / ")}`);
 
+    // ── Seeded applicant: applicantA@cdpc.test (e2e harness) ───────────
+    // Pre-walked through register + verify + intent + claim. Lands on
+    // /checklist when signed in via dev magic-link. Additive to the staff
+    // users above — smoke-apply (qa-apply-handoff.mjs) is untouched.
+    const applicantEmail = "applicantA@cdpc.test";
+    const applicantHash = await bcrypt.hash("password123", 10);
+    const applicantRes = await query(
+      `INSERT INTO users (email, password_hash, first_name, last_name, role, email_verified_at, is_active)
+       VALUES ($1, $2, 'Alex', 'Applicant', 'applicant', NOW(), true)
+       ON CONFLICT (email) DO UPDATE
+         SET role = 'applicant', email_verified_at = NOW(), is_active = true
+       RETURNING id`,
+      [applicantEmail, applicantHash]
+    );
+    const applicantId: string = applicantRes.rows[0].id;
+
+    // Pin the claim to a deterministic unit on the family property so the
+    // applicant lands somewhere stable across re-seeds.
+    const claimUnit = await query(
+      `SELECT u.id, u.property_id, u.monthly_rent
+         FROM units u
+         JOIN properties p ON p.id = u.property_id
+        WHERE p.name = 'David J. Hoggard Family Community'
+          AND u.unit_number = 'B-201'
+        LIMIT 1`
+    );
+    if (claimUnit.rows.length === 0) {
+      throw new Error("Seeded applicant: expected unit B-201 on David J. Hoggard Family Community");
+    }
+    const unitId: string = claimUnit.rows[0].id;
+    const propertyId: string = claimUnit.rows[0].property_id;
+    const rent: number = Number(claimUnit.rows[0].monthly_rent);
+
+    // Hold the unit for the seeded applicant (24h claim window keeps it
+    // fresh after long pauses; the e2e harness reseeds each run anyway).
+    await query(
+      `UPDATE units
+          SET status = 'held',
+              claim_expires_at = NOW() + INTERVAL '24 hours',
+              updated_at = NOW()
+        WHERE id = $1`,
+      [unitId]
+    );
+
+    // Application: post-intent + post-claim draft. Intent fields match a
+    // 2-person household at 60% AMI for the Las Vegas MSA ($45,600/yr).
+    const existingApp = await query(
+      `SELECT a.id FROM applications a
+         JOIN user_applications ua ON ua.application_id = a.id
+        WHERE ua.user_id = $1
+        LIMIT 1`,
+      [applicantId]
+    );
+    let applicationId: string;
+    if (existingApp.rows.length > 0) {
+      applicationId = existingApp.rows[0].id;
+      await query(
+        `UPDATE applications
+            SET property_id = $2,
+                claimed_unit_id = $3,
+                claim_expires_at = NOW() + INTERVAL '24 hours',
+                intent_bedrooms = 2,
+                intent_budget_min = 1000,
+                intent_budget_max = 1300,
+                intent_move_in_date = (CURRENT_DATE + INTERVAL '60 days')::date,
+                intent_household_size = 2,
+                gross_annual_income = 45000,
+                qualifying_ami_tier = '60',
+                qualifying_household_size = 2,
+                qualifying_ami_calculated_at = NOW(),
+                requested_rent_amount = $4,
+                household_size = 2,
+                status = 'draft',
+                updated_at = NOW()
+          WHERE id = $1`,
+        [applicationId, propertyId, unitId, rent]
+      );
+    } else {
+      const appRes = await query(
+        `INSERT INTO applications (
+           property_id, first_name, last_name, email,
+           household_size, status,
+           intent_bedrooms, intent_budget_min, intent_budget_max,
+           intent_move_in_date, intent_household_size,
+           gross_annual_income, qualifying_ami_tier,
+           qualifying_household_size, qualifying_ami_calculated_at,
+           claimed_unit_id, claim_expires_at, requested_rent_amount
+         )
+         VALUES (
+           $1, 'Alex', 'Applicant', $2,
+           2, 'draft',
+           2, 1000, 1300,
+           (CURRENT_DATE + INTERVAL '60 days')::date, 2,
+           45000, '60',
+           2, NOW(),
+           $3, NOW() + INTERVAL '24 hours', $4
+         )
+         RETURNING id`,
+        [propertyId, applicantEmail, unitId, rent]
+      );
+      applicationId = appRes.rows[0].id;
+    }
+
+    await query(
+      `INSERT INTO user_applications (user_id, application_id, relationship)
+       VALUES ($1, $2, 'primary')
+       ON CONFLICT (user_id, application_id) DO NOTHING`,
+      [applicantId, applicationId]
+    );
+    console.log(`  Seeded applicant: ${applicantEmail} (post-claim on B-201 @ David J. Hoggard)`);
+
     // Seed known problem addresses
     const problemAddresses = [
       { address: "999 Fraud Lane", city: "Las Vegas", state: "NV", zip: "89101", reason: "Multiple fraudulent applications originating from this address" },


### PR DESCRIPTION
## What

Adds a Playwright e2e harness for the tenant client, scaffolding the first end-to-end coverage of the apply + discover flows. Recovered from an uncommitted worktree and committed so it isn't lost.

## Contents

- `client-tenant/e2e/` — README, `fixtures.ts`, `qaDrain.ts`
- `client-tenant/e2e/scenarios/` — `apply-checklist.spec.ts`, `discover.spec.ts`
- `client-tenant/playwright.config.ts`
- `scripts/e2e-up.mjs` — bring-up helper
- Supporting tweaks: `seed.ts` hooks, `package.json` deps, `main.tsx`, `.gitignore`

## Notes

- Branch's prior commits are already in `main`; this PR is a clean diff of just the e2e scaffold (`ce0b5a5`).
- Backend jest suite unaffected (`roots: ['<rootDir>/src']` — does not scan e2e).

🤖 Generated with [Claude Code](https://claude.com/claude-code)