### PR TITLE
feat(pm-console): collapsible sidebar via header hamburger toggle

### DIFF
--- a/client/src/components/Layout.tsx
+++ b/client/src/components/Layout.tsx
@@ -1,18 +1,36 @@
 import { Outlet } from 'react-router-dom';
-import { LogOut } from 'lucide-react';
+import { useState } from 'react';
+import { LogOut, Menu } from 'lucide-react';
 import { Sidebar } from './Sidebar';
 import { useAuth } from '@/hooks/useAuth';
 import { formatRole } from '@/types';
 
 export function Layout() {
   const { user, logout } = useAuth();
+  const [collapsed, setCollapsed] = useState(
+    () => localStorage.getItem('sidebar-collapsed') === 'true'
+  );
+
+  const toggleSidebar = () =>
+    setCollapsed((prev) => {
+      const next = !prev;
+      localStorage.setItem('sidebar-collapsed', String(next));
+      return next;
+    });
 
   return (
     <div className="flex h-screen bg-gray-50">
-      <Sidebar />
+      <Sidebar collapsed={collapsed} />
       <div className="flex flex-1 flex-col overflow-hidden">
         <header className="flex h-16 items-center justify-between border-b border-gray-200 bg-white px-6">
-          <div />
+          <button
+            onClick={toggleSidebar}
+            aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+            aria-expanded={!collapsed}
+            className="flex h-9 w-9 items-center justify-center rounded-lg text-gray-500 hover:bg-gray-100 hover:text-gray-700"
+          >
+            <Menu className="h-5 w-5" />
+          </button>
           <div className="flex items-center gap-4">
             {user && (
               <>

--- a/client/src/components/Sidebar.tsx
+++ b/client/src/components/Sidebar.tsx
@@ -47,17 +47,25 @@ const NAV_ITEMS: NavItem[] = [
   { label: 'QA Bundles', path: '/qa-bundles', icon: Camera, minRole: 'regional_manager' },
 ];
 
-export function Sidebar() {
+export function Sidebar({ collapsed = false }: { collapsed?: boolean }) {
   const { user } = useAuth();
   if (!user) return null;
 
   const visible = NAV_ITEMS.filter((item) => hasMinRole(user.role, item.minRole));
 
   return (
-    <aside className="flex h-full w-64 flex-col border-r border-gray-200 bg-white">
-      <div className="flex h-16 items-center gap-2 border-b border-gray-200 px-6">
-        <Building2 className="h-6 w-6 text-emerald-600" />
-        <span className="text-lg font-semibold text-gray-900">CDPC Hub</span>
+    <aside
+      className={`flex h-full flex-col border-r border-gray-200 bg-white transition-[width] duration-200 ${
+        collapsed ? 'w-16' : 'w-64'
+      }`}
+    >
+      <div
+        className={`flex h-16 items-center gap-2 border-b border-gray-200 ${
+          collapsed ? 'justify-center px-0' : 'px-6'
+        }`}
+      >
+        <Building2 className="h-6 w-6 shrink-0 text-emerald-600" />
+        {!collapsed && <span className="text-lg font-semibold text-gray-900">CDPC Hub</span>}
       </div>
       <nav className="flex-1 space-y-1 p-3">
         {visible.map((item) => (
@@ -65,21 +73,24 @@ export function Sidebar() {
             key={item.path}
             to={item.path}
             end={item.path === '/'}
+            title={collapsed ? item.label : undefined}
             className={({ isActive }) =>
-              `flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors ${
+              `flex items-center gap-3 rounded-lg py-2 text-sm font-medium transition-colors ${
+                collapsed ? 'justify-center px-0' : 'px-3'
+              } ${
                 isActive
                   ? 'bg-emerald-50 text-emerald-700'
                   : 'text-gray-600 hover:bg-gray-50 hover:text-gray-900'
               }`
             }
           >
-            <item.icon className="h-5 w-5" />
-            {item.label}
+            <item.icon className="h-5 w-5 shrink-0" />
+            {!collapsed && item.label}
           </NavLink>
         ))}
       </nav>
       <div className="border-t border-gray-200 p-4">
-        <p className="text-xs text-gray-400">CDPC Nevada</p>
+        {!collapsed && <p className="text-xs text-gray-400">CDPC Nevada</p>}
       </div>
     </aside>
   );


### PR DESCRIPTION
## What
Adds a hamburger (☰) toggle in the previously-empty top-left header slot that collapses the PM console sidebar to a 64px icon rail and back.

## Why
The header had a dead `<div/>` placeholder next to the logo. Filling it with a sidebar toggle reclaims horizontal space for the content area (tables/wizards) — useful on smaller laptops.

## Changes
- **Layout.tsx** — lift `collapsed` state, persist to `localStorage`; hamburger button replaces the empty `<div/>`; `aria-expanded` + dynamic `aria-label`.
- **Sidebar.tsx** — accepts `collapsed` prop: `w-64 → w-16`, hides the "CDPC Hub" wordmark, nav labels, and footer; centers icons; adds native `title` tooltips per item when collapsed.

## Verified live (prod)
- Toggle collapses/expands the rail (screenshots in thread)
- State persists across reload (localStorage)
- `tsc -b && vite build` clean
- Active-route highlight + RBAC item filtering unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)