### PR TITLE
feat(pm-console): clickable dashboard cards + Property column on Applications

### DIFF
--- a/client/src/pages/Applications.tsx
+++ b/client/src/pages/Applications.tsx
@@ -31,6 +31,11 @@ const columns: Column<Application>[] = [
     header: 'Status',
     render: (r) => <StatusBadge status={r.status} />,
   },
+  {
+    key: 'property_name',
+    header: 'Property',
+    render: (r) => r.property_name ?? '—',
+  },
   { key: 'unit_number', header: 'Unit' },
   {
     key: 'household_size',

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -1,4 +1,5 @@
 import { FileText, Search, CheckCircle, Building2, Clock, UserPlus } from 'lucide-react';
+import { Link } from 'react-router-dom';
 import { useAuth } from '@/hooks/useAuth';
 import { useApiQuery } from '@/hooks/useApiQuery';
 import { RoleGate } from '@/components/RoleGate';
@@ -6,21 +7,32 @@ import { StatusBadge } from '@/components/StatusBadge';
 import { formatRole, hasMinRole, type ApplicationListResponse, type PropertyListResponse, type AuditLogResponse, type SignupStatsResponse } from '@/types';
 import type { LucideIcon } from 'lucide-react';
 
-function StatCard({ icon: Icon, label, value, loading }: { icon: LucideIcon; label: string; value: string | number; loading?: boolean }) {
-  return (
-    <div className="rounded-xl border border-gray-200 bg-white p-5">
-      <div className="flex items-center gap-3">
-        <div className="rounded-lg bg-emerald-50 p-2">
-          <Icon className="h-5 w-5 text-emerald-600" />
-        </div>
-        <div>
-          <p className="text-sm text-gray-500">{label}</p>
-          <p className="text-2xl font-semibold text-gray-900">
-            {loading ? <span className="inline-block h-6 w-10 animate-pulse rounded bg-gray-200" /> : value}
-          </p>
-        </div>
+function StatCard({ icon: Icon, label, value, loading, to }: { icon: LucideIcon; label: string; value: string | number; loading?: boolean; to?: string }) {
+  const inner = (
+    <div className="flex items-center gap-3">
+      <div className="rounded-lg bg-emerald-50 p-2">
+        <Icon className="h-5 w-5 text-emerald-600" />
+      </div>
+      <div>
+        <p className="text-sm text-gray-500">{label}</p>
+        <p className="text-2xl font-semibold text-gray-900">
+          {loading ? <span className="inline-block h-6 w-10 animate-pulse rounded bg-gray-200" /> : value}
+        </p>
       </div>
     </div>
+  );
+
+  if (!to) {
+    return <div className="rounded-xl border border-gray-200 bg-white p-5">{inner}</div>;
+  }
+
+  return (
+    <Link
+      to={to}
+      className="block rounded-xl border border-gray-200 bg-white p-5 transition-all hover:border-emerald-300 hover:shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500"
+    >
+      {inner}
+    </Link>
   );
 }
 
@@ -56,17 +68,17 @@ export function Dashboard() {
       </div>
 
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-        <StatCard icon={FileText} label="Active Applications" value={activeCount} loading={apps.loading} />
+        <StatCard icon={FileText} label="Active Applications" value={activeCount} loading={apps.loading} to="/applications" />
         <RoleGate minRole="senior_manager">
-          <StatCard icon={UserPlus} label="Signups" value={signups.data?.registered ?? '--'} loading={signups.loading} />
+          <StatCard icon={UserPlus} label="Signups" value={signups.data?.registered ?? '--'} loading={signups.loading} to="/applications" />
         </RoleGate>
         <RoleGate minRole="senior_manager">
-          <StatCard icon={Search} label="Pending Screening" value={screeningCount} loading={apps.loading} />
+          <StatCard icon={Search} label="Pending Screening" value={screeningCount} loading={apps.loading} to="/screening" />
         </RoleGate>
         <RoleGate minRole="senior_manager">
-          <StatCard icon={CheckCircle} label="Pending Approvals" value={approvalCount} loading={apps.loading} />
+          <StatCard icon={CheckCircle} label="Pending Approvals" value={approvalCount} loading={apps.loading} to="/approvals" />
         </RoleGate>
-        <StatCard icon={Building2} label="Properties" value={props.data?.total ?? '--'} loading={props.loading} />
+        <StatCard icon={Building2} label="Properties" value={props.data?.total ?? '--'} loading={props.loading} to="/properties" />
       </div>
 
       <RoleGate minRole="regional_manager">


### PR DESCRIPTION
## What

Two PM-console UX fixes, both already verified live on prod (`frank-pilot-client.vercel.app`):

1. **Clickable Dashboard StatCards** — all 5 cards now navigate on click, with hover/focus affordance (`<Link>`):
   - Active Applications → `/applications`
   - Signups → `/applications`
   - Pending Screening → `/screening`
   - Pending Approvals → `/approvals`
   - Properties → `/properties`

2. **Property column on Applications table** — adds a `Property` column between Status and Unit (the empty slot flagged in QA). The list endpoint already returns `p.name as property_name`; this is a frontend-only column add.

## Verification (e2e, chrome-devtools on prod)

- All 5 dashboard cards render as links with correct hrefs; clicking Properties navigated to `/properties`.
- Applications table shows Property values: "Donna Louise Apartments 2", "Mike O'Callaghan Legacy Apartments".
- `tsc -b && vite build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)