### PR TITLE
test(pm-console): Playwright e2e harness + shared-UI a11y/polish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,104 @@ jobs:
         working-directory: client-tenant
         run: node scripts/check-i18n-parity.mjs
 
+  pm-console-e2e:
+    name: pm-console-e2e (staff console Playwright)
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: frank_pilot_pm_e2e
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/frank_pilot_pm_e2e
+      NODE_ENV: development
+      PORT: '3002'
+      JWT_SECRET: ci-pm-e2e-secret-do-not-reuse
+      # Point Playwright at the manually-started Vite below; this also makes
+      # playwright.config skip its own webServer boot (which assumes a local
+      # Docker/Postgres via `npm run e2e:up`).
+      E2E_BASE_URL: http://127.0.0.1:5176
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Use Node.js 22
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: 'npm'
+
+      - name: Install root deps (backend)
+        run: npm ci
+
+      - name: Install client deps
+        working-directory: client
+        run: npm ci
+
+      - name: Install Playwright chromium
+        working-directory: client
+        run: npx playwright install --with-deps chromium
+
+      - name: Migrate database
+        run: npm run migrate
+
+      - name: Seed database
+        run: npm run seed
+
+      - name: Start backend
+        run: |
+          mkdir -p /tmp/pm-e2e-logs
+          nohup npm run dev > /tmp/pm-e2e-logs/backend.log 2>&1 &
+          echo $! > /tmp/pm-e2e-logs/backend.pid
+          for i in $(seq 1 40); do
+            if curl -fsS http://127.0.0.1:3002/health > /dev/null 2>&1; then
+              echo "backend ready after ${i}s"; exit 0
+            fi
+            sleep 1
+          done
+          echo "backend failed to come up"; tail -200 /tmp/pm-e2e-logs/backend.log; exit 1
+
+      - name: Start Vite dev server (PM console)
+        working-directory: client
+        run: |
+          nohup npx vite --host 127.0.0.1 --port 5176 > /tmp/pm-e2e-logs/vite.log 2>&1 &
+          echo $! > /tmp/pm-e2e-logs/vite.pid
+          for i in $(seq 1 30); do
+            if curl -fsS http://127.0.0.1:5176 > /dev/null 2>&1; then
+              echo "vite ready after ${i}s"; exit 0
+            fi
+            sleep 1
+          done
+          echo "vite failed to come up"; tail -200 /tmp/pm-e2e-logs/vite.log; exit 1
+
+      - name: Run PM console e2e
+        working-directory: client
+        run: npm run e2e
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: pm-console-e2e-report
+          path: |
+            client/playwright-report
+            client/test-results
+            /tmp/pm-e2e-logs
+          if-no-files-found: warn
+          retention-days: 7
+
   smoke-apply:
     name: smoke-apply (Welcome → Claim e2e)
     runs-on: ubuntu-latest

--- a/client/.gitignore
+++ b/client/.gitignore
@@ -1,1 +1,10 @@
 .vercel
+
+# Build cache
+tsconfig.tsbuildinfo
+
+# Playwright
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/client/e2e/README.md
+++ b/client/e2e/README.md
@@ -1,0 +1,60 @@
+# PM Console E2E (Playwright)
+
+End-to-end tests for the staff / PM console ("CDPC Compliance Hub").
+
+## Running
+
+```bash
+cd client
+npm install
+npm run e2e:install   # one-time: download the chromium browser
+npm run e2e           # boots the full stack + this app, runs the suite
+npm run e2e:ui        # interactive UI mode
+```
+
+`npm run e2e` boots two servers automatically (both idempotent — they reuse
+anything already listening):
+
+1. **Backend stack** via the repo-root `npm run e2e:up` — Postgres (Docker or a
+   local install on :5432) + `migrate` + `seed` + the Express API on **:3002**.
+2. **This console's Vite dev server** on **:5176** (proxies `/api` → :3002).
+
+Ports are chosen so the harness coexists with a normal `npm run dev` (:5173)
+and the tenant-portal e2e harness (:5175).
+
+### Against a deployed environment
+
+```bash
+E2E_BASE_URL=https://frank-pilot-client.vercel.app npm run e2e
+```
+
+Setting `E2E_BASE_URL` skips the local server boot. The target must share the
+seed accounts and reach the same API.
+
+## Auth
+
+Seed accounts (password `password123`):
+
+| Email             | Role           | Fixture      |
+| ----------------- | -------------- | ------------ |
+| `agent@cdpc.test` | leasing_agent  | `agentPage`  |
+| `senior@cdpc.test`| senior_manager | `seniorPage` |
+| `admin@cdpc.test` | system_admin   | `adminPage`  |
+
+Fixtures sign in via `POST /api/auth/login`, then plant `frank_token` /
+`frank_user` in localStorage (the keys the SPA's `AuthProvider` reads) so the
+app boots already authenticated. `auth.spec.ts` still exercises the real login
+form. `seedDemoData(page)` (admin-only) loads applications across every
+pipeline stage for tests that need a populated table.
+
+## Layout
+
+```
+e2e/
+  fixtures.ts            # signIn helper + per-role page fixtures + seedDemoData
+  scenarios/
+    auth.spec.ts         # login form + route protection
+    dashboard.spec.ts    # 5 clickable stat cards
+    applications.spec.ts # column set + row → detail + tab filter
+    navigation.spec.ts   # core pages load; work-order priority enum
+```

--- a/client/e2e/fixtures.ts
+++ b/client/e2e/fixtures.ts
@@ -1,0 +1,94 @@
+// Playwright fixtures for the Frank-Pilot PM / staff console.
+//
+// Auth here is email + password (POST /api/auth/login → { token, user }),
+// unlike the tenant portal's magic-link flow. We sign in via the page's
+// request context, then plant the same localStorage keys the SPA reads
+// (frank_token / frank_user — see client/src/context/AuthContext.tsx) so the
+// app boots already authenticated. The bearer token is also lifted onto the
+// browser context so `page.request.*` calls in tests are authenticated.
+//
+// Pre-authenticated page handles, one per seeded role:
+//   seniorPage — senior@cdpc.test (senior_manager — sees most pages)
+//   adminPage  — admin@cdpc.test  (system_admin — sees everything)
+//   agentPage  — agent@cdpc.test  (leasing_agent — most restricted)
+
+import { test as base, expect, type Page } from "@playwright/test";
+
+const PASSWORD = "password123";
+const TOKEN_KEY = "frank_token";
+const USER_KEY = "frank_user";
+
+type Fixtures = {
+  seniorPage: Page;
+  adminPage: Page;
+  agentPage: Page;
+};
+
+interface LoginResult {
+  token: string;
+  user: Record<string, unknown>;
+}
+
+/**
+ * Authenticate `page` as `email` and return it parked at the dashboard ("/").
+ * Plants frank_token/frank_user in localStorage so the SPA's AuthProvider
+ * hydrates without a round-trip through the login form.
+ */
+export async function signIn(page: Page, email: string): Promise<LoginResult> {
+  const res = await page.request.post("/api/auth/login", {
+    data: { email, password: PASSWORD },
+  });
+  expect(
+    res.ok(),
+    `login failed for ${email} (${res.status()}) — is the API seeded?`
+  ).toBeTruthy();
+  const body = (await res.json()) as LoginResult;
+  if (!body.token || !body.user) {
+    throw new Error(`login response missing token/user for ${email}`);
+  }
+
+  // Establish the origin before touching localStorage, then seed the keys and
+  // reload so AuthProvider picks them up on mount.
+  await page.goto("/login");
+  await page.evaluate(
+    ({ token, user, tokenKey, userKey }) => {
+      localStorage.setItem(tokenKey, token);
+      localStorage.setItem(userKey, JSON.stringify(user));
+    },
+    { token: body.token, user: body.user, tokenKey: TOKEN_KEY, userKey: USER_KEY }
+  );
+  await page.context().setExtraHTTPHeaders({ Authorization: `Bearer ${body.token}` });
+  await page.goto("/");
+  await page.waitForURL((u) => !u.pathname.startsWith("/login"), { timeout: 15_000 });
+  return body;
+}
+
+/**
+ * Idempotently load the rich demo dataset (applications across every pipeline
+ * stage) via the admin-only seed endpoint. Used by tests that need populated
+ * tables — the base seed only creates a single application.
+ */
+export async function seedDemoData(page: Page): Promise<void> {
+  const res = await page.request.post("/api/demo/seed");
+  expect(
+    res.ok(),
+    `demo seed failed (${res.status()}) — must be authenticated as system_admin`
+  ).toBeTruthy();
+}
+
+export const test = base.extend<Fixtures>({
+  seniorPage: async ({ page }, use) => {
+    await signIn(page, "senior@cdpc.test");
+    await use(page);
+  },
+  adminPage: async ({ page }, use) => {
+    await signIn(page, "admin@cdpc.test");
+    await use(page);
+  },
+  agentPage: async ({ page }, use) => {
+    await signIn(page, "agent@cdpc.test");
+    await use(page);
+  },
+});
+
+export { expect };

--- a/client/e2e/scenarios/applications.spec.ts
+++ b/client/e2e/scenarios/applications.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect, seedDemoData } from "../fixtures";
+
+// Applications list → detail. Seeds the rich demo dataset first (admin-only)
+// so the table is populated across pipeline stages, then opens a row.
+
+test.describe("Applications", () => {
+  test.beforeEach(async ({ adminPage }) => {
+    await seedDemoData(adminPage);
+  });
+
+  test("table shows the full column set", async ({ adminPage: page }) => {
+    await page.goto("/applications");
+    await expect(page.getByRole("heading", { name: /^Applications$/ })).toBeVisible();
+
+    for (const header of [
+      "Applicant",
+      "Status",
+      "Property",
+      "Unit",
+      "Household",
+      "Income",
+      "AMI Tier",
+      "Created",
+    ]) {
+      await expect(
+        page.getByRole("columnheader", { name: header, exact: true })
+      ).toBeVisible();
+    }
+  });
+
+  test("clicking a row opens that application's detail", async ({ adminPage: page }) => {
+    await page.goto("/applications");
+    const firstRow = page.locator("tbody tr").first();
+    await expect(firstRow).toBeVisible();
+    await firstRow.click();
+
+    await expect(page).toHaveURL(/\/applications\/[0-9a-f-]{36}$/);
+  });
+
+  test("status tabs filter the table", async ({ adminPage: page }) => {
+    await page.goto("/applications");
+    await page.getByRole("button", { name: /^Submitted/ }).click();
+    // Either rows render or the empty-state message — both are valid; the page
+    // must not crash and the tab must become active.
+    await expect(
+      page.locator("tbody tr").first().or(page.getByText(/No applications found/i))
+    ).toBeVisible();
+  });
+});

--- a/client/e2e/scenarios/auth.spec.ts
+++ b/client/e2e/scenarios/auth.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect } from "../fixtures";
+
+// Login form (the real password flow staff use) + route protection.
+
+test.describe("Auth", () => {
+  test("unauthenticated visit redirects to /login", async ({ page }) => {
+    await page.goto("/");
+    await page.waitForURL(/\/login/, { timeout: 15_000 });
+    await expect(page.getByRole("heading", { name: /CDPC Compliance Hub/i })).toBeVisible();
+  });
+
+  test("signing in via the form lands on the dashboard", async ({ page }) => {
+    await page.goto("/login");
+    await page.getByLabel(/email/i).fill("senior@cdpc.test");
+    await page.getByLabel(/password/i).fill("password123");
+    await page.getByRole("button", { name: /sign in/i }).click();
+
+    await page.waitForURL((u) => !u.pathname.startsWith("/login"), { timeout: 15_000 });
+    await expect(page.getByRole("heading", { name: /welcome back/i })).toBeVisible();
+  });
+
+  test("bad credentials surface an inline error", async ({ page }) => {
+    await page.goto("/login");
+    await page.getByLabel(/email/i).fill("senior@cdpc.test");
+    await page.getByLabel(/password/i).fill("wrong-password");
+    await page.getByRole("button", { name: /sign in/i }).click();
+
+    await expect(page.getByText(/invalid credentials/i)).toBeVisible();
+    await expect(page).toHaveURL(/\/login/);
+  });
+});

--- a/client/e2e/scenarios/dashboard.spec.ts
+++ b/client/e2e/scenarios/dashboard.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from "../fixtures";
+
+// Dashboard for a senior_manager: 5 clickable stat cards that deep-link into
+// the relevant queues (PR #140 made every card a <Link>). Locators are scoped
+// to <main> so they don't collide with same-named sidebar nav links.
+
+test.describe("Dashboard (senior_manager)", () => {
+  test("renders all five clickable stat cards", async ({ seniorPage: page }) => {
+    await expect(page.getByRole("heading", { name: /welcome back/i })).toBeVisible();
+    const main = page.getByRole("main");
+
+    for (const label of [
+      /Active Applications/i,
+      /Signups/i,
+      /Pending Screening/i,
+      /Pending Approvals/i,
+      /^Properties/i,
+    ]) {
+      await expect(main.getByRole("link", { name: label })).toBeVisible();
+    }
+  });
+
+  test("Pending Screening card navigates to /screening", async ({ seniorPage: page }) => {
+    await page.getByRole("main").getByRole("link", { name: /Pending Screening/i }).click();
+    await expect(page).toHaveURL(/\/screening$/);
+    await expect(page.getByRole("heading", { name: /^Screening$/ })).toBeVisible();
+  });
+
+  test("Properties card navigates to /properties", async ({ seniorPage: page }) => {
+    await page.getByRole("main").getByRole("link", { name: /^Properties/i }).click();
+    await expect(page).toHaveURL(/\/properties$/);
+    await expect(page.getByRole("heading", { name: /^Properties$/ })).toBeVisible();
+  });
+});

--- a/client/e2e/scenarios/navigation.spec.ts
+++ b/client/e2e/scenarios/navigation.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from "../fixtures";
+
+// Core staff pages load without error for a senior_manager, both via the
+// sidebar and by deep-link. Guards against blank-screen / crash regressions.
+
+const PAGES = [
+  { nav: "Screening", path: "/screening", heading: /^Screening$/ },
+  { nav: "Approvals", path: "/approvals", heading: /^Approvals$/ },
+  { nav: "Properties", path: "/properties", heading: /^Properties$/ },
+  { nav: "Maintenance", path: "/maintenance", heading: /^Maintenance$/ },
+] as const;
+
+test.describe("Navigation (senior_manager)", () => {
+  for (const p of PAGES) {
+    test(`sidebar → ${p.nav} renders its page`, async ({ seniorPage: page }) => {
+      await page.getByRole("navigation").getByRole("link", { name: p.nav }).click();
+      await expect(page).toHaveURL(new RegExp(`${p.path}$`));
+      await expect(page.getByRole("heading", { name: p.heading })).toBeVisible();
+    });
+  }
+
+  test("deep-linking straight to a page works", async ({ seniorPage: page }) => {
+    await page.goto("/maintenance");
+    await expect(page.getByRole("heading", { name: /^Maintenance$/ })).toBeVisible();
+    // The three KPI cards are always present, even with zero work orders.
+    await expect(page.getByText(/Emergencies/i)).toBeVisible();
+    await expect(page.getByText(/Open Orders/i)).toBeVisible();
+  });
+
+  test("New Work Order modal offers only valid priorities", async ({ seniorPage: page }) => {
+    await page.goto("/maintenance");
+    await page.getByRole("button", { name: /New Work Order/i }).click();
+
+    const priority = page.locator("select").filter({ hasText: /Routine/ }).first();
+    await expect(priority).toBeVisible();
+    // Must match the work_order_priority enum — no medium/high/critical.
+    const options = await priority.locator("option").allInnerTexts();
+    expect(options.map((o) => o.toLowerCase())).toEqual([
+      "low",
+      "routine",
+      "urgent",
+      "emergency",
+    ]);
+  });
+});

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -16,6 +16,7 @@
         "rrweb-player": "^1.0.0-alpha.4"
       },
       "devDependencies": {
+        "@playwright/test": "^1.60.0",
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
         "@vitejs/plugin-react": "^4.3.4",
@@ -849,6 +850,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@remix-run/router": {
@@ -2123,6 +2140,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/client/package.json
+++ b/client/package.json
@@ -6,7 +6,10 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "e2e": "playwright test",
+    "e2e:ui": "playwright test --ui",
+    "e2e:install": "playwright install chromium"
   },
   "dependencies": {
     "lucide-react": "^0.460.0",
@@ -17,6 +20,7 @@
     "rrweb-player": "^1.0.0-alpha.4"
   },
   "devDependencies": {
+    "@playwright/test": "^1.60.0",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.4",

--- a/client/playwright.config.ts
+++ b/client/playwright.config.ts
@@ -1,0 +1,66 @@
+import { defineConfig, devices } from "@playwright/test";
+
+// Playwright harness for the PM / staff console ("CDPC Compliance Hub").
+//
+// Two web servers are booted (both idempotent via reuseExistingServer):
+//   1. The full backend stack — Docker/local Postgres + migrate + seed + the
+//      Express API on :3002 — via the repo-root `npm run e2e:up`. We probe the
+//      API's /health rather than the tenant vite it also starts, so this app's
+//      harness doesn't depend on the sibling tenant build.
+//   2. This console's Vite dev server on :5176 (proxies /api -> :3002). We pick
+//      5176 so it coexists with a normal `npm run dev` (:5173) and the tenant
+//      e2e harness (:5175).
+//
+// Override the base URL with E2E_BASE_URL to point at a deployed environment.
+
+const VITE_PORT = Number(process.env.PM_VITE_PORT ?? 5176);
+const BASE_URL = process.env.E2E_BASE_URL ?? `http://127.0.0.1:${VITE_PORT}`;
+const API_HEALTH = process.env.E2E_API_HEALTH ?? "http://127.0.0.1:3002/health";
+
+export default defineConfig({
+  testDir: "./e2e/scenarios",
+  testMatch: /.*\.spec\.ts/,
+  fullyParallel: false, // tests share one DB; serial avoids race conditions
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  reporter: process.env.CI
+    ? [["github"], ["html", { open: "never" }]]
+    : [["list"], ["html", { open: "never" }]],
+  use: {
+    baseURL: BASE_URL,
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+    actionTimeout: 10_000,
+    navigationTimeout: 30_000,
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  // Skip server boot when pointing at a deployed environment.
+  webServer: process.env.E2E_BASE_URL
+    ? undefined
+    : [
+        {
+          command: "npm run e2e:up",
+          cwd: "..",
+          url: API_HEALTH,
+          reuseExistingServer: true,
+          timeout: 180_000,
+          stdout: "pipe",
+          stderr: "pipe",
+        },
+        {
+          command: `npm run dev -- --port ${VITE_PORT} --host 127.0.0.1`,
+          url: BASE_URL,
+          reuseExistingServer: true,
+          timeout: 60_000,
+          stdout: "pipe",
+          stderr: "pipe",
+        },
+      ],
+});

--- a/client/src/components/DataTable.tsx
+++ b/client/src/components/DataTable.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import type { ReactNode, KeyboardEvent as ReactKeyboardEvent } from 'react';
 
 export interface Column<T> {
   key: string;
@@ -13,6 +13,8 @@ interface DataTableProps<T> {
   onRowClick?: (row: T) => void;
   emptyMessage?: string;
   loading?: boolean;
+  /** When set, renders an error state instead of the (misleading) empty state. */
+  error?: string | null;
 }
 
 export function DataTable<T>({
@@ -21,11 +23,28 @@ export function DataTable<T>({
   onRowClick,
   emptyMessage = 'No data found',
   loading,
+  error,
 }: DataTableProps<T>) {
   if (loading) {
     return (
-      <div className="rounded-xl border border-gray-200 bg-white p-8 text-center">
+      <div
+        className="rounded-xl border border-gray-200 bg-white p-8 text-center"
+        role="status"
+        aria-live="polite"
+        aria-label="Loading"
+      >
         <div className="mx-auto h-6 w-6 animate-spin rounded-full border-2 border-emerald-600 border-t-transparent" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div
+        className="rounded-xl border border-red-200 bg-red-50 p-8 text-center text-sm text-red-700"
+        role="alert"
+      >
+        {error}
       </div>
     );
   }
@@ -56,7 +75,20 @@ export function DataTable<T>({
               <tr
                 key={(row as Record<string, unknown>).id as string || String(i)}
                 onClick={() => onRowClick?.(row)}
-                className={`border-b border-gray-100 last:border-0 ${onRowClick ? 'cursor-pointer hover:bg-gray-50' : ''}`}
+                {...(onRowClick
+                  ? {
+                      role: 'button',
+                      tabIndex: 0,
+                      'aria-label': 'View details',
+                      onKeyDown: (e: ReactKeyboardEvent) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                          e.preventDefault();
+                          onRowClick(row);
+                        }
+                      },
+                    }
+                  : {})}
+                className={`border-b border-gray-100 last:border-0 ${onRowClick ? 'cursor-pointer hover:bg-gray-50 focus:bg-gray-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-emerald-500' : ''}`}
               >
                 {columns.map((col) => (
                   <td key={col.key} className={`px-4 py-3 text-gray-700 ${col.className || ''}`}>

--- a/client/src/components/Modal.tsx
+++ b/client/src/components/Modal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, type ReactNode } from 'react';
+import { useEffect, useId, useRef, type ReactNode } from 'react';
 import { X } from 'lucide-react';
 
 interface ModalProps {
@@ -10,26 +10,48 @@ interface ModalProps {
 }
 
 export function Modal({ open, onClose, title, children, wide }: ModalProps) {
+  const titleId = useId();
+  const panelRef = useRef<HTMLDivElement>(null);
+
   useEffect(() => {
-    if (open) {
-      const handler = (e: KeyboardEvent) => e.key === 'Escape' && onClose();
-      document.addEventListener('keydown', handler);
-      return () => document.removeEventListener('keydown', handler);
-    }
+    if (!open) return;
+    const handler = (e: KeyboardEvent) => e.key === 'Escape' && onClose();
+    document.addEventListener('keydown', handler);
+    // Move focus into the dialog so keyboard + screen-reader users land inside
+    // it (and Escape works without first clicking). Restore focus on close.
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+    panelRef.current?.focus();
+    return () => {
+      document.removeEventListener('keydown', handler);
+      previouslyFocused?.focus?.();
+    };
   }, [open, onClose]);
 
   if (!open) return null;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40" onClick={onClose}>
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+      onClick={onClose}
+    >
       <div
-        className={`relative max-h-[90vh] overflow-y-auto rounded-xl bg-white p-6 shadow-xl ${wide ? 'w-full max-w-2xl' : 'w-full max-w-md'}`}
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        tabIndex={-1}
+        className={`relative max-h-[90vh] overflow-y-auto rounded-xl bg-white p-6 shadow-xl outline-none ${wide ? 'w-full max-w-2xl' : 'w-full max-w-md'}`}
         onClick={(e) => e.stopPropagation()}
       >
         <div className="mb-4 flex items-center justify-between">
-          <h2 className="text-lg font-semibold text-gray-900">{title}</h2>
-          <button onClick={onClose} className="rounded-lg p-1 hover:bg-gray-100">
-            <X className="h-5 w-5 text-gray-400" />
+          <h2 id={titleId} className="text-lg font-semibold text-gray-900">{title}</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close dialog"
+            className="rounded-lg p-1 text-gray-400 hover:bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500"
+          >
+            <X className="h-5 w-5" />
           </button>
         </div>
         {children}

--- a/client/src/components/Sidebar.tsx
+++ b/client/src/components/Sidebar.tsx
@@ -67,7 +67,7 @@ export function Sidebar({ collapsed = false }: { collapsed?: boolean }) {
         <Building2 className="h-6 w-6 shrink-0 text-emerald-600" />
         {!collapsed && <span className="text-lg font-semibold text-gray-900">CDPC Hub</span>}
       </div>
-      <nav className="flex-1 space-y-1 p-3">
+      <nav aria-label="Primary" className="flex-1 space-y-1 p-3">
         {visible.map((item) => (
           <NavLink
             key={item.path}

--- a/client/src/components/StatusBadge.tsx
+++ b/client/src/components/StatusBadge.tsx
@@ -14,6 +14,7 @@ const STATUS_COLORS: Record<string, string> = {
   tier3_approved: 'bg-emerald-100 text-emerald-700',
   tier3_denied: 'bg-red-100 text-red-700',
   lease_generated: 'bg-purple-100 text-purple-700',
+  lease_signed: 'bg-purple-100 text-purple-700',
   onboarded: 'bg-emerald-100 text-emerald-700',
   cancelled: 'bg-gray-100 text-gray-500',
   pass: 'bg-emerald-100 text-emerald-700',
@@ -21,6 +22,20 @@ const STATUS_COLORS: Record<string, string> = {
   review_required: 'bg-yellow-100 text-yellow-700',
   active: 'bg-emerald-100 text-emerald-700',
   inactive: 'bg-gray-100 text-gray-500',
+  // Maintenance work-order priorities (work_order_priority enum)
+  emergency: 'bg-red-100 text-red-700',
+  urgent: 'bg-amber-100 text-amber-700',
+  routine: 'bg-blue-100 text-blue-700',
+  low: 'bg-gray-100 text-gray-600',
+  // Maintenance work-order lifecycle (work_order_status enum)
+  assigned: 'bg-blue-100 text-blue-700',
+  in_progress: 'bg-amber-100 text-amber-700',
+  completed: 'bg-emerald-100 text-emerald-700',
+  // Waitlist / generic outcomes
+  waitlisted: 'bg-indigo-100 text-indigo-700',
+  pending: 'bg-yellow-100 text-yellow-700',
+  approved: 'bg-emerald-100 text-emerald-700',
+  denied: 'bg-red-100 text-red-700',
 };
 
 export function StatusBadge({ status }: { status: string }) {

--- a/client/src/pages/Maintenance.tsx
+++ b/client/src/pages/Maintenance.tsx
@@ -16,7 +16,7 @@ const CATEGORIES = [
 ];
 
 export function MaintenancePage() {
-  const { data, loading, refetch } = useApiQuery<{ workOrders: WorkOrder[]; total: number }>('/api/maintenance?limit=100');
+  const { data, loading, error, refetch } = useApiQuery<{ workOrders: WorkOrder[]; total: number }>('/api/maintenance?limit=100');
   const { data: propsData } = useApiQuery<PropertyListResponse>('/api/properties');
   const { data: usersData } = useApiQuery<UserListResponse>('/api/users');
   const [selected, setSelected] = useState<WorkOrder | null>(null);
@@ -81,7 +81,7 @@ export function MaintenancePage() {
 
       {actionMsg && <div className={`rounded-lg px-4 py-3 text-sm ${actionMsg.type === 'success' ? 'bg-green-50 text-green-700' : 'bg-red-50 text-red-700'}`}>{actionMsg.text}</div>}
 
-      <DataTable columns={columns} data={workOrders} loading={loading} onRowClick={setSelected} emptyMessage="No work orders" />
+      <DataTable columns={columns} data={workOrders} loading={loading} error={error} onRowClick={setSelected} emptyMessage="No work orders" />
 
       {/* Create Modal */}
       <Modal open={showCreate} onClose={() => setShowCreate(false)} title="New Work Order" wide>


### PR DESCRIPTION
## What

Adds the **first Playwright e2e suite for the PM / staff console** (`client/` had none) and a round of shared-component polish.

### E2E
Mirrors the tenant harness pattern (`client-tenant/`):
- **`playwright.config.ts`** — two web servers (idempotent): root `npm run e2e:up` (Postgres + API on :3002) and this console's Vite on **:5176** (coexists with normal dev :5173 and tenant e2e :5175). `E2E_BASE_URL=…` targets a deployed env and skips local boot.
- **`e2e/fixtures.ts`** — password-login `signIn` helper, per-role page fixtures (`seniorPage` / `adminPage` / `agentPage`), and a `seedDemoData` helper. Plants `frank_token`/`frank_user` so the SPA boots authenticated.
- **Scenarios (15 tests):**
  - `auth` — real login form + route protection + bad-creds error
  - `dashboard` — 5 clickable stat cards render + navigate (PR #140)
  - `applications` — full column set, row → detail, tab filtering
  - `navigation` — Screening / Approvals / Properties / Maintenance load; work-order priority enum guard
- `@playwright/test` + `e2e` / `e2e:ui` / `e2e:install` scripts added to `client/package.json`.

```
15 passed (6.8s)
```

### UI polish (kept clear of `Dashboard.tsx` / `Applications.tsx` — owned by another session)
- **StatusBadge** — added color coverage for work-order priorities (`emergency`/`urgent`/`routine`/`low`), lifecycle (`assigned`/`in_progress`/`completed`), `lease_signed`, `waitlisted`, and generic outcomes. These previously fell through to gray.
- **Modal** — `role=dialog` + `aria-modal` + `aria-labelledby`, accessible close button, focus-in-on-open / restore-on-close.
- **DataTable** — keyboard-operable clickable rows (role/tabindex/Enter+Space + focus ring) and an optional `error` state so failed queries surface instead of masquerading as "No data" (wired through Maintenance).
- **Sidebar** — `aria-label` on the primary nav landmark.

## Note on the brief's Maintenance bug
The "New Work Order" priority enum mismatch (`low/medium/high/critical`) described in the task is **already fixed on main** — the form, backend (`src/modules/maintenance/routes.ts`), and DB enum all agree on `low/routine/urgent/emergency`. `navigation.spec.ts` adds a regression guard so it stays that way.

## Test
`cd client && npm run build` ✅ &nbsp;·&nbsp; `npm run e2e` → 15 passed ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)