### PR TITLE
feat(acquisitions): Phase 2 — Project Scoring Tool over the QAP subset

### DIFF
--- a/client-acq/src/App.tsx
+++ b/client-acq/src/App.tsx
@@ -4,6 +4,7 @@ import { ProtectedRoute } from '@/components/ProtectedRoute';
 import { Layout } from '@/components/Layout';
 import { Login } from '@/pages/Login';
 import { Demand } from '@/pages/Demand';
+import { Projects } from '@/pages/Projects';
 
 export default function App() {
   return (
@@ -14,6 +15,7 @@ export default function App() {
           <Route element={<ProtectedRoute />}>
             <Route element={<Layout />}>
               <Route index element={<Demand />} />
+              <Route path="projects" element={<Projects />} />
               <Route path="*" element={<Navigate to="/" replace />} />
             </Route>
           </Route>

--- a/client-acq/src/api/client.ts
+++ b/client-acq/src/api/client.ts
@@ -34,6 +34,8 @@ export const api = {
   get: <T>(path: string) => request<T>(path),
   post: <T>(path: string, body?: unknown) =>
     request<T>(path, { method: 'POST', body: body ? JSON.stringify(body) : undefined }),
+  put: <T>(path: string, body?: unknown) =>
+    request<T>(path, { method: 'PUT', body: body ? JSON.stringify(body) : undefined }),
   patch: <T>(path: string, body?: unknown) =>
     request<T>(path, { method: 'PATCH', body: body ? JSON.stringify(body) : undefined }),
   del: <T>(path: string) => request<T>(path, { method: 'DELETE' }),

--- a/client-acq/src/components/Layout.tsx
+++ b/client-acq/src/components/Layout.tsx
@@ -1,12 +1,13 @@
 import { Outlet, NavLink } from 'react-router-dom';
-import { LogOut, BarChart3, Building2 } from 'lucide-react';
+import { LogOut, BarChart3, Building2, FolderKanban } from 'lucide-react';
 import { useAuth } from '@/hooks/useAuth';
 import { formatRole } from '@/types';
 
-// Acquisitions nav. Phase 1 ships Demand; Projects (Phase 2) and Awards
-// (Phase 3) are placeholders so the routes slot in without a layout change.
+// Acquisitions nav. Phase 1 ships Demand; Phase 2 adds Projects; Awards
+// (Phase 3) slots in next without a layout change.
 const NAV = [
   { to: '/', label: 'Demand Evidence', icon: BarChart3, end: true },
+  { to: '/projects', label: 'Candidate Projects', icon: FolderKanban, end: false },
 ];
 
 export function Layout() {

--- a/client-acq/src/pages/Projects.tsx
+++ b/client-acq/src/pages/Projects.tsx
@@ -1,0 +1,610 @@
+import { useState, type ReactNode } from 'react';
+import {
+  Building2,
+  Plus,
+  Pencil,
+  Trash2,
+  Target,
+  X,
+  MapPin,
+  CheckCircle2,
+  AlertTriangle,
+} from 'lucide-react';
+import { PageHeader } from '@/components/PageHeader';
+import { useApiQuery } from '@/hooks/useApiQuery';
+import { api } from '@/api/client';
+import {
+  type AcqProject,
+  type ProjectInput,
+  type ProjectScore,
+  type ScoredProject,
+  type GeographicAccount,
+  type SetAsideAccount,
+  type ElectionKind,
+  type ResidentService,
+  GEO_LABELS,
+  SET_ASIDE_LABELS,
+  ELECTION_LABELS,
+  RESIDENT_SERVICE_OPTIONS,
+} from '@/types';
+
+const ACCOUNTS: GeographicAccount[] = ['CLARK', 'WASHOE', 'OTHER'];
+const ELECTIONS: ElectionKind[] = ['STD_40_60', 'STD_20_50', 'AVERAGE_INCOME'];
+const SET_ASIDES: SetAsideAccount[] = ['NONPROFIT', 'USDA_RD', 'TRIBAL', 'ADDITIONAL'];
+
+export function Projects() {
+  const { data, loading, error, refetch } = useApiQuery<{ projects: AcqProject[] }>(
+    '/api/acquisitions/projects',
+  );
+  // `editing` holds 'new', an existing project, or null (closed).
+  const [editing, setEditing] = useState<AcqProject | 'new' | null>(null);
+  const [scoringId, setScoringId] = useState<string | null>(null);
+  const [deleting, setDeleting] = useState<string | null>(null);
+
+  const projects = data?.projects ?? [];
+
+  async function remove(id: string) {
+    if (!window.confirm('Delete this candidate project? This cannot be undone.')) return;
+    setDeleting(id);
+    try {
+      await api.del(`/api/acquisitions/projects/${id}`);
+      refetch();
+    } catch (err) {
+      window.alert(err instanceof Error ? err.message : 'Delete failed');
+    } finally {
+      setDeleting(null);
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        icon={Building2}
+        title="Candidate Projects"
+        description="Score a candidate LIHTC project against the funnel-relevant QAP subset (§7.4.1/2/3, §7.3.1) and the live §6.1 market-study demand."
+        action={
+          <button
+            onClick={() => setEditing('new')}
+            className="flex items-center gap-1.5 rounded-lg bg-emerald-600 px-3 py-2 text-sm font-medium text-white hover:bg-emerald-700"
+          >
+            <Plus className="h-4 w-4" />
+            New project
+          </button>
+        }
+      />
+
+      {error && <p className="rounded-lg bg-red-50 px-4 py-3 text-sm text-red-600">{error}</p>}
+
+      <div className="rounded-xl border border-gray-200 bg-white">
+        <div className="border-b border-gray-200 px-5 py-3">
+          <h2 className="text-sm font-semibold text-gray-900">Candidate projects</h2>
+        </div>
+        {loading ? (
+          <div className="flex items-center justify-center py-12">
+            <div className="h-6 w-6 animate-spin rounded-full border-4 border-emerald-600 border-t-transparent" />
+          </div>
+        ) : projects.length > 0 ? (
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-gray-100 text-left text-xs uppercase tracking-wide text-gray-400">
+                <th className="px-5 py-2 font-medium">Project</th>
+                <th className="px-5 py-2 font-medium">Account</th>
+                <th className="px-5 py-2 font-medium">Election</th>
+                <th className="px-5 py-2 text-right font-medium">Units</th>
+                <th className="px-5 py-2 text-right font-medium">Restricted</th>
+                <th className="px-5 py-2 font-medium">Siting</th>
+                <th className="px-5 py-2 text-right font-medium">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {projects.map((p) => {
+                const restricted = p.units30Ami + p.units50Ami + p.units60Ami;
+                return (
+                  <tr key={p.id} className="border-b border-gray-50 hover:bg-gray-50/60">
+                    <td className="px-5 py-2.5">
+                      <p className="font-medium text-gray-900">{p.name}</p>
+                      {p.city && <p className="text-xs text-gray-400">{p.city}</p>}
+                    </td>
+                    <td className="px-5 py-2.5 text-gray-700">{GEO_LABELS[p.geographicAccount]}</td>
+                    <td className="px-5 py-2.5 text-gray-700">{ELECTION_LABELS[p.electionKind]}</td>
+                    <td className="px-5 py-2.5 text-right text-gray-900">{p.totalUnits}</td>
+                    <td className="px-5 py-2.5 text-right text-gray-900">{restricted}</td>
+                    <td className="px-5 py-2.5">
+                      {p.isQct || p.isDda ? (
+                        <span className="inline-flex items-center gap-1 rounded-full bg-emerald-50 px-2 py-0.5 text-xs font-medium text-emerald-700">
+                          <MapPin className="h-3 w-3" />
+                          {p.isQct && p.isDda ? 'QCT+DDA' : p.isQct ? 'QCT' : 'DDA'}
+                        </span>
+                      ) : (
+                        <span className="text-xs text-gray-400">—</span>
+                      )}
+                    </td>
+                    <td className="px-5 py-2.5">
+                      <div className="flex items-center justify-end gap-1">
+                        <IconButton title="Score" onClick={() => setScoringId(p.id)}>
+                          <Target className="h-4 w-4" />
+                        </IconButton>
+                        <IconButton title="Edit" onClick={() => setEditing(p)}>
+                          <Pencil className="h-4 w-4" />
+                        </IconButton>
+                        <IconButton
+                          title="Delete"
+                          onClick={() => remove(p.id)}
+                          disabled={deleting === p.id}
+                          danger
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </IconButton>
+                      </div>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        ) : (
+          <p className="px-5 py-12 text-center text-sm text-gray-400">
+            No candidate projects yet. Add one to score it against the QAP subset.
+          </p>
+        )}
+      </div>
+
+      {editing && (
+        <ProjectForm
+          project={editing === 'new' ? null : editing}
+          onClose={() => setEditing(null)}
+          onSaved={() => {
+            setEditing(null);
+            refetch();
+          }}
+        />
+      )}
+
+      {scoringId && <ScoreModal projectId={scoringId} onClose={() => setScoringId(null)} />}
+    </div>
+  );
+}
+
+// ── Create / edit form ───────────────────────────────────────────────────────
+
+interface FormState {
+  name: string;
+  geographicAccount: GeographicAccount;
+  city: string;
+  setAside: SetAsideAccount | '';
+  electionKind: ElectionKind;
+  totalUnits: number;
+  units30Ami: number;
+  units50Ami: number;
+  units60Ami: number;
+  isQct: boolean;
+  isDda: boolean;
+  residentServices: ResidentService[];
+  notes: string;
+}
+
+function toFormState(p: AcqProject | null): FormState {
+  return {
+    name: p?.name ?? '',
+    geographicAccount: p?.geographicAccount ?? 'CLARK',
+    city: p?.city ?? '',
+    setAside: p?.setAside ?? '',
+    electionKind: p?.electionKind ?? 'STD_40_60',
+    totalUnits: p?.totalUnits ?? 0,
+    units30Ami: p?.units30Ami ?? 0,
+    units50Ami: p?.units50Ami ?? 0,
+    units60Ami: p?.units60Ami ?? 0,
+    isQct: p?.isQct ?? false,
+    isDda: p?.isDda ?? false,
+    residentServices: p?.residentServices ?? [],
+    notes: p?.notes ?? '',
+  };
+}
+
+function ProjectForm({
+  project,
+  onClose,
+  onSaved,
+}: {
+  project: AcqProject | null;
+  onClose: () => void;
+  onSaved: () => void;
+}) {
+  const [form, setForm] = useState<FormState>(() => toFormState(project));
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const restricted = form.units30Ami + form.units50Ami + form.units60Ami;
+  const overcommitted = restricted > form.totalUnits;
+  const nameMissing = form.name.trim().length === 0;
+  const canSave = !overcommitted && !nameMissing && !saving;
+
+  function set<K extends keyof FormState>(key: K, value: FormState[K]) {
+    setForm((f) => ({ ...f, [key]: value }));
+  }
+
+  function toggleService(key: ResidentService) {
+    setForm((f) => ({
+      ...f,
+      residentServices: f.residentServices.includes(key)
+        ? f.residentServices.filter((s) => s !== key)
+        : [...f.residentServices, key],
+    }));
+  }
+
+  async function submit() {
+    if (!canSave) return;
+    setSaving(true);
+    setError(null);
+    const payload: ProjectInput = {
+      name: form.name.trim(),
+      geographicAccount: form.geographicAccount,
+      city: form.city.trim() || null,
+      setAside: form.setAside || null,
+      electionKind: form.electionKind,
+      totalUnits: form.totalUnits,
+      units30Ami: form.units30Ami,
+      units50Ami: form.units50Ami,
+      units60Ami: form.units60Ami,
+      isQct: form.isQct,
+      isDda: form.isDda,
+      residentServices: form.residentServices,
+      notes: form.notes.trim() || null,
+    };
+    try {
+      if (project) {
+        await api.put(`/api/acquisitions/projects/${project.id}`, payload);
+      } else {
+        await api.post('/api/acquisitions/projects', payload);
+      }
+      onSaved();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Save failed');
+      setSaving(false);
+    }
+  }
+
+  return (
+    <Modal title={project ? 'Edit project' : 'New candidate project'} onClose={onClose}>
+      <div className="space-y-4">
+        <Field label="Project name">
+          <input
+            className="input"
+            value={form.name}
+            onChange={(e) => set('name', e.target.value)}
+            placeholder="e.g. Desert Vista Apartments"
+            autoFocus
+          />
+        </Field>
+
+        <div className="grid grid-cols-2 gap-4">
+          <Field label="Geographic account">
+            <select
+              className="input"
+              value={form.geographicAccount}
+              onChange={(e) => set('geographicAccount', e.target.value as GeographicAccount)}
+            >
+              {ACCOUNTS.map((a) => (
+                <option key={a} value={a}>
+                  {GEO_LABELS[a]}
+                </option>
+              ))}
+            </select>
+          </Field>
+          <Field label="City (optional)">
+            <input className="input" value={form.city} onChange={(e) => set('city', e.target.value)} />
+          </Field>
+        </div>
+
+        <div className="grid grid-cols-2 gap-4">
+          <Field label="Set-aside (optional)">
+            <select
+              className="input"
+              value={form.setAside}
+              onChange={(e) => set('setAside', e.target.value as SetAsideAccount | '')}
+            >
+              <option value="">None</option>
+              {SET_ASIDES.map((s) => (
+                <option key={s} value={s}>
+                  {SET_ASIDE_LABELS[s]}
+                </option>
+              ))}
+            </select>
+          </Field>
+          <Field label="Rent/income election (§7.4.2)">
+            <select
+              className="input"
+              value={form.electionKind}
+              onChange={(e) => set('electionKind', e.target.value as ElectionKind)}
+            >
+              {ELECTIONS.map((k) => (
+                <option key={k} value={k}>
+                  {ELECTION_LABELS[k]}
+                </option>
+              ))}
+            </select>
+          </Field>
+        </div>
+
+        <div>
+          <p className="mb-1.5 text-xs font-medium uppercase tracking-wide text-gray-400">
+            Unit mix (§7.4.1 — units committed AT each tier)
+          </p>
+          <div className="grid grid-cols-4 gap-3">
+            <NumField label="Total units" value={form.totalUnits} onChange={(v) => set('totalUnits', v)} />
+            <NumField label="@ 30% AMI" value={form.units30Ami} onChange={(v) => set('units30Ami', v)} />
+            <NumField label="@ 50% AMI" value={form.units50Ami} onChange={(v) => set('units50Ami', v)} />
+            <NumField label="@ 60% AMI" value={form.units60Ami} onChange={(v) => set('units60Ami', v)} />
+          </div>
+          {overcommitted && (
+            <p className="mt-1.5 flex items-center gap-1 text-xs text-red-600">
+              <AlertTriangle className="h-3.5 w-3.5" />
+              Restricted units ({restricted}) exceed total units ({form.totalUnits}).
+            </p>
+          )}
+        </div>
+
+        <Field label="Location (§7.3.1 / §11 basis boost)">
+          <div className="flex gap-5 pt-1">
+            <Checkbox label="In a Qualified Census Tract (QCT)" checked={form.isQct} onChange={(v) => set('isQct', v)} />
+            <Checkbox label="In a Difficult Development Area (DDA)" checked={form.isDda} onChange={(v) => set('isDda', v)} />
+          </div>
+        </Field>
+
+        <Field label="Resident services (§7.4.3 — sum of points, capped at 6)">
+          <div className="grid grid-cols-2 gap-x-5 gap-y-1.5 pt-1">
+            {RESIDENT_SERVICE_OPTIONS.map((s) => (
+              <Checkbox
+                key={s.key}
+                label={`${s.label} (${s.points} pt${s.points === 1 ? '' : 's'})`}
+                checked={form.residentServices.includes(s.key)}
+                onChange={() => toggleService(s.key)}
+              />
+            ))}
+          </div>
+        </Field>
+
+        <Field label="Notes (optional)">
+          <textarea
+            className="input min-h-[64px]"
+            value={form.notes}
+            onChange={(e) => set('notes', e.target.value)}
+          />
+        </Field>
+
+        {error && <p className="rounded-lg bg-red-50 px-3 py-2 text-sm text-red-600">{error}</p>}
+
+        <div className="flex justify-end gap-2 border-t border-gray-100 pt-4">
+          <button
+            onClick={onClose}
+            className="rounded-lg px-4 py-2 text-sm font-medium text-gray-600 hover:bg-gray-100"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={submit}
+            disabled={!canSave}
+            className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-700 disabled:opacity-50"
+          >
+            {saving ? 'Saving…' : project ? 'Save changes' : 'Create project'}
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+// ── Score modal ──────────────────────────────────────────────────────────────
+
+function ScoreModal({ projectId, onClose }: { projectId: string; onClose: () => void }) {
+  const { data, loading, error } = useApiQuery<ScoredProject>(
+    `/api/acquisitions/projects/${projectId}/score`,
+  );
+
+  return (
+    <Modal title={data ? `Score — ${data.project.name}` : 'Score'} onClose={onClose}>
+      {loading && (
+        <div className="flex items-center justify-center py-12">
+          <div className="h-6 w-6 animate-spin rounded-full border-4 border-emerald-600 border-t-transparent" />
+        </div>
+      )}
+      {error && <p className="rounded-lg bg-red-50 px-4 py-3 text-sm text-red-600">{error}</p>}
+      {data && <ScoreDetail score={data.score} />}
+    </Modal>
+  );
+}
+
+function ScoreDetail({ score }: { score: ProjectScore }) {
+  const pct = score.eligibility.subsetPct;
+  return (
+    <div className="space-y-5">
+      {/* Headline: subset score */}
+      <div className="rounded-xl border border-gray-200 bg-gray-50 p-5">
+        <div className="flex items-end justify-between">
+          <div>
+            <p className="text-xs font-medium uppercase tracking-wide text-gray-400">
+              Funnel-relevant subset score
+            </p>
+            <p className="mt-1 text-3xl font-semibold text-gray-900">
+              {score.funnelPoints}
+              <span className="text-lg text-gray-400"> / {score.funnelMaxPoints} pts</span>
+            </p>
+          </div>
+          <p className="text-2xl font-semibold text-emerald-600">{pct}%</p>
+        </div>
+        <div className="mt-3 h-2 overflow-hidden rounded-full bg-gray-200">
+          <div className="h-full bg-emerald-500" style={{ width: `${Math.min(100, pct)}%` }} />
+        </div>
+        <p className="mt-2 text-xs text-gray-400">{score.eligibility.note}</p>
+      </div>
+
+      {/* Criteria breakdown */}
+      <div className="space-y-2">
+        {score.criteria.map((c) => (
+          <div key={c.key} className="rounded-lg border border-gray-100 p-3">
+            <div className="flex items-baseline justify-between">
+              <p className="text-sm font-medium text-gray-900">
+                <span className="mr-1.5 text-xs text-gray-400">{c.section}</span>
+                {c.label}
+              </p>
+              <p className="text-sm font-semibold text-gray-900">
+                {c.points}
+                <span className="text-gray-400"> / {c.maxPoints}</span>
+              </p>
+            </div>
+            <p className="mt-0.5 text-xs text-gray-500">{c.detail}</p>
+          </div>
+        ))}
+      </div>
+
+      {/* Market study + basis boost */}
+      <div className="grid grid-cols-2 gap-4">
+        <div className="rounded-lg border border-gray-100 bg-gray-50 p-4">
+          <p className="text-xs font-medium text-gray-600">Market study (§6.1)</p>
+          <p
+            className={`mt-1 text-xl font-semibold ${
+              score.marketStudy.captureRatePct == null
+                ? 'text-gray-400'
+                : score.marketStudy.meetsThreshold
+                  ? 'text-emerald-600'
+                  : 'text-amber-600'
+            }`}
+          >
+            {score.marketStudy.captureRatePct == null
+              ? '—'
+              : `${score.marketStudy.captureRatePct}% capture`}
+          </p>
+          <p className="mt-0.5 text-xs text-gray-400">
+            {score.marketStudy.affordableUnits} affordable units vs {score.marketStudy.qualifiedDemand}{' '}
+            qualified applicants · ceiling {score.marketStudy.maxAcceptableCaptureRatePct}%
+          </p>
+          <StatusChip
+            ok={score.marketStudy.meetsThreshold}
+            okText="Within capture ceiling"
+            badText={
+              score.marketStudy.captureRatePct == null ? 'No demand captured yet' : 'Exceeds ceiling'
+            }
+          />
+        </div>
+        <div className="rounded-lg border border-gray-100 bg-gray-50 p-4">
+          <p className="text-xs font-medium text-gray-600">Basis boost (§11)</p>
+          <p
+            className={`mt-1 text-xl font-semibold ${
+              score.basisBoost.eligible ? 'text-emerald-600' : 'text-gray-400'
+            }`}
+          >
+            {score.basisBoost.eligible ? `+${score.basisBoost.boostPct}%` : 'None'}
+          </p>
+          <p className="mt-0.5 text-xs text-gray-400">
+            {score.basisBoost.eligible ? 'QCT/DDA siting unlocks the eligible-basis boost.' : 'Requires QCT/DDA siting.'}
+          </p>
+          <StatusChip ok={score.basisBoost.eligible} okText="Eligible" badText="Not eligible" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Small shared UI ──────────────────────────────────────────────────────────
+
+function Modal({ title, onClose, children }: { title: string; onClose: () => void; children: ReactNode }) {
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto bg-black/30 p-4 sm:p-8"
+      onClick={onClose}
+    >
+      <div
+        className="my-4 w-full max-w-2xl rounded-2xl bg-white shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between border-b border-gray-200 px-5 py-3.5">
+          <h2 className="text-base font-semibold text-gray-900">{title}</h2>
+          <button onClick={onClose} className="rounded-lg p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-700">
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+        <div className="p-5">{children}</div>
+      </div>
+    </div>
+  );
+}
+
+function Field({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div>
+      <label className="label">{label}</label>
+      {children}
+    </div>
+  );
+}
+
+function NumField({ label, value, onChange }: { label: string; value: number; onChange: (v: number) => void }) {
+  return (
+    <div>
+      <label className="mb-1 block text-xs text-gray-500">{label}</label>
+      <input
+        type="number"
+        min={0}
+        className="input"
+        value={value}
+        onChange={(e) => onChange(Math.max(0, Number(e.target.value) || 0))}
+      />
+    </div>
+  );
+}
+
+function Checkbox({ label, checked, onChange }: { label: string; checked: boolean; onChange: (v: boolean) => void }) {
+  return (
+    <label className="flex cursor-pointer items-center gap-2 text-sm text-gray-700">
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={(e) => onChange(e.target.checked)}
+        className="h-4 w-4 rounded border-gray-300 text-emerald-600 focus:ring-emerald-500"
+      />
+      {label}
+    </label>
+  );
+}
+
+function IconButton({
+  children,
+  title,
+  onClick,
+  disabled,
+  danger,
+}: {
+  children: ReactNode;
+  title: string;
+  onClick: () => void;
+  disabled?: boolean;
+  danger?: boolean;
+}) {
+  return (
+    <button
+      title={title}
+      onClick={onClick}
+      disabled={disabled}
+      className={`rounded-lg p-1.5 disabled:opacity-40 ${
+        danger
+          ? 'text-gray-400 hover:bg-red-50 hover:text-red-600'
+          : 'text-gray-400 hover:bg-gray-100 hover:text-gray-700'
+      }`}
+    >
+      {children}
+    </button>
+  );
+}
+
+function StatusChip({ ok, okText, badText }: { ok: boolean; okText: string; badText: string }) {
+  return (
+    <span
+      className={`mt-2 inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium ${
+        ok ? 'bg-emerald-50 text-emerald-700' : 'bg-amber-50 text-amber-700'
+      }`}
+    >
+      {ok ? <CheckCircle2 className="h-3 w-3" /> : <AlertTriangle className="h-3 w-3" />}
+      {ok ? okText : badText}
+    </span>
+  );
+}

--- a/client-acq/src/types/index.ts
+++ b/client-acq/src/types/index.ts
@@ -96,3 +96,97 @@ export interface DemandPacket {
 export function bedroomLabel(n: number): string {
   return n === 0 ? 'Studio' : `${n} BR`;
 }
+
+// ── Candidate projects + scoring (Phase 2, mirrors scoring.ts / qap-2026.ts) ──
+
+export type SetAsideAccount = 'NONPROFIT' | 'USDA_RD' | 'TRIBAL' | 'ADDITIONAL';
+export type ElectionKind = 'STD_40_60' | 'STD_20_50' | 'AVERAGE_INCOME';
+export type ResidentService =
+  | 'after_school'
+  | 'job_training'
+  | 'health_screening'
+  | 'financial_literacy'
+  | 'transportation'
+  | 'case_management';
+
+export const SET_ASIDE_LABELS: Record<SetAsideAccount, string> = {
+  NONPROFIT: 'Nonprofit',
+  USDA_RD: 'USDA Rural Development',
+  TRIBAL: 'Tribal',
+  ADDITIONAL: 'Additional / general',
+};
+
+export const ELECTION_LABELS: Record<ElectionKind, string> = {
+  STD_40_60: '40% @ 60% AMI',
+  STD_20_50: '20% @ 50% AMI',
+  AVERAGE_INCOME: 'Average income (≤60% avg)',
+};
+
+// Per-service points mirror RESIDENT_SERVICES in qap-2026.ts (case mgmt = 2).
+export const RESIDENT_SERVICE_OPTIONS: Array<{ key: ResidentService; label: string; points: number }> = [
+  { key: 'after_school', label: 'After-school program', points: 1 },
+  { key: 'job_training', label: 'Job training / placement', points: 1 },
+  { key: 'health_screening', label: 'Health screening', points: 1 },
+  { key: 'financial_literacy', label: 'Financial literacy', points: 1 },
+  { key: 'transportation', label: 'Transportation assistance', points: 1 },
+  { key: 'case_management', label: 'Case management', points: 2 },
+];
+
+export interface ProjectInput {
+  name: string;
+  geographicAccount: GeographicAccount;
+  city?: string | null;
+  setAside?: SetAsideAccount | null;
+  electionKind: ElectionKind;
+  totalUnits: number;
+  units30Ami: number;
+  units50Ami: number;
+  units60Ami: number;
+  isQct: boolean;
+  isDda: boolean;
+  residentServices: ResidentService[];
+  notes?: string | null;
+}
+
+export interface AcqProject extends ProjectInput {
+  id: string;
+  createdBy: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CriterionScore {
+  key: string;
+  section: string;
+  label: string;
+  points: number;
+  maxPoints: number;
+  detail: string;
+}
+
+export interface ProjectScore {
+  funnelPoints: number;
+  funnelMaxPoints: number;
+  criteria: CriterionScore[];
+  marketStudy: {
+    affordableUnits: number;
+    qualifiedDemand: number;
+    captureRatePct: number | null;
+    maxAcceptableCaptureRatePct: number;
+    meetsThreshold: boolean;
+  };
+  basisBoost: {
+    eligible: boolean;
+    boostPct: number;
+  };
+  eligibility: {
+    minPct: number;
+    subsetPct: number;
+    note: string;
+  };
+}
+
+export interface ScoredProject {
+  project: AcqProject;
+  score: ProjectScore;
+}

--- a/src/__tests__/acquisitions-projects.test.ts
+++ b/src/__tests__/acquisitions-projects.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Service-layer tests for src/modules/acquisitions/project-service.ts.
+ *
+ * `query` is mocked. CRUD maps snake_case rows → camelCase; `score` fires the
+ * project SELECT (1) then DemandService.getDemand's three queries (applicants,
+ * waitlist, units), so score() sequences four mockResolvedValueOnce calls and
+ * the scoring engine receives the folded qualified-demand total.
+ */
+import type { QueryResult } from 'pg';
+import { ProjectService } from '../modules/acquisitions/project-service';
+import { query } from '../config/database';
+
+jest.mock('../config/database', () => ({ query: jest.fn() }));
+jest.mock('../utils/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+function qr<T extends Record<string, unknown>>(rows: T[], rowCount?: number): QueryResult<T> {
+  return { rows, rowCount: rowCount ?? rows.length } as unknown as QueryResult<T>;
+}
+
+const mockQuery = query as jest.MockedFunction<typeof query>;
+
+function row(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'proj-1',
+    name: 'Desert Vista',
+    geographic_account: 'CLARK',
+    city: 'Las Vegas',
+    set_aside: 'NONPROFIT',
+    election_kind: 'STD_20_50',
+    total_units: 100,
+    units_30_ami: 10,
+    units_50_ami: 20,
+    units_60_ami: 0,
+    is_qct: true,
+    is_dda: false,
+    resident_services: ['case_management'],
+    notes: null,
+    created_by: 'user-1',
+    created_at: '2026-05-22T00:00:00.000Z',
+    updated_at: '2026-05-22T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+const service = new ProjectService();
+
+beforeEach(() => mockQuery.mockReset());
+
+describe('ProjectService CRUD', () => {
+  it('list maps rows to camelCase projects', async () => {
+    mockQuery.mockResolvedValueOnce(qr([row(), row({ id: 'proj-2', name: 'Pine Ridge' })]));
+    const list = await service.list();
+    expect(list).toHaveLength(2);
+    expect(list[0]).toMatchObject({
+      id: 'proj-1',
+      name: 'Desert Vista',
+      geographicAccount: 'CLARK',
+      electionKind: 'STD_20_50',
+      units30Ami: 10,
+      isQct: true,
+      residentServices: ['case_management'],
+    });
+  });
+
+  it('get returns null when the row is missing', async () => {
+    mockQuery.mockResolvedValueOnce(qr([]));
+    expect(await service.get('nope')).toBeNull();
+  });
+
+  it('create passes mapped params in column order and returns the row', async () => {
+    mockQuery.mockResolvedValueOnce(qr([row()]));
+    const created = await service.create(
+      {
+        name: 'Desert Vista',
+        geographicAccount: 'CLARK',
+        city: 'Las Vegas',
+        setAside: 'NONPROFIT',
+        electionKind: 'STD_20_50',
+        totalUnits: 100,
+        units30Ami: 10,
+        units50Ami: 20,
+        units60Ami: 0,
+        isQct: true,
+        isDda: false,
+        residentServices: ['case_management'],
+        notes: null,
+      },
+      'user-1',
+    );
+    expect(created.id).toBe('proj-1');
+    const [, params] = mockQuery.mock.calls[0];
+    // $1 name … $12 resident_services (array) … $14 created_by
+    expect(params).toEqual([
+      'Desert Vista', 'CLARK', 'Las Vegas', 'NONPROFIT', 'STD_20_50',
+      100, 10, 20, 0, true, false, ['case_management'], null, 'user-1',
+    ]);
+  });
+
+  it('update returns null when no row matches', async () => {
+    mockQuery.mockResolvedValueOnce(qr([]));
+    const updated = await service.update('nope', {
+      name: 'X', geographicAccount: 'WASHOE', electionKind: 'STD_40_60',
+      totalUnits: 0, units30Ami: 0, units50Ami: 0, units60Ami: 0,
+      isQct: false, isDda: false, residentServices: [],
+    });
+    expect(updated).toBeNull();
+  });
+
+  it('remove reports whether a row was deleted', async () => {
+    mockQuery.mockResolvedValueOnce(qr([], 1));
+    expect(await service.remove('proj-1')).toBe(true);
+    mockQuery.mockResolvedValueOnce(qr([], 0));
+    expect(await service.remove('gone')).toBe(false);
+  });
+});
+
+describe('ProjectService.score', () => {
+  it('returns null for a missing project', async () => {
+    mockQuery.mockResolvedValueOnce(qr([])); // get → none
+    expect(await service.score('nope')).toBeNull();
+  });
+
+  it('joins funnel demand into the scoring engine', async () => {
+    // 1) project SELECT
+    mockQuery.mockResolvedValueOnce(qr([row()]));
+    // 2-4) DemandService.getDemand: applicants, waitlist, units.
+    // CLARK has 60 qualified applicants across two cities.
+    mockQuery
+      .mockResolvedValueOnce(
+        qr([
+          { city: 'Las Vegas', bedrooms: 2, tier: '50', applicants: 40, is_qct: true, is_dda: false },
+          { city: 'Henderson', bedrooms: 1, tier: '30', applicants: 20, is_qct: false, is_dda: false },
+        ]),
+      )
+      .mockResolvedValueOnce(qr([{ city: 'Las Vegas', bedrooms: 2, depth: 5 }]))
+      .mockResolvedValueOnce(qr([{ city: 'Las Vegas', bedrooms: 2, available: 3, total: 12 }]));
+
+    const scored = await service.score('proj-1');
+    expect(scored).not.toBeNull();
+    expect(scored!.project.id).toBe('proj-1');
+
+    // affordable units = 10 (@30) + 20 (@50) + 0 = 30; demand = 60 → 50% capture.
+    expect(scored!.score.marketStudy.qualifiedDemand).toBe(60);
+    expect(scored!.score.marketStudy.affordableUnits).toBe(30);
+    expect(scored!.score.marketStudy.captureRatePct).toBe(50);
+    expect(scored!.score.marketStudy.meetsThreshold).toBe(false); // 50% > 30%
+
+    // 10% units ≤30% AMI → 6; STD_20_50 → 2; case_management → 2; QCT → 3 = 13.
+    expect(scored!.score.funnelPoints).toBe(13);
+  });
+});

--- a/src/__tests__/acquisitions-scoring.test.ts
+++ b/src/__tests__/acquisitions-scoring.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Unit tests for src/modules/acquisitions/scoring.ts.
+ *
+ * scoreProject is pure (demand passed in), so no DB mock. Covers every scoring
+ * branch: §7.4.1 low-rent tiers + the "at or below" cumulative logic, §7.4.2
+ * election bonus, §7.4.3 service sum + cap, §7.3.1 QCT/DDA, the §6.1 capture
+ * rate, and the eligibility subset math.
+ */
+import {
+  scoreProject,
+  FUNNEL_MAX_POINTS,
+  type ScorableProject,
+} from '../modules/acquisitions/scoring';
+import type { ResidentService } from '../modules/acquisitions/qap-2026';
+
+function project(overrides: Partial<ScorableProject> = {}): ScorableProject {
+  return {
+    geographicAccount: 'CLARK',
+    electionKind: 'STD_40_60',
+    totalUnits: 100,
+    units30Ami: 0,
+    units50Ami: 0,
+    units60Ami: 0,
+    isQct: false,
+    isDda: false,
+    residentServices: [],
+    ...overrides,
+  };
+}
+
+const points = (s: ReturnType<typeof scoreProject>, key: string) =>
+  s.criteria.find((c) => c.key === key)!.points;
+
+describe('FUNNEL_MAX_POINTS', () => {
+  it('sums the four funnel-relevant criteria to 17', () => {
+    expect(FUNNEL_MAX_POINTS).toBe(17); // 6 + 2 + 6 + 3
+  });
+});
+
+describe('§7.4.1 low-rent targeting', () => {
+  it('awards 6 pts at ≥10% of units ≤30% AMI', () => {
+    expect(points(scoreProject(project({ units30Ami: 10 }), 0), 'low_rent_targeting')).toBe(6);
+  });
+
+  it('awards 4 pts at ≥5% (but <10%) of units ≤30% AMI', () => {
+    expect(points(scoreProject(project({ units30Ami: 5 }), 0), 'low_rent_targeting')).toBe(4);
+  });
+
+  it('awards 3 pts at ≥20% of units ≤50% AMI', () => {
+    expect(points(scoreProject(project({ units50Ami: 20 }), 0), 'low_rent_targeting')).toBe(3);
+  });
+
+  it('awards 2 pts at ≥10% (but <20%) of units ≤50% AMI', () => {
+    expect(points(scoreProject(project({ units50Ami: 10 }), 0), 'low_rent_targeting')).toBe(2);
+  });
+
+  it('awards 1 pt at ≥40% of units ≤60% AMI', () => {
+    expect(points(scoreProject(project({ units60Ami: 40 }), 0), 'low_rent_targeting')).toBe(1);
+  });
+
+  it('awards 0 when no threshold is met', () => {
+    expect(points(scoreProject(project({ units60Ami: 10 }), 0), 'low_rent_targeting')).toBe(0);
+  });
+
+  it('counts deeper tiers cumulatively toward shallower thresholds (at-or-below)', () => {
+    // 5 units @30% + 5 @50% = 10% ≤50% (→2pts) but also 5% ≤30% (→4pts).
+    // Highest-first means the 30%@5% tier (4pts) wins.
+    const s = scoreProject(project({ units30Ami: 5, units50Ami: 5 }), 0);
+    expect(points(s, 'low_rent_targeting')).toBe(4);
+  });
+
+  it('awards 0 with zero total units', () => {
+    const s = scoreProject(project({ totalUnits: 0, units30Ami: 0 }), 0);
+    expect(points(s, 'low_rent_targeting')).toBe(0);
+    expect(s.criteria[0].detail).toMatch(/no units/i);
+  });
+});
+
+describe('§7.4.2 low-income targeting', () => {
+  it('awards 2 pts for the 20%@50% election', () => {
+    expect(points(scoreProject(project({ electionKind: 'STD_20_50' }), 0), 'low_income_targeting')).toBe(2);
+  });
+
+  it('awards 2 pts for the average-income election', () => {
+    expect(points(scoreProject(project({ electionKind: 'AVERAGE_INCOME' }), 0), 'low_income_targeting')).toBe(2);
+  });
+
+  it('awards 0 for the standard 40%@60% election', () => {
+    expect(points(scoreProject(project({ electionKind: 'STD_40_60' }), 0), 'low_income_targeting')).toBe(0);
+  });
+});
+
+describe('§7.4.3 resident services', () => {
+  it('awards 0 with no services', () => {
+    expect(points(scoreProject(project(), 0), 'resident_services')).toBe(0);
+  });
+
+  it('sums per-service points (case management = 2)', () => {
+    expect(points(scoreProject(project({ residentServices: ['case_management'] }), 0), 'resident_services')).toBe(2);
+  });
+
+  it('caps at the section maximum of 6', () => {
+    const all: ResidentService[] = [
+      'after_school',
+      'job_training',
+      'health_screening',
+      'financial_literacy',
+      'transportation',
+      'case_management',
+    ]; // raw = 7
+    expect(points(scoreProject(project({ residentServices: all }), 0), 'resident_services')).toBe(6);
+  });
+
+  it('ignores unknown service keys', () => {
+    const s = scoreProject(
+      project({ residentServices: ['after_school', 'bogus' as ResidentService] }),
+      0,
+    );
+    expect(points(s, 'resident_services')).toBe(1);
+  });
+});
+
+describe('§7.3.1 location (QCT/DDA)', () => {
+  it('awards 3 pts for a QCT', () => {
+    expect(points(scoreProject(project({ isQct: true }), 0), 'location')).toBe(3);
+  });
+
+  it('awards 3 pts for a DDA', () => {
+    expect(points(scoreProject(project({ isDda: true }), 0), 'location')).toBe(3);
+  });
+
+  it('does not double-count QCT + DDA (it is a flag, max 3)', () => {
+    expect(points(scoreProject(project({ isQct: true, isDda: true }), 0), 'location')).toBe(3);
+  });
+
+  it('awards 0 for neither, and basisBoost is ineligible', () => {
+    const s = scoreProject(project(), 0);
+    expect(points(s, 'location')).toBe(0);
+    expect(s.basisBoost.eligible).toBe(false);
+  });
+
+  it('sets basisBoost eligible + 30% when in a QCT/DDA', () => {
+    const s = scoreProject(project({ isDda: true }), 0);
+    expect(s.basisBoost).toEqual({ eligible: true, boostPct: 30 });
+  });
+});
+
+describe('§6.1 market-study capture rate', () => {
+  it('is null with zero demand and does not meet the threshold', () => {
+    const s = scoreProject(project({ units50Ami: 20 }), 0);
+    expect(s.marketStudy.captureRatePct).toBeNull();
+    expect(s.marketStudy.meetsThreshold).toBe(false);
+  });
+
+  it('computes affordable units / demand and passes under the 30% ceiling', () => {
+    const s = scoreProject(project({ units50Ami: 20 }), 100); // 20/100 = 20%
+    expect(s.marketStudy.affordableUnits).toBe(20);
+    expect(s.marketStudy.captureRatePct).toBe(20);
+    expect(s.marketStudy.meetsThreshold).toBe(true);
+  });
+
+  it('fails when capture rate exceeds the 30% ceiling', () => {
+    const s = scoreProject(project({ units50Ami: 40 }), 100); // 40%
+    expect(s.marketStudy.captureRatePct).toBe(40);
+    expect(s.marketStudy.meetsThreshold).toBe(false);
+  });
+
+  it('passes exactly at the 30% boundary', () => {
+    const s = scoreProject(project({ units60Ami: 30 }), 100); // 30%
+    expect(s.marketStudy.meetsThreshold).toBe(true);
+  });
+});
+
+describe('total score + eligibility', () => {
+  it('scores a maximal project at 17/17 (100% of the subset)', () => {
+    const s = scoreProject(
+      project({
+        units30Ami: 10, // 6
+        electionKind: 'STD_20_50', // 2
+        residentServices: ['case_management', 'after_school', 'job_training', 'health_screening', 'financial_literacy'], // 6
+        isQct: true, // 3
+      }),
+      50,
+    );
+    expect(s.funnelPoints).toBe(17);
+    expect(s.funnelMaxPoints).toBe(17);
+    expect(s.eligibility.subsetPct).toBe(100);
+    expect(s.eligibility.minPct).toBe(60);
+  });
+
+  it('computes subsetPct from earned / max', () => {
+    // low-rent 1 + location 3 = 4 of 17 → 23.5%
+    const s = scoreProject(project({ units60Ami: 40, isQct: true }), 0);
+    expect(s.funnelPoints).toBe(4);
+    expect(s.eligibility.subsetPct).toBe(23.5);
+  });
+});

--- a/src/db/migrations/2026-05-22-acq-projects.sql
+++ b/src/db/migrations/2026-05-22-acq-projects.sql
@@ -1,0 +1,29 @@
+-- QAP acquisitions layer — candidate projects (Phase 2).
+-- Idempotent. Matches the acq_projects block in schema.ts (SCHEMA_SQL bootstrap).
+--
+-- A prospective LIHTC development evaluated for a 9%/4% credit application,
+-- scored against the focused funnel-relevant QAP subset. Demand evidence is
+-- joined at score time from the funnel; only the project's own commitments
+-- (unit mix, election, services, location) are persisted here.
+
+CREATE TABLE IF NOT EXISTS acq_projects (
+  id                  UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  name                TEXT NOT NULL,
+  geographic_account  TEXT NOT NULL CHECK (geographic_account IN ('CLARK','WASHOE','OTHER')),
+  city                TEXT,
+  set_aside           TEXT CHECK (set_aside IN ('NONPROFIT','USDA_RD','TRIBAL','ADDITIONAL')),
+  election_kind       TEXT NOT NULL CHECK (election_kind IN ('STD_40_60','STD_20_50','AVERAGE_INCOME')),
+  total_units         INTEGER NOT NULL DEFAULT 0 CHECK (total_units >= 0),
+  units_30_ami        INTEGER NOT NULL DEFAULT 0 CHECK (units_30_ami >= 0),
+  units_50_ami        INTEGER NOT NULL DEFAULT 0 CHECK (units_50_ami >= 0),
+  units_60_ami        INTEGER NOT NULL DEFAULT 0 CHECK (units_60_ami >= 0),
+  is_qct              BOOLEAN NOT NULL DEFAULT false,
+  is_dda              BOOLEAN NOT NULL DEFAULT false,
+  resident_services   TEXT[] NOT NULL DEFAULT '{}',
+  notes               TEXT,
+  created_by          UUID REFERENCES users(id),
+  created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_acq_projects_account ON acq_projects(geographic_account);

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1082,9 +1082,37 @@ CREATE TABLE IF NOT EXISTS lease_signatures (
   signed_at           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
+
+-- QAP acquisitions layer — candidate projects (Phase 2). A prospective LIHTC
+-- development being evaluated for a 9%/4% credit application. Scored against
+-- the focused, funnel-relevant QAP subset (§7.4.1 low-rent, §7.4.2 low-income,
+-- §7.4.3 resident services, §7.3.1 location/basis-boost) with the unit mix and
+-- election the project commits to. Demand evidence is joined at score time from
+-- the funnel (see demand-service.ts), not stored here.
+CREATE TABLE IF NOT EXISTS acq_projects (
+  id                  UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  name                TEXT NOT NULL,
+  geographic_account  TEXT NOT NULL CHECK (geographic_account IN ('CLARK','WASHOE','OTHER')),
+  city                TEXT,
+  set_aside           TEXT CHECK (set_aside IN ('NONPROFIT','USDA_RD','TRIBAL','ADDITIONAL')),
+  election_kind       TEXT NOT NULL CHECK (election_kind IN ('STD_40_60','STD_20_50','AVERAGE_INCOME')),
+  total_units         INTEGER NOT NULL DEFAULT 0 CHECK (total_units >= 0),
+  units_30_ami        INTEGER NOT NULL DEFAULT 0 CHECK (units_30_ami >= 0),
+  units_50_ami        INTEGER NOT NULL DEFAULT 0 CHECK (units_50_ami >= 0),
+  units_60_ami        INTEGER NOT NULL DEFAULT 0 CHECK (units_60_ami >= 0),
+  is_qct              BOOLEAN NOT NULL DEFAULT false,
+  is_dda              BOOLEAN NOT NULL DEFAULT false,
+  resident_services   TEXT[] NOT NULL DEFAULT '{}',
+  notes               TEXT,
+  created_by          UUID REFERENCES users(id),
+  created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_acq_projects_account ON acq_projects(geographic_account);
 `;
 
 export const DROP_SCHEMA_SQL = `
+DROP TABLE IF EXISTS acq_projects CASCADE;
 DROP TABLE IF EXISTS lease_signatures CASCADE;
 DROP TABLE IF EXISTS stripe_webhook_dlq CASCADE;
 DROP TABLE IF EXISTS stripe_processed_events CASCADE;

--- a/src/middleware/rbac.ts
+++ b/src/middleware/rbac.ts
@@ -89,6 +89,7 @@ const PERMISSIONS: Record<string, string[]> = {
   // QAP acquisitions layer — credit-acquisition side (Demand-Evidence Engine,
   // project scoring, award). Asset managers and admins only.
   "acquisition:view": ["asset_manager", "system_admin"],
+  "acquisition:manage": ["asset_manager", "system_admin"],
 };
 
 export function requireRole(...roles: string[]) {

--- a/src/modules/acquisitions/project-service.ts
+++ b/src/modules/acquisitions/project-service.ts
@@ -1,0 +1,189 @@
+/**
+ * Candidate-project store + scoring orchestration (Phase 2).
+ *
+ * CRUD over acq_projects, plus `scoreProject` which joins the funnel's demand
+ * (Demand-Evidence Engine, Phase 1) into the pure scoring engine (scoring.ts).
+ * SQL lives here; the scoring math stays a pure function so it can be tested
+ * without a database.
+ */
+import { query } from '../../config/database';
+import { DemandService } from './demand-service';
+import { scoreProject as runScore, type ScorableProject, type ProjectScore } from './scoring';
+import type { GeographicAccount, SetAsideAccount, ElectionKind, ResidentService } from './qap-2026';
+
+export interface ProjectInput {
+  name: string;
+  geographicAccount: GeographicAccount;
+  city?: string | null;
+  setAside?: SetAsideAccount | null;
+  electionKind: ElectionKind;
+  totalUnits: number;
+  units30Ami: number;
+  units50Ami: number;
+  units60Ami: number;
+  isQct: boolean;
+  isDda: boolean;
+  residentServices: ResidentService[];
+  notes?: string | null;
+}
+
+export interface AcqProject extends ProjectInput {
+  id: string;
+  createdBy: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ScoredProject {
+  project: AcqProject;
+  score: ProjectScore;
+}
+
+interface ProjectRow {
+  id: string;
+  name: string;
+  geographic_account: GeographicAccount;
+  city: string | null;
+  set_aside: SetAsideAccount | null;
+  election_kind: ElectionKind;
+  total_units: number;
+  units_30_ami: number;
+  units_50_ami: number;
+  units_60_ami: number;
+  is_qct: boolean;
+  is_dda: boolean;
+  resident_services: string[];
+  notes: string | null;
+  created_by: string | null;
+  created_at: Date | string;
+  updated_at: Date | string;
+}
+
+function mapRow(r: ProjectRow): AcqProject {
+  return {
+    id: r.id,
+    name: r.name,
+    geographicAccount: r.geographic_account,
+    city: r.city,
+    setAside: r.set_aside,
+    electionKind: r.election_kind,
+    totalUnits: r.total_units,
+    units30Ami: r.units_30_ami,
+    units50Ami: r.units_50_ami,
+    units60Ami: r.units_60_ami,
+    isQct: r.is_qct,
+    isDda: r.is_dda,
+    residentServices: (r.resident_services ?? []) as ResidentService[],
+    notes: r.notes,
+    createdBy: r.created_by,
+    createdAt: new Date(r.created_at).toISOString(),
+    updatedAt: new Date(r.updated_at).toISOString(),
+  };
+}
+
+/** The fields scoring reads — projected from a stored project. */
+function toScorable(p: AcqProject): ScorableProject {
+  return {
+    geographicAccount: p.geographicAccount,
+    electionKind: p.electionKind,
+    totalUnits: p.totalUnits,
+    units30Ami: p.units30Ami,
+    units50Ami: p.units50Ami,
+    units60Ami: p.units60Ami,
+    isQct: p.isQct,
+    isDda: p.isDda,
+    residentServices: p.residentServices,
+  };
+}
+
+export class ProjectService {
+  private demand = new DemandService();
+
+  async list(): Promise<AcqProject[]> {
+    const res = await query(
+      `SELECT * FROM acq_projects ORDER BY created_at DESC`,
+    );
+    return (res.rows as ProjectRow[]).map(mapRow);
+  }
+
+  async get(id: string): Promise<AcqProject | null> {
+    const res = await query(`SELECT * FROM acq_projects WHERE id = $1`, [id]);
+    const row = (res.rows as ProjectRow[])[0];
+    return row ? mapRow(row) : null;
+  }
+
+  async create(input: ProjectInput, createdBy: string | null): Promise<AcqProject> {
+    const res = await query(
+      `INSERT INTO acq_projects
+         (name, geographic_account, city, set_aside, election_kind,
+          total_units, units_30_ami, units_50_ami, units_60_ami,
+          is_qct, is_dda, resident_services, notes, created_by)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)
+       RETURNING *`,
+      [
+        input.name,
+        input.geographicAccount,
+        input.city ?? null,
+        input.setAside ?? null,
+        input.electionKind,
+        input.totalUnits,
+        input.units30Ami,
+        input.units50Ami,
+        input.units60Ami,
+        input.isQct,
+        input.isDda,
+        input.residentServices,
+        input.notes ?? null,
+        createdBy,
+      ],
+    );
+    return mapRow((res.rows as ProjectRow[])[0]);
+  }
+
+  async update(id: string, input: ProjectInput): Promise<AcqProject | null> {
+    const res = await query(
+      `UPDATE acq_projects SET
+         name = $2, geographic_account = $3, city = $4, set_aside = $5,
+         election_kind = $6, total_units = $7, units_30_ami = $8,
+         units_50_ami = $9, units_60_ami = $10, is_qct = $11, is_dda = $12,
+         resident_services = $13, notes = $14, updated_at = NOW()
+       WHERE id = $1
+       RETURNING *`,
+      [
+        id,
+        input.name,
+        input.geographicAccount,
+        input.city ?? null,
+        input.setAside ?? null,
+        input.electionKind,
+        input.totalUnits,
+        input.units30Ami,
+        input.units50Ami,
+        input.units60Ami,
+        input.isQct,
+        input.isDda,
+        input.residentServices,
+        input.notes ?? null,
+      ],
+    );
+    const row = (res.rows as ProjectRow[])[0];
+    return row ? mapRow(row) : null;
+  }
+
+  async remove(id: string): Promise<boolean> {
+    const res = await query(`DELETE FROM acq_projects WHERE id = $1`, [id]);
+    return (res.rowCount ?? 0) > 0;
+  }
+
+  /**
+   * Score a stored project against the QAP subset, joining the current funnel
+   * demand for the project's geographic account as the §6.1 market-study input.
+   */
+  async score(id: string): Promise<ScoredProject | null> {
+    const project = await this.get(id);
+    if (!project) return null;
+    const rollup = await this.demand.getDemand({ account: project.geographicAccount });
+    const score = runScore(toScorable(project), rollup.totals.qualifiedApplicants);
+    return { project, score };
+  }
+}

--- a/src/modules/acquisitions/routes.ts
+++ b/src/modules/acquisitions/routes.ts
@@ -1,13 +1,20 @@
 /**
- * Acquisitions API — QAP Demand-Evidence Engine (Phase 1).
+ * Acquisitions API — QAP Demand-Evidence Engine (Phase 1) + Project Scoring
+ * (Phase 2).
  *
  * Internal, staff-only surface (asset_manager / system_admin) for the credit
- * acquisition side of the lifecycle. Phase 1 exposes the demand rollup and the
- * market-study-shaped demand packet. Phases 2 (project scoring) and 3
- * (compliance bridge / award) mount additional routes here.
+ * acquisition side of the lifecycle. Reads gate on `acquisition:view`; writes
+ * (project create/update/delete) gate on `acquisition:manage`. Phase 3
+ * (compliance bridge / award) mounts additional routes here.
  *
- *   GET /api/acquisitions/demand          — rollup, filterable
- *   GET /api/acquisitions/demand/packet   — market-study packet per submarket
+ *   GET    /api/acquisitions/demand          — rollup, filterable
+ *   GET    /api/acquisitions/demand/packet   — market-study packet per submarket
+ *   GET    /api/acquisitions/projects        — list candidate projects
+ *   POST   /api/acquisitions/projects        — create
+ *   GET    /api/acquisitions/projects/:id    — get one
+ *   PUT    /api/acquisitions/projects/:id    — update
+ *   DELETE /api/acquisitions/projects/:id    — delete
+ *   GET    /api/acquisitions/projects/:id/score — score vs QAP subset + demand
  */
 import { Router } from 'express';
 import { z } from 'zod';
@@ -15,12 +22,23 @@ import { authenticate, AuthRequest } from '../../middleware/auth';
 import { requirePermission } from '../../middleware/rbac';
 import { logger } from '../../utils/logger';
 import { DemandService, type DemandFilters, type AmiTier } from './demand-service';
-import { GEOGRAPHIC_ACCOUNTS, type GeographicAccount } from './qap-2026';
+import { ProjectService, type ProjectInput } from './project-service';
+import {
+  GEOGRAPHIC_ACCOUNTS,
+  SET_ASIDES,
+  RENT_ELECTIONS,
+  RESIDENT_SERVICES,
+  type GeographicAccount,
+} from './qap-2026';
 
 const router = Router();
 const service = new DemandService();
+const projects = new ProjectService();
 
 const ACCOUNTS = Object.keys(GEOGRAPHIC_ACCOUNTS) as [GeographicAccount, ...GeographicAccount[]];
+const SET_ASIDE_KEYS = Object.keys(SET_ASIDES) as [string, ...string[]];
+const ELECTION_KEYS = Object.keys(RENT_ELECTIONS) as [string, ...string[]];
+const SERVICE_KEYS = Object.keys(RESIDENT_SERVICES) as [string, ...string[]];
 
 const DemandQuerySchema = z.object({
   // `account` is the QAP geographic account; `county` accepted as an alias
@@ -89,6 +107,155 @@ router.get(
     } catch (err) {
       logger.error('acquisitions: demand packet failed', { err });
       res.status(500).json({ error: 'Failed to build demand packet' });
+    }
+  },
+);
+
+// ── Phase 2: candidate projects ──────────────────────────────────────────────
+
+const ProjectSchema = z
+  .object({
+    name: z.string().trim().min(1).max(200),
+    geographicAccount: z.enum(ACCOUNTS),
+    city: z.string().trim().max(120).optional().nullable(),
+    setAside: z.enum(SET_ASIDE_KEYS).optional().nullable(),
+    electionKind: z.enum(ELECTION_KEYS),
+    totalUnits: z.coerce.number().int().min(0).max(100000),
+    units30Ami: z.coerce.number().int().min(0).max(100000),
+    units50Ami: z.coerce.number().int().min(0).max(100000),
+    units60Ami: z.coerce.number().int().min(0).max(100000),
+    isQct: z.boolean().default(false),
+    isDda: z.boolean().default(false),
+    residentServices: z.array(z.enum(SERVICE_KEYS)).default([]),
+    notes: z.string().trim().max(5000).optional().nullable(),
+  })
+  // Restricted units can't exceed the unit count — a unit-mix sanity check.
+  .refine((p) => p.units30Ami + p.units50Ami + p.units60Ami <= p.totalUnits, {
+    message: 'Restricted units (30+50+60% AMI) cannot exceed total units.',
+    path: ['totalUnits'],
+  });
+
+/** GET /api/acquisitions/projects — list candidate projects. */
+router.get(
+  '/projects',
+  authenticate,
+  requirePermission('acquisition:view'),
+  async (_req: AuthRequest, res) => {
+    try {
+      res.json({ projects: await projects.list() });
+    } catch (err) {
+      logger.error('acquisitions: list projects failed', { err });
+      res.status(500).json({ error: 'Failed to list projects' });
+    }
+  },
+);
+
+/** POST /api/acquisitions/projects — create a candidate project. */
+router.post(
+  '/projects',
+  authenticate,
+  requirePermission('acquisition:manage'),
+  async (req: AuthRequest, res) => {
+    const parsed = ProjectSchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({ error: 'Invalid project', details: parsed.error.flatten() });
+      return;
+    }
+    try {
+      const created = await projects.create(parsed.data as ProjectInput, req.user?.id ?? null);
+      res.status(201).json({ project: created });
+    } catch (err) {
+      logger.error('acquisitions: create project failed', { err });
+      res.status(500).json({ error: 'Failed to create project' });
+    }
+  },
+);
+
+/** GET /api/acquisitions/projects/:id — fetch one. */
+router.get(
+  '/projects/:id',
+  authenticate,
+  requirePermission('acquisition:view'),
+  async (req: AuthRequest, res) => {
+    try {
+      const project = await projects.get((req.params.id as string));
+      if (!project) {
+        res.status(404).json({ error: 'Project not found' });
+        return;
+      }
+      res.json({ project });
+    } catch (err) {
+      logger.error('acquisitions: get project failed', { err });
+      res.status(500).json({ error: 'Failed to fetch project' });
+    }
+  },
+);
+
+/** PUT /api/acquisitions/projects/:id — update. */
+router.put(
+  '/projects/:id',
+  authenticate,
+  requirePermission('acquisition:manage'),
+  async (req: AuthRequest, res) => {
+    const parsed = ProjectSchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({ error: 'Invalid project', details: parsed.error.flatten() });
+      return;
+    }
+    try {
+      const updated = await projects.update((req.params.id as string), parsed.data as ProjectInput);
+      if (!updated) {
+        res.status(404).json({ error: 'Project not found' });
+        return;
+      }
+      res.json({ project: updated });
+    } catch (err) {
+      logger.error('acquisitions: update project failed', { err });
+      res.status(500).json({ error: 'Failed to update project' });
+    }
+  },
+);
+
+/** DELETE /api/acquisitions/projects/:id. */
+router.delete(
+  '/projects/:id',
+  authenticate,
+  requirePermission('acquisition:manage'),
+  async (req: AuthRequest, res) => {
+    try {
+      const removed = await projects.remove((req.params.id as string));
+      if (!removed) {
+        res.status(404).json({ error: 'Project not found' });
+        return;
+      }
+      res.status(204).end();
+    } catch (err) {
+      logger.error('acquisitions: delete project failed', { err });
+      res.status(500).json({ error: 'Failed to delete project' });
+    }
+  },
+);
+
+/**
+ * GET /api/acquisitions/projects/:id/score
+ * Score the project against the focused QAP subset, joining current funnel
+ * demand for its geographic account as the §6.1 market-study input.
+ */
+router.get(
+  '/projects/:id/score',
+  authenticate,
+  requirePermission('acquisition:view'),
+  async (req: AuthRequest, res) => {
+    try {
+      const scored = await projects.score((req.params.id as string));
+      if (!scored) {
+        res.status(404).json({ error: 'Project not found' });
+        return;
+      }
+      res.json(scored);
+    } catch (err) {
+      logger.error('acquisitions: score project failed', { err });
+      res.status(500).json({ error: 'Failed to score project' });
     }
   },
 );

--- a/src/modules/acquisitions/scoring.ts
+++ b/src/modules/acquisitions/scoring.ts
@@ -1,0 +1,234 @@
+/**
+ * Project Scoring Tool — scores a candidate LIHTC project against the focused,
+ * funnel-relevant QAP subset (Phase 2).
+ *
+ * The thesis carries through from Phase 1: the funnel's AMI-qualified demand is
+ * the asset that wins credits. Phase 1 measured the demand; Phase 2 scores a
+ * *project* against the criteria that demand makes credible — and joins the
+ * demand back in as the §6.1 market-study check.
+ *
+ * Scored here (funnel-relevant subset only):
+ *   §7.4.1 Low-Rent Targeting      (6 pts) — share of units at deep AMI tiers
+ *   §7.4.2 Low-Income Targeting    (2 pts) — deeper set-aside election
+ *   §7.4.3 Resident Services       (6 pts) — committed on-site services
+ *   §7.3.1 Location / basis boost  (3 pts) — QCT/DDA siting
+ *                                  ─────────
+ *                          max     17 pts
+ *
+ * The full 97-point §7 rubric, pro-forma feasibility, and developer-capacity
+ * scoring are intentionally out of scope (see qap-2026.ts). This is a pure
+ * function: demand is passed in (fetched by the service) so scoring stays
+ * deterministic and unit-testable without a database.
+ */
+import {
+  LOW_RENT_TARGETING,
+  LOW_RENT_TARGETING_MAX_POINTS,
+  LOW_INCOME_TARGETING,
+  RESIDENT_SERVICES,
+  RESIDENT_SERVICES_MAX_POINTS,
+  LOCATION_SCORING,
+  MARKET_STUDY,
+  MIN_ELIGIBILITY_PCT,
+  RENT_ELECTIONS,
+  type ElectionKind,
+  type ResidentService,
+  type GeographicAccount,
+} from './qap-2026';
+
+/** The project commitments scoring reads. Mirrors the persisted acq_projects. */
+export interface ScorableProject {
+  geographicAccount: GeographicAccount;
+  electionKind: ElectionKind;
+  totalUnits: number;
+  /** Units committed AT each AMI tier (disjoint bands, not cumulative). */
+  units30Ami: number;
+  units50Ami: number;
+  units60Ami: number;
+  isQct: boolean;
+  isDda: boolean;
+  residentServices: ResidentService[];
+}
+
+export interface CriterionScore {
+  key: string;
+  section: string;
+  label: string;
+  points: number;
+  maxPoints: number;
+  detail: string;
+}
+
+export interface ProjectScore {
+  funnelPoints: number;
+  funnelMaxPoints: number;
+  criteria: CriterionScore[];
+  marketStudy: {
+    affordableUnits: number;
+    qualifiedDemand: number;
+    captureRatePct: number | null;
+    maxAcceptableCaptureRatePct: number;
+    meetsThreshold: boolean;
+  };
+  basisBoost: {
+    eligible: boolean;
+    boostPct: number;
+  };
+  eligibility: {
+    minPct: number;
+    subsetPct: number;
+    note: string;
+  };
+}
+
+/** Funnel-relevant maximum: the four scored criteria sum to 17. */
+export const FUNNEL_MAX_POINTS =
+  LOW_RENT_TARGETING_MAX_POINTS +
+  LOW_INCOME_TARGETING.maxPoints +
+  RESIDENT_SERVICES_MAX_POINTS +
+  LOCATION_SCORING.qctDdaPoints;
+
+function round1(n: number): number {
+  return Math.round(n * 10) / 10;
+}
+
+/** Total units committed at or below the funnel's restricted tiers (≤60% AMI). */
+function affordableUnits(p: ScorableProject): number {
+  return p.units30Ami + p.units50Ami + p.units60Ami;
+}
+
+/**
+ * §7.4.1 — points scale with the share of units at the deepest rent tiers.
+ * `unitSharePct` is measured "at or below" the tier's AMI ceiling, so deep
+ * (30%) units also count toward the 50% and 60% thresholds. LOW_RENT_TARGETING
+ * is highest-first, so the first qualifying tier is the best score.
+ */
+function scoreLowRent(p: ScorableProject): CriterionScore {
+  const base: Omit<CriterionScore, 'points' | 'detail'> = {
+    key: 'low_rent_targeting',
+    section: '§7.4.1',
+    label: 'Low-Rent Targeting',
+    maxPoints: LOW_RENT_TARGETING_MAX_POINTS,
+  };
+  if (p.totalUnits <= 0) {
+    return { ...base, points: 0, detail: 'No units defined.' };
+  }
+  const shareAtOrBelow = (ami: 30 | 50 | 60): number => {
+    let units = 0;
+    if (ami >= 30) units += p.units30Ami;
+    if (ami >= 50) units += p.units50Ami;
+    if (ami >= 60) units += p.units60Ami;
+    return (units / p.totalUnits) * 100;
+  };
+  for (const tier of LOW_RENT_TARGETING) {
+    if (shareAtOrBelow(tier.amiPct) >= tier.unitSharePct) {
+      return {
+        ...base,
+        points: tier.points,
+        detail: `${round1(shareAtOrBelow(tier.amiPct))}% of units at ≤${tier.amiPct}% AMI (≥${tier.unitSharePct}% threshold).`,
+      };
+    }
+  }
+  return {
+    ...base,
+    points: 0,
+    detail: 'Unit mix does not meet the shallowest low-rent threshold.',
+  };
+}
+
+/** §7.4.2 — flat bonus for electing a deeper set-aside than the standard 40%@60%. */
+function scoreLowIncome(p: ScorableProject): CriterionScore {
+  const qualifies = LOW_INCOME_TARGETING.qualifyingElections.includes(p.electionKind);
+  return {
+    key: 'low_income_targeting',
+    section: '§7.4.2',
+    label: 'Low-Income Targeting',
+    points: qualifies ? LOW_INCOME_TARGETING.maxPoints : 0,
+    maxPoints: LOW_INCOME_TARGETING.maxPoints,
+    detail: qualifies
+      ? `Election "${RENT_ELECTIONS[p.electionKind].label}" earns the deep-targeting bonus.`
+      : `Election "${RENT_ELECTIONS[p.electionKind].label}" does not earn the bonus (electing 20%@50% or average-income would).`,
+  };
+}
+
+/** §7.4.3 — sum of committed on-site services, capped at the section max. */
+function scoreResidentServices(p: ScorableProject): CriterionScore {
+  const selected = p.residentServices.filter((s) => s in RESIDENT_SERVICES);
+  const raw = selected.reduce((sum, key) => sum + RESIDENT_SERVICES[key].points, 0);
+  const points = Math.min(raw, RESIDENT_SERVICES_MAX_POINTS);
+  return {
+    key: 'resident_services',
+    section: '§7.4.3',
+    label: 'Resident Services',
+    points,
+    maxPoints: RESIDENT_SERVICES_MAX_POINTS,
+    detail:
+      selected.length === 0
+        ? 'No services committed.'
+        : `${selected.length} service${selected.length === 1 ? '' : 's'} committed (${raw} raw pts${raw > RESIDENT_SERVICES_MAX_POINTS ? `, capped at ${RESIDENT_SERVICES_MAX_POINTS}` : ''}).`,
+  };
+}
+
+/** §7.3.1 / §11 — siting in a HUD QCT or DDA earns points and the basis boost. */
+function scoreLocation(p: ScorableProject): CriterionScore {
+  const eligible = p.isQct || p.isDda;
+  const where = p.isQct && p.isDda ? 'QCT + DDA' : p.isQct ? 'QCT' : p.isDda ? 'DDA' : 'neither';
+  return {
+    key: 'location',
+    section: '§7.3.1',
+    label: 'Location (QCT/DDA)',
+    points: eligible ? LOCATION_SCORING.qctDdaPoints : 0,
+    maxPoints: LOCATION_SCORING.qctDdaPoints,
+    detail: eligible
+      ? `Sited in ${where} — also unlocks the §11 +${LOCATION_SCORING.basisBoostPct}% basis boost.`
+      : 'Not in a QCT or DDA.',
+  };
+}
+
+/**
+ * Score a candidate project against the focused QAP subset, joining funnel
+ * demand for the §6.1 market-study check. `qualifiedDemand` is the count of
+ * AMI-qualified applicants in the project's geographic account (from the
+ * Demand-Evidence Engine).
+ */
+export function scoreProject(p: ScorableProject, qualifiedDemand: number): ProjectScore {
+  const criteria = [
+    scoreLowRent(p),
+    scoreLowIncome(p),
+    scoreResidentServices(p),
+    scoreLocation(p),
+  ];
+  const funnelPoints = criteria.reduce((sum, c) => sum + c.points, 0);
+
+  // §6.1 capture rate: the project's affordable units as a share of the
+  // qualified demand it would draw from. Lower = a demonstrably under-served
+  // submarket. Null (no demand captured yet) is not a pass.
+  const affordable = affordableUnits(p);
+  const captureRatePct =
+    qualifiedDemand > 0 ? round1((affordable / qualifiedDemand) * 100) : null;
+
+  const subsetPct = round1((funnelPoints / FUNNEL_MAX_POINTS) * 100);
+
+  return {
+    funnelPoints,
+    funnelMaxPoints: FUNNEL_MAX_POINTS,
+    criteria,
+    marketStudy: {
+      affordableUnits: affordable,
+      qualifiedDemand,
+      captureRatePct,
+      maxAcceptableCaptureRatePct: MARKET_STUDY.maxCaptureRatePct,
+      meetsThreshold:
+        captureRatePct != null && captureRatePct <= MARKET_STUDY.maxCaptureRatePct,
+    },
+    basisBoost: {
+      eligible: p.isQct || p.isDda,
+      boostPct: LOCATION_SCORING.basisBoostPct,
+    },
+    eligibility: {
+      minPct: MIN_ELIGIBILITY_PCT,
+      subsetPct,
+      // Honest scoping: this is the funnel-relevant subset, not the full rubric.
+      note: `Funnel-relevant subset score. Full QAP eligibility requires ${MIN_ELIGIBILITY_PCT}% of the complete §7 rubric (feasibility, developer capacity, etc. — out of scope).`,
+    },
+  };
+}


### PR DESCRIPTION
## QAP Integration — Phase 2 of 3

Phase 1 (PR #144) shipped the **Demand-Evidence Engine** — it measures the funnel's AMI-qualified demand. Phase 2 adds the **Project Scoring Tool**: score a candidate LIHTC project against the funnel-relevant QAP subset, and join that live demand back in as the §6.1 market-study check.

> **Thesis (carried from Phase 1):** the funnel's AMI-qualified demand *is* the asset that wins credits. Phase 1 measured it; Phase 2 scores a project against the criteria that demand makes credible.

### Scored subset (17 pts)

```
§7.4.1  Low-Rent Targeting      6   share of units at deep AMI tiers (at-or-below)
§7.4.2  Low-Income Targeting    2   deeper set-aside election (20%@50% / avg-income)
§7.4.3  Resident Services       6   committed on-site services, summed + capped
§7.3.1  Location / basis-boost  3   QCT/DDA siting (also unlocks §11 +30% basis boost)
────────────────────────────────
                               17
§6.1  Market study              live funnel demand → capture rate (≤30% ceiling)
```

The full 97-pt §7 rubric, pro-forma feasibility, and developer-capacity scoring are **intentionally out of scope** — reported as an honest scoping note, not a synthetic pass/fail.

### Backend
- **`scoring.ts`** — pure scoring engine; demand is passed in, so it stays deterministic and unit-testable without a DB.
- **`project-service.ts`** — `acq_projects` CRUD + `score()` that joins the Phase 1 `DemandService` for the project's geographic account.
- **`routes.ts`** — `/projects` CRUD + `/:id/score`; reads gate on `acquisition:view`, writes on `acquisition:manage`.
- **`rbac.ts`** — adds `acquisition:manage`.
- **`schema.ts` + migration** — `acq_projects` table (CHECK constraints, FK to users, account index).

### Frontend (`client-acq`)
- **`Projects.tsx`** — list · create/edit modal (with a unit-mix overcommit guard) · score-breakdown modal (per-criterion points, capture rate, basis boost).
- Types, `api.put()`, Layout nav entry, App route.

### Verification
- Backend `tsc --noEmit` clean; **full jest suite green (1080 passing)**.
- **34 new tests** — scoring branches (every tier + at-or-below cumulative + cap) and service CRUD/score with mocked `query`.
- `client-acq` production build clean.
- Migration applied to local DB; service `INSERT`/`SELECT` (incl. `TEXT[]` round-trip) verified via psql.

### Scope notes
- `schema.ts` change is purely additive (`acq_projects` + its DROP entry); the `lease_signatures` lines are unchanged context already on `main`.
- Demand evidence is **not** stored on `acq_projects` — it is joined live at score time from the funnel.

Phase 3 (Compliance Bridge / award) mounts onto these routes next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)