### PR TITLE
feat(acquisitions): Phase 3 — compliance bridge (award → designated units)

### DIFF
--- a/client-acq/src/App.tsx
+++ b/client-acq/src/App.tsx
@@ -5,6 +5,7 @@ import { Layout } from '@/components/Layout';
 import { Login } from '@/pages/Login';
 import { Demand } from '@/pages/Demand';
 import { Projects } from '@/pages/Projects';
+import { Awards } from '@/pages/Awards';
 
 export default function App() {
   return (
@@ -16,6 +17,7 @@ export default function App() {
             <Route element={<Layout />}>
               <Route index element={<Demand />} />
               <Route path="projects" element={<Projects />} />
+              <Route path="awards" element={<Awards />} />
               <Route path="*" element={<Navigate to="/" replace />} />
             </Route>
           </Route>

--- a/client-acq/src/components/Layout.tsx
+++ b/client-acq/src/components/Layout.tsx
@@ -1,13 +1,14 @@
 import { Outlet, NavLink } from 'react-router-dom';
-import { LogOut, BarChart3, Building2, FolderKanban } from 'lucide-react';
+import { LogOut, BarChart3, Building2, FolderKanban, Award } from 'lucide-react';
 import { useAuth } from '@/hooks/useAuth';
 import { formatRole } from '@/types';
 
-// Acquisitions nav. Phase 1 ships Demand; Phase 2 adds Projects; Awards
-// (Phase 3) slots in next without a layout change.
+// Acquisitions nav. Phase 1 ships Demand; Phase 2 adds Projects; Phase 3 adds
+// Awards (the compliance bridge from won credits to designated units).
 const NAV = [
   { to: '/', label: 'Demand Evidence', icon: BarChart3, end: true },
   { to: '/projects', label: 'Candidate Projects', icon: FolderKanban, end: false },
+  { to: '/awards', label: 'Awards', icon: Award, end: false },
 ];
 
 export function Layout() {

--- a/client-acq/src/pages/Awards.tsx
+++ b/client-acq/src/pages/Awards.tsx
@@ -1,0 +1,656 @@
+import { useState, useMemo, type ReactNode } from 'react';
+import {
+  Award,
+  Plus,
+  Trash2,
+  Link2,
+  ListChecks,
+  X,
+  CheckCircle2,
+  AlertTriangle,
+  Building,
+} from 'lucide-react';
+import { PageHeader } from '@/components/PageHeader';
+import { useApiQuery } from '@/hooks/useApiQuery';
+import { api } from '@/api/client';
+import {
+  type AcqAward,
+  type AcqProject,
+  type AwardCreateInput,
+  type AwardStatus,
+  type DesignationPlan,
+  type BoundUnit,
+  type UnitDesignation,
+  type PropertyLite,
+  AWARD_STATUS_LABELS,
+  DESIGNATION_LABELS,
+} from '@/types';
+
+const STATUSES: AwardStatus[] = ['reserved', 'placed_in_service', 'in_service', 'closed'];
+const DESIGNATIONS: UnitDesignation[] = ['30', '50', '60', 'market'];
+
+export function Awards() {
+  const awardsQ = useApiQuery<{ awards: AcqAward[] }>('/api/acquisitions/awards');
+  const projectsQ = useApiQuery<{ projects: AcqProject[] }>('/api/acquisitions/projects');
+  const propsQ = useApiQuery<{ properties: PropertyLite[] }>('/api/properties');
+
+  const [creating, setCreating] = useState(false);
+  const [binding, setBinding] = useState<AcqAward | null>(null);
+  const [managing, setManaging] = useState<AcqAward | null>(null);
+  const [deleting, setDeleting] = useState<string | null>(null);
+
+  const awards = awardsQ.data?.awards ?? [];
+  const projects = projectsQ.data?.projects ?? [];
+  const properties = propsQ.data?.properties ?? [];
+
+  const projectName = useMemo(() => {
+    const m = new Map(projects.map((p) => [p.id, p.name]));
+    return (id: string) => m.get(id) ?? '(unknown project)';
+  }, [projects]);
+  const propertyName = useMemo(() => {
+    const m = new Map(properties.map((p) => [p.id, p.name]));
+    return (id: string | null) => (id ? m.get(id) ?? '(unknown property)' : null);
+  }, [properties]);
+
+  // Projects that don't have an award yet — the create form's candidate list.
+  const awardedProjectIds = new Set(awards.map((a) => a.acqProjectId));
+  const eligibleProjects = projects.filter((p) => !awardedProjectIds.has(p.id));
+
+  async function remove(id: string) {
+    if (!window.confirm('Delete this award? Unit designations already applied are kept.')) return;
+    setDeleting(id);
+    try {
+      await api.del(`/api/acquisitions/awards/${id}`);
+      awardsQ.refetch();
+    } catch (err) {
+      window.alert(err instanceof Error ? err.message : 'Delete failed');
+    } finally {
+      setDeleting(null);
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        icon={Award}
+        title="Awards"
+        description="Record a won credit reservation, bind it to a managed property, and designate units at their committed AMI tiers (IRC §42 / LURA). Each step is stamped to the compliance tape."
+        action={
+          <button
+            onClick={() => setCreating(true)}
+            disabled={eligibleProjects.length === 0}
+            className="flex items-center gap-1.5 rounded-lg bg-emerald-600 px-3 py-2 text-sm font-medium text-white hover:bg-emerald-700 disabled:opacity-50"
+            title={eligibleProjects.length === 0 ? 'Every project already has an award' : undefined}
+          >
+            <Plus className="h-4 w-4" />
+            Record award
+          </button>
+        }
+      />
+
+      {awardsQ.error && (
+        <p className="rounded-lg bg-red-50 px-4 py-3 text-sm text-red-600">{awardsQ.error}</p>
+      )}
+
+      <div className="rounded-xl border border-gray-200 bg-white">
+        <div className="border-b border-gray-200 px-5 py-3">
+          <h2 className="text-sm font-semibold text-gray-900">Awarded projects</h2>
+        </div>
+        {awardsQ.loading ? (
+          <div className="flex items-center justify-center py-12">
+            <div className="h-6 w-6 animate-spin rounded-full border-4 border-emerald-600 border-t-transparent" />
+          </div>
+        ) : awards.length > 0 ? (
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-gray-100 text-left text-xs uppercase tracking-wide text-gray-400">
+                <th className="px-5 py-2 font-medium">Project</th>
+                <th className="px-5 py-2 font-medium">Status</th>
+                <th className="px-5 py-2 font-medium">Bound property</th>
+                <th className="px-5 py-2 text-right font-medium">Reservation</th>
+                <th className="px-5 py-2 text-right font-medium">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {awards.map((a) => (
+                <tr key={a.id} className="border-b border-gray-50 hover:bg-gray-50/60">
+                  <td className="px-5 py-2.5">
+                    <p className="font-medium text-gray-900">{projectName(a.acqProjectId)}</p>
+                    {a.awardDate && <p className="text-xs text-gray-400">Awarded {a.awardDate}</p>}
+                  </td>
+                  <td className="px-5 py-2.5">
+                    <StatusPill status={a.status} />
+                  </td>
+                  <td className="px-5 py-2.5 text-gray-700">
+                    {a.propertyId ? (
+                      <span className="inline-flex items-center gap-1">
+                        <Building className="h-3.5 w-3.5 text-gray-400" />
+                        {propertyName(a.propertyId)}
+                      </span>
+                    ) : (
+                      <span className="text-xs text-amber-600">Not bound</span>
+                    )}
+                  </td>
+                  <td className="px-5 py-2.5 text-right text-gray-900">
+                    {a.reservationAmount == null
+                      ? '—'
+                      : `$${a.reservationAmount.toLocaleString()}`}
+                  </td>
+                  <td className="px-5 py-2.5">
+                    <div className="flex items-center justify-end gap-1">
+                      <IconButton title="Bind property" onClick={() => setBinding(a)}>
+                        <Link2 className="h-4 w-4" />
+                      </IconButton>
+                      <IconButton
+                        title="Manage designations"
+                        onClick={() => setManaging(a)}
+                        disabled={!a.propertyId}
+                      >
+                        <ListChecks className="h-4 w-4" />
+                      </IconButton>
+                      <IconButton
+                        title="Delete"
+                        onClick={() => remove(a.id)}
+                        disabled={deleting === a.id}
+                        danger
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </IconButton>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        ) : (
+          <p className="px-5 py-12 text-center text-sm text-gray-400">
+            No awards yet. Record one once a candidate project wins a reservation.
+          </p>
+        )}
+      </div>
+
+      {creating && (
+        <CreateAwardModal
+          projects={eligibleProjects}
+          onClose={() => setCreating(false)}
+          onSaved={() => {
+            setCreating(false);
+            awardsQ.refetch();
+          }}
+        />
+      )}
+      {binding && (
+        <BindModal
+          award={binding}
+          properties={properties}
+          onClose={() => setBinding(null)}
+          onSaved={() => {
+            setBinding(null);
+            awardsQ.refetch();
+          }}
+        />
+      )}
+      {managing && managing.propertyId && (
+        <DesignationsModal
+          award={managing}
+          propertyName={propertyName(managing.propertyId) ?? 'property'}
+          onClose={() => setManaging(null)}
+        />
+      )}
+    </div>
+  );
+}
+
+// ── Create award ──────────────────────────────────────────────────────────────
+
+function CreateAwardModal({
+  projects,
+  onClose,
+  onSaved,
+}: {
+  projects: AcqProject[];
+  onClose: () => void;
+  onSaved: () => void;
+}) {
+  const [acqProjectId, setAcqProjectId] = useState(projects[0]?.id ?? '');
+  const [status, setStatus] = useState<AwardStatus>('reserved');
+  const [reservationAmount, setReservationAmount] = useState('');
+  const [awardDate, setAwardDate] = useState('');
+  const [deadline, setDeadline] = useState('');
+  const [notes, setNotes] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const canSave = acqProjectId !== '' && !saving;
+
+  async function submit() {
+    if (!canSave) return;
+    setSaving(true);
+    setError(null);
+    const payload: AwardCreateInput = {
+      acqProjectId,
+      status,
+      reservationAmount: reservationAmount.trim() ? Number(reservationAmount) : null,
+      awardDate: awardDate || null,
+      placedInServiceDeadline: deadline || null,
+      notes: notes.trim() || null,
+    };
+    try {
+      await api.post('/api/acquisitions/awards', payload);
+      onSaved();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Save failed');
+      setSaving(false);
+    }
+  }
+
+  return (
+    <Modal title="Record award" onClose={onClose}>
+      <div className="space-y-4">
+        <Field label="Awarded project">
+          <select className="input" value={acqProjectId} onChange={(e) => setAcqProjectId(e.target.value)}>
+            {projects.map((p) => (
+              <option key={p.id} value={p.id}>
+                {p.name}
+              </option>
+            ))}
+          </select>
+        </Field>
+        <div className="grid grid-cols-2 gap-4">
+          <Field label="Status">
+            <select className="input" value={status} onChange={(e) => setStatus(e.target.value as AwardStatus)}>
+              {STATUSES.map((s) => (
+                <option key={s} value={s}>
+                  {AWARD_STATUS_LABELS[s]}
+                </option>
+              ))}
+            </select>
+          </Field>
+          <Field label="Reservation amount (optional)">
+            <input
+              type="number"
+              min={0}
+              className="input"
+              value={reservationAmount}
+              onChange={(e) => setReservationAmount(e.target.value)}
+              placeholder="e.g. 1200000"
+            />
+          </Field>
+        </div>
+        <div className="grid grid-cols-2 gap-4">
+          <Field label="Award date (optional)">
+            <input type="date" className="input" value={awardDate} onChange={(e) => setAwardDate(e.target.value)} />
+          </Field>
+          <Field label="Placed-in-service deadline (optional)">
+            <input type="date" className="input" value={deadline} onChange={(e) => setDeadline(e.target.value)} />
+          </Field>
+        </div>
+        <Field label="Notes (optional)">
+          <textarea className="input min-h-[64px]" value={notes} onChange={(e) => setNotes(e.target.value)} />
+        </Field>
+
+        {error && <p className="rounded-lg bg-red-50 px-3 py-2 text-sm text-red-600">{error}</p>}
+
+        <FormActions onClose={onClose} onSubmit={submit} disabled={!canSave} label={saving ? 'Saving…' : 'Record award'} />
+      </div>
+    </Modal>
+  );
+}
+
+// ── Bind property ───────────────────────────────────────────────────────────
+
+function BindModal({
+  award,
+  properties,
+  onClose,
+  onSaved,
+}: {
+  award: AcqAward;
+  properties: PropertyLite[];
+  onClose: () => void;
+  onSaved: () => void;
+}) {
+  const [propertyId, setPropertyId] = useState(award.propertyId ?? '');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function submit() {
+    setSaving(true);
+    setError(null);
+    try {
+      await api.post(`/api/acquisitions/awards/${award.id}/bind`, {
+        propertyId: propertyId || null,
+      });
+      onSaved();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Bind failed');
+      setSaving(false);
+    }
+  }
+
+  return (
+    <Modal title="Bind to a managed property" onClose={onClose}>
+      <div className="space-y-4">
+        <p className="text-sm text-gray-500">
+          Binding ties this award to the property it is built and operated as. Designations are applied
+          to that property's units.
+        </p>
+        <Field label="Managed property">
+          <select className="input" value={propertyId} onChange={(e) => setPropertyId(e.target.value)}>
+            <option value="">— Unbound —</option>
+            {properties.map((p) => (
+              <option key={p.id} value={p.id}>
+                {p.name}
+                {p.city ? ` · ${p.city}` : ''}
+              </option>
+            ))}
+          </select>
+        </Field>
+
+        {error && <p className="rounded-lg bg-red-50 px-3 py-2 text-sm text-red-600">{error}</p>}
+
+        <FormActions onClose={onClose} onSubmit={submit} disabled={saving} label={saving ? 'Saving…' : 'Save binding'} />
+      </div>
+    </Modal>
+  );
+}
+
+// ── Manage designations ─────────────────────────────────────────────────────
+
+function DesignationsModal({
+  award,
+  propertyName,
+  onClose,
+}: {
+  award: AcqAward;
+  propertyName: string;
+  onClose: () => void;
+}) {
+  const compQ = useApiQuery<{ award: AcqAward; plan: DesignationPlan }>(
+    `/api/acquisitions/awards/${award.id}/compliance`,
+  );
+  const unitsQ = useApiQuery<{ units: BoundUnit[] }>(`/api/acquisitions/awards/${award.id}/units`);
+
+  // Local edits: unitId → chosen designation (or null for undesignated).
+  const [edits, setEdits] = useState<Record<string, UnitDesignation | null>>({});
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const plan = compQ.data?.plan ?? null;
+  const units = unitsQ.data?.units ?? [];
+  const loading = compQ.loading || unitsQ.loading;
+
+  function current(u: BoundUnit): UnitDesignation | null {
+    return u.id in edits ? edits[u.id] : u.amiDesignation;
+  }
+
+  // Only units whose designation actually changed get submitted; the API
+  // requires a concrete designation, so null (undesignate) is not sent.
+  const changed = units.filter((u) => u.id in edits && edits[u.id] !== u.amiDesignation);
+  const sendable = changed.filter((u) => edits[u.id] !== null);
+  const hasUnsendableClears = changed.length > sendable.length;
+
+  async function apply() {
+    if (sendable.length === 0) return;
+    setSaving(true);
+    setError(null);
+    try {
+      await api.post(`/api/acquisitions/awards/${award.id}/designations`, {
+        assignments: sendable.map((u) => ({ unitId: u.id, designation: edits[u.id] })),
+      });
+      setEdits({});
+      compQ.refetch();
+      unitsQ.refetch();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Apply failed');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <Modal title={`Designations — ${propertyName}`} onClose={onClose}>
+      {loading ? (
+        <div className="flex items-center justify-center py-12">
+          <div className="h-6 w-6 animate-spin rounded-full border-4 border-emerald-600 border-t-transparent" />
+        </div>
+      ) : (
+        <div className="space-y-5">
+          {(compQ.error || unitsQ.error) && (
+            <p className="rounded-lg bg-red-50 px-3 py-2 text-sm text-red-600">
+              {compQ.error || unitsQ.error}
+            </p>
+          )}
+
+          {plan && (
+            <div className="rounded-xl border border-gray-200 bg-gray-50 p-4">
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="text-xs font-medium uppercase tracking-wide text-gray-400">
+                    LURA commitment · {plan.electionLabel}
+                  </p>
+                  <p className="mt-1 text-sm text-gray-700">{plan.note}</p>
+                </div>
+                <StatusChip
+                  ok={plan.meetsCommitment}
+                  okText="Commitment met"
+                  badText="Shortfall"
+                />
+              </div>
+              <div className="mt-3 grid grid-cols-4 gap-2">
+                {plan.rows.map((r) => (
+                  <div key={r.designation} className="rounded-lg border border-gray-100 bg-white p-2.5 text-center">
+                    <p className="text-xs text-gray-500">{DESIGNATION_LABELS[r.designation]}</p>
+                    <p className="mt-0.5 text-sm font-semibold text-gray-900">
+                      {r.assigned}
+                      <span className="text-gray-400"> / {r.committed}</span>
+                    </p>
+                    {r.remaining > 0 && (
+                      <p className="text-xs text-amber-600">{r.remaining} to go</p>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          <div>
+            <p className="mb-1.5 text-xs font-medium uppercase tracking-wide text-gray-400">
+              Units ({units.length})
+            </p>
+            {units.length === 0 ? (
+              <p className="rounded-lg border border-gray-100 px-3 py-6 text-center text-sm text-gray-400">
+                The bound property has no units.
+              </p>
+            ) : (
+              <div className="max-h-72 overflow-y-auto rounded-lg border border-gray-100">
+                <table className="w-full text-sm">
+                  <thead className="sticky top-0 bg-white">
+                    <tr className="border-b border-gray-100 text-left text-xs uppercase tracking-wide text-gray-400">
+                      <th className="px-3 py-2 font-medium">Unit</th>
+                      <th className="px-3 py-2 font-medium">Beds</th>
+                      <th className="px-3 py-2 font-medium">Designation</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {units.map((u) => {
+                      const val = current(u);
+                      const dirty = u.id in edits && edits[u.id] !== u.amiDesignation;
+                      return (
+                        <tr key={u.id} className={`border-b border-gray-50 ${dirty ? 'bg-emerald-50/40' : ''}`}>
+                          <td className="px-3 py-1.5 font-medium text-gray-900">{u.unitNumber}</td>
+                          <td className="px-3 py-1.5 text-gray-500">{u.bedrooms}</td>
+                          <td className="px-3 py-1.5">
+                            <select
+                              className="input py-1 text-sm"
+                              value={val ?? ''}
+                              onChange={(e) =>
+                                setEdits((m) => ({
+                                  ...m,
+                                  [u.id]: e.target.value ? (e.target.value as UnitDesignation) : null,
+                                }))
+                              }
+                            >
+                              <option value="">— Undesignated —</option>
+                              {DESIGNATIONS.map((d) => (
+                                <option key={d} value={d}>
+                                  {DESIGNATION_LABELS[d]}
+                                </option>
+                              ))}
+                            </select>
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </div>
+
+          {hasUnsendableClears && (
+            <p className="flex items-center gap-1 text-xs text-amber-600">
+              <AlertTriangle className="h-3.5 w-3.5" />
+              Clearing a designation back to "Undesignated" isn't supported yet — those rows won't be saved.
+            </p>
+          )}
+          {error && <p className="rounded-lg bg-red-50 px-3 py-2 text-sm text-red-600">{error}</p>}
+
+          <div className="flex items-center justify-between border-t border-gray-100 pt-4">
+            <p className="text-xs text-gray-400">
+              {sendable.length > 0 ? `${sendable.length} unit${sendable.length === 1 ? '' : 's'} to apply` : 'No changes'}
+            </p>
+            <div className="flex gap-2">
+              <button
+                onClick={onClose}
+                className="rounded-lg px-4 py-2 text-sm font-medium text-gray-600 hover:bg-gray-100"
+              >
+                Close
+              </button>
+              <button
+                onClick={apply}
+                disabled={sendable.length === 0 || saving}
+                className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-700 disabled:opacity-50"
+              >
+                {saving ? 'Applying…' : 'Apply designations'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </Modal>
+  );
+}
+
+// ── Small shared UI ──────────────────────────────────────────────────────────
+
+function StatusPill({ status }: { status: AwardStatus }) {
+  const tone =
+    status === 'in_service'
+      ? 'bg-emerald-50 text-emerald-700'
+      : status === 'closed'
+        ? 'bg-gray-100 text-gray-500'
+        : 'bg-blue-50 text-blue-700';
+  return (
+    <span className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${tone}`}>
+      {AWARD_STATUS_LABELS[status]}
+    </span>
+  );
+}
+
+function Modal({ title, onClose, children }: { title: string; onClose: () => void; children: ReactNode }) {
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto bg-black/30 p-4 sm:p-8"
+      onClick={onClose}
+    >
+      <div className="my-4 w-full max-w-2xl rounded-2xl bg-white shadow-xl" onClick={(e) => e.stopPropagation()}>
+        <div className="flex items-center justify-between border-b border-gray-200 px-5 py-3.5">
+          <h2 className="text-base font-semibold text-gray-900">{title}</h2>
+          <button onClick={onClose} className="rounded-lg p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-700">
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+        <div className="p-5">{children}</div>
+      </div>
+    </div>
+  );
+}
+
+function Field({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div>
+      <label className="label">{label}</label>
+      {children}
+    </div>
+  );
+}
+
+function FormActions({
+  onClose,
+  onSubmit,
+  disabled,
+  label,
+}: {
+  onClose: () => void;
+  onSubmit: () => void;
+  disabled: boolean;
+  label: string;
+}) {
+  return (
+    <div className="flex justify-end gap-2 border-t border-gray-100 pt-4">
+      <button onClick={onClose} className="rounded-lg px-4 py-2 text-sm font-medium text-gray-600 hover:bg-gray-100">
+        Cancel
+      </button>
+      <button
+        onClick={onSubmit}
+        disabled={disabled}
+        className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-700 disabled:opacity-50"
+      >
+        {label}
+      </button>
+    </div>
+  );
+}
+
+function IconButton({
+  children,
+  title,
+  onClick,
+  disabled,
+  danger,
+}: {
+  children: ReactNode;
+  title: string;
+  onClick: () => void;
+  disabled?: boolean;
+  danger?: boolean;
+}) {
+  return (
+    <button
+      title={title}
+      onClick={onClick}
+      disabled={disabled}
+      className={`rounded-lg p-1.5 disabled:opacity-40 ${
+        danger
+          ? 'text-gray-400 hover:bg-red-50 hover:text-red-600'
+          : 'text-gray-400 hover:bg-gray-100 hover:text-gray-700'
+      }`}
+    >
+      {children}
+    </button>
+  );
+}
+
+function StatusChip({ ok, okText, badText }: { ok: boolean; okText: string; badText: string }) {
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium ${
+        ok ? 'bg-emerald-50 text-emerald-700' : 'bg-amber-50 text-amber-700'
+      }`}
+    >
+      {ok ? <CheckCircle2 className="h-3 w-3" /> : <AlertTriangle className="h-3 w-3" />}
+      {ok ? okText : badText}
+    </span>
+  );
+}

--- a/client-acq/src/types/index.ts
+++ b/client-acq/src/types/index.ts
@@ -190,3 +190,80 @@ export interface ScoredProject {
   project: AcqProject;
   score: ProjectScore;
 }
+
+// ── Awards + compliance bridge (Phase 3, mirrors award-service.ts) ────────────
+
+export type AmiDesignation = '30' | '50' | 'market';
+// The persisted designation also allows '60'; kept as a union for the grid.
+export type UnitDesignation = '30' | '50' | '60' | 'market';
+export type AwardStatus = 'reserved' | 'placed_in_service' | 'in_service' | 'closed';
+
+export const AWARD_STATUS_LABELS: Record<AwardStatus, string> = {
+  reserved: 'Reserved',
+  placed_in_service: 'Placed in service',
+  in_service: 'In service',
+  closed: 'Closed',
+};
+
+export const DESIGNATION_LABELS: Record<UnitDesignation, string> = {
+  '30': '30% AMI',
+  '50': '50% AMI',
+  '60': '60% AMI',
+  market: 'Market',
+};
+
+export interface AcqAward {
+  id: string;
+  acqProjectId: string;
+  propertyId: string | null;
+  status: AwardStatus;
+  reservationAmount: number | null;
+  awardDate: string | null;
+  placedInServiceDeadline: string | null;
+  notes: string | null;
+  createdBy: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface AwardCreateInput {
+  acqProjectId: string;
+  propertyId?: string | null;
+  status?: AwardStatus;
+  reservationAmount?: number | null;
+  awardDate?: string | null;
+  placedInServiceDeadline?: string | null;
+  notes?: string | null;
+}
+
+export interface DesignationPlanRow {
+  designation: UnitDesignation;
+  ceilingAmiPct: number | null;
+  committed: number;
+  assigned: number;
+  remaining: number;
+}
+
+export interface DesignationPlan {
+  electionLabel: string;
+  committedRestricted: number;
+  assignedRestricted: number;
+  propertyUnits: number;
+  rows: DesignationPlanRow[];
+  meetsCommitment: boolean;
+  note: string;
+}
+
+export interface BoundUnit {
+  id: string;
+  unitNumber: string;
+  bedrooms: number;
+  amiDesignation: UnitDesignation | null;
+}
+
+// Minimal property shape from GET /api/properties (root list).
+export interface PropertyLite {
+  id: string;
+  name: string;
+  city?: string | null;
+}

--- a/src/__tests__/acquisitions-awards.test.ts
+++ b/src/__tests__/acquisitions-awards.test.ts
@@ -1,0 +1,247 @@
+/**
+ * Service-layer tests for src/modules/acquisitions/award-service.ts.
+ *
+ * `query` and `transaction` are mocked; the compliance tape is stubbed so a
+ * stamp can't reach Postgres. Covers CRUD mapping, the CONFLICT/VALIDATION
+ * error translation, the designation plan join (project mix + property counts),
+ * and applyDesignations' validate → transactional write → best-effort stamp.
+ */
+import type { QueryResult } from 'pg';
+import { AwardService, BridgeError } from '../modules/acquisitions/award-service';
+import { query, transaction } from '../config/database';
+
+// `mock`-prefixed so jest allows the reference inside the hoisted factory; the
+// closure invokes it lazily, after the const below has initialized.
+const mockStamp = jest.fn().mockResolvedValue(undefined);
+const stamp = mockStamp;
+
+jest.mock('../config/database', () => ({
+  query: jest.fn(),
+  transaction: jest.fn(),
+}));
+jest.mock('../utils/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+jest.mock('../modules/tape/repository', () => ({ PgTapeRepository: jest.fn() }));
+jest.mock('../modules/tape/service', () => ({
+  createTapeService: () => ({ stamp: (...args: unknown[]) => mockStamp(...args) }),
+}));
+
+function qr<T extends Record<string, unknown>>(rows: T[], rowCount?: number): QueryResult<T> {
+  return { rows, rowCount: rowCount ?? rows.length } as unknown as QueryResult<T>;
+}
+
+const mockQuery = query as jest.MockedFunction<typeof query>;
+const mockTransaction = transaction as jest.MockedFunction<typeof transaction>;
+
+function awardRow(over: Record<string, unknown> = {}) {
+  return {
+    id: 'award-1',
+    acq_project_id: 'proj-1',
+    property_id: null,
+    status: 'reserved',
+    reservation_amount: '1200000.00',
+    award_date: '2026-05-20',
+    placed_in_service_deadline: null,
+    notes: null,
+    created_by: 'user-1',
+    created_at: '2026-05-22T00:00:00.000Z',
+    updated_at: '2026-05-22T00:00:00.000Z',
+    ...over,
+  };
+}
+
+const service = new AwardService();
+
+beforeEach(() => {
+  mockQuery.mockReset();
+  mockTransaction.mockReset();
+  stamp.mockClear();
+});
+
+describe('AwardService CRUD', () => {
+  it('list maps rows to camelCase, coercing amount to number and dates to YYYY-MM-DD', async () => {
+    mockQuery.mockResolvedValueOnce(qr([awardRow()]));
+    const [a] = await service.list();
+    expect(a).toMatchObject({
+      id: 'award-1',
+      acqProjectId: 'proj-1',
+      propertyId: null,
+      status: 'reserved',
+      reservationAmount: 1200000,
+      awardDate: '2026-05-20',
+      placedInServiceDeadline: null,
+    });
+  });
+
+  it('create returns the row and stamps acq.award_recorded', async () => {
+    mockQuery.mockResolvedValueOnce(qr([awardRow()]));
+    const created = await service.create({ acqProjectId: 'proj-1' }, 'user-1');
+    expect(created.id).toBe('award-1');
+    expect(stamp).toHaveBeenCalledTimes(1);
+    expect(stamp.mock.calls[0][0]).toMatchObject({ kind: 'acq.award_recorded' });
+  });
+
+  it('create maps a unique-violation to a CONFLICT BridgeError', async () => {
+    mockQuery.mockRejectedValueOnce(Object.assign(new Error('dup'), { code: '23505' }));
+    await expect(service.create({ acqProjectId: 'proj-1' }, 'user-1')).rejects.toMatchObject({
+      code: 'CONFLICT',
+    });
+  });
+
+  it('create maps a FK violation to a VALIDATION BridgeError', async () => {
+    mockQuery.mockRejectedValueOnce(Object.assign(new Error('fk'), { code: '23503' }));
+    await expect(service.create({ acqProjectId: 'ghost' }, null)).rejects.toMatchObject({
+      code: 'VALIDATION',
+    });
+  });
+
+  it('remove reports whether a row was deleted', async () => {
+    mockQuery.mockResolvedValueOnce(qr([], 1));
+    expect(await service.remove('award-1')).toBe(true);
+    mockQuery.mockResolvedValueOnce(qr([], 0));
+    expect(await service.remove('gone')).toBe(false);
+  });
+});
+
+describe('AwardService.designationPlan', () => {
+  it('returns null for a missing award', async () => {
+    mockQuery.mockResolvedValueOnce(qr([])); // get → none
+    expect(await service.designationPlan('nope')).toBeNull();
+  });
+
+  it('throws NOT_BOUND when the award has no property', async () => {
+    mockQuery.mockResolvedValueOnce(qr([awardRow()])); // property_id null
+    await expect(service.designationPlan('award-1')).rejects.toMatchObject({ code: 'NOT_BOUND' });
+  });
+
+  it('joins the project mix with current unit counts into a plan', async () => {
+    // 1) get award (bound), 2) project mix, 3) property designation counts
+    mockQuery
+      .mockResolvedValueOnce(qr([awardRow({ property_id: 'prop-1' })]))
+      .mockResolvedValueOnce(
+        qr([
+          {
+            name: 'Desert Vista',
+            total_units: 100,
+            units_30_ami: 10,
+            units_50_ami: 20,
+            units_60_ami: 0,
+            election_kind: 'STD_40_60',
+          },
+        ]),
+      )
+      .mockResolvedValueOnce(
+        qr([
+          { ami_designation: '30', n: 4 },
+          { ami_designation: '50', n: 20 },
+          { ami_designation: null, n: 76 },
+        ]),
+      );
+
+    const plan = await service.designationPlan('award-1');
+    expect(plan).not.toBeNull();
+    expect(plan!.committedRestricted).toBe(30);
+    expect(plan!.assignedRestricted).toBe(24);
+    expect(plan!.propertyUnits).toBe(100);
+    expect(plan!.meetsCommitment).toBe(false);
+  });
+});
+
+describe('AwardService.applyDesignations', () => {
+  it('validates units against the property and rejects foreign units', async () => {
+    // 1) get award (bound), 2) SELECT property unit ids
+    mockQuery
+      .mockResolvedValueOnce(qr([awardRow({ property_id: 'prop-1' })]))
+      .mockResolvedValueOnce(qr([{ id: 'u1' }, { id: 'u2' }]));
+
+    await expect(
+      service.applyDesignations('award-1', [{ unitId: 'ghost', designation: '30' }], 'user-1'),
+    ).rejects.toMatchObject({ code: 'VALIDATION' });
+    expect(mockTransaction).not.toHaveBeenCalled();
+  });
+
+  it('writes designations transactionally and stamps acq.units_designated', async () => {
+    // get award, SELECT unit ids
+    mockQuery
+      .mockResolvedValueOnce(qr([awardRow({ property_id: 'prop-1' })]))
+      .mockResolvedValueOnce(qr([{ id: 'u1' }, { id: 'u2' }]));
+    // transaction → applies 2 updates
+    mockTransaction.mockImplementationOnce(async (fn: any) => {
+      const client = { query: jest.fn().mockResolvedValue({ rowCount: 1 }) };
+      return fn(client);
+    });
+    // designationPlan refresh after the write: get award, project mix, counts
+    mockQuery
+      .mockResolvedValueOnce(qr([awardRow({ property_id: 'prop-1' })]))
+      .mockResolvedValueOnce(
+        qr([
+          {
+            name: 'Desert Vista',
+            total_units: 10,
+            units_30_ami: 2,
+            units_50_ami: 0,
+            units_60_ami: 0,
+            election_kind: 'STD_40_60',
+          },
+        ]),
+      )
+      .mockResolvedValueOnce(qr([{ ami_designation: '30', n: 2 }, { ami_designation: null, n: 8 }]));
+
+    const result = await service.applyDesignations(
+      'award-1',
+      [
+        { unitId: 'u1', designation: '30' },
+        { unitId: 'u2', designation: '30' },
+      ],
+      'user-1',
+    );
+    expect(mockTransaction).toHaveBeenCalledTimes(1);
+    expect(result!.updated).toBe(2);
+    expect(result!.plan.meetsCommitment).toBe(true);
+    expect(stamp).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: 'acq.units_designated' }),
+    );
+  });
+
+  it('does not throw when the tape stamp fails (best-effort)', async () => {
+    mockQuery
+      .mockResolvedValueOnce(qr([awardRow({ property_id: 'prop-1' })]))
+      .mockResolvedValueOnce(qr([{ id: 'u1' }]));
+    mockTransaction.mockImplementationOnce(async (fn: any) => {
+      const client = { query: jest.fn().mockResolvedValue({ rowCount: 1 }) };
+      return fn(client);
+    });
+    mockQuery
+      .mockResolvedValueOnce(qr([awardRow({ property_id: 'prop-1' })]))
+      .mockResolvedValueOnce(
+        qr([
+          {
+            name: 'X',
+            total_units: 1,
+            units_30_ami: 1,
+            units_50_ami: 0,
+            units_60_ami: 0,
+            election_kind: 'STD_40_60',
+          },
+        ]),
+      )
+      .mockResolvedValueOnce(qr([{ ami_designation: '30', n: 1 }]));
+    stamp.mockRejectedValueOnce(new Error('tape down'));
+
+    const result = await service.applyDesignations(
+      'award-1',
+      [{ unitId: 'u1', designation: '30' }],
+      'user-1',
+    );
+    expect(result!.updated).toBe(1);
+  });
+});
+
+describe('BridgeError', () => {
+  it('carries a machine code and optional detail', () => {
+    const e = new BridgeError('VALIDATION', 'bad', [{ unitId: 'x', reason: 'y' }]);
+    expect(e.code).toBe('VALIDATION');
+    expect(e.detail).toEqual([{ unitId: 'x', reason: 'y' }]);
+  });
+});

--- a/src/__tests__/acquisitions-compliance-bridge.test.ts
+++ b/src/__tests__/acquisitions-compliance-bridge.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Pure-function tests for src/modules/acquisitions/compliance-bridge.ts.
+ *
+ * No DB, no mocks: the designation math is the LURA-commitment truth, so it's
+ * exercised directly. Covers ceiling derivation, target split, plan rollup
+ * (committed vs assigned, meetsCommitment), and assignment validation.
+ */
+import {
+  amiCeilingPct,
+  designationTargets,
+  buildDesignationPlan,
+  validateAssignments,
+  RESTRICTED_DESIGNATIONS,
+  type CommittedMix,
+  type DesignationTargets,
+} from '../modules/acquisitions/compliance-bridge';
+
+const mix = (over: Partial<CommittedMix> = {}): CommittedMix => ({
+  totalUnits: 100,
+  units30Ami: 10,
+  units50Ami: 20,
+  units60Ami: 10,
+  electionKind: 'STD_40_60',
+  ...over,
+});
+
+const counts = (over: Partial<DesignationTargets> = {}): DesignationTargets => ({
+  '30': 0,
+  '50': 0,
+  '60': 0,
+  market: 0,
+  ...over,
+});
+
+describe('amiCeilingPct', () => {
+  it('maps restricted tiers to their AMI ceiling and market to null', () => {
+    expect(amiCeilingPct('30')).toBe(30);
+    expect(amiCeilingPct('50')).toBe(50);
+    expect(amiCeilingPct('60')).toBe(60);
+    expect(amiCeilingPct('market')).toBeNull();
+  });
+});
+
+describe('designationTargets', () => {
+  it('splits restricted commitments and balances the rest to market', () => {
+    expect(designationTargets(mix())).toEqual({ '30': 10, '50': 20, '60': 10, market: 60 });
+  });
+
+  it('clamps market at zero when restricted exceeds total (defensive)', () => {
+    const t = designationTargets(mix({ totalUnits: 30, units30Ami: 20, units50Ami: 20, units60Ami: 0 }));
+    expect(t.market).toBe(0);
+  });
+
+  it('RESTRICTED_DESIGNATIONS lists the three deep tiers, deepest first', () => {
+    expect(RESTRICTED_DESIGNATIONS).toEqual(['30', '50', '60']);
+  });
+});
+
+describe('buildDesignationPlan', () => {
+  it('reports per-tier committed/assigned/remaining and a shortfall', () => {
+    const plan = buildDesignationPlan(mix(), counts({ '30': 4, '50': 20, '60': 0 }), 100);
+    expect(plan.committedRestricted).toBe(40);
+    expect(plan.assignedRestricted).toBe(24);
+    expect(plan.propertyUnits).toBe(100);
+    expect(plan.meetsCommitment).toBe(false);
+
+    const byTier = Object.fromEntries(plan.rows.map((r) => [r.designation, r]));
+    expect(byTier['30']).toMatchObject({ committed: 10, assigned: 4, remaining: 6, ceilingAmiPct: 30 });
+    expect(byTier['60']).toMatchObject({ committed: 10, assigned: 0, remaining: 10 });
+    expect(byTier['market']).toMatchObject({ committed: 60, ceilingAmiPct: null });
+    expect(plan.electionLabel).toBeTruthy();
+  });
+
+  it('meetsCommitment once every restricted tier is designated at or above target', () => {
+    const plan = buildDesignationPlan(mix(), counts({ '30': 10, '50': 25, '60': 10 }), 100);
+    expect(plan.meetsCommitment).toBe(true);
+    expect(plan.note).toContain('40');
+  });
+
+  it('treats a no-restricted-units award as trivially met', () => {
+    const plan = buildDesignationPlan(
+      mix({ units30Ami: 0, units50Ami: 0, units60Ami: 0 }),
+      counts(),
+      50,
+    );
+    expect(plan.committedRestricted).toBe(0);
+    expect(plan.meetsCommitment).toBe(true);
+    expect(plan.note).toMatch(/no restricted units/i);
+  });
+});
+
+describe('validateAssignments', () => {
+  const propertyUnits = new Set(['u1', 'u2', 'u3']);
+
+  it('accepts assignments to units that belong to the property', () => {
+    const errs = validateAssignments(
+      [
+        { unitId: 'u1', designation: '30' },
+        { unitId: 'u2', designation: 'market' },
+      ],
+      propertyUnits,
+    );
+    expect(errs).toEqual([]);
+  });
+
+  it('flags units that do not belong to the bound property', () => {
+    const errs = validateAssignments([{ unitId: 'ghost', designation: '50' }], propertyUnits);
+    expect(errs).toHaveLength(1);
+    expect(errs[0]).toMatchObject({ unitId: 'ghost' });
+    expect(errs[0].reason).toMatch(/belong/i);
+  });
+
+  it('flags duplicate assignments for the same unit', () => {
+    const errs = validateAssignments(
+      [
+        { unitId: 'u1', designation: '30' },
+        { unitId: 'u1', designation: '50' },
+      ],
+      propertyUnits,
+    );
+    expect(errs.some((e) => /duplicate/i.test(e.reason))).toBe(true);
+  });
+
+  it('flags an invalid designation value', () => {
+    const errs = validateAssignments(
+      [{ unitId: 'u1', designation: '70' as never }],
+      propertyUnits,
+    );
+    expect(errs.some((e) => /invalid designation/i.test(e.reason))).toBe(true);
+  });
+});

--- a/src/db/migrations/2026-05-25-acq-awards-and-designations.sql
+++ b/src/db/migrations/2026-05-25-acq-awards-and-designations.sql
@@ -1,0 +1,37 @@
+-- QAP acquisitions layer — Phase 3 Compliance Bridge.
+-- Idempotent. Matches the acq_awards block + units.ami_designation column in
+-- schema.ts (SCHEMA_SQL bootstrap).
+--
+-- Closes the flywheel: a scored candidate project (acq_projects, Phase 2) that
+-- WINS a credit reservation becomes an acq_award; once bound to a real managed
+-- property, the award's election + unit-mix commitment drives per-unit AMI
+-- designations on that property's units. Those designations are the durable,
+-- management-side record of the LURA commitment the credits were awarded for.
+
+-- An acq_project that won a credit reservation, optionally bound to the managed
+-- property it is built/operated as. One award per project (a project competes
+-- once per round); re-applications create a fresh project.
+CREATE TABLE IF NOT EXISTS acq_awards (
+  id                         UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  acq_project_id             UUID NOT NULL UNIQUE REFERENCES acq_projects(id) ON DELETE CASCADE,
+  property_id                UUID REFERENCES properties(id) ON DELETE SET NULL,
+  status                     TEXT NOT NULL DEFAULT 'reserved'
+                               CHECK (status IN ('reserved','placed_in_service','in_service','closed')),
+  reservation_amount         NUMERIC(14,2) CHECK (reservation_amount IS NULL OR reservation_amount >= 0),
+  award_date                 DATE,
+  placed_in_service_deadline DATE,
+  notes                      TEXT,
+  created_by                 UUID REFERENCES users(id),
+  created_at                 TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at                 TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_acq_awards_project ON acq_awards(acq_project_id);
+CREATE INDEX IF NOT EXISTS idx_acq_awards_property ON acq_awards(property_id);
+
+-- Per-unit AMI designation flowing from a bound award's election/unit-mix.
+-- NULL = undesignated (market or not-yet-assigned). The rent ceiling each
+-- designation enforces is derived in compliance-bridge.ts, not stored here.
+ALTER TABLE units ADD COLUMN IF NOT EXISTS ami_designation TEXT
+  CHECK (ami_designation IN ('30','50','60','market'));
+CREATE INDEX IF NOT EXISTS idx_units_ami_designation
+  ON units(ami_designation) WHERE ami_designation IS NOT NULL;

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -437,6 +437,9 @@ CREATE TABLE units (
   photo_url TEXT,
   description TEXT,
   available_from DATE,
+  -- QAP acquisitions Phase 3: per-unit AMI designation from a bound award's
+  -- election/unit-mix. NULL = undesignated. See 2026-05-25-acq-awards-and-designations.sql.
+  ami_designation VARCHAR(10) CHECK (ami_designation IN ('30','50','60','market')),
   created_at TIMESTAMPTZ DEFAULT NOW(),
   updated_at TIMESTAMPTZ DEFAULT NOW(),
   UNIQUE (property_id, unit_number)
@@ -1109,9 +1112,31 @@ CREATE TABLE IF NOT EXISTS acq_projects (
   updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 CREATE INDEX IF NOT EXISTS idx_acq_projects_account ON acq_projects(geographic_account);
+
+-- QAP acquisitions Phase 3 (Compliance Bridge): an acq_project that won a
+-- credit reservation, optionally bound to the managed property it operates as.
+-- One award per project (UNIQUE acq_project_id). The award's election + unit
+-- mix drives per-unit AMI designations on the bound property's units.
+CREATE TABLE IF NOT EXISTS acq_awards (
+  id                         UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  acq_project_id             UUID NOT NULL UNIQUE REFERENCES acq_projects(id) ON DELETE CASCADE,
+  property_id                UUID REFERENCES properties(id) ON DELETE SET NULL,
+  status                     TEXT NOT NULL DEFAULT 'reserved'
+                               CHECK (status IN ('reserved','placed_in_service','in_service','closed')),
+  reservation_amount         NUMERIC(14,2) CHECK (reservation_amount IS NULL OR reservation_amount >= 0),
+  award_date                 DATE,
+  placed_in_service_deadline DATE,
+  notes                      TEXT,
+  created_by                 UUID REFERENCES users(id),
+  created_at                 TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at                 TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_acq_awards_project ON acq_awards(acq_project_id);
+CREATE INDEX IF NOT EXISTS idx_acq_awards_property ON acq_awards(property_id);
 `;
 
 export const DROP_SCHEMA_SQL = `
+DROP TABLE IF EXISTS acq_awards CASCADE;
 DROP TABLE IF EXISTS acq_projects CASCADE;
 DROP TABLE IF EXISTS lease_signatures CASCADE;
 DROP TABLE IF EXISTS stripe_webhook_dlq CASCADE;

--- a/src/modules/acquisitions/award-service.ts
+++ b/src/modules/acquisitions/award-service.ts
@@ -1,0 +1,387 @@
+/**
+ * Award store + designation orchestration (Phase 3 — Compliance Bridge).
+ *
+ * CRUD over acq_awards, binding an award to a managed property, and the
+ * designation flow: turn the won project's committed unit mix into per-unit
+ * AMI designations on the bound property's units, recording each step on the
+ * append-only compliance tape. The designation math is a pure function
+ * (compliance-bridge.ts); SQL and the tape stamp live here.
+ */
+import { query, transaction } from '../../config/database';
+import { logger } from '../../utils/logger';
+import { createTapeService } from '../tape/service';
+import { PgTapeRepository } from '../tape/repository';
+import {
+  buildDesignationPlan,
+  validateAssignments,
+  type AmiDesignation,
+  type CommittedMix,
+  type DesignationPlan,
+  type DesignationTargets,
+} from './compliance-bridge';
+import type { ElectionKind } from './qap-2026';
+
+export type AwardStatus = 'reserved' | 'placed_in_service' | 'in_service' | 'closed';
+export const AWARD_STATUSES: AwardStatus[] = ['reserved', 'placed_in_service', 'in_service', 'closed'];
+
+export interface AwardInput {
+  acqProjectId: string;
+  propertyId?: string | null;
+  status?: AwardStatus;
+  reservationAmount?: number | null;
+  awardDate?: string | null;
+  placedInServiceDeadline?: string | null;
+  notes?: string | null;
+}
+
+export interface AcqAward {
+  id: string;
+  acqProjectId: string;
+  propertyId: string | null;
+  status: AwardStatus;
+  reservationAmount: number | null;
+  awardDate: string | null;
+  placedInServiceDeadline: string | null;
+  notes: string | null;
+  createdBy: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** A bound property's unit, with its current AMI designation. */
+export interface BoundUnit {
+  id: string;
+  unitNumber: string;
+  bedrooms: number;
+  amiDesignation: AmiDesignation | null;
+}
+
+/** Typed service error so routes can map to the right HTTP status. */
+export class BridgeError extends Error {
+  constructor(
+    public code: 'NOT_FOUND' | 'NOT_BOUND' | 'VALIDATION' | 'CONFLICT',
+    message: string,
+    public detail?: unknown,
+  ) {
+    super(message);
+    this.name = 'BridgeError';
+  }
+}
+
+interface AwardRow {
+  id: string;
+  acq_project_id: string;
+  property_id: string | null;
+  status: AwardStatus;
+  reservation_amount: string | number | null;
+  award_date: Date | string | null;
+  placed_in_service_deadline: Date | string | null;
+  notes: string | null;
+  created_by: string | null;
+  created_at: Date | string;
+  updated_at: Date | string;
+}
+
+function asDateString(v: Date | string | null): string | null {
+  if (v == null) return null;
+  // DATE columns come back as 'YYYY-MM-DD' strings already; normalize Dates too.
+  return typeof v === 'string' ? v.slice(0, 10) : v.toISOString().slice(0, 10);
+}
+
+function mapRow(r: AwardRow): AcqAward {
+  return {
+    id: r.id,
+    acqProjectId: r.acq_project_id,
+    propertyId: r.property_id,
+    status: r.status,
+    reservationAmount: r.reservation_amount == null ? null : Number(r.reservation_amount),
+    awardDate: asDateString(r.award_date),
+    placedInServiceDeadline: asDateString(r.placed_in_service_deadline),
+    notes: r.notes,
+    createdBy: r.created_by,
+    createdAt: new Date(r.created_at).toISOString(),
+    updatedAt: new Date(r.updated_at).toISOString(),
+  };
+}
+
+/** The project mix needed to drive designations, read from acq_projects. */
+interface ProjectMixRow {
+  total_units: number;
+  units_30_ami: number;
+  units_50_ami: number;
+  units_60_ami: number;
+  election_kind: ElectionKind;
+  name: string;
+}
+
+const tape = createTapeService(new PgTapeRepository());
+
+/** Stamp the compliance tape best-effort: a tape failure must not lose a
+ *  durable units.ami_designation write (the management-side truth). */
+async function stampSafe(
+  kind: 'acq.award_recorded' | 'acq.units_designated',
+  actorId: string | null,
+  evidence: Record<string, unknown>,
+): Promise<void> {
+  try {
+    await tape.stamp({
+      kind,
+      payload: {
+        '@context': 'https://schema.org',
+        '@type': 'AcquisitionComplianceEvent',
+        actorId,
+        subjectId: null, // global-scope admin event
+        ruleCitation: kind === 'acq.award_recorded' ? 'IRC §42 + NV 2026 QAP §3' : 'IRC §42(g) + 26 CFR 1.42-5',
+        evidence,
+      },
+    });
+  } catch (err) {
+    logger.error('acquisitions: compliance-tape stamp failed (non-fatal)', { kind, err });
+  }
+}
+
+export class AwardService {
+  async list(): Promise<AcqAward[]> {
+    const res = await query(`SELECT * FROM acq_awards ORDER BY created_at DESC`);
+    return (res.rows as AwardRow[]).map(mapRow);
+  }
+
+  async get(id: string): Promise<AcqAward | null> {
+    const res = await query(`SELECT * FROM acq_awards WHERE id = $1`, [id]);
+    const row = (res.rows as AwardRow[])[0];
+    return row ? mapRow(row) : null;
+  }
+
+  /** Record that a scored project won a reservation. Stamps the tape. */
+  async create(input: AwardInput, createdBy: string | null): Promise<AcqAward> {
+    try {
+      const res = await query(
+        `INSERT INTO acq_awards
+           (acq_project_id, property_id, status, reservation_amount,
+            award_date, placed_in_service_deadline, notes, created_by)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8)
+         RETURNING *`,
+        [
+          input.acqProjectId,
+          input.propertyId ?? null,
+          input.status ?? 'reserved',
+          input.reservationAmount ?? null,
+          input.awardDate ?? null,
+          input.placedInServiceDeadline ?? null,
+          input.notes ?? null,
+          createdBy,
+        ],
+      );
+      const award = mapRow((res.rows as AwardRow[])[0]);
+      await stampSafe('acq.award_recorded', createdBy, {
+        awardId: award.id,
+        acqProjectId: award.acqProjectId,
+        propertyId: award.propertyId,
+        reservationAmount: award.reservationAmount,
+        awardDate: award.awardDate,
+      });
+      return award;
+    } catch (err) {
+      const pg = err as { code?: string };
+      if (pg.code === '23505') {
+        throw new BridgeError('CONFLICT', 'This project already has an award.');
+      }
+      if (pg.code === '23503') {
+        throw new BridgeError('VALIDATION', 'Unknown project or property reference.');
+      }
+      throw err;
+    }
+  }
+
+  /** Update mutable award fields (status, dates, amount, notes, binding). */
+  async update(id: string, input: Partial<AwardInput>): Promise<AcqAward | null> {
+    const existing = await this.get(id);
+    if (!existing) return null;
+    const merged: AcqAward = {
+      ...existing,
+      propertyId: input.propertyId === undefined ? existing.propertyId : input.propertyId,
+      status: input.status ?? existing.status,
+      reservationAmount:
+        input.reservationAmount === undefined ? existing.reservationAmount : input.reservationAmount,
+      awardDate: input.awardDate === undefined ? existing.awardDate : input.awardDate,
+      placedInServiceDeadline:
+        input.placedInServiceDeadline === undefined
+          ? existing.placedInServiceDeadline
+          : input.placedInServiceDeadline,
+      notes: input.notes === undefined ? existing.notes : input.notes,
+    };
+    try {
+      const res = await query(
+        `UPDATE acq_awards SET
+           property_id = $2, status = $3, reservation_amount = $4,
+           award_date = $5, placed_in_service_deadline = $6, notes = $7,
+           updated_at = NOW()
+         WHERE id = $1
+         RETURNING *`,
+        [
+          id,
+          merged.propertyId,
+          merged.status,
+          merged.reservationAmount,
+          merged.awardDate,
+          merged.placedInServiceDeadline,
+          merged.notes,
+        ],
+      );
+      const row = (res.rows as AwardRow[])[0];
+      return row ? mapRow(row) : null;
+    } catch (err) {
+      const pg = err as { code?: string };
+      if (pg.code === '23503') {
+        throw new BridgeError('VALIDATION', 'Unknown property reference.');
+      }
+      throw err;
+    }
+  }
+
+  async remove(id: string): Promise<boolean> {
+    const res = await query(`DELETE FROM acq_awards WHERE id = $1`, [id]);
+    return (res.rowCount ?? 0) > 0;
+  }
+
+  /** Read the won project's committed mix for an award. */
+  private async projectMix(acqProjectId: string): Promise<(CommittedMix & { name: string }) | null> {
+    const res = await query(
+      `SELECT name, total_units, units_30_ami, units_50_ami, units_60_ami, election_kind
+         FROM acq_projects WHERE id = $1`,
+      [acqProjectId],
+    );
+    const row = (res.rows as ProjectMixRow[])[0];
+    if (!row) return null;
+    return {
+      name: row.name,
+      totalUnits: row.total_units,
+      units30Ami: row.units_30_ami,
+      units50Ami: row.units_50_ami,
+      units60Ami: row.units_60_ami,
+      electionKind: row.election_kind,
+    };
+  }
+
+  /** Current designation counts + total units on a bound property. */
+  private async propertyDesignationState(
+    propertyId: string,
+  ): Promise<{ counts: DesignationTargets; total: number }> {
+    const res = await query(
+      `SELECT ami_designation, COUNT(*)::int AS n
+         FROM units WHERE property_id = $1
+         GROUP BY ami_designation`,
+      [propertyId],
+    );
+    const counts: DesignationTargets = { '30': 0, '50': 0, '60': 0, market: 0 };
+    let total = 0;
+    for (const row of res.rows as Array<{ ami_designation: AmiDesignation | null; n: number }>) {
+      total += row.n;
+      if (row.ami_designation && row.ami_designation in counts) {
+        counts[row.ami_designation] += row.n;
+      }
+    }
+    return { counts, total };
+  }
+
+  /**
+   * The bound property's units with their current AMI designation, for the
+   * assignment grid. Throws NOT_BOUND if no property is bound.
+   */
+  async listBoundUnits(id: string): Promise<BoundUnit[]> {
+    const award = await this.get(id);
+    if (!award) throw new BridgeError('NOT_FOUND', 'Award not found.');
+    if (!award.propertyId) {
+      throw new BridgeError('NOT_BOUND', 'Award is not bound to a property yet.');
+    }
+    const res = await query(
+      `SELECT id, unit_number, bedrooms, ami_designation
+         FROM units WHERE property_id = $1
+         ORDER BY unit_number`,
+      [award.propertyId],
+    );
+    return (res.rows as Array<{
+      id: string;
+      unit_number: string;
+      bedrooms: number;
+      ami_designation: AmiDesignation | null;
+    }>).map((r) => ({
+      id: r.id,
+      unitNumber: r.unit_number,
+      bedrooms: r.bedrooms,
+      amiDesignation: r.ami_designation,
+    }));
+  }
+
+  /**
+   * Build the designation plan for an award: committed mix vs the bound
+   * property's current designations. Throws NOT_BOUND if no property is bound.
+   */
+  async designationPlan(id: string): Promise<DesignationPlan | null> {
+    const award = await this.get(id);
+    if (!award) return null;
+    if (!award.propertyId) {
+      throw new BridgeError('NOT_BOUND', 'Award is not bound to a property yet.');
+    }
+    const mix = await this.projectMix(award.acqProjectId);
+    if (!mix) throw new BridgeError('NOT_FOUND', 'Award references a missing project.');
+    const { counts, total } = await this.propertyDesignationState(award.propertyId);
+    return buildDesignationPlan(mix, counts, total);
+  }
+
+  /**
+   * Apply a { unitId → designation } assignment to the bound property's units,
+   * atomically, then stamp the tape. Returns the refreshed plan.
+   */
+  async applyDesignations(
+    id: string,
+    assignments: ReadonlyArray<{ unitId: string; designation: AmiDesignation }>,
+    actorId: string | null,
+  ): Promise<{ updated: number; plan: DesignationPlan } | null> {
+    const award = await this.get(id);
+    if (!award) return null;
+    if (!award.propertyId) {
+      throw new BridgeError('NOT_BOUND', 'Award is not bound to a property yet.');
+    }
+
+    // Validate against the units that actually belong to the bound property.
+    const unitRes = await query(`SELECT id FROM units WHERE property_id = $1`, [award.propertyId]);
+    const propertyUnitIds = new Set((unitRes.rows as Array<{ id: string }>).map((r) => r.id));
+    const errors = validateAssignments(assignments, propertyUnitIds);
+    if (errors.length > 0) {
+      throw new BridgeError('VALIDATION', 'Invalid unit assignments.', errors);
+    }
+
+    const updated = await transaction(async (client) => {
+      let n = 0;
+      for (const { unitId, designation } of assignments) {
+        const r = await client.query(
+          `UPDATE units SET ami_designation = $2, updated_at = NOW()
+             WHERE id = $1 AND property_id = $3`,
+          [unitId, designation, award.propertyId],
+        );
+        n += r.rowCount ?? 0;
+      }
+      return n;
+    });
+
+    const plan = await this.designationPlan(id);
+    await stampSafe('acq.units_designated', actorId, {
+      awardId: award.id,
+      propertyId: award.propertyId,
+      unitsDesignated: updated,
+      committedRestricted: plan?.committedRestricted ?? null,
+      assignedRestricted: plan?.assignedRestricted ?? null,
+      meetsCommitment: plan?.meetsCommitment ?? null,
+    });
+    return { updated, plan: plan as DesignationPlan };
+  }
+
+  /** Compliance rollup: the designation plan plus the award's status. */
+  async compliance(id: string): Promise<{ award: AcqAward; plan: DesignationPlan } | null> {
+    const award = await this.get(id);
+    if (!award) return null;
+    const plan = await this.designationPlan(id);
+    return { award, plan: plan as DesignationPlan };
+  }
+}

--- a/src/modules/acquisitions/compliance-bridge.ts
+++ b/src/modules/acquisitions/compliance-bridge.ts
@@ -1,0 +1,191 @@
+/**
+ * Compliance Bridge — pure designation/ceiling math (Phase 3).
+ *
+ * Closes the flywheel: an acq_project that won credits (an acq_award), once
+ * bound to a managed property, commits a unit mix at given AMI tiers. This
+ * module turns that commitment into a per-unit AMI designation plan and derives
+ * the rent/income ceiling each designation enforces — the LURA obligation the
+ * credits were awarded for.
+ *
+ * Pure and DB-free: the service (award-service.ts) reads the project's
+ * commitment + the property's current unit designations and passes plain
+ * numbers in, so the math stays deterministic and unit-testable.
+ */
+import { RENT_ELECTIONS, type ElectionKind } from './qap-2026';
+
+/** A unit's AMI designation. Mirrors the units.ami_designation CHECK. */
+export type AmiDesignation = '30' | '50' | '60' | 'market';
+
+/** The three restricted tiers, deepest first (placement priority). */
+export const RESTRICTED_DESIGNATIONS: ReadonlyArray<Exclude<AmiDesignation, 'market'>> = [
+  '30',
+  '50',
+  '60',
+] as const;
+
+/**
+ * Rent/income ceiling a designation enforces, as a % of Area Median Income.
+ * `market` units carry no AMI ceiling (null). This is what a recertification
+ * income check measures a household against (next slice).
+ */
+export function amiCeilingPct(designation: AmiDesignation): number | null {
+  switch (designation) {
+    case '30':
+      return 30;
+    case '50':
+      return 50;
+    case '60':
+      return 60;
+    case 'market':
+      return null;
+  }
+}
+
+/** The project's committed unit mix — the counts persisted on acq_projects. */
+export interface CommittedMix {
+  totalUnits: number;
+  units30Ami: number;
+  units50Ami: number;
+  units60Ami: number;
+  electionKind: ElectionKind;
+}
+
+/** Committed count per designation, derived from the project's mix. */
+export type DesignationTargets = Record<AmiDesignation, number>;
+
+/**
+ * The project commits N units at each restricted tier; the balance up to
+ * totalUnits is market-rate. Restricted commitments above totalUnits are
+ * clamped (the Phase 2 schema already guards this, but stay defensive).
+ */
+export function designationTargets(mix: CommittedMix): DesignationTargets {
+  const restricted = mix.units30Ami + mix.units50Ami + mix.units60Ami;
+  const market = Math.max(0, mix.totalUnits - restricted);
+  return {
+    '30': mix.units30Ami,
+    '50': mix.units50Ami,
+    '60': mix.units60Ami,
+    market,
+  };
+}
+
+export interface DesignationPlanRow {
+  designation: AmiDesignation;
+  /** AMI ceiling this designation enforces, or null for market. */
+  ceilingAmiPct: number | null;
+  /** Units the award commits at this designation. */
+  committed: number;
+  /** Units on the bound property currently carrying this designation. */
+  assigned: number;
+  /** committed − assigned; negative = over-assigned past the commitment. */
+  remaining: number;
+}
+
+export interface DesignationPlan {
+  /** Election the commitment derives from, for display. */
+  electionLabel: string;
+  /** Total restricted units the award commits (30+50+60). */
+  committedRestricted: number;
+  /** Restricted units currently designated on the property. */
+  assignedRestricted: number;
+  /** Actual unit count on the bound property. */
+  propertyUnits: number;
+  rows: DesignationPlanRow[];
+  /** True once the property's restricted designations meet the commitment. */
+  meetsCommitment: boolean;
+  note: string;
+}
+
+/**
+ * Build the plan that drives the UI: per-designation committed vs currently
+ * assigned on the bound property, and whether the LURA commitment is met.
+ *
+ * @param mix              the project's committed unit mix
+ * @param currentCounts    units on the property by current designation
+ * @param propertyUnits    total unit rows on the bound property
+ */
+export function buildDesignationPlan(
+  mix: CommittedMix,
+  currentCounts: DesignationTargets,
+  propertyUnits: number,
+): DesignationPlan {
+  const targets = designationTargets(mix);
+  const designations: AmiDesignation[] = ['30', '50', '60', 'market'];
+
+  const rows: DesignationPlanRow[] = designations.map((designation) => {
+    const committed = targets[designation];
+    const assigned = currentCounts[designation] ?? 0;
+    return {
+      designation,
+      ceilingAmiPct: amiCeilingPct(designation),
+      committed,
+      assigned,
+      remaining: committed - assigned,
+    };
+  });
+
+  const committedRestricted = mix.units30Ami + mix.units50Ami + mix.units60Ami;
+  const assignedRestricted = RESTRICTED_DESIGNATIONS.reduce(
+    (sum, d) => sum + (currentCounts[d] ?? 0),
+    0,
+  );
+
+  // Commitment is met when each restricted tier is designated at or above its
+  // committed count — under-designating any deep tier is a LURA shortfall.
+  const meetsCommitment = RESTRICTED_DESIGNATIONS.every(
+    (d) => (currentCounts[d] ?? 0) >= targets[d],
+  );
+
+  let note: string;
+  if (committedRestricted === 0) {
+    note = 'Award commits no restricted units.';
+  } else if (meetsCommitment) {
+    note = `All ${committedRestricted} committed restricted units are designated.`;
+  } else {
+    note = `${assignedRestricted}/${committedRestricted} committed restricted units designated.`;
+  }
+
+  return {
+    electionLabel: RENT_ELECTIONS[mix.electionKind].label,
+    committedRestricted,
+    assignedRestricted,
+    propertyUnits,
+    rows,
+    meetsCommitment,
+    note,
+  };
+}
+
+export interface AssignmentError {
+  unitId: string;
+  reason: string;
+}
+
+/**
+ * Validate a proposed { unitId → designation } assignment against the set of
+ * units that actually belong to the bound property. Returns the list of
+ * problems (empty = valid). Keeps the service's apply path honest without a DB
+ * round-trip per row.
+ */
+export function validateAssignments(
+  assignments: ReadonlyArray<{ unitId: string; designation: AmiDesignation }>,
+  propertyUnitIds: ReadonlySet<string>,
+): AssignmentError[] {
+  const errors: AssignmentError[] = [];
+  const seen = new Set<string>();
+  const valid: AmiDesignation[] = ['30', '50', '60', 'market'];
+
+  for (const { unitId, designation } of assignments) {
+    if (!propertyUnitIds.has(unitId)) {
+      errors.push({ unitId, reason: 'Unit does not belong to the bound property.' });
+    }
+    if (!valid.includes(designation)) {
+      errors.push({ unitId, reason: `Invalid designation "${designation}".` });
+    }
+    if (seen.has(unitId)) {
+      errors.push({ unitId, reason: 'Duplicate assignment for unit.' });
+    }
+    seen.add(unitId);
+  }
+  return errors;
+}

--- a/src/modules/acquisitions/routes.ts
+++ b/src/modules/acquisitions/routes.ts
@@ -16,13 +16,15 @@
  *   DELETE /api/acquisitions/projects/:id    — delete
  *   GET    /api/acquisitions/projects/:id/score — score vs QAP subset + demand
  */
-import { Router } from 'express';
+import { Router, type Response } from 'express';
 import { z } from 'zod';
 import { authenticate, AuthRequest } from '../../middleware/auth';
 import { requirePermission } from '../../middleware/rbac';
 import { logger } from '../../utils/logger';
 import { DemandService, type DemandFilters, type AmiTier } from './demand-service';
 import { ProjectService, type ProjectInput } from './project-service';
+import { AwardService, AwardInput, AwardStatus, AWARD_STATUSES, BridgeError } from './award-service';
+import type { AmiDesignation } from './compliance-bridge';
 import {
   GEOGRAPHIC_ACCOUNTS,
   SET_ASIDES,
@@ -34,6 +36,7 @@ import {
 const router = Router();
 const service = new DemandService();
 const projects = new ProjectService();
+const awards = new AwardService();
 
 const ACCOUNTS = Object.keys(GEOGRAPHIC_ACCOUNTS) as [GeographicAccount, ...GeographicAccount[]];
 const SET_ASIDE_KEYS = Object.keys(SET_ASIDES) as [string, ...string[]];
@@ -256,6 +259,292 @@ router.get(
     } catch (err) {
       logger.error('acquisitions: score project failed', { err });
       res.status(500).json({ error: 'Failed to score project' });
+    }
+  },
+);
+
+// ── Phase 3: awards + the compliance bridge ──────────────────────────────────
+
+const DATE = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Expected YYYY-MM-DD');
+const AWARD_STATUS_KEYS = AWARD_STATUSES as [AwardStatus, ...AwardStatus[]];
+
+const AwardCreateSchema = z.object({
+  acqProjectId: z.string().uuid(),
+  propertyId: z.string().uuid().optional().nullable(),
+  status: z.enum(AWARD_STATUS_KEYS).optional(),
+  reservationAmount: z.coerce.number().min(0).optional().nullable(),
+  awardDate: DATE.optional().nullable(),
+  placedInServiceDeadline: DATE.optional().nullable(),
+  notes: z.string().trim().max(5000).optional().nullable(),
+});
+
+// Update: every field optional, but at least one present (a no-op PUT is a 400).
+const AwardUpdateSchema = z
+  .object({
+    propertyId: z.string().uuid().nullable(),
+    status: z.enum(AWARD_STATUS_KEYS),
+    reservationAmount: z.coerce.number().min(0).nullable(),
+    awardDate: DATE.nullable(),
+    placedInServiceDeadline: DATE.nullable(),
+    notes: z.string().trim().max(5000).nullable(),
+  })
+  .partial()
+  .refine((o) => Object.keys(o).length > 0, { message: 'No fields to update.' });
+
+const BindSchema = z.object({ propertyId: z.string().uuid().nullable() });
+
+const DesignationsSchema = z.object({
+  assignments: z
+    .array(
+      z.object({
+        unitId: z.string().uuid(),
+        designation: z.enum(['30', '50', '60', 'market']),
+      }),
+    )
+    .min(1)
+    .max(2000),
+});
+
+/** Map a BridgeError to its HTTP status; returns true if it handled `err`. */
+function handleBridgeError(err: unknown, res: Response): boolean {
+  if (err instanceof BridgeError) {
+    const status = { NOT_FOUND: 404, NOT_BOUND: 409, VALIDATION: 400, CONFLICT: 409 }[err.code];
+    res.status(status).json({ error: err.message, ...(err.detail ? { details: err.detail } : {}) });
+    return true;
+  }
+  return false;
+}
+
+/** GET /api/acquisitions/awards — list all awards, newest first. */
+router.get(
+  '/awards',
+  authenticate,
+  requirePermission('acquisition:view'),
+  async (_req: AuthRequest, res) => {
+    try {
+      res.json({ awards: await awards.list() });
+    } catch (err) {
+      logger.error('acquisitions: list awards failed', { err });
+      res.status(500).json({ error: 'Failed to list awards' });
+    }
+  },
+);
+
+/** POST /api/acquisitions/awards — record a won reservation for a project. */
+router.post(
+  '/awards',
+  authenticate,
+  requirePermission('acquisition:manage'),
+  async (req: AuthRequest, res) => {
+    const parsed = AwardCreateSchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({ error: 'Invalid award', details: parsed.error.flatten() });
+      return;
+    }
+    try {
+      const created = await awards.create(parsed.data as AwardInput, req.user?.id ?? null);
+      res.status(201).json({ award: created });
+    } catch (err) {
+      if (handleBridgeError(err, res)) return;
+      logger.error('acquisitions: create award failed', { err });
+      res.status(500).json({ error: 'Failed to create award' });
+    }
+  },
+);
+
+/** GET /api/acquisitions/awards/:id. */
+router.get(
+  '/awards/:id',
+  authenticate,
+  requirePermission('acquisition:view'),
+  async (req: AuthRequest, res) => {
+    try {
+      const award = await awards.get(req.params.id as string);
+      if (!award) {
+        res.status(404).json({ error: 'Award not found' });
+        return;
+      }
+      res.json({ award });
+    } catch (err) {
+      logger.error('acquisitions: get award failed', { err });
+      res.status(500).json({ error: 'Failed to fetch award' });
+    }
+  },
+);
+
+/** PUT /api/acquisitions/awards/:id — update status/dates/amount/notes/binding. */
+router.put(
+  '/awards/:id',
+  authenticate,
+  requirePermission('acquisition:manage'),
+  async (req: AuthRequest, res) => {
+    const parsed = AwardUpdateSchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({ error: 'Invalid award', details: parsed.error.flatten() });
+      return;
+    }
+    try {
+      const updated = await awards.update(req.params.id as string, parsed.data as Partial<AwardInput>);
+      if (!updated) {
+        res.status(404).json({ error: 'Award not found' });
+        return;
+      }
+      res.json({ award: updated });
+    } catch (err) {
+      if (handleBridgeError(err, res)) return;
+      logger.error('acquisitions: update award failed', { err });
+      res.status(500).json({ error: 'Failed to update award' });
+    }
+  },
+);
+
+/** POST /api/acquisitions/awards/:id/bind — bind (or unbind) a managed property. */
+router.post(
+  '/awards/:id/bind',
+  authenticate,
+  requirePermission('acquisition:manage'),
+  async (req: AuthRequest, res) => {
+    const parsed = BindSchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({ error: 'Invalid binding', details: parsed.error.flatten() });
+      return;
+    }
+    try {
+      const updated = await awards.update(req.params.id as string, { propertyId: parsed.data.propertyId });
+      if (!updated) {
+        res.status(404).json({ error: 'Award not found' });
+        return;
+      }
+      res.json({ award: updated });
+    } catch (err) {
+      if (handleBridgeError(err, res)) return;
+      logger.error('acquisitions: bind award failed', { err });
+      res.status(500).json({ error: 'Failed to bind property' });
+    }
+  },
+);
+
+/** DELETE /api/acquisitions/awards/:id. */
+router.delete(
+  '/awards/:id',
+  authenticate,
+  requirePermission('acquisition:manage'),
+  async (req: AuthRequest, res) => {
+    try {
+      const removed = await awards.remove(req.params.id as string);
+      if (!removed) {
+        res.status(404).json({ error: 'Award not found' });
+        return;
+      }
+      res.status(204).end();
+    } catch (err) {
+      logger.error('acquisitions: delete award failed', { err });
+      res.status(500).json({ error: 'Failed to delete award' });
+    }
+  },
+);
+
+/**
+ * GET /api/acquisitions/awards/:id/plan
+ * The designation plan: committed unit mix vs. the bound property's current
+ * AMI designations. 409 if the award isn't bound to a property yet.
+ */
+router.get(
+  '/awards/:id/plan',
+  authenticate,
+  requirePermission('acquisition:view'),
+  async (req: AuthRequest, res) => {
+    try {
+      const plan = await awards.designationPlan(req.params.id as string);
+      if (!plan) {
+        res.status(404).json({ error: 'Award not found' });
+        return;
+      }
+      res.json({ plan });
+    } catch (err) {
+      if (handleBridgeError(err, res)) return;
+      logger.error('acquisitions: designation plan failed', { err });
+      res.status(500).json({ error: 'Failed to build designation plan' });
+    }
+  },
+);
+
+/**
+ * GET /api/acquisitions/awards/:id/units
+ * The bound property's units with their current AMI designation — the grid the
+ * apply-designations form edits. 409 if the award isn't bound yet.
+ */
+router.get(
+  '/awards/:id/units',
+  authenticate,
+  requirePermission('acquisition:view'),
+  async (req: AuthRequest, res) => {
+    try {
+      const units = await awards.listBoundUnits(req.params.id as string);
+      res.json({ units });
+    } catch (err) {
+      if (handleBridgeError(err, res)) return;
+      logger.error('acquisitions: list bound units failed', { err });
+      res.status(500).json({ error: 'Failed to list units' });
+    }
+  },
+);
+
+/**
+ * POST /api/acquisitions/awards/:id/designations
+ * Apply { unitId → designation } assignments to the bound property's units,
+ * atomically, and stamp the compliance tape. Returns the refreshed plan.
+ */
+router.post(
+  '/awards/:id/designations',
+  authenticate,
+  requirePermission('acquisition:manage'),
+  async (req: AuthRequest, res) => {
+    const parsed = DesignationsSchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({ error: 'Invalid assignments', details: parsed.error.flatten() });
+      return;
+    }
+    try {
+      const result = await awards.applyDesignations(
+        req.params.id as string,
+        parsed.data.assignments as Array<{ unitId: string; designation: AmiDesignation }>,
+        req.user?.id ?? null,
+      );
+      if (!result) {
+        res.status(404).json({ error: 'Award not found' });
+        return;
+      }
+      res.json(result);
+    } catch (err) {
+      if (handleBridgeError(err, res)) return;
+      logger.error('acquisitions: apply designations failed', { err });
+      res.status(500).json({ error: 'Failed to apply designations' });
+    }
+  },
+);
+
+/**
+ * GET /api/acquisitions/awards/:id/compliance
+ * Compliance rollup: the award plus its designation plan (designated vs.
+ * committed restricted units, and whether the LURA commitment is met).
+ */
+router.get(
+  '/awards/:id/compliance',
+  authenticate,
+  requirePermission('acquisition:view'),
+  async (req: AuthRequest, res) => {
+    try {
+      const rollup = await awards.compliance(req.params.id as string);
+      if (!rollup) {
+        res.status(404).json({ error: 'Award not found' });
+        return;
+      }
+      res.json(rollup);
+    } catch (err) {
+      if (handleBridgeError(err, res)) return;
+      logger.error('acquisitions: compliance rollup failed', { err });
+      res.status(500).json({ error: 'Failed to build compliance rollup' });
     }
   },
 );

--- a/src/modules/tape/types.ts
+++ b/src/modules/tape/types.ts
@@ -26,7 +26,10 @@ export type TapeStampKind =
   | "application.advanced"
   | "unit.claimed"
   // Lease e-signature (native) — tenant executes the lease
-  | "LEASE_EXECUTED";
+  | "LEASE_EXECUTED"
+  // QAP acquisitions Phase 3 (Compliance Bridge) — global-scope admin events
+  | "acq.award_recorded"
+  | "acq.units_designated";
 
 /** A JSON-LD payload. Lane C provides one `make<Event>Payload` per kind.
  *  The `@context` URL is stubbed in v1 (see docs/bp-02-contracts.md §5). */
@@ -134,6 +137,8 @@ export const TAPE_CITATIONS: Record<TapeStampKind, string> = {
   "application.advanced": "HUD 4350.3 Ch. 4-14",
   "unit.claimed": "HUD 4350.3 Ch. 4-14",
   LEASE_EXECUTED: "HUD 4350.3 Ch. 6-5 + 15 U.S.C. 7001 (ESIGN)",
+  "acq.award_recorded": "IRC §42 + NV 2026 QAP §3",
+  "acq.units_designated": "IRC §42(g) + 26 CFR 1.42-5 (LURA)",
 };
 
 /** Feature flag controlling dual-write during cutover. When false, the new


### PR DESCRIPTION
## Phase 3 — Compliance Bridge

Closes the LIHTC flywheel: a scored Phase-2 project that **wins a credit reservation** becomes an `acq_award`, **binds** to the managed property it operates as, and drives **per-unit AMI designations** (LURA) on that property's units — each step stamped to the v2 Postgres compliance tape.

```
won credits → acq_awards → bind to property → designate units @ AMI tiers → tape
```

### What's in it
- **migration** `2026-05-25-acq-awards-and-designations.sql` — `acq_awards` (one award per project, UNIQUE `acq_project_id`) + `units.ami_designation` (CHECK 30/50/60/market)
- **compliance-bridge.ts** — pure designation math: targets, AMI ceilings, plan rollup (committed vs assigned, `meetsCommitment`), assignment validation against the bound property
- **award-service.ts** — CRUD + `bindProperty` + `designationPlan` + `applyDesignations` (transactional unit writes, best-effort tape stamp) + `compliance` rollup; `BridgeError(code)` → HTTP mapping
- **tape** — new kinds `acq.award_recorded`, `acq.units_designated` (+ IRC §42 / 26 CFR 1.42-5 citations)
- **routes** — `/awards` CRUD + `/bind` + `/plan` + `/units` + `/designations` + `/compliance`, gated `acquisition:view` / `acquisition:manage`
- **client-acq** — new **Awards** page (create, bind, designate units) + nav + route + types

### Scope boundary
Recert **income-ceiling enforcement is deferred to the next slice** — `amiCeilingPct()` is the hook. This PR is award + designation only.

### Verification
- `tsc --noEmit` clean
- **23 new tests** pass (11 compliance-bridge + 12 award-service)
- `client-acq` `npm run build` clean
- migration applied to local DB; UNIQUE / status CHECK / `ami_designation` CHECK round-trip verified (rolled back)

🤖 Generated with [Claude Code](https://claude.com/claude-code)