### PR TITLE
feat(acquisitions): Phase 3.1 — recert income-ceiling enforcement (140% AUR)

### DIFF
--- a/src/__tests__/acquisitions-recert-compliance.test.ts
+++ b/src/__tests__/acquisitions-recert-compliance.test.ts
@@ -1,0 +1,203 @@
+/**
+ * QAP acquisitions Phase 3.1 — recert income-ceiling enforcement.
+ *
+ * Two layers:
+ *  1. Pure math (evaluateRecertIncome) — verdict tiers, the 140% Available Unit
+ *     Rule boundary, market/undesignated, and the indeterminate fallbacks.
+ *  2. Service (RecertComplianceService) — resolves recert → application →
+ *     claimed unit → designation, looks up the HUD limit (with prior-year
+ *     fallback), evaluates, persists the snapshot, and stamps the tape.
+ *
+ * `query` and the compliance tape are mocked so nothing touches Postgres.
+ */
+import type { QueryResult } from 'pg';
+import {
+  evaluateRecertIncome,
+  RECERT_AUR_FACTOR,
+} from '../modules/acquisitions/compliance-bridge';
+import { RecertComplianceService } from '../modules/acquisitions/recert-compliance';
+import { query } from '../config/database';
+
+const mockStamp = jest.fn().mockResolvedValue(undefined);
+const stamp = mockStamp;
+
+jest.mock('../config/database', () => ({ query: jest.fn() }));
+jest.mock('../utils/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+jest.mock('../modules/tape/repository', () => ({ PgTapeRepository: jest.fn() }));
+jest.mock('../modules/tape/service', () => ({
+  createTapeService: () => ({ stamp: (...args: unknown[]) => mockStamp(...args) }),
+}));
+
+function qr<T extends Record<string, unknown>>(rows: T[]): QueryResult<T> {
+  return { rows, rowCount: rows.length } as unknown as QueryResult<T>;
+}
+
+const mockQuery = query as jest.MockedFunction<typeof query>;
+
+// ---------------------------------------------------------------------------
+// 1. Pure math
+// ---------------------------------------------------------------------------
+describe('evaluateRecertIncome', () => {
+  it('treats a market unit as not_restricted with no ceiling', () => {
+    const r = evaluateRecertIncome({ designation: 'market', applicableLimit: null, householdIncome: 40000 });
+    expect(r.verdict).toBe('not_restricted');
+    expect(r.ceilingAmiPct).toBeNull();
+    expect(r.aurThreshold).toBeNull();
+  });
+
+  it('treats an undesignated (null) unit as not_restricted', () => {
+    const r = evaluateRecertIncome({ designation: null, applicableLimit: null, householdIncome: 40000 });
+    expect(r.verdict).toBe('not_restricted');
+  });
+
+  it('qualifies income at or under the applicable limit', () => {
+    const r = evaluateRecertIncome({ designation: '60', applicableLimit: 50000, householdIncome: 50000 });
+    expect(r.verdict).toBe('qualified');
+    expect(r.ceilingAmiPct).toBe(60);
+    expect(r.pctOfLimit).toBe(100);
+  });
+
+  it('flags over_income_aur when income is over the limit but within 140%', () => {
+    const r = evaluateRecertIncome({ designation: '50', applicableLimit: 50000, householdIncome: 60000 });
+    expect(r.verdict).toBe('over_income_aur');
+    expect(r.aurThreshold).toBe(50000 * RECERT_AUR_FACTOR);
+  });
+
+  it('treats income exactly at 140% as still over_income_aur (boundary inclusive)', () => {
+    const limit = 50000;
+    const r = evaluateRecertIncome({ designation: '30', applicableLimit: limit, householdIncome: limit * 1.4 });
+    expect(r.verdict).toBe('over_income_aur');
+  });
+
+  it('flags over_income just past the 140% threshold', () => {
+    const limit = 50000;
+    const r = evaluateRecertIncome({ designation: '30', applicableLimit: limit, householdIncome: limit * 1.4 + 1 });
+    expect(r.verdict).toBe('over_income');
+  });
+
+  it('is indeterminate when the limit is missing for a restricted unit', () => {
+    const r = evaluateRecertIncome({ designation: '60', applicableLimit: null, householdIncome: 40000 });
+    expect(r.verdict).toBe('indeterminate');
+    expect(r.ceilingAmiPct).toBe(60);
+  });
+
+  it('is indeterminate when income is missing', () => {
+    const r = evaluateRecertIncome({ designation: '60', applicableLimit: 50000, householdIncome: null });
+    expect(r.verdict).toBe('indeterminate');
+    expect(r.aurThreshold).toBe(50000 * RECERT_AUR_FACTOR);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Service
+// ---------------------------------------------------------------------------
+function resolveRow(over: Record<string, unknown> = {}) {
+  return {
+    id: 'recert-1',
+    property_id: 'prop-1',
+    tenant_name: 'Jane Doe',
+    new_annual_income: '62000',
+    previous_annual_income: '48000',
+    application_id: 'app-1',
+    claimed_unit_id: 'unit-1',
+    household_size: 3,
+    application_income: '45000',
+    unit_id: 'unit-1',
+    unit_number: '204',
+    ami_designation: '60',
+    ami_area: 'Clark County',
+    ...over,
+  };
+}
+
+const limitRow = { ami_30_percent: '25000', ami_50_percent: '42000', ami_60_percent: '50000' };
+
+const service = new RecertComplianceService();
+
+beforeEach(() => {
+  mockQuery.mockReset();
+  stamp.mockClear();
+});
+
+describe('RecertComplianceService.check', () => {
+  it('returns null for an unknown recert', async () => {
+    mockQuery.mockResolvedValueOnce(qr([]));
+    const r = await service.check('nope', { persist: false, stamp: false });
+    expect(r).toBeNull();
+  });
+
+  it('resolves the chain, evaluates over_income_aur, persists, and stamps', async () => {
+    mockQuery
+      .mockResolvedValueOnce(qr([resolveRow()])) // chain resolve
+      .mockResolvedValueOnce(qr([limitRow])) // ami_limits this year
+      .mockResolvedValueOnce(qr([])) // persist UPDATE
+      .mockResolvedValue(qr([])); // any further
+
+    const r = await service.check('recert-1', { actorId: 'rev-1' });
+    expect(r).not.toBeNull();
+    // income 62000 vs 60% limit 50000 → over but within 140% (70000)
+    expect(r!.check.verdict).toBe('over_income_aur');
+    expect(r!.context.designation).toBe('60');
+    expect(r!.context.unitNumber).toBe('204');
+
+    // persist UPDATE fired
+    const updateCall = mockQuery.mock.calls.find((c) => String(c[0]).includes('UPDATE recertifications'));
+    expect(updateCall).toBeDefined();
+
+    // tape stamped with the recert as subject
+    expect(stamp).toHaveBeenCalledTimes(1);
+    const payload = (stamp.mock.calls[0][0] as any).payload;
+    expect((stamp.mock.calls[0][0] as any).kind).toBe('acq.recert_income_checked');
+    expect(payload.subjectId).toBe('recert-1');
+    expect(payload.evidence.verdict).toBe('over_income_aur');
+  });
+
+  it('falls back to the prior year when the current-year limit is absent', async () => {
+    mockQuery
+      .mockResolvedValueOnce(qr([resolveRow({ new_annual_income: '40000' })])) // chain
+      .mockResolvedValueOnce(qr([])) // this year — empty
+      .mockResolvedValueOnce(qr([limitRow])) // prior year
+      .mockResolvedValue(qr([])); // persist + stamp path
+
+    const r = await service.check('recert-1', { actorId: 'rev-1', stamp: false });
+    expect(r!.check.verdict).toBe('qualified'); // 40000 <= 50000
+    expect(r!.context.limitYear).toBe(new Date().getFullYear() - 1);
+  });
+
+  it('degrades to not_restricted when the unit is not resolved (market/no claim)', async () => {
+    mockQuery
+      .mockResolvedValueOnce(
+        qr([resolveRow({ claimed_unit_id: null, unit_id: null, unit_number: null, ami_designation: null })]),
+      )
+      .mockResolvedValue(qr([]));
+
+    const r = await service.check('recert-1', { persist: false, stamp: false });
+    expect(r!.check.verdict).toBe('not_restricted');
+    // no ami_limits lookup happens for an undesignated unit
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+  });
+
+  it('honours an explicit income override', async () => {
+    mockQuery
+      .mockResolvedValueOnce(qr([resolveRow()]))
+      .mockResolvedValueOnce(qr([limitRow]))
+      .mockResolvedValue(qr([]));
+
+    // override 80000 vs 50000 → over 140% (70000) → over_income
+    const r = await service.check('recert-1', { income: 80000, persist: false, stamp: false });
+    expect(r!.check.verdict).toBe('over_income');
+    expect(r!.check.householdIncome).toBe(80000);
+  });
+
+  it('does not throw when the tape stamp fails', async () => {
+    mockQuery
+      .mockResolvedValueOnce(qr([resolveRow()]))
+      .mockResolvedValueOnce(qr([limitRow]))
+      .mockResolvedValue(qr([]));
+    stamp.mockRejectedValueOnce(new Error('tape down'));
+
+    await expect(service.check('recert-1', { persist: false, actorId: 'rev-1' })).resolves.not.toBeNull();
+  });
+});

--- a/src/db/migrations/2026-05-27-recert-income-ceiling.sql
+++ b/src/db/migrations/2026-05-27-recert-income-ceiling.sql
@@ -1,0 +1,25 @@
+-- QAP acquisitions Phase 3.1 — recert income-ceiling enforcement.
+-- Idempotent. Matches the income_ceiling_* columns added to the
+-- recertifications block in schema.ts.
+--
+-- At recertification a household's recertified income is measured against the
+-- income ceiling its occupied unit's AMI designation enforces (units.ami_designation,
+-- Phase 3), applying the 140% Available Unit Rule (IRC §42(g)(2)(D)(ii)). The
+-- resulting verdict + the limit it was measured against are snapshotted here so
+-- the review UI/API can show the auto-check alongside the manual decision; the
+-- immutable record lives on the compliance tape (acq.recert_income_checked).
+
+ALTER TABLE recertifications
+  ADD COLUMN IF NOT EXISTS income_ceiling_verdict TEXT
+    CHECK (income_ceiling_verdict IN
+      ('not_restricted','qualified','over_income_aur','over_income','indeterminate')),
+  ADD COLUMN IF NOT EXISTS income_ceiling_designation TEXT
+    CHECK (income_ceiling_designation IN ('30','50','60','market')),
+  ADD COLUMN IF NOT EXISTS income_ceiling_limit DECIMAL(12,2),
+  ADD COLUMN IF NOT EXISTS income_ceiling_income DECIMAL(12,2),
+  ADD COLUMN IF NOT EXISTS income_ceiling_checked_at TIMESTAMPTZ;
+
+-- Surface over-income recerts for follow-up (Available Unit Rule queue).
+CREATE INDEX IF NOT EXISTS idx_recertifications_income_verdict
+  ON recertifications(income_ceiling_verdict)
+  WHERE income_ceiling_verdict IN ('over_income_aur','over_income');

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -853,6 +853,18 @@ CREATE TABLE recertifications (
   market_rent_applied_at TIMESTAMPTZ,
   market_rent_amount DECIMAL(10,2),
 
+  -- QAP acquisitions Phase 3.1: income-ceiling enforcement snapshot. Recertified
+  -- income measured against the occupied unit's AMI designation (Phase 3) with
+  -- the 140% Available Unit Rule. See 2026-05-27-recert-income-ceiling.sql.
+  income_ceiling_verdict TEXT
+    CHECK (income_ceiling_verdict IN
+      ('not_restricted','qualified','over_income_aur','over_income','indeterminate')),
+  income_ceiling_designation TEXT
+    CHECK (income_ceiling_designation IN ('30','50','60','market')),
+  income_ceiling_limit DECIMAL(12,2),
+  income_ceiling_income DECIMAL(12,2),
+  income_ceiling_checked_at TIMESTAMPTZ,
+
   created_at TIMESTAMPTZ DEFAULT NOW(),
   updated_at TIMESTAMPTZ DEFAULT NOW()
 );

--- a/src/modules/acquisitions/compliance-bridge.ts
+++ b/src/modules/acquisitions/compliance-bridge.ts
@@ -156,6 +156,129 @@ export function buildDesignationPlan(
   };
 }
 
+/**
+ * Available Unit Rule factor (IRC §42(g)(2)(D)(ii)). At recertification a
+ * household keeps qualifying until its income exceeds 140% of the applicable
+ * income limit. Past that the unit no longer counts toward the set-aside until
+ * the Next Available Unit Rule is satisfied — the *initial* certification uses
+ * 100% of the limit, but recerts use this higher ceiling.
+ */
+export const RECERT_AUR_FACTOR = 1.4;
+
+/**
+ * Verdict of a recertification income-ceiling check against the unit's actual
+ * AMI designation:
+ *  - not_restricted: market unit (or undesignated) — no LIHTC income ceiling.
+ *  - qualified:      income at or under the applicable limit.
+ *  - over_income_aur: over the limit but ≤140% — still LIHTC-qualified, but the
+ *      Available Unit Rule now governs the next comparable vacancy.
+ *  - over_income:    over 140% — unit out of compliance until AUR is satisfied.
+ *  - indeterminate:  missing designation/limit/income — needs manual review.
+ */
+export type RecertIncomeVerdict =
+  | 'not_restricted'
+  | 'qualified'
+  | 'over_income_aur'
+  | 'over_income'
+  | 'indeterminate';
+
+export interface RecertIncomeInput {
+  /** The occupied unit's AMI designation (units.ami_designation), or null. */
+  designation: AmiDesignation | null;
+  /** Applicable annual income limit ($) for the tier + household size, or null. */
+  applicableLimit: number | null;
+  /** Recertified household annual income ($), or null if not on file. */
+  householdIncome: number | null;
+}
+
+export interface RecertIncomeCheck {
+  verdict: RecertIncomeVerdict;
+  /** AMI ceiling % the designation enforces (30/50/60), or null. */
+  ceilingAmiPct: number | null;
+  /** The applicable income limit ($) measured against, or null. */
+  applicableLimit: number | null;
+  /** 140% Available Unit Rule threshold ($), or null when not restricted. */
+  aurThreshold: number | null;
+  /** Income measured ($), or null. */
+  householdIncome: number | null;
+  /** Income as a % of the applicable limit, or null. */
+  pctOfLimit: number | null;
+  /** Human-readable explanation for the reviewer / tape evidence. */
+  note: string;
+}
+
+/**
+ * Evaluate a household's recertified income against the income ceiling its
+ * occupied unit's AMI designation enforces, applying the 140% Available Unit
+ * Rule. Pure: the service resolves designation + limit + income from the DB and
+ * passes plain numbers in.
+ */
+export function evaluateRecertIncome(input: RecertIncomeInput): RecertIncomeCheck {
+  const { designation, applicableLimit, householdIncome } = input;
+  const ceilingAmiPct = designation ? amiCeilingPct(designation) : null;
+
+  // Market or undesignated unit → no LIHTC income ceiling to enforce.
+  if (designation === null || designation === 'market') {
+    return {
+      verdict: 'not_restricted',
+      ceilingAmiPct: null,
+      applicableLimit: null,
+      aurThreshold: null,
+      householdIncome,
+      pctOfLimit: null,
+      note:
+        designation === 'market'
+          ? 'Unit is market-rate — no LIHTC income ceiling applies.'
+          : 'Unit has no AMI designation — no income ceiling to enforce.',
+    };
+  }
+
+  if (applicableLimit === null || householdIncome === null) {
+    return {
+      verdict: 'indeterminate',
+      ceilingAmiPct,
+      applicableLimit,
+      aurThreshold: applicableLimit === null ? null : applicableLimit * RECERT_AUR_FACTOR,
+      householdIncome,
+      pctOfLimit:
+        applicableLimit && householdIncome !== null
+          ? (householdIncome / applicableLimit) * 100
+          : null,
+      note:
+        applicableLimit === null
+          ? `No income limit on file for the ${ceilingAmiPct}% AMI tier and household size — manual review required.`
+          : 'No recertified income on file — manual review required.',
+    };
+  }
+
+  const aurThreshold = applicableLimit * RECERT_AUR_FACTOR;
+  const pctOfLimit = (householdIncome / applicableLimit) * 100;
+  const fmt = (n: number) => `$${Math.round(n).toLocaleString()}`;
+
+  let verdict: RecertIncomeVerdict;
+  let note: string;
+  if (householdIncome <= applicableLimit) {
+    verdict = 'qualified';
+    note = `Income ${fmt(householdIncome)} is within the ${ceilingAmiPct}% AMI limit ${fmt(applicableLimit)}.`;
+  } else if (householdIncome <= aurThreshold) {
+    verdict = 'over_income_aur';
+    note = `Income ${fmt(householdIncome)} exceeds the ${ceilingAmiPct}% AMI limit ${fmt(applicableLimit)} but is within 140% (${fmt(aurThreshold)}). Household stays qualified; the Available Unit Rule now governs the next comparable vacancy.`;
+  } else {
+    verdict = 'over_income';
+    note = `Income ${fmt(householdIncome)} exceeds 140% of the ${ceilingAmiPct}% AMI limit (${fmt(aurThreshold)}). Unit is out of compliance until the Next Available Unit Rule is satisfied.`;
+  }
+
+  return {
+    verdict,
+    ceilingAmiPct,
+    applicableLimit,
+    aurThreshold,
+    householdIncome,
+    pctOfLimit,
+    note,
+  };
+}
+
 export interface AssignmentError {
   unitId: string;
   reason: string;

--- a/src/modules/acquisitions/recert-compliance.ts
+++ b/src/modules/acquisitions/recert-compliance.ts
@@ -1,0 +1,250 @@
+/**
+ * Recert income-ceiling enforcement (QAP acquisitions Phase 3.1).
+ *
+ * Bridges the Phase 3 designation layer to annual recertification: a household's
+ * recertified income is measured against the income ceiling its occupied unit's
+ * AMI designation enforces, applying the 140% Available Unit Rule
+ * (IRC §42(g)(2)(D)(ii)). The math is pure (compliance-bridge.ts); this service
+ * resolves the chain recertification → application → claimed unit → designation,
+ * looks up the applicable HUD income limit (ami_limits), persists a verdict
+ * snapshot on the recert, and stamps the immutable compliance tape.
+ *
+ * Read-only on the recert lifecycle: it never auto-adjusts rent or changes the
+ * reviewer's pass/fail decision — it surfaces a verdict the reviewer acts on.
+ */
+import { query } from '../../config/database';
+import { logger } from '../../utils/logger';
+import { createTapeService } from '../tape/service';
+import { PgTapeRepository } from '../tape/repository';
+import {
+  evaluateRecertIncome,
+  type AmiDesignation,
+  type RecertIncomeCheck,
+} from './compliance-bridge';
+
+const tape = createTapeService(new PgTapeRepository());
+
+/** The resolved context behind a check, returned alongside the verdict so the
+ *  reviewer/API can see what the income was measured against. */
+export interface RecertCheckContext {
+  recertId: string;
+  applicationId: string;
+  propertyId: string;
+  tenantName: string;
+  unitId: string | null;
+  unitNumber: string | null;
+  designation: AmiDesignation | null;
+  amiArea: string | null;
+  householdSize: number;
+  /** Calendar year the income limit was drawn from (current or prior fallback). */
+  limitYear: number | null;
+}
+
+export interface RecertComplianceResult {
+  context: RecertCheckContext;
+  check: RecertIncomeCheck;
+}
+
+interface ResolveRow {
+  id: string;
+  property_id: string;
+  tenant_name: string;
+  new_annual_income: string | null;
+  previous_annual_income: string | null;
+  application_id: string;
+  claimed_unit_id: string | null;
+  household_size: number | null;
+  application_income: string | null;
+  unit_id: string | null;
+  unit_number: string | null;
+  ami_designation: string | null;
+  ami_area: string | null;
+}
+
+interface AmiLimitRow {
+  ami_30_percent: string | null;
+  ami_50_percent: string | null;
+  ami_60_percent: string | null;
+}
+
+function num(v: string | number | null | undefined): number | null {
+  if (v === null || v === undefined) return null;
+  const n = typeof v === 'number' ? v : parseFloat(v);
+  return Number.isFinite(n) ? n : null;
+}
+
+export class RecertComplianceService {
+  /**
+   * Evaluate a recertification's income against its unit's AMI ceiling.
+   *
+   * @param recertId  the recertification to check.
+   * @param opts.income   override income to measure (e.g. a freshly submitted
+   *                      figure not yet persisted); otherwise the recert's
+   *                      recertified → previous → application income is used.
+   * @param opts.persist  write the verdict snapshot onto the recert (default true).
+   * @param opts.stamp    stamp the compliance tape (default true).
+   * @param opts.actorId  actor for the tape stamp.
+   * @returns the verdict + resolved context, or null if the recert is unknown.
+   */
+  async check(
+    recertId: string,
+    opts: {
+      income?: number | null;
+      persist?: boolean;
+      stamp?: boolean;
+      actorId?: string | null;
+    } = {},
+  ): Promise<RecertComplianceResult | null> {
+    const persist = opts.persist ?? true;
+    const stamp = opts.stamp ?? true;
+
+    const res = await query(
+      `SELECT r.id, r.property_id, r.tenant_name,
+              r.new_annual_income, r.previous_annual_income,
+              a.id AS application_id, a.claimed_unit_id,
+              a.household_size, a.annual_income AS application_income,
+              u.id AS unit_id, u.unit_number, u.ami_designation,
+              p.ami_area
+         FROM recertifications r
+         JOIN applications a ON r.application_id = a.id
+         LEFT JOIN units u ON a.claimed_unit_id = u.id
+         JOIN properties p ON r.property_id = p.id
+        WHERE r.id = $1`,
+      [recertId],
+    );
+    const row = (res.rows as ResolveRow[])[0];
+    if (!row) return null;
+
+    const householdSize = row.household_size && row.household_size > 0 ? row.household_size : 1;
+    const designation = (row.ami_designation as AmiDesignation | null) ?? null;
+
+    // Income to measure: explicit override → recertified → previous → application.
+    const income =
+      opts.income ??
+      num(row.new_annual_income) ??
+      num(row.previous_annual_income) ??
+      num(row.application_income);
+
+    // Resolve the applicable HUD income limit for the designation tier, only
+    // when the unit is restricted (market/undesignated need no limit).
+    let applicableLimit: number | null = null;
+    let limitYear: number | null = null;
+    if (designation && designation !== 'market' && row.ami_area) {
+      const resolved = await this.resolveLimit(row.ami_area, householdSize, designation);
+      applicableLimit = resolved.limit;
+      limitYear = resolved.year;
+    }
+
+    const check = evaluateRecertIncome({ designation, applicableLimit, householdIncome: income });
+
+    const context: RecertCheckContext = {
+      recertId: row.id,
+      applicationId: row.application_id,
+      propertyId: row.property_id,
+      tenantName: row.tenant_name,
+      unitId: row.unit_id,
+      unitNumber: row.unit_number,
+      designation,
+      amiArea: row.ami_area,
+      householdSize,
+      limitYear,
+    };
+
+    if (persist) await this.persist(recertId, designation, check);
+    if (stamp) await this.stampSafe(context, check, opts.actorId ?? null);
+
+    return { context, check };
+  }
+
+  /** Look up the income limit for a tier + household size, falling back to the
+   *  prior calendar year (mirrors the screening ComplianceService behaviour). */
+  private async resolveLimit(
+    amiArea: string,
+    householdSize: number,
+    designation: Exclude<AmiDesignation, 'market'>,
+  ): Promise<{ limit: number | null; year: number | null }> {
+    const column = `ami_${designation}_percent` as keyof AmiLimitRow;
+    const thisYear = new Date().getFullYear();
+
+    for (const year of [thisYear, thisYear - 1]) {
+      const res = await query(
+        `SELECT ami_30_percent, ami_50_percent, ami_60_percent
+           FROM ami_limits
+          WHERE area = $1 AND year = $2 AND household_size = $3`,
+        [amiArea, year, householdSize],
+      );
+      const limit = num((res.rows as AmiLimitRow[])[0]?.[column]);
+      if (limit !== null) return { limit, year };
+    }
+    return { limit: null, year: null };
+  }
+
+  /** Snapshot the verdict on the recert so the review UI/API can show it without
+   *  recomputing. The tape is the immutable record; this is a convenience cache. */
+  private async persist(
+    recertId: string,
+    designation: AmiDesignation | null,
+    check: RecertIncomeCheck,
+  ): Promise<void> {
+    await query(
+      `UPDATE recertifications
+          SET income_ceiling_verdict = $2,
+              income_ceiling_designation = $3,
+              income_ceiling_limit = $4,
+              income_ceiling_income = $5,
+              income_ceiling_checked_at = NOW(),
+              updated_at = NOW()
+        WHERE id = $1`,
+      [
+        recertId,
+        check.verdict,
+        designation,
+        check.applicableLimit,
+        check.householdIncome,
+      ],
+    );
+  }
+
+  /** Stamp best-effort: a tape failure must not block a recert review. Subject
+   *  is the recert id so the entry reads under that recert's scope. */
+  private async stampSafe(
+    context: RecertCheckContext,
+    check: RecertIncomeCheck,
+    actorId: string | null,
+  ): Promise<void> {
+    try {
+      await tape.stamp({
+        kind: 'acq.recert_income_checked',
+        payload: {
+          '@context': 'https://schema.org',
+          '@type': 'AcquisitionComplianceEvent',
+          actorId,
+          subjectId: context.recertId,
+          ruleCitation: 'IRC §42(g)(2)(D)(ii) (Available Unit Rule) + 26 CFR 1.42-5',
+          evidence: {
+            recertId: context.recertId,
+            propertyId: context.propertyId,
+            unitId: context.unitId,
+            unitNumber: context.unitNumber,
+            designation: context.designation,
+            amiArea: context.amiArea,
+            householdSize: context.householdSize,
+            limitYear: context.limitYear,
+            verdict: check.verdict,
+            ceilingAmiPct: check.ceilingAmiPct,
+            applicableLimit: check.applicableLimit,
+            aurThreshold: check.aurThreshold,
+            householdIncome: check.householdIncome,
+            pctOfLimit: check.pctOfLimit,
+            note: check.note,
+          },
+        },
+      });
+    } catch (err) {
+      logger.error('acquisitions: recert income-check tape stamp failed (non-fatal)', {
+        recertId: context.recertId,
+        err,
+      });
+    }
+  }
+}

--- a/src/modules/recertification/routes.ts
+++ b/src/modules/recertification/routes.ts
@@ -3,10 +3,12 @@ import { z } from "zod";
 import { authenticate, AuthRequest } from "../../middleware/auth";
 import { requirePermission } from "../../middleware/rbac";
 import { RecertificationService } from "./service";
+import { RecertComplianceService } from "../acquisitions/recert-compliance";
 import { logger } from "../../utils/logger";
 
 const router = Router();
 const service = new RecertificationService();
+const compliance = new RecertComplianceService();
 
 // List recertifications with filters
 router.get(
@@ -62,6 +64,37 @@ router.get(
     } catch (err: any) {
       logger.error("Failed to get recertification", { error: err.message });
       res.status(500).json({ error: "Failed to get recertification" });
+    }
+  }
+);
+
+// Income-ceiling check (QAP Phase 3.1): measure recertified income against the
+// occupied unit's AMI designation w/ the 140% Available Unit Rule. Read-only
+// preview — does not persist or stamp (submit/review do that); scope enforced
+// via getById so a manager can't probe recerts outside their portfolio.
+router.get(
+  "/:id/income-check",
+  authenticate,
+  requirePermission("recertification:view"),
+  async (req: AuthRequest, res: Response): Promise<void> => {
+    try {
+      const recert = await service.getById(req.params.id as string, req);
+      if (!recert) {
+        res.status(404).json({ error: "Recertification not found" });
+        return;
+      }
+      const result = await compliance.check(req.params.id as string, {
+        persist: false,
+        stamp: false,
+      });
+      if (!result) {
+        res.status(404).json({ error: "Recertification not found" });
+        return;
+      }
+      res.json(result);
+    } catch (err: any) {
+      logger.error("Failed to run recert income check", { error: err.message });
+      res.status(500).json({ error: "Failed to run recert income check" });
     }
   }
 );

--- a/src/modules/recertification/service.ts
+++ b/src/modules/recertification/service.ts
@@ -4,9 +4,11 @@ import { logger } from "../../utils/logger";
 import { TwilioService } from "../integrations/twilio";
 import { AuthRequest } from "../../middleware/auth";
 import { buildPropertyScope } from "../../middleware/scope";
+import { RecertComplianceService } from "../acquisitions/recert-compliance";
 
 export class RecertificationService {
   private twilio = new TwilioService();
+  private compliance = new RecertComplianceService();
 
   /**
    * Create an annual recertification record for a newly onboarded tenant.
@@ -211,6 +213,15 @@ export class RecertificationService {
       resourceId: recertId,
       details: { newIncome },
     });
+
+    // QAP Phase 3.1: measure the recertified income against the unit's AMI
+    // ceiling (140% Available Unit Rule) and snapshot/stamp the verdict.
+    // Best-effort — a compliance hiccup must never block the submission.
+    try {
+      await this.compliance.check(recertId, { income: newIncome ?? null, actorId });
+    } catch (err: any) {
+      logger.error("Recert income-ceiling check failed on submit (non-fatal)", { recertId, error: err?.message });
+    }
   }
 
   /**
@@ -248,6 +259,15 @@ export class RecertificationService {
       resourceId: recertId,
       details: { decision, notes, rentAdjustment },
     });
+
+    // QAP Phase 3.1: re-evaluate the income ceiling against the reviewed
+    // income (now persisted) and stamp the verdict under the reviewer's actor.
+    // The reviewer acts on this verdict; we never auto-change their decision.
+    try {
+      await this.compliance.check(recertId, { income: newIncome ?? null, actorId });
+    } catch (err: any) {
+      logger.error("Recert income-ceiling check failed on review (non-fatal)", { recertId, error: err?.message });
+    }
 
     // If approved, create next year's recertification automatically
     if (decision === "pass") {

--- a/src/modules/tape/types.ts
+++ b/src/modules/tape/types.ts
@@ -29,7 +29,9 @@ export type TapeStampKind =
   | "LEASE_EXECUTED"
   // QAP acquisitions Phase 3 (Compliance Bridge) — global-scope admin events
   | "acq.award_recorded"
-  | "acq.units_designated";
+  | "acq.units_designated"
+  // QAP acquisitions Phase 3.1 — recert income-ceiling enforcement (subject = recert)
+  | "acq.recert_income_checked";
 
 /** A JSON-LD payload. Lane C provides one `make<Event>Payload` per kind.
  *  The `@context` URL is stubbed in v1 (see docs/bp-02-contracts.md §5). */
@@ -139,6 +141,7 @@ export const TAPE_CITATIONS: Record<TapeStampKind, string> = {
   LEASE_EXECUTED: "HUD 4350.3 Ch. 6-5 + 15 U.S.C. 7001 (ESIGN)",
   "acq.award_recorded": "IRC §42 + NV 2026 QAP §3",
   "acq.units_designated": "IRC §42(g) + 26 CFR 1.42-5 (LURA)",
+  "acq.recert_income_checked": "IRC §42(g)(2)(D)(ii) (Available Unit Rule) + 26 CFR 1.42-5",
 };
 
 /** Feature flag controlling dual-write during cutover. When false, the new


### PR DESCRIPTION
## QAP acquisitions Phase 3.1 — recert income-ceiling enforcement

Bridges the Phase 3 per-unit AMI designations ([#146](https://github.com/a13xperi/frank-pilot/pull/146)) to annual recertification. At recert a household's income is measured against the income ceiling its occupied unit's `units.ami_designation` enforces, applying the **140% Available Unit Rule** (IRC §42(g)(2)(D)(ii)).

### Verdicts
- `not_restricted` — market / undesignated unit (no LIHTC ceiling)
- `qualified` — income ≤ applicable limit
- `over_income_aur` — over the limit but ≤140% (still qualified; AUR governs next vacancy)
- `over_income` — over 140% (out of compliance until Next Available Unit Rule satisfied)
- `indeterminate` — missing designation/limit/income → manual review

### Scope
Verdict + tape only. **No** auto rent adjustment, **no** Next-Available-Unit workflow, **no** new client page — surfaced via API verdict in the existing recert review flow.

### Changes
- `evaluateRecertIncome()` pure math + `RECERT_AUR_FACTOR=1.4` in `compliance-bridge.ts`
- `RecertComplianceService` — resolves recert→app→claimed unit→designation, looks up `ami_limits` (prior-year fallback), persists verdict snapshot, stamps tape kind `acq.recert_income_checked` (subject = recert; IRC §42(g)(2)(D)(ii) + 26 CFR 1.42-5)
- `GET /recertifications/:id/income-check` read-only preview (scope-gated)
- `submit` + `review` run the check (persist+stamp), best-effort so a compliance hiccup never blocks the recert lifecycle
- Migration + schema: 5 `income_ceiling_*` columns + partial index on over-income verdicts

### Tests
14 new tests (pure math verdict tiers + 140% boundary + service resolve/fallback/degrade/override/stamp-failure); full acquisitions + tape suite (146) green; `tsc` clean; migration verified on local DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)