### PR TITLE
feat(client-acq): Recertifications + Compliance Queue UI

### DIFF
--- a/client-acq/src/App.tsx
+++ b/client-acq/src/App.tsx
@@ -6,6 +6,8 @@ import { Login } from '@/pages/Login';
 import { Demand } from '@/pages/Demand';
 import { Projects } from '@/pages/Projects';
 import { Awards } from '@/pages/Awards';
+import { Recertifications } from '@/pages/Recertifications';
+import { ComplianceQueue } from '@/pages/ComplianceQueue';
 
 export default function App() {
   return (
@@ -18,6 +20,8 @@ export default function App() {
               <Route index element={<Demand />} />
               <Route path="projects" element={<Projects />} />
               <Route path="awards" element={<Awards />} />
+              <Route path="recertifications" element={<Recertifications />} />
+              <Route path="compliance-queue" element={<ComplianceQueue />} />
               <Route path="*" element={<Navigate to="/" replace />} />
             </Route>
           </Route>

--- a/client-acq/src/api/client.ts
+++ b/client-acq/src/api/client.ts
@@ -39,4 +39,32 @@ export const api = {
   patch: <T>(path: string, body?: unknown) =>
     request<T>(path, { method: 'PATCH', body: body ? JSON.stringify(body) : undefined }),
   del: <T>(path: string) => request<T>(path, { method: 'DELETE' }),
+
+  // ── Recertifications ─────────────────────────────────────────────────────
+
+  /** List all recertifications. */
+  getRecertifications: <T>() => request<T>('/api/recertifications'),
+
+  /** Fetch the income-check verdict for one recertification. */
+  getRecertIncomeCheck: <T>(id: string) =>
+    request<T>(`/api/recertifications/${id}/income-check`),
+
+  /** Resolve NAU (Non-Arm's-Length Unit) for a recertification. */
+  resolveNau: <T>(id: string, body: { resolvingUnitId: string; notes?: string | null }) =>
+    request<T>(`/api/recertifications/${id}/nau-resolve`, {
+      method: 'POST',
+      body: JSON.stringify(body),
+    }),
+
+  // ── AUR compliance queue ─────────────────────────────────────────────────
+
+  /** List over-income / AUR households queue. */
+  getAurQueue: <T>(params: { propertyId?: string; limit?: number; offset?: number } = {}) => {
+    const qs = new URLSearchParams();
+    if (params.propertyId) qs.set('propertyId', params.propertyId);
+    if (params.limit != null) qs.set('limit', String(params.limit));
+    if (params.offset != null) qs.set('offset', String(params.offset));
+    const query = qs.toString();
+    return request<T>(`/api/acquisitions/aur-queue${query ? `?${query}` : ''}`);
+  },
 };

--- a/client-acq/src/components/Layout.tsx
+++ b/client-acq/src/components/Layout.tsx
@@ -1,14 +1,17 @@
 import { Outlet, NavLink } from 'react-router-dom';
-import { LogOut, BarChart3, Building2, FolderKanban, Award } from 'lucide-react';
+import { LogOut, BarChart3, Building2, FolderKanban, Award, ClipboardList, ShieldAlert } from 'lucide-react';
 import { useAuth } from '@/hooks/useAuth';
 import { formatRole } from '@/types';
 
 // Acquisitions nav. Phase 1 ships Demand; Phase 2 adds Projects; Phase 3 adds
 // Awards (the compliance bridge from won credits to designated units).
+// Phase 3.1 adds Recertifications and the Compliance Queue (AUR/over-income).
 const NAV = [
   { to: '/', label: 'Demand Evidence', icon: BarChart3, end: true },
   { to: '/projects', label: 'Candidate Projects', icon: FolderKanban, end: false },
   { to: '/awards', label: 'Awards', icon: Award, end: false },
+  { to: '/recertifications', label: 'Recertifications', icon: ClipboardList, end: false },
+  { to: '/compliance-queue', label: 'Compliance Queue', icon: ShieldAlert, end: false },
 ];
 
 export function Layout() {

--- a/client-acq/src/pages/ComplianceQueue.tsx
+++ b/client-acq/src/pages/ComplianceQueue.tsx
@@ -269,13 +269,21 @@ function NauResolveModal({
 
 function NauStatusPill({ status }: { status: NauStatus }) {
   const tone =
-    status === 'resolved'
+    status === 'satisfied'
       ? 'bg-emerald-50 text-emerald-700'
       : status === 'open'
         ? 'bg-amber-50 text-amber-700'
-        : 'bg-gray-100 text-gray-500';
+        : status === 'lost'
+          ? 'bg-red-50 text-red-700'
+          : 'bg-gray-100 text-gray-500';
   const label =
-    status === 'resolved' ? 'Resolved' : status === 'open' ? 'Open' : 'N/A';
+    status === 'satisfied'
+      ? 'Satisfied'
+      : status === 'open'
+        ? 'Open'
+        : status === 'lost'
+          ? 'Lost'
+          : 'N/A';
   return (
     <span className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${tone}`}>
       {label}

--- a/client-acq/src/pages/ComplianceQueue.tsx
+++ b/client-acq/src/pages/ComplianceQueue.tsx
@@ -1,0 +1,319 @@
+import { useState, type ReactNode } from 'react';
+import { ShieldAlert, X } from 'lucide-react';
+import { PageHeader } from '@/components/PageHeader';
+import { useApiQuery } from '@/hooks/useApiQuery';
+import { api } from '@/api/client';
+import {
+  type AurQueueItem,
+  type AurQueueResponse,
+  type NauStatus,
+  DESIGNATION_LABELS,
+  type UnitDesignation,
+} from '@/types';
+import { VerdictBadge } from './Recertifications';
+
+const PAGE_SIZE = 50;
+
+export function ComplianceQueue() {
+  const [propertyFilter, setPropertyFilter] = useState('');
+  const [resolveTarget, setResolveTarget] = useState<AurQueueItem | null>(null);
+
+  // Build the query path reactively based on the filter.
+  const queryPath = buildPath(propertyFilter);
+  const { data, loading, error, refetch } = useApiQuery<AurQueueResponse>(queryPath);
+
+  const queue = data?.queue ?? [];
+  const total = data?.total ?? 0;
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        icon={ShieldAlert}
+        title="Compliance Queue"
+        description="Over-income and AUR-governed households flagged by the annual recertification income check. Resolve Non-Arm's-Length Unit (NAU) findings for households that qualify under the 140% AUR rule."
+      />
+
+      {/* Property filter */}
+      <div className="flex items-center gap-3">
+        <label className="text-sm font-medium text-gray-700">Filter by property</label>
+        <input
+          type="text"
+          className="input max-w-xs"
+          placeholder="Property ID or leave blank for all"
+          value={propertyFilter}
+          onChange={(e) => setPropertyFilter(e.target.value.trim())}
+        />
+        {propertyFilter && (
+          <button
+            onClick={() => setPropertyFilter('')}
+            className="text-sm text-gray-400 hover:text-gray-700"
+          >
+            Clear
+          </button>
+        )}
+      </div>
+
+      {error && (
+        <p className="rounded-lg bg-red-50 px-4 py-3 text-sm text-red-600">{error}</p>
+      )}
+
+      <div className="rounded-xl border border-gray-200 bg-white">
+        <div className="flex items-center justify-between border-b border-gray-200 px-5 py-3">
+          <h2 className="text-sm font-semibold text-gray-900">Over-income households</h2>
+          {!loading && (
+            <span className="text-xs text-gray-400">
+              {total} household{total === 1 ? '' : 's'}
+            </span>
+          )}
+        </div>
+
+        {loading ? (
+          <div className="flex items-center justify-center py-12">
+            <div className="h-6 w-6 animate-spin rounded-full border-4 border-emerald-600 border-t-transparent" />
+          </div>
+        ) : queue.length > 0 ? (
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-gray-100 text-left text-xs uppercase tracking-wide text-gray-400">
+                <th className="px-5 py-2 font-medium">Tenant</th>
+                <th className="px-5 py-2 font-medium">Property · Unit</th>
+                <th className="px-5 py-2 font-medium">Designation</th>
+                <th className="px-5 py-2 font-medium">Verdict</th>
+                <th className="px-5 py-2 text-right font-medium">Household income</th>
+                <th className="px-5 py-2 text-right font-medium">Limit</th>
+                <th className="px-5 py-2 text-right font-medium">AUR threshold</th>
+                <th className="px-5 py-2 font-medium">NAU</th>
+                <th className="px-5 py-2 text-right font-medium">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {queue.map((item) => (
+                <tr key={item.recertId} className="border-b border-gray-50 hover:bg-gray-50/60">
+                  <td className="px-5 py-2.5">
+                    <p className="font-medium text-gray-900">{item.tenantName ?? '—'}</p>
+                  </td>
+                  <td className="px-5 py-2.5 text-gray-700">
+                    <span>{item.propertyName ?? '—'}</span>
+                    {item.unitNumber && (
+                      <span className="ml-1 text-gray-400">· {item.unitNumber}</span>
+                    )}
+                  </td>
+                  <td className="px-5 py-2.5 text-gray-700">
+                    {item.designation
+                      ? DESIGNATION_LABELS[item.designation as UnitDesignation] ?? item.designation
+                      : <span className="text-gray-400">—</span>}
+                  </td>
+                  <td className="px-5 py-2.5">
+                    <VerdictBadge verdict={item.verdict} />
+                  </td>
+                  <td className="px-5 py-2.5 text-right text-gray-900">
+                    {item.householdIncome != null
+                      ? `$${item.householdIncome.toLocaleString()}`
+                      : <span className="text-gray-400">—</span>}
+                  </td>
+                  <td className="px-5 py-2.5 text-right text-gray-900">
+                    {item.applicableLimit != null
+                      ? `$${item.applicableLimit.toLocaleString()}`
+                      : <span className="text-gray-400">—</span>}
+                  </td>
+                  <td className="px-5 py-2.5 text-right text-gray-900">
+                    {item.aurThreshold != null
+                      ? `$${item.aurThreshold.toLocaleString()}`
+                      : <span className="text-gray-400">—</span>}
+                  </td>
+                  <td className="px-5 py-2.5">
+                    <NauStatusPill status={item.nauStatus} />
+                  </td>
+                  <td className="px-5 py-2.5 text-right">
+                    {item.verdict === 'over_income' && item.nauStatus === 'open' ? (
+                      <button
+                        onClick={() => setResolveTarget(item)}
+                        className="rounded-lg bg-amber-50 px-2.5 py-1 text-xs font-medium text-amber-700 hover:bg-amber-100"
+                      >
+                        Resolve NAU
+                      </button>
+                    ) : (
+                      <span className="text-xs text-gray-300">—</span>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        ) : (
+          <p className="px-5 py-12 text-center text-sm text-gray-400">
+            {propertyFilter
+              ? 'No flagged households for this property.'
+              : 'No flagged households in the compliance queue.'}
+          </p>
+        )}
+      </div>
+
+      {resolveTarget && (
+        <NauResolveModal
+          item={resolveTarget}
+          onClose={() => setResolveTarget(null)}
+          onResolved={() => {
+            setResolveTarget(null);
+            refetch();
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+// ── NAU Resolve Modal ─────────────────────────────────────────────────────────
+
+function NauResolveModal({
+  item,
+  onClose,
+  onResolved,
+}: {
+  item: AurQueueItem;
+  onClose: () => void;
+  onResolved: () => void;
+}) {
+  const [resolvingUnitId, setResolvingUnitId] = useState('');
+  const [notes, setNotes] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const canSave = resolvingUnitId.trim().length > 0 && !saving;
+
+  async function submit() {
+    if (!canSave) return;
+    setSaving(true);
+    setError(null);
+    try {
+      await api.resolveNau(`${item.recertId}`, {
+        resolvingUnitId: resolvingUnitId.trim(),
+        notes: notes.trim() || null,
+      });
+      onResolved();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Resolve failed');
+      setSaving(false);
+    }
+  }
+
+  const tenantLabel = [item.tenantName, item.unitNumber ? `Unit ${item.unitNumber}` : null]
+    .filter(Boolean)
+    .join(' · ');
+
+  return (
+    <Modal title={`Resolve NAU — ${tenantLabel || 'Household'}`} onClose={onClose}>
+      <div className="space-y-4">
+        <div className="rounded-lg border border-amber-100 bg-amber-50 p-4 text-sm text-amber-800">
+          <p className="font-medium">Over-income household</p>
+          <p className="mt-1 text-xs">
+            Household income{' '}
+            {item.householdIncome != null ? `$${item.householdIncome.toLocaleString()}` : '(unknown)'}
+            {' '}exceeds the applicable limit{' '}
+            {item.applicableLimit != null ? `$${item.applicableLimit.toLocaleString()}` : ''}.
+            {' '}If a comparable Non-Arm's-Length Unit (NAU) is available, entering its ID marks
+            NAU satisfied and removes this household from the queue.
+          </p>
+        </div>
+
+        <div>
+          <label className="label">Resolving unit ID (NAU comparable)</label>
+          <input
+            type="text"
+            className="input"
+            placeholder="e.g. unit-uuid-here"
+            value={resolvingUnitId}
+            onChange={(e) => setResolvingUnitId(e.target.value)}
+            autoFocus
+          />
+          <p className="mt-1 text-xs text-gray-400">
+            The unit ID of the non-arm's-length unit used as the NAU comparable.
+          </p>
+        </div>
+
+        <div>
+          <label className="label">Notes (optional)</label>
+          <textarea
+            className="input min-h-[64px]"
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            placeholder="Why this unit satisfies the NAU requirement..."
+          />
+        </div>
+
+        {error && (
+          <p className="rounded-lg bg-red-50 px-3 py-2 text-sm text-red-600">{error}</p>
+        )}
+
+        <div className="flex justify-end gap-2 border-t border-gray-100 pt-4">
+          <button
+            onClick={onClose}
+            className="rounded-lg px-4 py-2 text-sm font-medium text-gray-600 hover:bg-gray-100"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={submit}
+            disabled={!canSave}
+            className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-700 disabled:opacity-50"
+          >
+            {saving ? 'Resolving…' : 'Mark NAU resolved'}
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+// ── NAU status pill ───────────────────────────────────────────────────────────
+
+function NauStatusPill({ status }: { status: NauStatus }) {
+  const tone =
+    status === 'resolved'
+      ? 'bg-emerald-50 text-emerald-700'
+      : status === 'open'
+        ? 'bg-amber-50 text-amber-700'
+        : 'bg-gray-100 text-gray-500';
+  const label =
+    status === 'resolved' ? 'Resolved' : status === 'open' ? 'Open' : 'N/A';
+  return (
+    <span className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${tone}`}>
+      {label}
+    </span>
+  );
+}
+
+// ── Small shared UI ───────────────────────────────────────────────────────────
+
+function Modal({ title, onClose, children }: { title: string; onClose: () => void; children: ReactNode }) {
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto bg-black/30 p-4 sm:p-8"
+      onClick={onClose}
+    >
+      <div
+        className="my-4 w-full max-w-xl rounded-2xl bg-white shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between border-b border-gray-200 px-5 py-3.5">
+          <h2 className="text-base font-semibold text-gray-900">{title}</h2>
+          <button
+            onClick={onClose}
+            className="rounded-lg p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-700"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+        <div className="p-5">{children}</div>
+      </div>
+    </div>
+  );
+}
+
+function buildPath(propertyFilter: string): string {
+  const qs = new URLSearchParams();
+  qs.set('limit', String(PAGE_SIZE));
+  qs.set('offset', '0');
+  if (propertyFilter) qs.set('propertyId', propertyFilter);
+  return `/api/acquisitions/aur-queue?${qs.toString()}`;
+}

--- a/client-acq/src/pages/Recertifications.tsx
+++ b/client-acq/src/pages/Recertifications.tsx
@@ -1,0 +1,388 @@
+import { useState, type ReactNode } from 'react';
+import { ClipboardList, X, AlertTriangle, CheckCircle2, HelpCircle, Minus } from 'lucide-react';
+import { PageHeader } from '@/components/PageHeader';
+import { useApiQuery } from '@/hooks/useApiQuery';
+import {
+  type Recertification,
+  type RecertIncomeCheck,
+  type IncomeVerdict,
+  type RecertStatus,
+  RECERT_STATUS_LABELS,
+  DESIGNATION_LABELS,
+  type UnitDesignation,
+} from '@/types';
+
+export function Recertifications() {
+  const { data, loading, error } = useApiQuery<{ recertifications: Recertification[] }>(
+    '/api/recertifications',
+  );
+  const [checkId, setCheckId] = useState<string | null>(null);
+  const [selectedRecert, setSelectedRecert] = useState<Recertification | null>(null);
+
+  const recerts = data?.recertifications ?? [];
+
+  function openCheck(r: Recertification) {
+    setCheckId(r.id);
+    setSelectedRecert(r);
+  }
+
+  function closeCheck() {
+    setCheckId(null);
+    setSelectedRecert(null);
+  }
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        icon={ClipboardList}
+        title="Recertifications"
+        description="Annual income recertifications for restricted units. View the income-check verdict for each household against the applicable AMI ceiling and 140% AUR threshold."
+      />
+
+      {error && (
+        <p className="rounded-lg bg-red-50 px-4 py-3 text-sm text-red-600">{error}</p>
+      )}
+
+      <div className="rounded-xl border border-gray-200 bg-white">
+        <div className="border-b border-gray-200 px-5 py-3">
+          <h2 className="text-sm font-semibold text-gray-900">All recertifications</h2>
+        </div>
+
+        {loading ? (
+          <div className="flex items-center justify-center py-12">
+            <div className="h-6 w-6 animate-spin rounded-full border-4 border-emerald-600 border-t-transparent" />
+          </div>
+        ) : recerts.length > 0 ? (
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-gray-100 text-left text-xs uppercase tracking-wide text-gray-400">
+                <th className="px-5 py-2 font-medium">Tenant</th>
+                <th className="px-5 py-2 font-medium">Property</th>
+                <th className="px-5 py-2 font-medium">Unit</th>
+                <th className="px-5 py-2 font-medium">Designation</th>
+                <th className="px-5 py-2 font-medium">Status</th>
+                <th className="px-5 py-2 font-medium">Due Date</th>
+                <th className="px-5 py-2 text-right font-medium">Income Check</th>
+              </tr>
+            </thead>
+            <tbody>
+              {recerts.map((r) => (
+                <tr key={r.id} className="border-b border-gray-50 hover:bg-gray-50/60">
+                  <td className="px-5 py-2.5">
+                    <p className="font-medium text-gray-900">{r.tenantName ?? '—'}</p>
+                  </td>
+                  <td className="px-5 py-2.5 text-gray-700">{r.propertyName ?? '—'}</td>
+                  <td className="px-5 py-2.5 text-gray-700">{r.unitNumber ?? '—'}</td>
+                  <td className="px-5 py-2.5">
+                    {r.designation ? (
+                      <span className="text-gray-700">
+                        {DESIGNATION_LABELS[r.designation as UnitDesignation] ?? r.designation}
+                      </span>
+                    ) : (
+                      <span className="text-gray-400">—</span>
+                    )}
+                  </td>
+                  <td className="px-5 py-2.5">
+                    <RecertStatusPill status={r.status} />
+                  </td>
+                  <td className="px-5 py-2.5 text-gray-700">
+                    {r.dueDate ? formatDate(r.dueDate) : <span className="text-gray-400">—</span>}
+                  </td>
+                  <td className="px-5 py-2.5 text-right">
+                    <button
+                      onClick={() => openCheck(r)}
+                      className="rounded-lg px-2.5 py-1 text-xs font-medium text-emerald-700 hover:bg-emerald-50"
+                    >
+                      View check
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        ) : (
+          <p className="px-5 py-12 text-center text-sm text-gray-400">
+            No recertifications found.
+          </p>
+        )}
+      </div>
+
+      {checkId && selectedRecert && (
+        <IncomeCheckModal
+          recertId={checkId}
+          tenantName={selectedRecert.tenantName}
+          unitNumber={selectedRecert.unitNumber}
+          onClose={closeCheck}
+        />
+      )}
+    </div>
+  );
+}
+
+// ── Income Check Modal ────────────────────────────────────────────────────────
+
+function IncomeCheckModal({
+  recertId,
+  tenantName,
+  unitNumber,
+  onClose,
+}: {
+  recertId: string;
+  tenantName: string | null;
+  unitNumber: string | null;
+  onClose: () => void;
+}) {
+  const { data, loading, error } = useApiQuery<RecertIncomeCheck>(
+    `/api/recertifications/${recertId}/income-check`,
+  );
+
+  const title = [tenantName, unitNumber ? `Unit ${unitNumber}` : null]
+    .filter(Boolean)
+    .join(' · ') || 'Income Check';
+
+  return (
+    <Modal title={title} onClose={onClose}>
+      {loading && (
+        <div className="flex items-center justify-center py-12">
+          <div className="h-6 w-6 animate-spin rounded-full border-4 border-emerald-600 border-t-transparent" />
+        </div>
+      )}
+      {error && (
+        <p className="rounded-lg bg-red-50 px-3 py-2 text-sm text-red-600">{error}</p>
+      )}
+      {data && <IncomeCheckDetail data={data} onClose={onClose} />}
+    </Modal>
+  );
+}
+
+function IncomeCheckDetail({ data, onClose }: { data: RecertIncomeCheck; onClose: () => void }) {
+  const { context, check } = data;
+  return (
+    <div className="space-y-5">
+      {/* Verdict badge */}
+      <div className="flex items-center justify-between rounded-xl border border-gray-200 bg-gray-50 p-4">
+        <div>
+          <p className="text-xs font-medium uppercase tracking-wide text-gray-400">
+            Income verdict
+          </p>
+          <p className="mt-1 text-sm text-gray-500">{check.note ?? 'No additional notes.'}</p>
+        </div>
+        <VerdictBadge verdict={check.verdict} large />
+      </div>
+
+      {/* Context grid */}
+      <div className="grid grid-cols-2 gap-3 text-sm">
+        {context.amiArea && (
+          <InfoCell label="AMI Area" value={context.amiArea} />
+        )}
+        {context.limitYear && (
+          <InfoCell label="Limit Year" value={String(context.limitYear)} />
+        )}
+        {context.designation && (
+          <InfoCell
+            label="Designation"
+            value={
+              DESIGNATION_LABELS[context.designation as UnitDesignation] ??
+              String(context.designation)
+            }
+          />
+        )}
+        {check.ceilingAmiPct != null && (
+          <InfoCell label="Income Ceiling" value={`${check.ceilingAmiPct}% AMI`} />
+        )}
+      </div>
+
+      {/* Income comparison */}
+      {(check.householdIncome != null || check.applicableLimit != null) && (
+        <div className="rounded-lg border border-gray-100 p-4">
+          <p className="mb-3 text-xs font-medium uppercase tracking-wide text-gray-400">
+            Income comparison
+          </p>
+          <div className="grid grid-cols-3 gap-4 text-center">
+            <div>
+              <p className="text-xs text-gray-500">Household income</p>
+              <p className="mt-0.5 text-lg font-semibold text-gray-900">
+                {check.householdIncome != null
+                  ? `$${check.householdIncome.toLocaleString()}`
+                  : '—'}
+              </p>
+            </div>
+            <div>
+              <p className="text-xs text-gray-500">Applicable limit</p>
+              <p className="mt-0.5 text-lg font-semibold text-gray-900">
+                {check.applicableLimit != null
+                  ? `$${check.applicableLimit.toLocaleString()}`
+                  : '—'}
+              </p>
+            </div>
+            <div>
+              <p className="text-xs text-gray-500">140% AUR threshold</p>
+              <p className="mt-0.5 text-lg font-semibold text-gray-900">
+                {check.aurThreshold != null
+                  ? `$${check.aurThreshold.toLocaleString()}`
+                  : '—'}
+              </p>
+            </div>
+          </div>
+          {check.pctOfLimit != null && (
+            <div className="mt-3">
+              <div className="flex items-center justify-between text-xs text-gray-500">
+                <span>% of applicable limit</span>
+                <span className="font-medium text-gray-900">{check.pctOfLimit}%</span>
+              </div>
+              <div className="mt-1 h-2 overflow-hidden rounded-full bg-gray-200">
+                <div
+                  className={`h-full ${pctColor(check.pctOfLimit)}`}
+                  style={{ width: `${Math.min(100, check.pctOfLimit)}%` }}
+                />
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      <div className="flex justify-end border-t border-gray-100 pt-4">
+        <button
+          onClick={onClose}
+          className="rounded-lg px-4 py-2 text-sm font-medium text-gray-600 hover:bg-gray-100"
+        >
+          Close
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ── Verdict badge ─────────────────────────────────────────────────────────────
+
+export function VerdictBadge({
+  verdict,
+  large = false,
+}: {
+  verdict: IncomeVerdict;
+  large?: boolean;
+}) {
+  const { label, className, Icon } = verdictConfig(verdict);
+  const size = large ? 'px-3 py-1.5 text-sm' : 'px-2 py-0.5 text-xs';
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded-full font-medium ${size} ${className}`}
+    >
+      <Icon className={large ? 'h-4 w-4' : 'h-3 w-3'} />
+      {label}
+    </span>
+  );
+}
+
+function verdictConfig(verdict: IncomeVerdict): {
+  label: string;
+  className: string;
+  Icon: React.FC<{ className?: string }>;
+} {
+  switch (verdict) {
+    case 'qualified':
+      return {
+        label: 'Qualified',
+        className: 'bg-emerald-50 text-emerald-700',
+        Icon: CheckCircle2,
+      };
+    case 'over_income_aur':
+      return {
+        label: 'AUR governs',
+        className: 'bg-amber-50 text-amber-700',
+        Icon: AlertTriangle,
+      };
+    case 'over_income':
+      return {
+        label: 'Over income',
+        className: 'bg-red-50 text-red-700',
+        Icon: AlertTriangle,
+      };
+    case 'indeterminate':
+      return {
+        label: 'Indeterminate',
+        className: 'bg-gray-100 text-gray-500',
+        Icon: HelpCircle,
+      };
+    case 'not_restricted':
+      return {
+        label: 'Not restricted',
+        className: 'bg-gray-100 text-gray-600',
+        Icon: Minus,
+      };
+  }
+}
+
+function pctColor(pct: number): string {
+  if (pct <= 100) return 'bg-emerald-500';
+  if (pct <= 140) return 'bg-amber-500';
+  return 'bg-red-500';
+}
+
+// ── Status pill ───────────────────────────────────────────────────────────────
+
+function RecertStatusPill({ status }: { status: RecertStatus }) {
+  const tone =
+    status === 'completed'
+      ? 'bg-emerald-50 text-emerald-700'
+      : status === 'overdue'
+        ? 'bg-red-50 text-red-700'
+        : status === 'in_progress'
+          ? 'bg-blue-50 text-blue-700'
+          : status === 'waived'
+            ? 'bg-gray-100 text-gray-500'
+            : 'bg-amber-50 text-amber-700'; // pending
+  return (
+    <span className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${tone}`}>
+      {RECERT_STATUS_LABELS[status] ?? status}
+    </span>
+  );
+}
+
+// ── Small shared UI ───────────────────────────────────────────────────────────
+
+function InfoCell({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-lg border border-gray-100 p-3">
+      <p className="text-xs text-gray-500">{label}</p>
+      <p className="mt-0.5 font-medium text-gray-900">{value}</p>
+    </div>
+  );
+}
+
+function Modal({ title, onClose, children }: { title: string; onClose: () => void; children: ReactNode }) {
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto bg-black/30 p-4 sm:p-8"
+      onClick={onClose}
+    >
+      <div
+        className="my-4 w-full max-w-xl rounded-2xl bg-white shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between border-b border-gray-200 px-5 py-3.5">
+          <h2 className="text-base font-semibold text-gray-900">{title}</h2>
+          <button
+            onClick={onClose}
+            className="rounded-lg p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-700"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+        <div className="p-5">{children}</div>
+      </div>
+    </div>
+  );
+}
+
+function formatDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    });
+  } catch {
+    return iso;
+  }
+}

--- a/client-acq/src/types/index.ts
+++ b/client-acq/src/types/index.ts
@@ -334,7 +334,10 @@ export interface RecertIncomeCheck {
 }
 
 // GET /api/acquisitions/aur-queue
-export type NauStatus = 'open' | 'resolved' | 'n/a';
+// Backend nau_status column (Lane 1): 'open' once an over_income obligation is
+// triggered, 'satisfied' when a comparable unit resolves it, 'lost' on failure,
+// or null when there is no NAU obligation (e.g. over_income_aur rows).
+export type NauStatus = 'open' | 'satisfied' | 'lost' | null;
 
 export interface AurQueueItem {
   recertId: string;

--- a/client-acq/src/types/index.ts
+++ b/client-acq/src/types/index.ts
@@ -267,3 +267,100 @@ export interface PropertyLite {
   name: string;
   city?: string | null;
 }
+
+// ── Recertifications (Phase 3.1 — income ceiling enforcement) ────────────────
+
+export type RecertStatus =
+  | 'pending'
+  | 'in_progress'
+  | 'completed'
+  | 'waived'
+  | 'overdue';
+
+export const RECERT_STATUS_LABELS: Record<RecertStatus, string> = {
+  pending: 'Pending',
+  in_progress: 'In Progress',
+  completed: 'Completed',
+  waived: 'Waived',
+  overdue: 'Overdue',
+};
+
+export interface Recertification {
+  id: string;
+  tenantId: string;
+  tenantName: string | null;
+  propertyId: string | null;
+  propertyName: string | null;
+  unitId: string | null;
+  unitNumber: string | null;
+  designation: UnitDesignation | null;
+  status: RecertStatus;
+  dueDate: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+// GET /api/recertifications/:id/income-check
+export type IncomeVerdict =
+  | 'not_restricted'
+  | 'qualified'
+  | 'over_income_aur'
+  | 'over_income'
+  | 'indeterminate';
+
+export interface RecertIncomeCheckContext {
+  recertId: string;
+  tenantName?: string | null;
+  unitNumber: string | null;
+  designation: UnitDesignation | null;
+  amiArea: string | null;
+  limitYear: number | null;
+  [key: string]: unknown;
+}
+
+export interface RecertIncomeCheckResult {
+  verdict: IncomeVerdict;
+  ceilingAmiPct: number | null;
+  applicableLimit: number | null;
+  aurThreshold: number | null;
+  householdIncome: number | null;
+  pctOfLimit: number | null;
+  note: string | null;
+}
+
+export interface RecertIncomeCheck {
+  context: RecertIncomeCheckContext;
+  check: RecertIncomeCheckResult;
+}
+
+// GET /api/acquisitions/aur-queue
+export type NauStatus = 'open' | 'resolved' | 'n/a';
+
+export interface AurQueueItem {
+  recertId: string;
+  tenantName: string | null;
+  propertyName: string | null;
+  unitNumber: string | null;
+  designation: UnitDesignation | null;
+  verdict: IncomeVerdict;
+  householdIncome: number | null;
+  applicableLimit: number | null;
+  aurThreshold: number | null;
+  nauStatus: NauStatus;
+}
+
+export interface AurQueueResponse {
+  queue: AurQueueItem[];
+  total: number;
+}
+
+// POST /api/recertifications/:id/nau-resolve
+export interface NauResolveInput {
+  resolvingUnitId: string;
+  notes?: string | null;
+}
+
+export interface NauResolveResponse {
+  id: string;
+  [key: string]: unknown;
+}


### PR DESCRIPTION
## Summary

- **Recertifications page** (`/recertifications`): full list of annual income recertifications (tenant, property, unit, designation, status, due date). Per-row "View check" fetches `GET /api/recertifications/:id/income-check` and renders the income verdict in a coloured badge — qualified (green), AUR governs (amber), over income (red), indeterminate (grey), not restricted (neutral) — plus household income vs. applicable limit and the 140% AUR threshold bar.
- **Compliance Queue page** (`/compliance-queue`): renders the `GET /api/acquisitions/aur-queue` list with a property-ID text filter wired to the `propertyId` query param. Columns: tenant, property·unit, designation, verdict badge, household income, applicable limit, AUR threshold, NAU status. For `over_income` rows with `nauStatus === 'open'`, a "Resolve NAU" button opens a modal form (resolving unit ID + notes) that POSTs to `POST /api/recertifications/:id/nau-resolve` then refetches the queue.
- Routing, API helpers, types, and nav links all wired.

## API contract (frozen — built against spec, not live routes)

| Method | Path | Used by |
|---|---|---|
| `GET` | `/api/recertifications` | Recertifications list |
| `GET` | `/api/recertifications/:id/income-check` | Income check modal |
| `GET` | `/api/acquisitions/aur-queue?propertyId=&limit=&offset=` | Compliance Queue |
| `POST` | `/api/recertifications/:id/nau-resolve` | NAU resolve form |

## Files changed

- `client-acq/src/pages/Recertifications.tsx` — new page + `VerdictBadge` (exported for reuse in ComplianceQueue)
- `client-acq/src/pages/ComplianceQueue.tsx` — new page + `NauResolveModal`
- `client-acq/src/App.tsx` — two new routes
- `client-acq/src/components/Layout.tsx` — two new nav entries (ClipboardList, ShieldAlert icons)
- `client-acq/src/api/client.ts` — `getRecertifications`, `getRecertIncomeCheck`, `getAurQueue`, `resolveNau`
- `client-acq/src/types/index.ts` — `RecertStatus`, `Recertification`, `RecertIncomeCheck`, `IncomeVerdict`, `AurQueueItem`, `AurQueueResponse`, `NauStatus`, `NauResolveInput`

## Test plan

- [ ] `npx tsc --noEmit` → clean (verified locally: 0 errors)
- [ ] `npm run build` → Vite success (verified locally: 240 kB JS, 16 kB CSS)
- [ ] No vitest runner installed in `client-acq` (not in `package.json`); existing CI does not include a `client-acq` test job
- [ ] `check-i18n` CI runs against `client-tenant/src/i18n/` only — `client-acq` has no i18n system and uses hardcoded EN strings throughout (same pattern as Awards.tsx, Projects.tsx, Demand.tsx). No parity issue.

## Judgment calls

- **i18n**: `client-acq` has no i18n infrastructure — no `i18next`, no translation files, no `t()` calls anywhere. The `check-i18n` CI job explicitly targets `client-tenant/scripts/check-i18n-parity.mjs` working in `client-tenant`. Adding EN/ES strings to `client-acq` would require installing and wiring a new i18n library, which is out of scope for this lane and inconsistent with the existing codebase pattern.
- **VerdictBadge export**: exported from `Recertifications.tsx` and imported into `ComplianceQueue.tsx` to avoid duplication — same verdict rendering in both pages.
- **Property filter**: implemented as a free-text input (property ID) rather than a populated dropdown, since the AUR queue API takes `propertyId` directly and a dropdown would require a separate `/api/properties` fetch that the contract doesn't specify for this endpoint.
- **NAU resolve trigger**: only shown for `verdict === 'over_income'` with `nauStatus === 'open'` — per the contract description ("For `over_income` rows with `nauStatus === 'open'`"). AUR-governed rows (`over_income_aur`) are flagged for display only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)