### PR TITLE
DO NOT MERGE: verify tenant-e2e blocks a broken map

### DIFF
--- a/client-tenant/public/nv-housing-map.html
+++ b/client-tenant/public/nv-housing-map.html
@@ -407,8 +407,10 @@ function hydrate(rows){
 // "Available now" filter; coverage rows fill out the statewide map.
 function okJson(r){ if(!r.ok) throw new Error('HTTP '+r.status); return r.json(); }
 function mergeLayers(availLayer, coverage){
-  const seen = new Set(availLayer.map(p=>p.slug || slugify(p.name)));
-  return availLayer.concat(coverage.filter(p=>!seen.has(p.slug || slugify(p.name))));
+  // INTENTIONAL REGRESSION (gate verification): drop the statewide coverage
+  // layer so the map collapses to the 17 availability rows — the exact
+  // reconcile-to-17 bug that broke prod twice. tenant-e2e Lane A must catch this.
+  return availLayer;
 }
 Promise.all([
   fetch('/api/applicants/properties/map').then(okJson).catch(()=>[]),


### PR DESCRIPTION
Throwaway PR to prove the new `tenant-e2e` required gate has teeth. This commit intentionally reintroduces the collapse-to-17 map regression. **Expected: tenant-e2e fails and blocks the merge.** Will be closed without merging.