### PR TITLE
DO NOT MERGE: verify tenant-e2e blocks a broken apply resume

### DIFF
--- a/client-tenant/src/pages/apply/steps/StepPick.tsx
+++ b/client-tenant/src/pages/apply/steps/StepPick.tsx
@@ -101,7 +101,10 @@ export function StepPick() {
 
   useEffect(() => {
     if (s.intentBedrooms === null || !s.intentMoveInDate) {
-      s.setStep('intent');
+      // INTENTIONAL REGRESSION (gate verify): dropped the s.setStep('intent')
+      // redirect, so a cold deep-link to ?step=pick no longer bounces back to
+      // intent. apply-resume.spec.ts:128 must catch this. (return kept so TS
+      // still narrows intentBedrooms below — keeps the build green.)
       return;
     }
     let cancelled = false;


### PR DESCRIPTION
Throwaway PR proving the `tenant-e2e` gate catches an apply-resume regression. This commit drops StepPick's cold-deep-link redirect guard, so `/apply?step=pick` no longer bounces to intent. **Expected: only tenant-e2e fails (apply-resume.spec.ts:128) and it BLOCKS the merge.** Will be closed without merging.