### PR TITLE
DO NOT MERGE — verify tenant-e2e blocks a broken discover filter

### DIFF
--- a/client-tenant/src/pages/discover/PropertyList.tsx
+++ b/client-tenant/src/pages/discover/PropertyList.tsx
@@ -336,7 +336,7 @@ export function PropertyList() {
         .map(tileFromApi)
         .filter((t) => {
           if (typeFilter !== 'all' && t.type !== typeFilter) return false;
-          if (cityFilter !== 'all' && t.city !== cityFilter) return false;
+          // [INTENTIONAL REGRESSION — DO NOT MERGE] city filter neutralized on the API path
           // Bedroom / availability already filtered server-side; type/city
           // narrowing happens here. The server's amiTier filter narrowed
           // there too, so we don't double-apply it.


### PR DESCRIPTION
Throwaway PR to prove the `tenant-e2e` gate has teeth on the **discover-filters** lane.

**Intentional break:** `PropertyList.tsx:339` — city filter neutralized on the **API render path** only (fixture-fallback filter left intact).

**Expected:** `tenant-e2e` fails at `discover-filters.spec.ts:70` (Henderson chip no longer narrows to 1 = Smith Williams). Notably `client-tenant (vitest)` should **stay green** — its `PropertyList.test.tsx:43` Henderson test runs the fixture-fallback path, which is untouched. This demonstrates the e2e gate catches a regression in the real integrated (API-data) path that the unit test is blind to.

Will be closed unmerged once the gate is confirmed BLOCKED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)