### PR TITLE
fix(tape): add missing kind_session unique index to compliance-tape migration

### DIFF
--- a/src/db/migrations/2026-05-23-compliance-tape.sql
+++ b/src/db/migrations/2026-05-23-compliance-tape.sql
@@ -49,6 +49,15 @@ CREATE INDEX IF NOT EXISTS idx_compliance_tape_applicant_sequence
   ON compliance_tape (applicant_id, sequence)
   WHERE applicant_id IS NOT NULL;
 
+-- Backs the repository's `ON CONFLICT (kind, session_id) DO NOTHING` idempotency
+-- clause (src/modules/tape/repository.ts). Without this index every INSERT raises
+-- "no unique or exclusion constraint matching the ON CONFLICT specification" — and
+-- because stamps are best-effort (stampSafe swallows), the failure is silent and
+-- the tape records nothing. Non-partial: NULL session_ids stay distinct so stamps
+-- without a session remain insertable as separate rows. Mirrors schema.ts.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_compliance_tape_kind_session
+  ON compliance_tape (kind, session_id);
+
 -- Append-only enforcement.
 CREATE OR REPLACE FUNCTION compliance_tape_reject_mutation()
   RETURNS trigger


### PR DESCRIPTION
## What

Adds the `idx_compliance_tape_kind_session` unique index (on `(kind, session_id)`) to the `2026-05-23-compliance-tape.sql` migration. The migration was stale relative to the canonical `src/db/schema.ts`, which has always defined this index.

## Why

`src/modules/tape/repository.ts` inserts with `ON CONFLICT (kind, session_id) DO NOTHING`. Postgres requires a matching unique constraint/index for that clause. The migration omitted it, so every tape INSERT raised:

> no unique or exclusion constraint matching the ON CONFLICT specification

Because all tape stamps are best-effort (`stampSafe` / `stampNau` swallow errors so a tape write never blocks the business action), the failure was **silent** — the immutable compliance ledger recorded nothing.

## How it surfaced

An end-to-end prod verification of the QAP acquisitions NAU flow: a live `POST /api/recertifications/:id/submit` persisted the income verdict + `nau_status=open` correctly, but wrote **zero** rows to `compliance_tape` — even after the table itself existed. Adding the index made the identical code path land two hash-chained rows (`acq.recert_income_checked` → `acq.nau_triggered`, chain verified).

## Scope

- One-line additive DDL, idempotent (`CREATE UNIQUE INDEX IF NOT EXISTS`), mirrors `schema.ts` verbatim.
- **Prod is already corrected** — both the table and this index were applied live and verified during the investigation. This PR only re-syncs the migration file so fresh DB builds include the index. No deploy required off this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)