### PR TITLE
feat(acquisitions): NAU 'lost' lifecycle — over-income unit → market rent

### DIFF
--- a/src/__tests__/acquisitions-nau-rule.test.ts
+++ b/src/__tests__/acquisitions-nau-rule.test.ts
@@ -286,6 +286,122 @@ describe('RecertComplianceService.resolveNau', () => {
   });
 });
 
+describe('RecertComplianceService.markNauLost', () => {
+  function overIncomeRecertRow(over: Record<string, unknown> = {}) {
+    return {
+      id: 'recert-1',
+      property_id: 'prop-1',
+      tenant_name: 'Jane Doe',
+      nau_status: 'open',
+      income_ceiling_verdict: 'over_income',
+      application_id: 'app-1',
+      household_size: 3,
+      unit_id: 'unit-1',
+      unit_number: '204',
+      ami_designation: '60',
+      bedrooms: 2,
+      ami_area: 'Clark County',
+      ...over,
+    };
+  }
+
+  function candidateRow(over: Record<string, unknown> = {}) {
+    return {
+      id: 'unit-9',
+      property_id: 'prop-1',
+      unit_number: '310',
+      bedrooms: 2,
+      ami_designation: '60',
+      status: 'occupied',
+      claimed_unit: 'app-77', // rented to a non-qualifying household (staff-attested via reason)
+      ...over,
+    };
+  }
+
+  it('with a triggering unit → lost + market_rent applied + acq.nau_lost stamped (subjectId null)', async () => {
+    mockQuery
+      .mockResolvedValueOnce(qr([overIncomeRecertRow()])) // load recert + unit
+      .mockResolvedValueOnce(qr([candidateRow()])) // load triggering unit
+      .mockResolvedValueOnce(qr([])) // UPDATE lost
+      .mockResolvedValue(qr([]));
+
+    const ctx = await service.markNauLost('recert-1', 'unit-9', 'rev-1', 'next comparable unit went to a market household');
+    expect(ctx.recertId).toBe('recert-1');
+
+    // single atomic UPDATE flips status AND applies the market-rent consequence
+    const lostUpdate = mockQuery.mock.calls.find((c) => String(c[0]).includes("nau_status = 'lost'"));
+    expect(lostUpdate).toBeDefined();
+    expect(String(lostUpdate![0])).toContain('market_rent_applied_at');
+
+    expect(stamp).toHaveBeenCalledTimes(1);
+    const s = stamp.mock.calls[0][0] as any;
+    expect(s.kind).toBe('acq.nau_lost');
+    expect(s.payload.subjectId).toBeNull();
+    expect(s.payload.evidence.recertId).toBe('recert-1');
+    expect(s.payload.evidence.triggeringUnitId).toBe('unit-9');
+    expect(s.payload.evidence.rentAction).toBe('market_rent');
+    expect(s.payload.evidence.reason).toMatch(/market household/);
+  });
+
+  it('without a triggering unit (lapsed obligation) → lost + stamp, no candidate lookup', async () => {
+    mockQuery
+      .mockResolvedValueOnce(qr([overIncomeRecertRow()])) // load recert + unit
+      .mockResolvedValueOnce(qr([])) // UPDATE lost (no candidate query in between)
+      .mockResolvedValue(qr([]));
+
+    const ctx = await service.markNauLost('recert-1', null, 'rev-1', 'compliance window lapsed without a comparable rental');
+    expect(ctx.recertId).toBe('recert-1');
+    expect(stamp).toHaveBeenCalledTimes(1);
+    const s = stamp.mock.calls[0][0] as any;
+    expect(s.kind).toBe('acq.nau_lost');
+    expect(s.payload.evidence.triggeringUnitId).toBeNull();
+    expect(s.payload.evidence.rentAction).toBe('market_rent');
+    // exactly two queries: load + UPDATE (no candidate lookup)
+    expect(mockQuery).toHaveBeenCalledTimes(2);
+  });
+
+  it('rejects a non-comparable triggering unit (fewer bedrooms)', async () => {
+    mockQuery
+      .mockResolvedValueOnce(qr([overIncomeRecertRow()]))
+      .mockResolvedValueOnce(qr([candidateRow({ bedrooms: 1 })]))
+      .mockResolvedValue(qr([]));
+
+    await expect(service.markNauLost('recert-1', 'unit-9', 'rev-1', 'x')).rejects.toThrow(/not comparable/i);
+    expect(mockQuery.mock.calls.find((c) => String(c[0]).includes("nau_status = 'lost'"))).toBeUndefined();
+    expect(stamp).not.toHaveBeenCalled();
+  });
+
+  it('rejects a comparable but still-available (not rented) triggering unit', async () => {
+    mockQuery
+      .mockResolvedValueOnce(qr([overIncomeRecertRow()]))
+      .mockResolvedValueOnce(qr([candidateRow({ status: 'available', claimed_unit: null })]))
+      .mockResolvedValue(qr([]));
+
+    await expect(service.markNauLost('recert-1', 'unit-9', 'rev-1', 'x')).rejects.toThrow(/must be rented/i);
+  });
+
+  it('rejects when the recert has no open NAU obligation', async () => {
+    mockQuery
+      .mockResolvedValueOnce(qr([overIncomeRecertRow({ nau_status: 'satisfied' })]))
+      .mockResolvedValue(qr([]));
+
+    await expect(service.markNauLost('recert-1', 'unit-9', 'rev-1', 'x')).rejects.toThrow(/not open/i);
+  });
+
+  it('rejects when the verdict is not over_income', async () => {
+    mockQuery
+      .mockResolvedValueOnce(qr([overIncomeRecertRow({ income_ceiling_verdict: 'qualified', nau_status: null })]))
+      .mockResolvedValue(qr([]));
+
+    await expect(service.markNauLost('recert-1', 'unit-9', 'rev-1', 'x')).rejects.toThrow(/no over-income verdict/i);
+  });
+
+  it('throws for an unknown recert', async () => {
+    mockQuery.mockResolvedValueOnce(qr([]));
+    await expect(service.markNauLost('nope', null, 'rev-1', 'x')).rejects.toThrow(/not found/i);
+  });
+});
+
 // ---------------------------------------------------------------------------
 // 3. Scope-routing regression guard — both NAU kinds are global-scope.
 //
@@ -339,6 +455,18 @@ describe('tape scope routing (regression: NAU stamps are global-scope)', () => {
       kind: 'acq.nau_satisfied',
       payload: nauPayload(null),
       sessionId: 'sess-nau-2',
+    });
+    expect(inserted).toHaveLength(1);
+    expect(inserted[0].applicantId).toBeNull();
+  });
+
+  it('routes acq.nau_lost (subjectId:null) to applicant_id=null', async () => {
+    const { repo, inserted } = captureRepo();
+    const realTape = realCreateTapeService(repo);
+    await realTape.stamp({
+      kind: 'acq.nau_lost',
+      payload: nauPayload(null),
+      sessionId: 'sess-nau-lost-1',
     });
     expect(inserted).toHaveLength(1);
     expect(inserted[0].applicantId).toBeNull();

--- a/src/modules/acquisitions/recert-compliance.ts
+++ b/src/modules/acquisitions/recert-compliance.ts
@@ -19,6 +19,7 @@ import { PgTapeRepository } from '../tape/repository';
 import {
   evaluateRecertIncome,
   comparableUnit,
+  recommendedRentAction,
   type AmiDesignation,
   type NauUnit,
   type RecertIncomeCheck,
@@ -337,11 +338,172 @@ export class RecertComplianceService {
     return context;
   }
 
+  /**
+   * Mark an open NAU obligation **lost** (QAP Phase 3.2 — the inverse of
+   * {@link resolveNau}). The Next Available Unit Rule is lost when the owner
+   * fails to honour it: the next comparable available unit at the property is
+   * rented to a *non-qualifying* household (consuming the slot), or the
+   * obligation otherwise lapses. The over-income unit then stops counting
+   * toward the set-aside and converts to market rent
+   * (IRC §42(g)(2)(D)(ii)).
+   *
+   * Staff-attested (mirrors resolveNau's manual flow): the reviewer records
+   * *why* the obligation was lost. If a `triggeringUnitId` is supplied it must
+   * be a comparable unit that is actually rented (the slot that was consumed);
+   * if omitted, the `reason` alone attests a lapse. On success sets
+   * `nau_status='lost'`, applies `market_rent_applied_at` (the real
+   * consequence), and stamps `acq.nau_lost`. Throws on any validation failure
+   * (the route maps it to 400).
+   *
+   * @returns the resolved check context.
+   */
+  async markNauLost(
+    recertId: string,
+    triggeringUnitId: string | null,
+    actorId: string | null,
+    reason: string,
+  ): Promise<RecertCheckContext> {
+    // Load the over-income recert + its occupied unit (same shape as resolveNau).
+    const res = await query(
+      `SELECT r.id, r.property_id, r.tenant_name, r.nau_status,
+              r.income_ceiling_verdict,
+              a.id AS application_id, a.household_size,
+              u.id AS unit_id, u.unit_number, u.ami_designation, u.bedrooms,
+              p.ami_area
+         FROM recertifications r
+         JOIN applications a ON r.application_id = a.id
+         LEFT JOIN units u ON a.claimed_unit_id = u.id
+         JOIN properties p ON r.property_id = p.id
+        WHERE r.id = $1`,
+      [recertId],
+    );
+    const row = (res.rows as (ResolveRow & {
+      nau_status: string | null;
+      income_ceiling_verdict: string | null;
+    })[])[0];
+    if (!row) throw new Error('Recertification not found');
+
+    if (row.income_ceiling_verdict !== 'over_income') {
+      throw new Error('Recertification has no over-income verdict — no NAU obligation to lose.');
+    }
+    if (row.nau_status !== 'open') {
+      throw new Error(
+        `NAU obligation is not open (current status: ${row.nau_status ?? 'none'}).`,
+      );
+    }
+    if (!row.unit_id) {
+      throw new Error('Recertification has no occupied unit — cannot evaluate NAU comparability.');
+    }
+
+    // If a triggering unit is named, it must be the comparable slot that was
+    // consumed: same property, ≥ bedrooms, equal-or-deeper tier, and actually
+    // rented. (That it went to a *non-qualifying* household is what staff
+    // attest via `reason` — the income of that household is not modelled here.)
+    let triggeringUnitNumber: string | null = null;
+    let triggeringDesignation: string | null = null;
+    let triggeringBedrooms: number | null = null;
+    if (triggeringUnitId) {
+      const overIncomeUnit: NauUnit = {
+        propertyId: row.property_id,
+        bedrooms: row.bedrooms ?? 0,
+        amiDesignation: (row.ami_designation as AmiDesignation | null) ?? null,
+      };
+
+      const candRes = await query(
+        `SELECT id, property_id, unit_number, bedrooms, ami_designation, status, claimed_unit
+           FROM (
+             SELECT u.id, u.property_id, u.unit_number, u.bedrooms,
+                    u.ami_designation, u.status,
+                    (SELECT a2.id FROM applications a2
+                      WHERE a2.claimed_unit_id = u.id LIMIT 1) AS claimed_unit
+               FROM units u
+              WHERE u.id = $1
+           ) c`,
+        [triggeringUnitId],
+      );
+      const cand = candRes.rows[0] as
+        | {
+            id: string;
+            property_id: string;
+            unit_number: string | null;
+            bedrooms: number | null;
+            ami_designation: string | null;
+            status: string | null;
+            claimed_unit: string | null;
+          }
+        | undefined;
+      if (!cand) throw new Error('Triggering unit not found.');
+
+      const candidateUnit: NauUnit = {
+        propertyId: cand.property_id,
+        bedrooms: cand.bedrooms ?? 0,
+        amiDesignation: (cand.ami_designation as AmiDesignation | null) ?? null,
+      };
+      if (!comparableUnit(overIncomeUnit, candidateUnit)) {
+        throw new Error(
+          'Triggering unit is not comparable: must be in the same property, have at least as many bedrooms, and carry an equal-or-deeper AMI tier.',
+        );
+      }
+      const occupied = cand.claimed_unit !== null && cand.status !== 'available' && cand.status !== 'held';
+      if (!occupied) {
+        throw new Error(
+          'Triggering unit must be rented (the consumed slot) to lose the Next Available Unit obligation; an available/held unit means the obligation is still open.',
+        );
+      }
+      triggeringUnitNumber = cand.unit_number;
+      triggeringDesignation = cand.ami_designation;
+      triggeringBedrooms = cand.bedrooms;
+    }
+
+    // Mark lost and apply the rent consequence (market_rent) atomically. The
+    // partial UPDATE guard (nau_status='open') makes this idempotent under a
+    // double-submit.
+    await query(
+      `UPDATE recertifications
+          SET nau_status = 'lost',
+              nau_resolved_at = NOW(),
+              nau_resolving_unit_id = $2,
+              market_rent_applied_at = COALESCE(market_rent_applied_at, NOW()),
+              updated_at = NOW()
+        WHERE id = $1 AND nau_status = 'open'`,
+      [recertId, triggeringUnitId],
+    );
+
+    const context: RecertCheckContext = {
+      recertId: row.id,
+      applicationId: row.application_id,
+      propertyId: row.property_id,
+      tenantName: row.tenant_name,
+      unitId: row.unit_id,
+      unitNumber: row.unit_number,
+      designation: (row.ami_designation as AmiDesignation | null) ?? null,
+      bedrooms: row.bedrooms ?? null,
+      amiArea: row.ami_area,
+      householdSize: row.household_size && row.household_size > 0 ? row.household_size : 1,
+      limitYear: null,
+    };
+
+    const rent = recommendedRentAction('over_income', { nauLost: true });
+    await this.stampNau('acq.nau_lost', context, actorId, {
+      triggeringUnitId,
+      triggeringUnitNumber,
+      triggeringDesignation,
+      triggeringBedrooms,
+      designation: context.designation,
+      bedrooms: context.bedrooms,
+      rentAction: rent.action,
+      rentActionReason: rent.reason,
+      reason,
+    });
+
+    return context;
+  }
+
   /** Stamp a NAU tape event best-effort. subjectId MUST be null (global-scope
    *  admin event): compliance_tape.applicant_id is FK'd to users(id), so the
    *  recert/unit ids ride in evidence, never the scope key. */
   private async stampNau(
-    kind: 'acq.nau_triggered' | 'acq.nau_satisfied',
+    kind: 'acq.nau_triggered' | 'acq.nau_satisfied' | 'acq.nau_lost',
     context: RecertCheckContext,
     actorId: string | null,
     evidence: Record<string, unknown>,

--- a/src/modules/recertification/routes.ts
+++ b/src/modules/recertification/routes.ts
@@ -226,6 +226,49 @@ router.post(
   }
 );
 
+// Mark an open NAU (Next Available Unit Rule) obligation LOST (QAP Phase 3.2):
+// the inverse of /nau-resolve. The next comparable available unit was rented
+// to a non-qualifying household (consuming the slot), or the obligation
+// otherwise lapsed — the over-income unit converts to market rent. Staff
+// attest the reason; an optional triggeringUnitId names the consumed slot
+// (must be comparable + rented). Scope-checked via getById. Validation
+// failures (no open obligation / non-comparable / not-rented) map to 400.
+const NauLostSchema = z.object({
+  triggeringUnitId: z.string().uuid().optional(),
+  reason: z.string().min(1, "A reason is required"),
+});
+
+router.post(
+  "/:id/nau-lost",
+  authenticate,
+  requirePermission("recertification:review"),
+  async (req: AuthRequest, res: Response): Promise<void> => {
+    const parsed = NauLostSchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({ error: "Validation failed", details: parsed.error.flatten() });
+      return;
+    }
+    try {
+      const recert = await service.getById(req.params.id as string, req);
+      if (!recert) {
+        res.status(404).json({ error: "Recertification not found" });
+        return;
+      }
+      const context = await compliance.markNauLost(
+        req.params.id as string,
+        parsed.data.triggeringUnitId ?? null,
+        req.user!.id,
+        parsed.data.reason
+      );
+      const updated = await service.getById(req.params.id as string, req);
+      res.json({ success: true, recertification: updated, context });
+    } catch (err: any) {
+      logger.error("Failed to mark NAU obligation lost", { error: err.message });
+      res.status(400).json({ error: err.message });
+    }
+  }
+);
+
 // Manual trigger: process all reminders (system_admin)
 router.post(
   "/process-reminders",

--- a/src/modules/tape/types.ts
+++ b/src/modules/tape/types.ts
@@ -34,7 +34,8 @@ export type TapeStampKind =
   | "acq.recert_income_checked"
   // QAP acquisitions Phase 3.2 — Next Available Unit Rule (global-scope admin events)
   | "acq.nau_triggered"
-  | "acq.nau_satisfied";
+  | "acq.nau_satisfied"
+  | "acq.nau_lost";
 
 /** A JSON-LD payload. Lane C provides one `make<Event>Payload` per kind.
  *  The `@context` URL is stubbed in v1 (see docs/bp-02-contracts.md §5). */
@@ -147,6 +148,7 @@ export const TAPE_CITATIONS: Record<TapeStampKind, string> = {
   "acq.recert_income_checked": "IRC §42(g)(2)(D)(ii) (Available Unit Rule) + 26 CFR 1.42-5",
   "acq.nau_triggered": "IRC §42(g)(2)(D)(ii) (Next Available Unit Rule)",
   "acq.nau_satisfied": "IRC §42(g)(2)(D)(ii) (Next Available Unit Rule)",
+  "acq.nau_lost": "IRC §42(g)(2)(D)(ii) (Next Available Unit Rule)",
 };
 
 /** Feature flag controlling dual-write during cutover. When false, the new


### PR DESCRIPTION
## What

Completes the **Next Available Unit Rule** (IRC §42(g)(2)(D)(ii)) state machine. Phase 3.2 wired `open→satisfied`; this adds the missing `open→lost` transition — the inverse of `resolveNau`.

When the next comparable available unit is rented to a **non-qualifying** household (consuming the slot) or the NAU obligation otherwise lapses, the over-income unit stops counting toward the set-aside and **converts to market rent**.

## Changes

- **`recert-compliance.ts`** — `markNauLost(recertId, triggeringUnitId?, actorId, reason)`: validates `over_income` verdict + `open` NAU; an optional `triggeringUnitId` must be a **comparable + rented** slot (reuses `comparableUnit` + the occupancy check); sets `nau_status='lost'` and applies `market_rent_applied_at` **atomically** (idempotent via the `WHERE nau_status='open'` guard); stamps `acq.nau_lost`.
- **`recertification/routes.ts`** — `POST /:id/nau-lost` (`recertification:review`, portfolio scope-checked via `getById`), mirroring `/nau-resolve`.
- **`tape/types.ts`** — new kind `acq.nau_lost` + citation; `stampNau` union widened.
- **tests** — 5 `markNauLost` cases + a `nau_lost` global-scope routing guard (subjectId:null → applicant_id null, the FK lesson).

## Compliance notes

- **No migration**: the `'lost'` enum value and `nau_resolved_at` / `nau_resolving_unit_id` / `market_rent_applied_at` columns already exist (from `2026-05-28-nau-rule.sql`).
- **Staff-attested** (same trust model as `resolveNau`): the qualifying-vs-non-qualifying distinction of the triggering occupant is recorded in `reason`, not computed — the occupant's income is not modelled here.
- **FK-safe**: `acq.nau_lost` stamps `subjectId:null`; recert/unit ids ride in `evidence` (`compliance_tape.applicant_id` is FK'd to `users(id)`).

## Verify

`npx tsc --noEmit` clean; `npx jest acquisitions-nau-rule recertification tape --runInBand` → 95 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)