### PR TITLE
chore(deps): migrate to zod 4 (4.4.3) — supersedes #118

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "twilio": "^5.3.0",
         "uuid": "^10.0.0",
         "winston": "^3.15.0",
-        "zod": "^3.23.8"
+        "zod": "4.4.3"
       },
       "devDependencies": {
         "@types/bcrypt": "^5.0.2",
@@ -2550,7 +2550,7 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
       "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6895,9 +6895,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "twilio": "^5.3.0",
     "uuid": "^10.0.0",
     "winston": "^3.15.0",
-    "zod": "^3.23.8"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/bcrypt": "^5.0.2",

--- a/src/modules/acquisitions/routes.ts
+++ b/src/modules/acquisitions/routes.ts
@@ -271,8 +271,8 @@ const DATE = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Expected YYYY-MM-DD');
 const AWARD_STATUS_KEYS = AWARD_STATUSES as [AwardStatus, ...AwardStatus[]];
 
 const AwardCreateSchema = z.object({
-  acqProjectId: z.string().uuid(),
-  propertyId: z.string().uuid().optional().nullable(),
+  acqProjectId: z.string().guid(),
+  propertyId: z.string().guid().optional().nullable(),
   status: z.enum(AWARD_STATUS_KEYS).optional(),
   reservationAmount: z.coerce.number().min(0).optional().nullable(),
   awardDate: DATE.optional().nullable(),
@@ -283,7 +283,7 @@ const AwardCreateSchema = z.object({
 // Update: every field optional, but at least one present (a no-op PUT is a 400).
 const AwardUpdateSchema = z
   .object({
-    propertyId: z.string().uuid().nullable(),
+    propertyId: z.string().guid().nullable(),
     status: z.enum(AWARD_STATUS_KEYS),
     reservationAmount: z.coerce.number().min(0).nullable(),
     awardDate: DATE.nullable(),
@@ -293,13 +293,13 @@ const AwardUpdateSchema = z
   .partial()
   .refine((o) => Object.keys(o).length > 0, { message: 'No fields to update.' });
 
-const BindSchema = z.object({ propertyId: z.string().uuid().nullable() });
+const BindSchema = z.object({ propertyId: z.string().guid().nullable() });
 
 const DesignationsSchema = z.object({
   assignments: z
     .array(
       z.object({
-        unitId: z.string().uuid(),
+        unitId: z.string().guid(),
         designation: z.enum(['30', '50', '60', 'market']),
       }),
     )
@@ -554,7 +554,7 @@ router.get(
 // ── Lane 2: over-income / AUR queue ─────────────────────────────────────────
 
 const AurQueueQuerySchema = z.object({
-  propertyId: z.string().uuid().optional(),
+  propertyId: z.string().guid().optional(),
   limit: z.coerce.number().int().min(1).max(200).optional(),
   offset: z.coerce.number().int().min(0).optional(),
 });

--- a/src/modules/applicants/routes.ts
+++ b/src/modules/applicants/routes.ts
@@ -132,7 +132,7 @@ router.post(
       // Request-shape rejection (malformed payload) — no DB work yet, so the
       // INFO-1 floor doesn't apply: this path doesn't disclose which branch
       // the email would have taken.
-      res.status(400).json({ error: "Validation failed", details: parsed.error.errors });
+      res.status(400).json({ error: "Validation failed", details: parsed.error.issues });
       return;
     }
 
@@ -281,7 +281,7 @@ router.post("/apply", authenticate, requireEmailVerified, async (req: AuthReques
     res.status(201).json(created);
   } catch (err: any) {
     if (err.name === "ZodError") {
-      res.status(400).json({ error: "Validation failed", details: err.errors });
+      res.status(400).json({ error: "Validation failed", details: err.issues });
       return;
     }
     logger.error("Applicant apply failed", { error: (err as Error).message });
@@ -604,7 +604,7 @@ router.get(
       if (!parsed.success) {
         res.status(400).json({
           error: "bedrooms query param is required (0–6)",
-          details: parsed.error.errors,
+          details: parsed.error.issues,
         });
         return;
       }
@@ -681,7 +681,7 @@ router.post(
       }
       const parsed = waitlistJoinSchema.safeParse(req.body);
       if (!parsed.success) {
-        res.status(400).json({ error: "Validation failed", details: parsed.error.errors });
+        res.status(400).json({ error: "Validation failed", details: parsed.error.issues });
         return;
       }
       const propertyId = await resolvePropertyIdBySlug(slug);
@@ -733,7 +733,7 @@ router.delete(
       if (!parsed.success) {
         res.status(400).json({
           error: "bedrooms query param is required (0–6)",
-          details: parsed.error.errors,
+          details: parsed.error.issues,
         });
         return;
       }
@@ -826,7 +826,7 @@ router.post(
 
       const parsed = intentSchema.safeParse(req.body);
       if (!parsed.success) {
-        res.status(400).json({ error: "Validation failed", details: parsed.error.errors });
+        res.status(400).json({ error: "Validation failed", details: parsed.error.issues });
         return;
       }
       const intent = parsed.data;
@@ -994,7 +994,7 @@ router.get(
         if (!parsed.success) {
           res.status(400).json({
             error: "Invalid amiTier",
-            details: parsed.error.errors,
+            details: parsed.error.issues,
             allowed: AMI_TIER_ORDER,
           });
           return;

--- a/src/modules/application/routes.ts
+++ b/src/modules/application/routes.ts
@@ -21,7 +21,7 @@ router.post(
       res.status(201).json(result);
     } catch (err: any) {
       if (err.name === "ZodError") {
-        res.status(400).json({ error: "Validation failed", details: err.errors });
+        res.status(400).json({ error: "Validation failed", details: err.issues });
         return;
       }
       logger.error("Failed to create application", { error: err.message });
@@ -83,7 +83,7 @@ router.patch(
       res.json(result);
     } catch (err: any) {
       if (err.name === "ZodError") {
-        res.status(400).json({ error: "Validation failed", details: err.errors });
+        res.status(400).json({ error: "Validation failed", details: err.issues });
         return;
       }
       logger.error("Failed to update application", { error: err.message });

--- a/src/modules/application/validation.ts
+++ b/src/modules/application/validation.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 export const createApplicationSchema = z.object({
-  propertyId: z.string().uuid(),
+  propertyId: z.string().guid(),
   unitNumber: z.string().max(20).optional(),
 
   // Applicant info
@@ -57,7 +57,7 @@ export const createApplicationSchema = z.object({
 });
 
 export const submitApplicationSchema = z.object({
-  applicationId: z.string().uuid(),
+  applicationId: z.string().guid(),
 });
 
 export const updateApplicationSchema = createApplicationSchema.partial().omit({

--- a/src/modules/approval/routes.ts
+++ b/src/modules/approval/routes.ts
@@ -32,7 +32,7 @@ router.post(
       res.json(result);
     } catch (err: any) {
       if (err.name === "ZodError") {
-        res.status(400).json({ error: "Validation failed", details: err.errors });
+        res.status(400).json({ error: "Validation failed", details: err.issues });
         return;
       }
       logger.error("Tier 1 review failed", { error: err.message });
@@ -59,7 +59,7 @@ router.post(
       res.json(result);
     } catch (err: any) {
       if (err.name === "ZodError") {
-        res.status(400).json({ error: "Validation failed", details: err.errors });
+        res.status(400).json({ error: "Validation failed", details: err.issues });
         return;
       }
       logger.error("Tier 2 review failed", { error: err.message });
@@ -86,7 +86,7 @@ router.post(
       res.json(result);
     } catch (err: any) {
       if (err.name === "ZodError") {
-        res.status(400).json({ error: "Validation failed", details: err.errors });
+        res.status(400).json({ error: "Validation failed", details: err.issues });
         return;
       }
       logger.error("Tier 3 review failed", { error: err.message });

--- a/src/modules/decision-matrix/routes.ts
+++ b/src/modules/decision-matrix/routes.ts
@@ -38,7 +38,7 @@ router.post(
       res.status(201).json(result);
     } catch (err: any) {
       if (err.name === "ZodError") {
-        res.status(400).json({ error: "Validation failed", details: err.errors });
+        res.status(400).json({ error: "Validation failed", details: err.issues });
         return;
       }
       logger.error("Failed to request modification", { error: err.message });
@@ -64,7 +64,7 @@ router.post(
       res.json(result);
     } catch (err: any) {
       if (err.name === "ZodError") {
-        res.status(400).json({ error: "Validation failed", details: err.errors });
+        res.status(400).json({ error: "Validation failed", details: err.issues });
         return;
       }
       logger.error("Failed to decide modification", { error: err.message });

--- a/src/modules/eviction/routes.ts
+++ b/src/modules/eviction/routes.ts
@@ -42,7 +42,7 @@ router.get("/violations/:id", authenticate, requirePermission("eviction:view"),
 );
 
 const ReportViolationSchema = z.object({
-  applicationId: z.string().uuid(),
+  applicationId: z.string().guid(),
   violationType: z.string().min(1),
   description: z.string().min(1),
   occurredAt: z.string(),
@@ -179,7 +179,7 @@ router.get("/cases", authenticate, requirePermission("eviction:view"),
 );
 
 const FileCaseSchema = z.object({
-  noticeId: z.string().uuid(),
+  noticeId: z.string().guid(),
   caseNumber: z.string().min(1),
   jurisdiction: z.string().min(1),
 });

--- a/src/modules/inspections/routes.ts
+++ b/src/modules/inspections/routes.ts
@@ -42,11 +42,11 @@ router.get("/:id", authenticate, requirePermission("inspection:view"),
 );
 
 const ScheduleSchema = z.object({
-  propertyId: z.string().uuid(),
+  propertyId: z.string().guid(),
   inspectionType: z.string().min(1),
   scheduledDate: z.string(),
   unitNumber: z.string().optional(),
-  applicationId: z.string().uuid().optional(),
+  applicationId: z.string().guid().optional(),
 });
 
 router.post("/", authenticate, requirePermission("inspection:manage"),

--- a/src/modules/maintenance/routes.ts
+++ b/src/modules/maintenance/routes.ts
@@ -34,12 +34,12 @@ router.get("/:id", authenticate, requirePermission("maintenance:view"),
 );
 
 const CreateSchema = z.object({
-  propertyId: z.string().uuid(),
+  propertyId: z.string().guid(),
   title: z.string().min(1),
   description: z.string().min(1),
   priority: z.enum(["emergency", "urgent", "routine", "low"]),
   unitNumber: z.string().optional(),
-  applicationId: z.string().uuid().optional(),
+  applicationId: z.string().guid().optional(),
   category: z.string().optional(),
 });
 
@@ -61,7 +61,7 @@ router.post("/", authenticate, requirePermission("maintenance:manage"),
   }
 );
 
-const AssignSchema = z.object({ assignedTo: z.string().uuid() });
+const AssignSchema = z.object({ assignedTo: z.string().guid() });
 
 router.post("/:id/assign", authenticate, requirePermission("maintenance:manage"),
   async (req: AuthRequest, res: Response): Promise<void> => {

--- a/src/modules/messages/routes.ts
+++ b/src/modules/messages/routes.ts
@@ -113,7 +113,7 @@ router.post(
       if (!parsed.success) {
         res
           .status(400)
-          .json({ error: "Validation failed", details: parsed.error.errors });
+          .json({ error: "Validation failed", details: parsed.error.issues });
         return;
       }
 

--- a/src/modules/moveout/routes.ts
+++ b/src/modules/moveout/routes.ts
@@ -40,7 +40,7 @@ router.get("/:id", authenticate, requirePermission("moveout:view"),
 );
 
 const InitiateSchema = z.object({
-  applicationId: z.string().uuid(),
+  applicationId: z.string().guid(),
   noticeDate: z.string(),
   forwardingAddress: z.string().min(1, "Forwarding address is required"),
 });

--- a/src/modules/payment/intents.ts
+++ b/src/modules/payment/intents.ts
@@ -37,7 +37,7 @@ import {
  */
 
 const intentSchema = z.object({
-  applicationId: z.string().uuid(),
+  applicationId: z.string().guid(),
   amountCents: z.number().int().positive().max(10_000_000),
   currency: z
     .string()
@@ -77,7 +77,7 @@ router.post(
       input = intentSchema.parse(req.body);
     } catch (err) {
       if (err instanceof z.ZodError) {
-        res.status(400).json({ error: "Validation failed", details: err.errors });
+        res.status(400).json({ error: "Validation failed", details: err.issues });
         return;
       }
       throw err;

--- a/src/modules/payment/routes.ts
+++ b/src/modules/payment/routes.ts
@@ -69,7 +69,7 @@ router.post(
       res.json(result);
     } catch (err: unknown) {
       if (err instanceof z.ZodError) {
-        res.status(400).json({ error: "Validation failed", details: err.errors });
+        res.status(400).json({ error: "Validation failed", details: err.issues });
         return;
       }
 

--- a/src/modules/recertification/routes.ts
+++ b/src/modules/recertification/routes.ts
@@ -101,7 +101,7 @@ router.get(
 
 // Create recertification manually
 const CreateSchema = z.object({
-  applicationId: z.string().uuid(),
+  applicationId: z.string().guid(),
 });
 
 router.post(
@@ -191,7 +191,7 @@ router.post(
 // manager can't resolve recerts outside their portfolio. Validation failures
 // (non-comparable / not-rented / no open obligation) map to 400.
 const NauResolveSchema = z.object({
-  resolvingUnitId: z.string().uuid(),
+  resolvingUnitId: z.string().guid(),
   notes: z.string().min(1, "Notes are required"),
 });
 

--- a/src/modules/renewal/routes.ts
+++ b/src/modules/renewal/routes.ts
@@ -31,7 +31,7 @@ router.get("/:id", authenticate, requirePermission("renewal:view"),
 );
 
 const CreateSchema = z.object({
-  applicationId: z.string().uuid(),
+  applicationId: z.string().guid(),
   proposedRent: z.number().positive(),
   proposedTermMonths: z.number().int().positive().optional(),
 });

--- a/src/modules/tape/routes-viewer.ts
+++ b/src/modules/tape/routes-viewer.ts
@@ -42,13 +42,13 @@ interface TapeViewerService {
 // ---------------------------------------------------------------------------
 
 const listQuerySchema = z.object({
-  applicantId: z.string().uuid().optional(),
+  applicantId: z.string().guid().optional(),
   afterSequence: z.coerce.number().int().nonnegative().optional(),
   limit: z.coerce.number().int().min(1).max(200).optional(),
 });
 
 const scopedQuerySchema = z.object({
-  applicantId: z.string().uuid().optional(),
+  applicantId: z.string().guid().optional(),
 });
 
 // ---------------------------------------------------------------------------

--- a/src/modules/tenant/routes.ts
+++ b/src/modules/tenant/routes.ts
@@ -262,7 +262,7 @@ router.post(
 
       const parsed = paySchema.safeParse(req.body);
       if (!parsed.success) {
-        res.status(400).json({ error: "Validation failed", details: parsed.error.errors });
+        res.status(400).json({ error: "Validation failed", details: parsed.error.issues });
         return;
       }
 
@@ -318,7 +318,7 @@ router.get(
 // POST /api/tenant/maintenance — submit a work order
 // ---------------------------------------------------------------
 const submitWorkOrderSchema = z.object({
-  applicationId: z.string().uuid(),
+  applicationId: z.string().guid(),
   title: z.string().min(1).max(200),
   description: z.string().min(1).max(2000),
   priority: z.enum(["routine", "urgent", "emergency"]).default("routine"),
@@ -329,7 +329,7 @@ router.post("/maintenance", async (req: AuthRequest, res: Response) => {
   try {
     const parsed = submitWorkOrderSchema.safeParse(req.body);
     if (!parsed.success) {
-      res.status(400).json({ error: "Validation failed", details: parsed.error.errors });
+      res.status(400).json({ error: "Validation failed", details: parsed.error.issues });
       return;
     }
     if (!(await assertApplicationOwnership(req, res, parsed.data.applicationId))) return;
@@ -436,7 +436,7 @@ router.post(
       if (!parsed.success) {
         res
           .status(400)
-          .json({ error: "Validation failed", details: parsed.error.errors });
+          .json({ error: "Validation failed", details: parsed.error.issues });
         return;
       }
 

--- a/src/modules/users/routes.ts
+++ b/src/modules/users/routes.ts
@@ -39,7 +39,7 @@ const CreateUserSchema = z.object({
     "asset_manager",
     "system_admin",
   ]),
-  propertyIds: z.array(z.string().uuid()).optional(),
+  propertyIds: z.array(z.string().guid()).optional(),
 });
 
 const ResetPasswordSchema = z.object({


### PR DESCRIPTION
Full breaking-change migration to **zod 4.4.3**, superseding the bare dependabot bump in #118 (which would fail CI without the source changes below).

## Breaking changes handled
- **`ZodError.errors` → `.issues`** — the `.errors` alias was removed in zod 4. Fixed across all `safeParse`/`catch` sites (8 route files). The `catch (err: any)` sites compiled fine but would have silently returned `undefined` in the 400 payload at runtime.
- **`z.string().uuid()` → `z.string().guid()`** — zod 4 tightened `.uuid()` to enforce RFC-9562 version/variant nibbles, which rejects non-compliant UUIDs (including fixtures and any already in prod). `.guid()` is zod 4's lenient validator matching zod-3's old `.uuid()` semantics **exactly**. Deliberately chosen to preserve validation behavior — tightening to strict `z.uuid()` would be a separate, fixture-breaking change.

## Verify
`npx tsc --noEmit` clean; `npx jest --runInBand` → 71 suites / 1165 tests green.

Closes #118.

🤖 Generated with [Claude Code](https://claude.com/claude-code)