### PR TITLE
feat(discover): popup conversion wins on statewide map (Phase 1)

### DIFF
--- a/client-tenant/public/nv-housing-map.html
+++ b/client-tenant/public/nv-housing-map.html
@@ -123,6 +123,16 @@
     background:var(--accent);color:#fff;font-family:var(--display);font-weight:700;
     font-size:12.5px;text-decoration:none;box-shadow:var(--sh-xs);transition:background .12s;}
   .pop .pop-cta:hover{background:var(--accentHi);}
+  /* Availability urgency badge — sage/ok green, sits under the title */
+  .pop .pop-avail{display:inline-flex;align-items:center;gap:5px;margin:0 0 8px;
+    padding:3px 9px;border-radius:999px;background:var(--sageLo);color:var(--ok);
+    border:1px solid #D2DDC9;font-family:var(--display);font-weight:700;font-size:11px;}
+  .pop .pop-avail b{color:var(--ok);}
+  /* AMI tier chips — tight popup-scoped pills reusing the neutral tag language */
+  .pop .pop-amis{display:flex;gap:5px;flex-wrap:wrap;margin:2px 0 1px;}
+  .pop .pop-ami{display:inline-flex;align-items:center;padding:2px 8px;border-radius:7px;
+    font-size:11px;font-weight:600;background:var(--cream);color:var(--ink2);
+    border:1px solid var(--border);}
 
   /* Legend */
   .legend{position:absolute;bottom:16px;left:16px;z-index:600;background:var(--paper);
@@ -232,18 +242,41 @@ const cluster = L.markerClusterGroup({
 map.addLayer(cluster);
 
 const markers = {};   // _id -> marker
+// Normalize an AMI tier label to the compact "60%" form. The two snapshots
+// disagree on format ("60%" vs "60% AMI"); strip a trailing "AMI" so chips
+// render consistently regardless of source.
+function normAmi(t){
+  return String(t||'').replace(/\s*ami\s*$/i,'').trim();
+}
+// Map the map's capitalized fType back to the lowercase GPMGType the React side
+// (initFiltersFromURL) expects, and build a querystring from only the active
+// (non-'all', truthy) filters to forward into the CTA href.
+function ctaQuery(){
+  const qs = new URLSearchParams();
+  if(fType && fType!=='all') qs.set('type', fType.toLowerCase());
+  if(fCity && fCity!=='all') qs.set('city', fCity);
+  if(fFund && fFund!=='all') qs.set('fund', fFund);
+  if(fAvail) qs.set('availability', 'available_now');
+  const s = qs.toString();
+  return s ? '?'+s : '';
+}
 function popupHTML(p){
-  const ami = p.amiTiers.length ? p.amiTiers.join(' · ') : '—';
+  const hasAvail = p.availableUnits > 0;
+  const amiChips = p.amiTiers.length
+    ? `<div class="pop-amis">${p.amiTiers.map(t=>`<span class="pop-ami">${normAmi(t)}</span>`).join('')}</div>`
+    : '<b>—</b>';
   const fund = p.funding.length ? p.funding.join(', ') : 'Not specified';
+  const ctaLabel = hasAvail ? 'Apply now &rarr;' : 'View / Apply &rarr;';
   return `<div class="pop"><h4>${p.name}</h4>`
+    + (hasAvail?`<div class="pop-avail">&#9679; <b>${p.availableUnits}</b> available now</div>`:'')
     + (p.aka?`<div class="addr">aka ${p.aka}</div>`:'')
     + `<div class="addr">${p.address}</div>`
     + `<div class="row"><b>${p.totalUnits??'—'}</b> total units`
     + (p.restrictedUnits!=null?` · <b>${p.restrictedUnits}</b> restricted`:'') + `</div>`
     + `<div class="row">Type: <b>${p.type}</b></div>`
-    + `<div class="row">AMI set-asides: <b>${ami}</b></div>`
+    + `<div class="row">AMI set-asides: ${amiChips}</div>`
     + `<div class="row">Funding: ${fund}</div>`
-    + `<a class="pop-cta" href="/property/${slugify(p.name)}" target="_top">View / Apply &rarr;</a></div>`;
+    + `<a class="pop-cta" href="/property/${slugify(p.name)}${ctaQuery()}" target="_top">${ctaLabel}</a></div>`;
 }
 
 // ---- Cards -----------------------------------------------------------


### PR DESCRIPTION
Phase 1 of /discover map optimization (Option A track). Popup-only changes to the vanilla-JS Leaflet map (`client-tenant/public/nv-housing-map.html`) served in the iframe by `PropertyList.tsx`. No filtering, merge, or hydrate logic touched.

## The 4 popup changes (`popupHTML`)
1. **Availability urgency badge** — when `availableUnits > 0` (the 17 GPMG availability rows), render a sage/ok-green pill `● N available now` under the title. Coverage rows (undefined `availableUnits`) render nothing — no "0 available".
2. **AMI tiers as chips** — each tier becomes a tight `.pop-ami` pill instead of a `·`-joined string. Display normalized to compact `60%` form (strips a trailing "AMI" so `"60%"` and `"60% AMI"` from the two snapshots render identically). Empty `amiTiers` keeps the `—` fallback.
3. **CTA verb switch** — `Apply now →` when there's live availability, otherwise the existing `View / Apply →`. Same `/property/{slug}` destination, same `target="_top"`.
4. **Active filters forwarded into the CTA href** — builds a querystring from non-`all`/truthy module filter state (`fType`/`fCity`/`fFund`/`fAvail`); maps the map's capitalized `fType` back to lowercase to match the React `initFiltersFromURL` contract. e.g. `/property/{slug}?type=family&city=...&availability=available_now`.

New CSS (`.pop-avail`, `.pop-amis`, `.pop-ami`) added to the existing warm-paper style block — reuses `--ok`, `--sageLo`, `--cream`, `--border`, `--display`; no new colors.

## Hard constraints respected
- `matches()`, `buildFilters()`, chip/select handlers, and the merge/hydrate pipeline are untouched (diff confirms). The `tenant-e2e` availability counts (17 / 4 / 13) depend only on that logic.
- Offline fallback chain intact; CTA still links `/property/{slugify(p.name)}` with `target="_top"`.

## e2e result
**Could not run in this environment.** `e2e/scenarios/discover-map.spec.ts` boots the full stack via `npm run e2e:up`, which requires Docker Postgres (+ migrate/seed/API/Vite). Docker is unavailable in the sandbox, so the stack never reached READY and all 7 cases failed on an empty `#count` (page never served data) — an environment limitation, **not** a logic failure. Verified instead that: (a) the inline script parses cleanly, (b) the diff touches only `popupHTML` + popup CSS, leaving `matches()`/`render()`/`mergeLayers()` unchanged, and (c) a node DOM render of `popupHTML` for both a GPMG row and a coverage row produces correct markup with no `undefined` leaks. CI will run the real gate.

## Deferred
Rent ranges — no rent/price data exists anywhere in the vanilla map's runtime payload (only `name, slug, aka, city, address, lat, lng, totalUnits, restrictedUnits, availableUnits, type, amiTiers, funding`). Out of scope for Phase 1, as specified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)