### PR TITLE
feat(demo): token-gated usability harness

### DIFF
--- a/client-tenant/src/App.tsx
+++ b/client-tenant/src/App.tsx
@@ -21,6 +21,7 @@ import { WaitlistPosition } from '@/pages/waitlist/Position';
 import { WaitlistFasterList } from '@/pages/waitlist/FasterList';
 import { MagicLinkSent } from '@/pages/apply/MagicLinkSent';
 import { ScreenshotButton } from '@/components/dev/ScreenshotButton';
+import { DemoStuckButton } from '@/components/dev/DemoStuckButton';
 import { CookieBanner } from '@/components/CookieBanner';
 import { SiteFooter } from '@/components/SiteFooter';
 import { PrivacyPolicy } from '@/pages/legal/PrivacyPolicy';
@@ -83,6 +84,7 @@ export default function App() {
     <SiteFooter />
     <CookieBanner />
     <ScreenshotButton />
+    <DemoStuckButton />
     </>
   );
 }

--- a/client-tenant/src/api/client.ts
+++ b/client-tenant/src/api/client.ts
@@ -1,3 +1,5 @@
+import { getDemoToken, getRunId } from '../lib/demoSession';
+
 const TOKEN_KEY = 'frank_tenant_token';
 
 export function getToken(): string | null {
@@ -23,6 +25,17 @@ async function request<T>(
   };
   if (token) {
     headers['Authorization'] = `Bearer ${token}`;
+  }
+  // Demo/usability sessions carry the shared secret so the backend echoes the
+  // magic-link in the response (register + magic-link/request). No-op outside
+  // a `?demo=<TOKEN>` walkthrough. See lib/demoSession + src/utils/demo-link.
+  const demoToken = getDemoToken();
+  if (demoToken) {
+    headers['x-demo-token'] = demoToken;
+    const runId = getRunId();
+    // Lets the backend tag demo signups (users.demo_run_id) for metric
+    // exclusion + teardown. Only meaningful alongside a valid x-demo-token.
+    if (runId) headers['x-demo-run'] = runId;
   }
 
   const relativePath = path.startsWith('/api') ? path : `/api${path.startsWith('/') ? path : `/${path}`}`;

--- a/client-tenant/src/components/DemoEmailCard.tsx
+++ b/client-tenant/src/components/DemoEmailCard.tsx
@@ -1,0 +1,67 @@
+import { Mail } from 'lucide-react';
+import { HF } from '@/styles/tokens';
+import { isDemoMode } from '@/lib/demoSession';
+
+// Faithful "the email arrived" card, shown in place of a raw devLink whenever
+// the server echoes a magic-link (dev / demo / staging — never on a closed
+// prod). During a usability walkthrough the inbox isn't real, so we render the
+// sign-in email *inline* and let the tester click it exactly as they would in
+// Gmail. This keeps the auth step in the test instead of dead-ending people
+// who'll never receive a message.
+//
+// Copy is intentionally hardcoded English: this is a test-only affordance, so
+// it stays out of the i18n parity gate.
+export function DemoEmailCard({
+  email,
+  onOpen,
+}: {
+  email: string;
+  onOpen: () => void;
+}) {
+  const demo = isDemoMode();
+  return (
+    <div
+      className="text-left"
+      style={{
+        background: HF.paper,
+        border: `1px solid ${HF.border}`,
+        borderRadius: HF.r.md,
+        overflow: 'hidden',
+        boxShadow: HF.shadow.sm,
+      }}
+    >
+      <div
+        className="flex items-center gap-2 px-4 py-2"
+        style={{ background: HF.cream, borderBottom: `1px solid ${HF.border}` }}
+      >
+        <Mail className="h-4 w-4" style={{ color: HF.sage }} />
+        <span className="text-xs font-semibold" style={{ color: HF.ink2 }}>
+          {demo ? 'Demo inbox' : 'Dev inbox'}
+        </span>
+      </div>
+      <div className="px-4 py-3 space-y-1">
+        <div className="text-sm font-semibold" style={{ color: HF.ink }}>
+          Your sign-in link
+        </div>
+        <div className="text-xs" style={{ color: HF.ink3 }}>
+          Frank Housing &lt;no-reply@frankhousing.com&gt; → {email}
+        </div>
+      </div>
+      <div className="px-4 pb-4">
+        <button
+          type="button"
+          onClick={onOpen}
+          className="block w-full px-4 py-2 text-center text-sm font-semibold"
+          style={{ background: HF.accent, color: HF.paper, borderRadius: HF.r.sm }}
+        >
+          Open the link
+        </button>
+        <p className="mt-2 text-center text-xs" style={{ color: HF.ink3 }}>
+          {demo
+            ? "We didn't actually email you — tap above to continue, just like clicking the link in your inbox."
+            : 'Email delivery is off in this environment.'}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/client-tenant/src/components/dev/DemoStuckButton.tsx
+++ b/client-tenant/src/components/dev/DemoStuckButton.tsx
@@ -1,0 +1,140 @@
+import { useEffect, useState } from 'react';
+import { HelpCircle, Check } from 'lucide-react';
+import { isDemoMode } from '@/lib/demoSession';
+import { logDemoEvent } from '@/lib/demoCapture';
+
+// "I'm stuck" marker for usability walkthroughs. Visible only inside a
+// `?demo=<TOKEN>` session. A tester taps it the moment they feel lost; we
+// stamp a `stuck` event (route + optional note) into the demo event log so a
+// reviewer can jump straight to the friction point in the session replay.
+//
+// data-screenshot-exclude / rr-block keep the widget itself out of captures.
+export function DemoStuckButton() {
+  const [show, setShow] = useState(false);
+  const [open, setOpen] = useState(false);
+  const [note, setNote] = useState('');
+  const [sent, setSent] = useState(false);
+
+  useEffect(() => {
+    setShow(isDemoMode());
+  }, []);
+
+  if (!show) return null;
+
+  function submit() {
+    logDemoEvent('stuck', { note: note.trim() || null });
+    setSent(true);
+    setNote('');
+    setOpen(false);
+    window.setTimeout(() => setSent(false), 2200);
+  }
+
+  return (
+    <div
+      data-screenshot-exclude="1"
+      className="rr-block"
+      style={{
+        position: 'fixed',
+        left: 16,
+        bottom: 16,
+        zIndex: 9999,
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'flex-start',
+        gap: 8,
+      }}
+    >
+      {open && (
+        <div
+          style={{
+            background: 'white',
+            border: '1px solid #d1d5db',
+            borderRadius: 10,
+            padding: 12,
+            width: 240,
+            boxShadow: '0 6px 20px rgba(0,0,0,0.18)',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 8,
+          }}
+        >
+          <div style={{ fontSize: 13, fontWeight: 600, color: '#111827' }}>
+            What's confusing here?
+          </div>
+          <textarea
+            autoFocus
+            value={note}
+            onChange={(e) => setNote(e.target.value)}
+            placeholder="Optional — what are you stuck on?"
+            rows={3}
+            data-pii
+            style={{
+              fontSize: 13,
+              padding: 8,
+              border: '1px solid #d1d5db',
+              borderRadius: 6,
+              resize: 'none',
+              fontFamily: 'inherit',
+            }}
+          />
+          <div style={{ display: 'flex', gap: 8 }}>
+            <button
+              type="button"
+              onClick={submit}
+              style={{
+                flex: 1,
+                fontSize: 13,
+                padding: '6px 10px',
+                border: 'none',
+                borderRadius: 6,
+                background: '#b45309',
+                color: 'white',
+                cursor: 'pointer',
+                fontWeight: 600,
+              }}
+            >
+              Send
+            </button>
+            <button
+              type="button"
+              onClick={() => setOpen(false)}
+              style={{
+                fontSize: 13,
+                padding: '6px 10px',
+                border: '1px solid #d1d5db',
+                borderRadius: 6,
+                background: '#f9fafb',
+                cursor: 'pointer',
+              }}
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+      <button
+        type="button"
+        aria-label="Mark that you're stuck"
+        onClick={() => (sent ? null : setOpen((v) => !v))}
+        style={{
+          height: 40,
+          padding: '0 14px',
+          borderRadius: 20,
+          border: 'none',
+          background: sent ? '#059669' : '#b45309',
+          color: 'white',
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 6,
+          fontSize: 13,
+          fontWeight: 600,
+          cursor: 'pointer',
+          boxShadow: '0 4px 12px rgba(0,0,0,0.25)',
+        }}
+      >
+        {sent ? <Check size={16} /> : <HelpCircle size={16} />}
+        {sent ? 'Got it' : "I'm stuck"}
+      </button>
+    </div>
+  );
+}

--- a/client-tenant/src/lib/demoCapture.ts
+++ b/client-tenant/src/lib/demoCapture.ts
@@ -1,0 +1,180 @@
+// Full-session capture for usability/demo walkthroughs.
+//
+// Distinct from qaSessionReplay.ts (a rolling 60s ring buffer feeding the
+// camera button): when a tester arrives via `?demo=<TOKEN>` we record the
+// ENTIRE session and stream it to Supabase, keyed by the per-tab runId, so a
+// reviewer can replay the whole funnel and see exactly where people stall.
+//
+// Layout under the shared QA bucket:
+//   demo/{runId}/replay-000.json, replay-001.json, …   rrweb event segments
+//   demo/{runId}/events.json                            funnel + "stuck" events
+//   demo/{runId}/manifest.json                          index written on exit
+//
+// rrweb checkpoints every CHECKOUT_MS (each checkout emits a fresh full
+// snapshot), so each segment is self-contained and the viewer can concatenate
+// them in order. Privacy config mirrors qaSessionReplay (maskAllInputs:true,
+// rr-block / rr-mask / [data-pii]) — never relax it; testers type real PII.
+
+import { isDemoMode, getRunId } from './demoSession';
+import { uploadToSupabase, qaUploadConfigured } from './qaUpload';
+
+const CHECKOUT_MS = 15_000;
+
+type RRWebEvent = unknown;
+
+export interface DemoEvent {
+  type: string;
+  ts: number;
+  route: string;
+  // step/note/etc. — caller-supplied context, kept loose on purpose.
+  [k: string]: unknown;
+}
+
+let started = false;
+let stopFn: (() => void) | undefined;
+let runId: string | null = null;
+
+// Current (unsealed) rrweb segment + the next segment index to write.
+let segment: RRWebEvent[] = [];
+let segSeq = 0;
+let segmentsWritten = 0;
+
+// Funnel/interaction events, flushed (debounced) as a single JSON array.
+const events: DemoEvent[] = [];
+let eventsFlushTimer: ReturnType<typeof setTimeout> | undefined;
+
+let startedAt = 0;
+
+function seg3(n: number): string {
+  return String(n).padStart(3, '0');
+}
+
+/** Seal the current segment and upload it as replay-{seq}.json. */
+function flushSegment(opts: { keepalive?: boolean } = {}): void {
+  if (!runId || segment.length === 0) return;
+  const batch = segment;
+  const seq = segSeq;
+  segment = [];
+  segSeq += 1;
+  segmentsWritten += 1;
+  void uploadToSupabase(
+    JSON.stringify(batch),
+    `demo/${runId}/replay-${seg3(seq)}.json`,
+    'application/json',
+    opts,
+  ).catch(() => {
+    /* best-effort — a dropped segment shouldn't break the walkthrough */
+  });
+}
+
+function flushEvents(opts: { keepalive?: boolean } = {}): void {
+  if (!runId || events.length === 0) return;
+  void uploadToSupabase(
+    JSON.stringify(events),
+    `demo/${runId}/events.json`,
+    'application/json',
+    opts,
+  ).catch(() => {
+    /* best-effort */
+  });
+}
+
+function writeManifest(opts: { keepalive?: boolean } = {}): void {
+  if (!runId) return;
+  const manifest = {
+    runId,
+    startedAt: new Date(startedAt).toISOString(),
+    endedAt: new Date().toISOString(),
+    replaySegments: segmentsWritten,
+    eventsCount: events.length,
+    finalRoute: typeof window !== 'undefined' ? window.location.pathname : null,
+    userAgent: typeof navigator !== 'undefined' ? navigator.userAgent : null,
+    language: typeof navigator !== 'undefined' ? navigator.language : null,
+  };
+  void uploadToSupabase(
+    JSON.stringify(manifest, null, 2),
+    `demo/${runId}/manifest.json`,
+    'application/json',
+    opts,
+  ).catch(() => {
+    /* best-effort */
+  });
+}
+
+/**
+ * Append a funnel/interaction event (step-entered, stuck, …). Route + ts are
+ * stamped automatically. No-op outside a demo session.
+ */
+export function logDemoEvent(type: string, data: Record<string, unknown> = {}): void {
+  if (!isDemoMode()) return;
+  events.push({
+    type,
+    ts: Date.now(),
+    route: typeof window !== 'undefined' ? window.location.pathname : '',
+    ...data,
+  });
+  // Debounce: coalesce rapid events, but land them within a couple seconds in
+  // case the tester closes the tab before pagehide fires reliably.
+  if (eventsFlushTimer) clearTimeout(eventsFlushTimer);
+  eventsFlushTimer = setTimeout(() => flushEvents(), 2_000);
+}
+
+/**
+ * Start full-session capture. No-op unless this tab is a demo session and the
+ * Supabase storage env is configured. Idempotent.
+ */
+export async function startDemoCapture(): Promise<void> {
+  if (started || typeof window === 'undefined') return;
+  if (!isDemoMode() || !qaUploadConfigured()) return;
+  runId = getRunId();
+  if (!runId) return;
+  started = true;
+  startedAt = Date.now();
+
+  // Flush on the way out — keepalive lets these land during unload.
+  const onExit = () => {
+    flushSegment({ keepalive: true });
+    flushEvents({ keepalive: true });
+    writeManifest({ keepalive: true });
+  };
+  window.addEventListener('pagehide', onExit);
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'hidden') onExit();
+  });
+
+  try {
+    const mod = await import('@rrweb/record');
+    if (!started) return;
+    const handle = mod.record<RRWebEvent>({
+      emit(event, isCheckout) {
+        if (isCheckout && segment.length > 0) {
+          // A new full snapshot is starting — seal the prior segment first.
+          flushSegment();
+        }
+        segment.push(event);
+      },
+      checkoutEveryNms: CHECKOUT_MS,
+      maskAllInputs: true,
+      maskTextClass: 'rr-mask',
+      blockClass: 'rr-block',
+      maskTextSelector: '[data-screenshot-exclude="1"], [data-pii]',
+      recordCanvas: false,
+      collectFonts: false,
+    });
+    stopFn = handle ?? undefined;
+    logDemoEvent('session-start');
+  } catch {
+    // rrweb failed to load — events.json still captures the funnel.
+  }
+}
+
+export function stopDemoCapture(): void {
+  if (stopFn) {
+    try { stopFn(); } catch { /* ignore */ }
+    stopFn = undefined;
+  }
+  flushSegment();
+  flushEvents();
+  writeManifest();
+  started = false;
+}

--- a/client-tenant/src/lib/demoSession.ts
+++ b/client-tenant/src/lib/demoSession.ts
@@ -1,0 +1,90 @@
+// Demo / usability-testing session state.
+//
+// A tester opens the app via a deep link: `https://…/?demo=<TOKEN>`. That
+// token is the shared `DEMO_LINK_SECRET` configured on the backend — holding
+// it is what unlocks the echoed magic-link (see src/utils/demo-link.ts), so a
+// tester can walk the *real* auth funnel without a working inbox.
+//
+// On first load with `?demo=`, we:
+//   1. stash the token in sessionStorage (so it survives navigation within the
+//      tab but does not leak into a shared/long-lived store),
+//   2. mint a per-tab `runId` (cohort key) used to group every captured
+//      artifact for this walkthrough under `demo/{runId}/…` in Supabase,
+//   3. strip `?demo=` from the visible URL so a tester can't accidentally
+//      copy/paste an account-takeover-grade link into a public channel.
+//
+// Everything is sessionStorage-scoped: close the tab and the demo identity is
+// gone. Nothing here changes behaviour unless a `?demo=` token was supplied.
+
+const TOKEN_KEY = "frank_demo_token";
+const RUN_KEY = "frank_demo_run";
+const QUERY_PARAM = "demo";
+
+function genRunId(): string {
+  // Short, sortable, collision-resistant enough for a handful of testers.
+  const rand = Math.random().toString(36).slice(2, 8);
+  return `r${Date.now().toString(36)}-${rand}`;
+}
+
+/**
+ * Read `?demo=<TOKEN>` once at boot, persist token + runId for the tab, and
+ * clean the param out of the address bar. Safe to call unconditionally; a
+ * no-op when the param is absent. Returns true if a demo session is active.
+ */
+export function initDemoSession(): boolean {
+  if (typeof window === "undefined") return false;
+
+  try {
+    const url = new URL(window.location.href);
+    const token = url.searchParams.get(QUERY_PARAM);
+    if (token) {
+      sessionStorage.setItem(TOKEN_KEY, token);
+      if (!sessionStorage.getItem(RUN_KEY)) {
+        sessionStorage.setItem(RUN_KEY, genRunId());
+      }
+      // Scrub the token from the visible URL without a navigation.
+      url.searchParams.delete(QUERY_PARAM);
+      window.history.replaceState({}, "", url.pathname + url.search + url.hash);
+    }
+  } catch {
+    // Malformed URL / storage disabled — demo mode simply stays off.
+  }
+
+  const active = isDemoMode();
+  if (active) {
+    // Dynamic import avoids a static cycle (demoCapture imports this module)
+    // and keeps rrweb out of the bundle for non-demo loads. Fire-and-forget.
+    void import("./demoCapture").then((m) => m.startDemoCapture());
+  }
+  return active;
+}
+
+/** True when this tab is running a captured usability walkthrough. */
+export function isDemoMode(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return !!sessionStorage.getItem(TOKEN_KEY);
+  } catch {
+    return false;
+  }
+}
+
+/** The shared demo token, sent as `x-demo-token` so the backend echoes links. */
+export function getDemoToken(): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return sessionStorage.getItem(TOKEN_KEY);
+  } catch {
+    return null;
+  }
+}
+
+/** The per-tab cohort id grouping all captured artifacts for this walkthrough. */
+export function getRunId(): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return sessionStorage.getItem(RUN_KEY);
+  } catch {
+    return null;
+  }
+}

--- a/client-tenant/src/lib/qaUpload.ts
+++ b/client-tenant/src/lib/qaUpload.ts
@@ -1,0 +1,49 @@
+// Shared Supabase-storage upload used by QA capture (ScreenshotButton) and the
+// demo/usability harness (session-replay + event timeline). Uploads go direct
+// from the browser to the public `frank-qa-screenshots` bucket using the
+// publishable key — no backend round-trip. Keep this the single writer so the
+// bucket name and headers stay in one place.
+
+export const SUPA_URL = import.meta.env.VITE_SUPABASE_URL as string | undefined;
+export const SUPA_KEY = import.meta.env.VITE_SUPABASE_PUBLISHABLE_KEY as
+  | string
+  | undefined;
+export const QA_BUCKET = 'frank-qa-screenshots';
+
+/** True when storage env vars are present and uploads can be attempted. */
+export function qaUploadConfigured(): boolean {
+  return Boolean(SUPA_URL && SUPA_KEY);
+}
+
+/**
+ * Upload a single object to `frank-qa-screenshots/{path}` (upsert) and return
+ * its public URL. Throws on missing env or a non-2xx response.
+ *
+ * `keepalive` lets a flush survive a `pagehide`/`visibilitychange:hidden` —
+ * the demo harness uses it to land the final replay segment + manifest as the
+ * tester navigates away or closes the tab.
+ */
+export async function uploadToSupabase(
+  body: BodyInit,
+  path: string,
+  contentType: string,
+  opts: { keepalive?: boolean } = {},
+): Promise<string> {
+  if (!SUPA_URL || !SUPA_KEY) throw new Error('Supabase storage env vars missing');
+  const res = await fetch(`${SUPA_URL}/storage/v1/object/${QA_BUCKET}/${path}`, {
+    method: 'POST',
+    headers: {
+      apikey: SUPA_KEY,
+      Authorization: `Bearer ${SUPA_KEY}`,
+      'Content-Type': contentType,
+      'x-upsert': 'true',
+    },
+    body,
+    keepalive: opts.keepalive ?? false,
+  });
+  if (!res.ok) {
+    const detail = await res.text().catch(() => '');
+    throw new Error(`upload ${res.status}: ${detail.slice(0, 120)}`);
+  }
+  return `${SUPA_URL}/storage/v1/object/public/${QA_BUCKET}/${path}`;
+}

--- a/client-tenant/src/main.tsx
+++ b/client-tenant/src/main.tsx
@@ -11,8 +11,14 @@ import {
   clearQaReplay,
   stopQaReplay,
 } from './lib/qaSessionReplay';
+import { initDemoSession } from './lib/demoSession';
 
 installQaBuffer();
+
+// Capture `?demo=<TOKEN>` before React mounts: stashes the token + mints a
+// runId, and scrubs the param from the address bar so an account-takeover-
+// grade link can't be copied out of a tester's URL. No-op without `?demo=`.
+initDemoSession();
 
 // DEV-only window shim — lets the Playwright harness (e2e/qaDrain.ts) read
 // the same buffers the in-app camera button uses, without dynamic-importing

--- a/client-tenant/src/pages/Apply.tsx
+++ b/client-tenant/src/pages/Apply.tsx
@@ -8,6 +8,7 @@ import { HF } from '@/styles/tokens';
 import { useTranslation } from 'react-i18next';
 import { useFlag } from '@/lib/flags';
 import { useIsMobile } from '@/hooks/useIsMobile';
+import { logDemoEvent } from '@/lib/demoCapture';
 import {
   ApplyProvider,
   useWizState,
@@ -131,6 +132,13 @@ export function Apply() {
     const next = parseStep(search.get('step'));
     setStepState((prev) => (prev === next ? prev : next));
   }, [search]);
+
+  // Funnel drop-off: stamp each step the tester reaches into the demo event
+  // log. No-op outside a `?demo=` session. The timeline of `step-entered`
+  // events is what surfaces where people stall or abandon the application.
+  useEffect(() => {
+    logDemoEvent('step-entered', { step: String(step) });
+  }, [step]);
 
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);

--- a/client-tenant/src/pages/Login.tsx
+++ b/client-tenant/src/pages/Login.tsx
@@ -1,10 +1,11 @@
 import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { Mail, ArrowRight } from 'lucide-react';
+import { Mail } from 'lucide-react';
 import { requestMagicLink } from '@/api/auth';
 import { HF } from '@/styles/tokens';
 import { CTA, Card } from '@/components/primitives';
 import { TurnstileWidget } from '@/components/TurnstileWidget';
+import { DemoEmailCard } from '@/components/DemoEmailCard';
 
 export function Login() {
   const navigate = useNavigate();
@@ -145,9 +146,9 @@ export function Login() {
               </p>
             </div>
             {devLink && (
-              <CTA onClick={handleDevLink} tone="sage">
-                Continue (dev) <ArrowRight className="h-4 w-4" />
-              </CTA>
+              <div style={{ marginTop: 12 }}>
+                <DemoEmailCard email={email} onOpen={handleDevLink} />
+              </div>
             )}
           </div>
         )}

--- a/client-tenant/src/pages/apply/steps/StepVerify.tsx
+++ b/client-tenant/src/pages/apply/steps/StepVerify.tsx
@@ -6,6 +6,7 @@ import { useApply } from '../ApplyContext';
 import { useTranslation } from 'react-i18next';
 import { CTA } from '@/components/primitives';
 import { HF } from '@/styles/tokens';
+import { DemoEmailCard } from '@/components/DemoEmailCard';
 
 export function StepVerify() {
   const s = useApply();
@@ -84,22 +85,17 @@ export function StepVerify() {
         {s.resending ? t('verify.resending') : t('verify.resend')}
       </CTA>
       {/* Show whenever the server emitted a devLink — it only does so when the
-          email isn't really sent (dev / staging), so this stays hidden in prod
-          and unblocks testers on deployed builds where import.meta.env.DEV is
-          false. Mirrors Login.tsx. */}
+          email isn't really sent (dev / demo / staging), so this stays hidden
+          on a closed prod. Rendered as a faithful "email arrived" card so
+          usability testers complete the auth step instead of dead-ending.
+          Mirrors Login.tsx. */}
       {s.devLink && (
-        <a
-          href={s.devLink}
-          className="block px-4 py-2 text-center text-sm font-medium"
-          style={{
-            background: `${HF.warn}14`,
-            color: HF.warn,
-            border: `1px solid ${HF.warn}55`,
-            borderRadius: HF.r.sm,
+        <DemoEmailCard
+          email={s.email}
+          onOpen={() => {
+            window.location.href = s.devLink!;
           }}
-        >
-          {t('verify.devLink')}
-        </a>
+        />
       )}
       <button
         onClick={() => s.setStep(1)}

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -13,6 +13,7 @@ import { Compliance } from '@/pages/Compliance';
 import { AuditLog } from '@/pages/AuditLog';
 import { QaBundles } from '@/pages/QaBundles';
 import { QaBundleDetail } from '@/pages/QaBundleDetail';
+import { DemoSessionDetail } from '@/pages/DemoSessionDetail';
 import { Recertifications } from '@/pages/Recertifications';
 import { LedgerOverview, LedgerDetail } from '@/pages/Ledger';
 import { Evictions } from '@/pages/Evictions';
@@ -50,6 +51,7 @@ export default function App() {
               <Route path="compliance" element={<Compliance />} />
               <Route path="audit-log" element={<AuditLog />} />
               <Route path="qa-bundles" element={<QaBundles />} />
+              <Route path="qa-bundles/demo/:runId" element={<DemoSessionDetail />} />
               <Route path="qa-bundles/:stem" element={<QaBundleDetail />} />
               <Route path="*" element={<Navigate to="/" replace />} />
             </Route>

--- a/client/src/pages/DemoSessionDetail.tsx
+++ b/client/src/pages/DemoSessionDetail.tsx
@@ -1,0 +1,313 @@
+import { useState, useEffect, useRef } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { Film, ArrowLeft, AlertTriangle, Flag } from 'lucide-react';
+import { useApiQuery } from '@/hooks/useApiQuery';
+import { useAuth } from '@/hooks/useAuth';
+import { PageHeader } from '@/components/PageHeader';
+import { hasMinRole } from '@/types';
+
+interface DemoRunDetail {
+  runId: string;
+  segments: string[];
+  events: string | null;
+  manifest: string | null;
+}
+
+interface DemoRunResponse {
+  run: DemoRunDetail;
+}
+
+interface DemoEvent {
+  type: string;
+  ts: number;
+  route?: string;
+  step?: string;
+  note?: string | null;
+  [k: string]: unknown;
+}
+
+function authHeaders(): Record<string, string> {
+  const token = localStorage.getItem('frank_token');
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const res = await fetch(url, { headers: authHeaders() });
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return res.json() as Promise<T>;
+}
+
+/**
+ * Concatenates the run's replay segments (each a full rrweb event array,
+ * uploaded in order with a full-snapshot checkpoint at the head) into one
+ * timeline and mounts rrweb-player over it.
+ */
+function ReplayPanel({
+  runId,
+  segments,
+}: {
+  runId: string;
+  segments: string[];
+}) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [err, setErr] = useState<string | null>(null);
+  const [status, setStatus] = useState('Loading replay…');
+
+  useEffect(() => {
+    if (!containerRef.current || segments.length === 0) return;
+    let disposed = false;
+    let cleanup: (() => void) | null = null;
+
+    (async () => {
+      try {
+        const [{ default: RrwebPlayer }] = await Promise.all([
+          import('rrweb-player'),
+          import('rrweb-player/dist/style.css'),
+        ]);
+        // Fetch every segment in parallel, then flatten in declared order.
+        const parts = await Promise.all(
+          segments.map((name) =>
+            fetchJson<unknown[]>(
+              `/api/qa/demo/${encodeURIComponent(runId)}/file/${encodeURIComponent(name)}`,
+            ),
+          ),
+        );
+        if (disposed || !containerRef.current) return;
+        const events = parts.flat();
+        if (!Array.isArray(events) || events.length < 2) {
+          setErr('Replay is empty or malformed (rrweb needs ≥2 events).');
+          return;
+        }
+        setStatus('');
+        const instance = new (RrwebPlayer as unknown as new (opts: {
+          target: HTMLElement;
+          props: {
+            events: unknown[];
+            autoPlay: boolean;
+            width?: number;
+            height?: number;
+          };
+        }) => unknown)({
+          target: containerRef.current,
+          props: { events, autoPlay: false, width: 900, height: 540 },
+        });
+        cleanup = () => {
+          if (containerRef.current) containerRef.current.innerHTML = '';
+          void instance;
+        };
+      } catch (e) {
+        if (!disposed)
+          setErr(e instanceof Error ? e.message : 'Replay failed to load');
+      }
+    })();
+
+    return () => {
+      disposed = true;
+      if (cleanup) cleanup();
+    };
+  }, [runId, segments]);
+
+  return (
+    <div>
+      {err && (
+        <div className="mb-2 rounded-lg bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-700">
+          {err}
+        </div>
+      )}
+      {!err && status && <p className="mb-2 text-xs text-gray-500">{status}</p>}
+      <div ref={containerRef} className="rounded-lg border border-gray-200 bg-white p-2" />
+    </div>
+  );
+}
+
+function EventTimeline({
+  runId,
+  hasEvents,
+}: {
+  runId: string;
+  hasEvents: boolean;
+}) {
+  const [events, setEvents] = useState<DemoEvent[] | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!hasEvents) {
+      setEvents([]);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const json = await fetchJson<DemoEvent[]>(
+          `/api/qa/demo/${encodeURIComponent(runId)}/file/events.json`,
+        );
+        if (!cancelled) setEvents(Array.isArray(json) ? json : []);
+      } catch (e) {
+        if (!cancelled)
+          setErr(e instanceof Error ? e.message : 'Events failed to load');
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [runId, hasEvents]);
+
+  if (err)
+    return (
+      <div className="rounded-lg bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-700">
+        {err}
+      </div>
+    );
+  if (!events) return <p className="text-xs text-gray-500">Loading events…</p>;
+  if (events.length === 0)
+    return <p className="text-xs text-gray-500">No events recorded.</p>;
+
+  const t0 = events[0]?.ts ?? 0;
+  return (
+    <ol className="space-y-1">
+      {events.map((e, i) => {
+        const rel = ((e.ts - t0) / 1000).toFixed(1);
+        const isStuck = e.type === 'stuck';
+        const isStep = e.type === 'step-entered';
+        return (
+          <li
+            key={i}
+            className={`flex items-start gap-2 rounded-md px-3 py-1.5 text-xs ${
+              isStuck ? 'bg-red-50 text-red-800' : 'text-gray-700'
+            }`}
+          >
+            <span className="w-12 shrink-0 font-mono text-gray-400">+{rel}s</span>
+            {isStuck ? (
+              <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-red-600" />
+            ) : isStep ? (
+              <Flag className="mt-0.5 h-3.5 w-3.5 shrink-0 text-emerald-600" />
+            ) : (
+              <span className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+            )}
+            <span className="min-w-0">
+              <span className="font-medium">
+                {isStep ? `Step: ${e.step}` : e.type}
+              </span>
+              {e.note ? (
+                <span className="ml-1 italic text-red-700">“{e.note}”</span>
+              ) : null}
+              {e.route ? (
+                <span className="ml-1 font-mono text-gray-400">{e.route}</span>
+              ) : null}
+            </span>
+          </li>
+        );
+      })}
+    </ol>
+  );
+}
+
+export function DemoSessionDetail() {
+  const { user } = useAuth();
+  const { runId } = useParams<{ runId: string }>();
+  const gated = !!user && hasMinRole(user.role, 'regional_manager');
+
+  const { data, loading, error } = useApiQuery<DemoRunResponse>(
+    gated && runId ? `/api/qa/demo/${encodeURIComponent(runId)}` : null,
+  );
+  const run = data?.run ?? null;
+
+  const [manifest, setManifest] = useState<Record<string, unknown> | null>(null);
+  useEffect(() => {
+    if (!run?.manifest || !runId) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const json = await fetchJson<Record<string, unknown>>(
+          `/api/qa/demo/${encodeURIComponent(runId)}/file/manifest.json`,
+        );
+        if (!cancelled) setManifest(json);
+      } catch {
+        /* manifest is best-effort */
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [run, runId]);
+
+  if (!user || !hasMinRole(user.role, 'regional_manager')) {
+    return (
+      <p className="text-sm text-red-600">
+        Access denied. Regional Manager or above required.
+      </p>
+    );
+  }
+
+  if (loading) return <p className="text-sm text-gray-500">Loading demo session…</p>;
+  if (error || !run) {
+    return (
+      <div className="space-y-3">
+        <Link
+          to="/qa-bundles"
+          className="inline-flex items-center gap-1 text-sm text-emerald-700 hover:text-emerald-800"
+        >
+          <ArrowLeft className="h-4 w-4" /> All bundles
+        </Link>
+        <div className="rounded-lg bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-700">
+          {error ?? 'Demo session not found.'}
+        </div>
+      </div>
+    );
+  }
+
+  const stuckCount =
+    manifest && typeof manifest.stuckCount === 'number'
+      ? (manifest.stuckCount as number)
+      : null;
+
+  return (
+    <div className="space-y-4">
+      <Link
+        to="/qa-bundles"
+        className="inline-flex items-center gap-1 text-sm text-emerald-700 hover:text-emerald-800"
+      >
+        <ArrowLeft className="h-4 w-4" /> All bundles
+      </Link>
+
+      <PageHeader
+        icon={Film}
+        title={run.runId}
+        description={`${run.segments.length} replay segment(s)${
+          stuckCount != null ? ` · ${stuckCount} stuck marker(s)` : ''
+        }`}
+      />
+
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+        <div className="lg:col-span-2">
+          <h2 className="mb-2 text-sm font-medium text-gray-700">Session replay</h2>
+          {run.segments.length > 0 ? (
+            <ReplayPanel runId={run.runId} segments={run.segments} />
+          ) : (
+            <div className="rounded-lg bg-amber-50 border border-amber-200 px-4 py-3 text-sm text-amber-800">
+              No replay segments — capture didn't initialise or the upload failed.
+            </div>
+          )}
+        </div>
+
+        <div className="space-y-4">
+          <div>
+            <h2 className="mb-2 text-sm font-medium text-gray-700">Funnel events</h2>
+            <div className="max-h-[540px] overflow-y-auto rounded-lg border border-gray-200 bg-white p-2">
+              <EventTimeline runId={run.runId} hasEvents={!!run.events} />
+            </div>
+          </div>
+
+          {manifest && (
+            <div>
+              <h2 className="mb-2 text-sm font-medium text-gray-700">Manifest</h2>
+              <pre className="overflow-x-auto rounded-md bg-gray-50 p-3 text-xs leading-relaxed text-gray-800">
+                {JSON.stringify(manifest, null, 2)}
+              </pre>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/QaBundles.tsx
+++ b/client/src/pages/QaBundles.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { Camera } from 'lucide-react';
 import { useApiQuery } from '@/hooks/useApiQuery';
@@ -19,6 +20,15 @@ export interface QaBundleSummary {
 
 interface QaBundlesResponse {
   bundles: QaBundleSummary[];
+  hint?: string;
+}
+
+export interface DemoRunSummary {
+  runId: string;
+}
+
+interface DemoRunsResponse {
+  runs: DemoRunSummary[];
   hint?: string;
 }
 
@@ -65,12 +75,71 @@ const columns: Column<QaBundleSummary>[] = [
   },
 ];
 
+const demoColumns: Column<DemoRunSummary>[] = [
+  {
+    key: 'runId',
+    header: 'Run',
+    render: (r) => (
+      <span className="rounded bg-gray-100 px-2 py-0.5 text-xs font-mono">
+        {r.runId}
+      </span>
+    ),
+  },
+  {
+    key: 'view',
+    header: '',
+    render: (r) => (
+      <Link
+        to={`/qa-bundles/demo/${r.runId}`}
+        className="text-sm font-medium text-emerald-700 hover:text-emerald-800"
+      >
+        View →
+      </Link>
+    ),
+    className: 'whitespace-nowrap text-right',
+  },
+];
+
+type Tab = 'captures' | 'demo';
+
+function TabButton({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className={`border-b-2 px-1 pb-2 text-sm font-medium ${
+        active
+          ? 'border-emerald-600 text-emerald-700'
+          : 'border-transparent text-gray-500 hover:text-gray-700'
+      }`}
+    >
+      {children}
+    </button>
+  );
+}
+
 export function QaBundles() {
   const { user } = useAuth();
   const gated = !!user && hasMinRole(user.role, 'regional_manager');
+  const [tab, setTab] = useState<Tab>('captures');
 
   const { data, loading, error } = useApiQuery<QaBundlesResponse>(
     gated ? '/api/qa/bundles' : null,
+  );
+  // Lazy: only fetch demo runs once the operator opens that tab.
+  const {
+    data: demoData,
+    loading: demoLoading,
+    error: demoError,
+  } = useApiQuery<DemoRunsResponse>(
+    gated && tab === 'demo' ? '/api/qa/demo' : null,
   );
 
   if (!user || !hasMinRole(user.role, 'regional_manager')) {
@@ -86,27 +155,61 @@ export function QaBundles() {
       <PageHeader
         icon={Camera}
         title="QA Bundles"
-        description="Operator viewer for camera-button capture bundles (PNG + JSON sidecar + rrweb replay)."
+        description="Operator viewer for camera-button captures and demo/usability walkthrough sessions."
       />
 
-      {data?.hint && (
-        <div className="rounded-lg bg-amber-50 border border-amber-200 px-4 py-3 text-sm text-amber-800">
-          {data.hint}
-        </div>
-      )}
+      <div className="flex gap-6 border-b border-gray-200">
+        <TabButton active={tab === 'captures'} onClick={() => setTab('captures')}>
+          Captures
+        </TabButton>
+        <TabButton active={tab === 'demo'} onClick={() => setTab('demo')}>
+          Demo sessions
+        </TabButton>
+      </div>
 
-      {error && (
-        <div className="rounded-lg bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-700">
-          Could not load bundles ({error}).
-        </div>
+      {tab === 'captures' ? (
+        <>
+          {data?.hint && (
+            <div className="rounded-lg bg-amber-50 border border-amber-200 px-4 py-3 text-sm text-amber-800">
+              {data.hint}
+            </div>
+          )}
+          {error && (
+            <div className="rounded-lg bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-700">
+              Could not load bundles ({error}).
+            </div>
+          )}
+          <DataTable
+            columns={columns}
+            data={data?.bundles ?? []}
+            loading={loading}
+            emptyMessage="No QA bundles uploaded yet."
+          />
+        </>
+      ) : (
+        <>
+          {demoData?.hint && (
+            <div className="rounded-lg bg-amber-50 border border-amber-200 px-4 py-3 text-sm text-amber-800">
+              {demoData.hint}
+            </div>
+          )}
+          {demoError && (
+            <div className="rounded-lg bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-700">
+              Could not load demo runs ({demoError}).
+            </div>
+          )}
+          <p className="text-xs text-gray-500">
+            Full-session walkthroughs from the <code>?demo=</code> harness — replay,
+            funnel step events, and "I'm stuck" markers, keyed by run id.
+          </p>
+          <DataTable
+            columns={demoColumns}
+            data={demoData?.runs ?? []}
+            loading={demoLoading}
+            emptyMessage="No demo sessions recorded yet."
+          />
+        </>
       )}
-
-      <DataTable
-        columns={columns}
-        data={data?.bundles ?? []}
-        loading={loading}
-        emptyMessage="No QA bundles uploaded yet."
-      />
     </div>
   );
 }

--- a/scripts/purge-demo-data.mjs
+++ b/scripts/purge-demo-data.mjs
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+// Reap accounts created during usability/demo walkthroughs.
+//
+// Every signup made via a `?demo=<TOKEN>` deep link is tagged with
+// users.demo_run_id (the per-tab runId). This script deletes those rows so a
+// testing round leaves no residue in the real applicant funnel. Magic-link
+// tokens, user_applications, applications etc. cascade or are cleaned via the
+// users FK chain (ON DELETE CASCADE on magic_link_tokens; application rows are
+// reported so an operator can decide).
+//
+// Usage:
+//   node scripts/purge-demo-data.mjs --list                 # show demo rows, delete nothing
+//   node scripts/purge-demo-data.mjs --run <RUN_ID>          # purge one run
+//   node scripts/purge-demo-data.mjs --all --yes             # purge every demo row
+//
+// Requires DATABASE_URL (same env the app uses). Dry-run by default: without
+// --yes (or with --list) it only reports. Captured replay/event artifacts in
+// Supabase storage (demo/{runId}/…) are NOT touched here — delete those from
+// the bucket separately if needed.
+
+import pg from 'pg';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const args = process.argv.slice(2);
+const has = (f) => args.includes(f);
+const valOf = (f) => {
+  const i = args.indexOf(f);
+  return i >= 0 ? args[i + 1] : undefined;
+};
+
+const LIST = has('--list');
+const ALL = has('--all');
+const RUN = valOf('--run');
+const CONFIRM = has('--yes');
+
+if (!process.env.DATABASE_URL) {
+  console.error('DATABASE_URL is required (point it at the target DB).');
+  process.exit(1);
+}
+if (!LIST && !ALL && !RUN) {
+  console.error('Specify one of: --list | --run <RUN_ID> | --all --yes');
+  process.exit(1);
+}
+
+const pool = new pg.Pool({
+  connectionString: process.env.DATABASE_URL,
+  ssl: process.env.NODE_ENV === 'production' ? { rejectUnauthorized: false } : false,
+});
+
+function scopeClause() {
+  if (RUN) return { sql: 'demo_run_id = $1', params: [RUN] };
+  return { sql: 'demo_run_id IS NOT NULL', params: [] };
+}
+
+async function main() {
+  const { sql, params } = scopeClause();
+
+  const preview = await pool.query(
+    `SELECT demo_run_id, COUNT(*)::int AS users,
+            MIN(created_at) AS first_seen, MAX(created_at) AS last_seen
+       FROM users
+      WHERE ${sql}
+      GROUP BY demo_run_id
+      ORDER BY last_seen DESC`,
+    params,
+  );
+
+  if (preview.rows.length === 0) {
+    console.log('No demo accounts match.');
+    await pool.end();
+    return;
+  }
+
+  console.log('Demo accounts:');
+  let total = 0;
+  for (const r of preview.rows) {
+    total += r.users;
+    console.log(
+      `  ${r.demo_run_id}  ${r.users} user(s)  ${new Date(r.first_seen).toISOString()} → ${new Date(r.last_seen).toISOString()}`,
+    );
+  }
+  console.log(`  total: ${total} user(s)`);
+
+  if (LIST || (!CONFIRM && !RUN)) {
+    if (!LIST) console.log('\nDry run — re-run with --yes to delete.');
+    await pool.end();
+    return;
+  }
+  if (ALL && !CONFIRM) {
+    console.log('\n--all requires --yes to actually delete.');
+    await pool.end();
+    return;
+  }
+
+  // Delete. magic_link_tokens cascade via FK. Report application rows that
+  // reference these users so they aren't silently orphaned.
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    const apps = await client.query(
+      `SELECT COUNT(*)::int AS n
+         FROM user_applications ua
+         JOIN users u ON u.id = ua.user_id
+        WHERE u.${sql}`,
+      params,
+    );
+    const del = await client.query(`DELETE FROM users WHERE ${sql} RETURNING id`, params);
+    await client.query('COMMIT');
+    console.log(`\nDeleted ${del.rowCount} user(s).`);
+    if (apps.rows[0]?.n > 0) {
+      console.log(
+        `Note: ${apps.rows[0].n} user_application link(s) referenced these users (cascade/orphan policy is FK-defined).`,
+      );
+    }
+  } catch (err) {
+    await client.query('ROLLBACK');
+    console.error('Purge failed, rolled back:', err.message);
+    process.exitCode = 1;
+  } finally {
+    client.release();
+    await pool.end();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/__tests__/demo-link.test.ts
+++ b/src/__tests__/demo-link.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Unit tests for the demo-link gate (utils/demo-link.ts).
+ *
+ * The gate decides whether a magic-link is echoed in the HTTP response. It is
+ * an auth bypass, so the matrix below is security-sensitive: the only path that
+ * may open on a tenant-facing deploy is a matching x-demo-token under
+ * DEMO_LINK_SECRET.
+ */
+
+import { shouldReturnDevLink, DEMO_TOKEN_HEADER } from "../utils/demo-link";
+
+function reqWith(headers: Record<string, string> = {}) {
+  const lower: Record<string, string> = {};
+  for (const [k, v] of Object.entries(headers)) lower[k.toLowerCase()] = v;
+  return { header: (name: string) => lower[name.toLowerCase()] };
+}
+
+describe("shouldReturnDevLink", () => {
+  const ORIG = { ...process.env };
+  afterEach(() => {
+    process.env = { ...ORIG };
+  });
+
+  it("opens in development regardless of headers/flags", () => {
+    process.env.NODE_ENV = "development";
+    delete process.env.DEMO_LINK_SECRET;
+    delete process.env.DEMO_LINK_IN_RESPONSE;
+    expect(shouldReturnDevLink(reqWith())).toBe(true);
+  });
+
+  it("opens when DEMO_LINK_SECRET is set and x-demo-token matches", () => {
+    process.env.NODE_ENV = "production";
+    process.env.DEMO_LINK_SECRET = "s3cret-demo";
+    expect(
+      shouldReturnDevLink(reqWith({ [DEMO_TOKEN_HEADER]: "s3cret-demo" }))
+    ).toBe(true);
+  });
+
+  it("stays closed when the token is wrong", () => {
+    process.env.NODE_ENV = "production";
+    process.env.DEMO_LINK_SECRET = "s3cret-demo";
+    expect(
+      shouldReturnDevLink(reqWith({ [DEMO_TOKEN_HEADER]: "nope" }))
+    ).toBe(false);
+  });
+
+  it("stays closed when the token is missing", () => {
+    process.env.NODE_ENV = "production";
+    process.env.DEMO_LINK_SECRET = "s3cret-demo";
+    expect(shouldReturnDevLink(reqWith())).toBe(false);
+  });
+
+  it("ignores DEMO_LINK_IN_RESPONSE once a secret is configured (secret wins)", () => {
+    process.env.NODE_ENV = "production";
+    process.env.DEMO_LINK_SECRET = "s3cret-demo";
+    process.env.DEMO_LINK_IN_RESPONSE = "true";
+    // No matching token -> closed, even though the legacy flag is "true".
+    expect(shouldReturnDevLink(reqWith())).toBe(false);
+  });
+
+  it("honors the legacy open flag only when no secret is set", () => {
+    process.env.NODE_ENV = "production";
+    delete process.env.DEMO_LINK_SECRET;
+    process.env.DEMO_LINK_IN_RESPONSE = "true";
+    expect(shouldReturnDevLink(reqWith())).toBe(true);
+  });
+
+  it("is fully closed by default in production (no secret, no flag)", () => {
+    process.env.NODE_ENV = "production";
+    delete process.env.DEMO_LINK_SECRET;
+    delete process.env.DEMO_LINK_IN_RESPONSE;
+    expect(shouldReturnDevLink(reqWith())).toBe(false);
+  });
+});

--- a/src/__tests__/qa-bundles.test.ts
+++ b/src/__tests__/qa-bundles.test.ts
@@ -8,6 +8,9 @@ import {
   parseStem,
   splitName,
   groupBundles,
+  classifyDemoFiles,
+  RUN_ID_RE,
+  DEMO_FILE_RE,
   QA_BUCKET,
   type StorageObject,
 } from "../modules/qa/routes";
@@ -171,5 +174,49 @@ describe("groupBundles", () => {
     expect(out[0].urls.json).toBe(
       "https://other.example/bucket/path/frank-home-20260522-143000.json"
     );
+  });
+});
+
+describe("demo run helpers", () => {
+  it("RUN_ID_RE accepts well-formed run ids and rejects traversal", () => {
+    expect(RUN_ID_RE.test("rabc123-xyz789")).toBe(true);
+    expect(RUN_ID_RE.test("r1-2")).toBe(true);
+    expect(RUN_ID_RE.test("../etc")).toBe(false);
+    expect(RUN_ID_RE.test("rabc/xyz")).toBe(false);
+    expect(RUN_ID_RE.test("frank-home")).toBe(false); // no leading r-token shape
+  });
+
+  it("DEMO_FILE_RE whitelists only known artifact names", () => {
+    expect(DEMO_FILE_RE.test("replay-000.json")).toBe(true);
+    expect(DEMO_FILE_RE.test("replay-12.json")).toBe(true);
+    expect(DEMO_FILE_RE.test("events.json")).toBe(true);
+    expect(DEMO_FILE_RE.test("manifest.json")).toBe(true);
+    expect(DEMO_FILE_RE.test("../../secret.json")).toBe(false);
+    expect(DEMO_FILE_RE.test("replay-000.json.exe")).toBe(false);
+    expect(DEMO_FILE_RE.test("replay-.json")).toBe(false);
+  });
+
+  it("classifyDemoFiles sorts replay segments ascending by sequence", () => {
+    const out = classifyDemoFiles([
+      "replay-2.json",
+      "manifest.json",
+      "replay-10.json",
+      "replay-1.json",
+      "events.json",
+    ]);
+    expect(out.segments).toEqual([
+      "replay-1.json",
+      "replay-2.json",
+      "replay-10.json",
+    ]);
+    expect(out.events).toBe("events.json");
+    expect(out.manifest).toBe("manifest.json");
+  });
+
+  it("classifyDemoFiles reports nulls when artifacts are absent", () => {
+    const out = classifyDemoFiles(["replay-0.json"]);
+    expect(out.segments).toEqual(["replay-0.json"]);
+    expect(out.events).toBeNull();
+    expect(out.manifest).toBeNull();
   });
 });

--- a/src/db/migrations/2026-05-23-users-demo-run-id.sql
+++ b/src/db/migrations/2026-05-23-users-demo-run-id.sql
@@ -1,0 +1,17 @@
+-- Demo/usability harness — tag accounts created during a `?demo=<TOKEN>`
+-- walkthrough so they can be (a) excluded from PM signup metrics and (b)
+-- reaped wholesale by scripts/purge-demo-data.mjs after a test round.
+--
+-- Idempotent. Mirrors the demo_run_id column added to the users block in
+-- schema.ts. The value is the per-tab runId minted client-side and echoed to
+-- the register call; NULL for every real signup.
+
+ALTER TABLE users
+  ADD COLUMN IF NOT EXISTS demo_run_id TEXT;
+
+-- Partial index: demo rows are a tiny minority, and both the metrics filter
+-- (WHERE demo_run_id IS NULL) and the purge (WHERE demo_run_id = $1) only ever
+-- care about the populated rows.
+CREATE INDEX IF NOT EXISTS idx_users_demo_run_id
+  ON users(demo_run_id)
+  WHERE demo_run_id IS NOT NULL;

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -244,6 +244,10 @@ CREATE TABLE users (
   is_active BOOLEAN DEFAULT true,
   last_login TIMESTAMPTZ,
   email_verified_at TIMESTAMPTZ,
+  -- Non-null only for accounts created during a usability/demo walkthrough
+  -- (register tags it from the x-demo-token run). Lets PM metrics exclude
+  -- demo signups and lets scripts/purge-demo-data.mjs reap them by run.
+  demo_run_id TEXT,
   created_at TIMESTAMPTZ DEFAULT NOW(),
   updated_at TIMESTAMPTZ DEFAULT NOW()
 );

--- a/src/modules/applicants/routes.ts
+++ b/src/modules/applicants/routes.ts
@@ -17,6 +17,7 @@ import {
   stampV2PositionLetterSent,
 } from "../tape/v2-stamp";
 import { logger } from "../../utils/logger";
+import { shouldReturnDevLink } from "../../utils/demo-link";
 
 const router: Router = Router();
 const applicationService = new ApplicationService();
@@ -138,6 +139,12 @@ router.post(
 
     const { email, firstName, lastName, phone, channel } = parsed.data;
 
+    // Demo/usability harness: tag accounts born of a `?demo=<TOKEN>` walkthrough
+    // so PM signup metrics can exclude them and scripts/purge-demo-data.mjs can
+    // reap them by run. Only honored when the demo-link gate opens (a matching
+    // x-demo-token), so anonymous traffic can't poison the column.
+    const demoRunId = shouldReturnDevLink(req) ? req.header("x-demo-run") ?? null : null;
+
     const existing = await query("SELECT id, role, is_active FROM users WHERE email = $1", [email]);
     let userId: string | undefined;
     let isNew = false;
@@ -155,10 +162,10 @@ router.post(
       }
     } else {
       const insertRes = await query(
-        `INSERT INTO users (email, first_name, last_name, phone, role, is_active, password_hash)
-         VALUES ($1, $2, $3, $4, 'applicant', true, NULL)
+        `INSERT INTO users (email, first_name, last_name, phone, role, is_active, password_hash, demo_run_id)
+         VALUES ($1, $2, $3, $4, 'applicant', true, NULL, $5)
          RETURNING id`,
-        [email, firstName, lastName, phone || null]
+        [email, firstName, lastName, phone || null, demoRunId]
       );
       userId = insertRes.rows[0].id;
       isNew = true;
@@ -199,15 +206,12 @@ router.post(
       message: "If this email is registered, a verification link has been sent.",
     };
     // In dev we always return the magic link so the post-register "check your
-    // email" banner can surface it. In prod we keep that gate closed (INFO-3:
-    // prevent devLink from leaking in production) UNLESS the operator has
-    // explicitly opted-in via DEMO_LINK_IN_RESPONSE=true. The demo-mode flag
-    // exists to let us walk a stakeholder through the funnel before real
-    // email/SMS delivery is wired; never set it on a tenant-facing deploy.
-    const includeDevLink =
-      process.env.NODE_ENV === "development" ||
-      process.env.DEMO_LINK_IN_RESPONSE === "true";
-    if (link && includeDevLink) {
+    // email" card can surface it. In prod the gate stays closed (INFO-3) unless
+    // the request carries a matching x-demo-token (DEMO_LINK_SECRET) — i.e. the
+    // tester arrived via the `?demo=<TOKEN>` deep link. The legacy fully-open
+    // DEMO_LINK_IN_RESPONSE switch is still honored as a transitional fallback.
+    // See utils/demo-link.ts.
+    if (link && shouldReturnDevLink(req)) {
       payload.devLink = link.link;
     }
     await respondAtFloor(res, t0, 202, payload);

--- a/src/modules/auth/routes.ts
+++ b/src/modules/auth/routes.ts
@@ -5,6 +5,7 @@ import { createMagicLink, verifyMagicLink, logMagicLink } from "./magic-link-ser
 import { authenticate, AuthRequest } from "../../middleware/auth";
 import { verifyTurnstile } from "../../middleware/verify-turnstile";
 import { logger } from "../../utils/logger";
+import { shouldReturnDevLink } from "../../utils/demo-link";
 
 const router: Router = Router();
 
@@ -58,10 +59,12 @@ router.post(
       // Always respond with success — don't leak which emails exist.
       if (result) {
         logMagicLink(parsed.data.email, result.link);
-        // In dev, surface the link in the response so it's clickable for demos.
-        // Fail-closed: only leak when NODE_ENV is explicitly "development".
-        // If the env var is unset on Railway, this stays redacted (WARN #3).
-        if (process.env.NODE_ENV === "development") {
+        // Surface the link in the response only when the demo-link gate opens
+        // (dev, or a matching x-demo-token under DEMO_LINK_SECRET). This is the
+        // returning-user counterpart to /applicants/register's devLink echo, so
+        // usability testers can log back in without a working inbox. Closed by
+        // default on a tenant-facing deploy (WARN #3 stays satisfied).
+        if (shouldReturnDevLink(req)) {
           res.json({ ok: true, devLink: result.link });
           return;
         }

--- a/src/modules/qa/routes.ts
+++ b/src/modules/qa/routes.ts
@@ -149,6 +149,53 @@ export function groupBundles(
 }
 
 // ---------------------------------------------------------------------------
+// Demo/usability sessions
+//
+// The tenant app's demo harness (client-tenant/src/lib/demoCapture.ts) uploads
+// full-session artifacts under `demo/{runId}/`:
+//   - replay-{seq:000}.json  — ordered rrweb segments (concatenate in seq order)
+//   - events.json            — funnel "step-entered" + "stuck" markers
+//   - manifest.json          — run metadata (start time, ua, route, counts)
+// runId is minted client-side (lib/demoSession): `r{base36-time}-{rand}`.
+// ---------------------------------------------------------------------------
+
+export const DEMO_PREFIX = "demo/";
+
+/** runId shape — `r{base36}-{base36}`. Anchored to reject path-traversal. */
+export const RUN_ID_RE = /^r[a-z0-9]+-[a-z0-9]+$/i;
+
+/** The only filenames the proxy will serve out of a demo run folder. */
+export const DEMO_FILE_RE = /^(replay-\d{1,6}\.json|events\.json|manifest\.json)$/;
+
+export interface DemoRunDetail {
+  runId: string;
+  segments: string[]; // object names (relative to the run folder), seq-ascending
+  events: string | null;
+  manifest: string | null;
+}
+
+function segOf(name: string): number {
+  const m = name.match(/^replay-(\d+)\.json$/);
+  return m ? parseInt(m[1], 10) : Number.MAX_SAFE_INTEGER;
+}
+
+/**
+ * Classify the files found directly under one `demo/{runId}/` folder. `names`
+ * are the leaf filenames (no folder prefix). Replay segments are returned in
+ * ascending sequence order so the viewer can concatenate them into one timeline.
+ */
+export function classifyDemoFiles(names: string[]): Omit<DemoRunDetail, "runId"> {
+  const segments = names
+    .filter((n) => /^replay-\d+\.json$/.test(n))
+    .sort((a, b) => segOf(a) - segOf(b));
+  return {
+    segments,
+    events: names.includes("events.json") ? "events.json" : null,
+    manifest: names.includes("manifest.json") ? "manifest.json" : null,
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Storage fetch (server → Supabase REST)
 // ---------------------------------------------------------------------------
 
@@ -169,7 +216,8 @@ function readStorageEnv(): StorageEnv | null {
 }
 
 async function listStorage(
-  env: StorageEnv
+  env: StorageEnv,
+  opts: { prefix?: string; limit?: number } = {}
 ): Promise<StorageObject[]> {
   const res = await fetch(
     `${env.url}/storage/v1/object/list/${env.bucket}`,
@@ -181,7 +229,8 @@ async function listStorage(
         "Content-Type": "application/json",
       },
       body: JSON.stringify({
-        limit: STORAGE_LIST_LIMIT,
+        limit: opts.limit ?? STORAGE_LIST_LIMIT,
+        prefix: opts.prefix ?? "",
         sortBy: { column: "created_at", order: "desc" },
       }),
     }
@@ -390,6 +439,138 @@ export function qaRouter(): Router {
       res.status(500).json({ error: "Failed to fetch QA bundle" });
     }
   });
+
+  // -------------------------------------------------------------------------
+  // Demo/usability sessions
+  // -------------------------------------------------------------------------
+
+  /**
+   * List demo runs. One storage call enumerates the `demo/` folder (Supabase
+   * returns each `{runId}` as a folder pseudo-entry); we keep only well-formed
+   * runIds. Cheap by design — segment counts and timelines are loaded lazily
+   * by the detail endpoint.
+   */
+  router.get("/demo", async (_req: Request, res: Response) => {
+    const env = readStorageEnv();
+    if (!env) {
+      res.json({
+        runs: [],
+        hint:
+          "Supabase Storage is not configured on this server — set SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY to enable the demo viewer.",
+      });
+      return;
+    }
+    try {
+      const items = await listStorage(env, { prefix: DEMO_PREFIX });
+      const runs = items
+        .map((it) => it.name)
+        .filter((name) => RUN_ID_RE.test(name))
+        .slice(0, MAX_BUNDLES)
+        .map((runId) => ({ runId }));
+      res.json({ runs });
+    } catch (err) {
+      logger.error("Demo run list failed", { error: (err as Error).message });
+      res.status(500).json({ error: "Failed to list demo runs" });
+    }
+  });
+
+  /** Detail for one run: ordered replay segments + events + manifest names. */
+  router.get("/demo/:runId", async (req: Request, res: Response) => {
+    const env = readStorageEnv();
+    if (!env) {
+      res.status(503).json({
+        error:
+          "Supabase Storage is not configured on this server — set SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY.",
+      });
+      return;
+    }
+    const raw = req.params.runId;
+    const runId = Array.isArray(raw) ? raw[0] : raw;
+    if (typeof runId !== "string" || !RUN_ID_RE.test(runId)) {
+      res.status(400).json({ error: "Malformed run id" });
+      return;
+    }
+    try {
+      const items = await listStorage(env, { prefix: `${DEMO_PREFIX}${runId}/` });
+      const detail: DemoRunDetail = {
+        runId,
+        ...classifyDemoFiles(items.map((it) => it.name)),
+      };
+      if (detail.segments.length === 0 && !detail.events && !detail.manifest) {
+        res.status(404).json({ error: "Demo run not found" });
+        return;
+      }
+      res.json({ run: detail });
+    } catch (err) {
+      logger.error("Demo run fetch failed", {
+        runId,
+        error: (err as Error).message,
+      });
+      res.status(500).json({ error: "Failed to fetch demo run" });
+    }
+  });
+
+  /**
+   * Stream one artifact (`replay-NNN.json` | `events.json` | `manifest.json`)
+   * out of a run folder via the service-role key, so the bucket can be
+   * private. Both path segments are regex-validated to block traversal, and a
+   * `qa_bundle_read` audit entry is written before any bytes are returned.
+   */
+  router.get(
+    "/demo/:runId/file/:name",
+    async (req: AuthRequest, res: Response): Promise<void> => {
+      const env = readStorageEnv();
+      if (!env) {
+        res.status(503).json({
+          error:
+            "Supabase Storage is not configured on this server — set SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY.",
+        });
+        return;
+      }
+      const rawRun = req.params.runId;
+      const rawName = req.params.name;
+      const runId = Array.isArray(rawRun) ? rawRun[0] : rawRun;
+      const name = Array.isArray(rawName) ? rawName[0] : rawName;
+      if (
+        typeof runId !== "string" ||
+        !RUN_ID_RE.test(runId) ||
+        typeof name !== "string" ||
+        !DEMO_FILE_RE.test(name)
+      ) {
+        res.status(400).json({ error: "Malformed demo artifact path" });
+        return;
+      }
+      const objectName = `${DEMO_PREFIX}${runId}/${name}`;
+      try {
+        const obj = await fetchStorageObject(env, objectName);
+        if (!obj) {
+          res.status(404).json({ error: "Demo artifact not found" });
+          return;
+        }
+        // Audit FIRST — never leak bytes if the audit write fails.
+        await writeAuditLog({
+          action: "qa_bundle_read",
+          actorId: req.user?.id,
+          actorRole: req.user?.role,
+          resourceType: "qa_bundle",
+          resourceId: `demo/${runId}`,
+          details: { artifact: name },
+          ipAddress: (req.ip || req.socket.remoteAddress) as string | undefined,
+          userAgent: req.headers["user-agent"] as string | undefined,
+        });
+        res.setHeader("Content-Type", obj.contentType ?? "application/json");
+        res.setHeader("Cache-Control", "private, no-store");
+        res.status(200).send(Buffer.from(obj.body));
+      } catch (err) {
+        logger.error("Demo artifact proxy failed", {
+          runId,
+          name,
+          error: (err as Error).message,
+        });
+        res.status(500).json({ error: "Failed to fetch demo artifact" });
+      }
+    }
+  );
 
   return router;
 }

--- a/src/modules/users/service.ts
+++ b/src/modules/users/service.ts
@@ -224,6 +224,8 @@ export class UserService {
    * `registered` = everyone who entered via the funnel (applicant or tenant
    * role); `verified` = the subset who have proven their email
    * (email_verified_at stamped). Staff roles are excluded by the role filter.
+   * Demo/usability-test accounts (demo_run_id set) are excluded so a testing
+   * round never inflates the real signup metric.
    */
   async signupStats(): Promise<{ registered: number; verified: number }> {
     const result = await query(
@@ -231,7 +233,8 @@ export class UserService {
          COUNT(*)::int AS registered,
          COUNT(*) FILTER (WHERE email_verified_at IS NOT NULL)::int AS verified
        FROM users
-       WHERE role IN ('applicant', 'tenant')`
+       WHERE role IN ('applicant', 'tenant')
+         AND demo_run_id IS NULL`
     );
     const row = result.rows[0];
     return { registered: row?.registered ?? 0, verified: row?.verified ?? 0 };

--- a/src/utils/demo-link.ts
+++ b/src/utils/demo-link.ts
@@ -1,0 +1,37 @@
+// Demo-link gate — decides whether a magic-link should be echoed back in the
+// HTTP response (instead of being delivered only by email/SMS).
+//
+// This exists so a controlled group of usability testers can walk the real
+// auth funnel without a working inbox (Resend is test-mode and only delivers
+// to the account owner). It is a deliberate auth bypass, so it is gated:
+//
+//   1. NODE_ENV === "development"        — always on locally.
+//   2. DEMO_LINK_SECRET set AND the request carries a matching `x-demo-token`
+//      header — the link is only echoed to clients that hold the shared demo
+//      token (i.e. arrived via the `?demo=<TOKEN>` deep link). This is the
+//      production-safe path: random internet traffic never receives a devLink.
+//   3. DEMO_LINK_IN_RESPONSE === "true"  — legacy fully-open switch, kept as a
+//      transitional fallback. Prefer the secret. NEVER leave this on once a
+//      DEMO_LINK_SECRET is configured.
+//
+// Returning a devLink for an arbitrary email is account-takeover-grade, so
+// option 2 is the only one that should ever be live on a tenant-facing deploy.
+
+export const DEMO_TOKEN_HEADER = "x-demo-token";
+
+/** Minimal request shape — Express's `Request` satisfies this. */
+export interface DemoLinkRequest {
+  header(name: string): string | undefined;
+}
+
+export function shouldReturnDevLink(req: DemoLinkRequest): boolean {
+  if (process.env.NODE_ENV === "development") return true;
+
+  const secret = process.env.DEMO_LINK_SECRET;
+  if (secret && secret.length > 0) {
+    const provided = req.header(DEMO_TOKEN_HEADER);
+    return typeof provided === "string" && provided === secret;
+  }
+
+  return process.env.DEMO_LINK_IN_RESPONSE === "true";
+}


### PR DESCRIPTION
## What it does
A `?demo=<TOKEN>` deep link lets a controlled tester walk the **real** auth funnel without a working inbox, and captures the full rrweb session for drop-off review.

- **Boot** (`main.tsx` → `lib/demoSession.initDemoSession`): reads `?demo=<TOKEN>` once, stashes token + mints a per-tab `runId` in sessionStorage, and scrubs the param from the address bar (the link is account-takeover-grade). Starts rrweb capture (`lib/demoCapture`, dynamic-imported so rrweb stays out of the non-demo bundle).
- **Auth funnel**: `api/client.ts` attaches `x-demo-token` (+ `x-demo-run`) only when a demo session is active, so the backend echoes the magic-link in the response (register + magic-link/request). `DemoEmailCard` renders the echoed link as a faithful "email arrived" card on Login + StepVerify so testers don't dead-end.
- **Metrics hygiene**: register tags the account with `users.demo_run_id` (new column + partial index, migration `2026-05-23-users-demo-run-id.sql`). `UserService.signupStats` excludes demo rows so a test round never inflates real signups. `scripts/purge-demo-data.mjs` reaps a run wholesale.
- **Review API** (`modules/qa/routes.ts`): `GET /qa/demo`, `/qa/demo/:runId`, and an audited `/qa/demo/:runId/file/:name` proxy stream the captured rrweb segments/events/manifest out of private Supabase storage (path-traversal-guarded, audit-logged before bytes).
- **Operator viewer** (PM console): `QaBundles` gains a **Demo sessions** tab (lazy-loaded) listing recorded runs; `DemoSessionDetail` (`/qa-bundles/demo/:runId`) concatenates the run's ordered `replay-NNN.json` segments into a single rrweb-player timeline and renders the funnel event log — `step-entered` flags plus the **"I'm stuck"** markers (note + route) — alongside the manifest. Every artifact is fetched through the same audit-gated server proxy; no public bucket URLs.

## The 3 gate modes (`src/utils/demo-link.ts` → `shouldReturnDevLink`)
1. `NODE_ENV === "development"` — always open locally.
2. `DEMO_LINK_SECRET` set **and** request carries a matching `x-demo-token` — the production-safe path; only `?demo=<TOKEN>` testers get a devLink, random traffic never does.
3. `DEMO_LINK_IN_RESPONSE === "true"` — legacy fully-open fallback; the secret wins if both are set; fully closed by default in prod.

## Dormant by default
Outside a `?demo=` session, `getDemoToken`/`getRunId`/`isDemoMode` all return falsy → no `x-demo-token` header, no capture, `logDemoEvent` is a no-op. The tenant apply funnel and tenant-e2e are unaffected.

## Deploy note
The `demo_run_id` column migration must be applied to the Railway DB before the tagged register path runs, and `DEMO_LINK_SECRET` must be set (with `DEMO_LINK_IN_RESPONSE` unset) on any tenant-facing deploy before the funnel is exercised — both are deliberately left as a separate, confirmed ops step.

## Test status
- Backend `tsc --noEmit`: PASS
- Frontend `tsc --noEmit` (tenant + PM console): PASS
- Tenant + PM-console production builds: PASS
- `jest demo-link qa-bundles qa-routes-proxy user-service user-routes applicants-routes-* magic-link-verify`: 113/113 PASS (gate matrix, new demo-route helpers incl. path-traversal guards + segment ordering, signupStats demo exclusion)
- Pre-existing app-boot suites (`compliance-tape-flag` et al.) `process.exit` under a local missing-Stripe-key env; unrelated to this PR and green in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
