### PR TITLE
feat(discover): collapse map filter rail into React via postMessage (Phase 2-A)

### DIFF
--- a/client-tenant/e2e/scenarios/discover-map.spec.ts
+++ b/client-tenant/e2e/scenarios/discover-map.spec.ts
@@ -1,12 +1,14 @@
 // 17/4/13 are the curated GPMG availability set (nv-gpmg-map-props.json).
 // If you edit that file, update these expected counts.
 //
-// NOTE: playwright.config.ts only defines a single "chromium" project (Desktop
-// Chrome). There is no mobile-chrome project with @mobile grep routing. The
-// mobile stacking test below manually sets a Pixel-5-sized viewport instead of
-// relying on project-level routing. Add a mobile-chrome project to
-// playwright.config.ts and reinstate a grepString/grepInvert pairing if you
-// want true multi-project mobile CI runs.
+// Phase 2-A: React (/discover?view=map) is now the single source of filter
+// truth. The map (/nv-housing-map.html) is a near-pure render surface — its own
+// filter rail + card list were removed. `#count` is now a small overlay pill on
+// the map surface (top-left, warm-paper style); it keeps a leading integer so
+// the count regression lock below still parses ^(\d+). The map still boots
+// filters from its src querystring (initFiltersFromURL) for deep-links + direct
+// nav, which is what the direct-navigation count tests exercise. The React
+// integration test exercises the postMessage transport.
 
 import { test, expect } from "../fixtures";
 
@@ -14,7 +16,7 @@ import { test, expect } from "../fixtures";
 // Data loads async (three parallel fetches + merge); we poll #count until a
 // non-zero leading integer appears before making count assertions.
 
-/** Parse the leading integer from `#count` innerText (e.g. "352 communities of 352"). */
+/** Parse the leading integer from `#count` innerText (e.g. "352 of 352"). */
 async function leadingCount(page: import("@playwright/test").Page): Promise<number> {
   const text = await page.locator("#count").innerText();
   return Number(text.match(/^(\d+)/)?.[1] ?? "0");
@@ -58,20 +60,6 @@ test.describe("nv-housing-map.html — hybrid map regression lock", () => {
     expect(await leadingCount(page)).toBe(13);
   });
 
-  // ── City dropdown (chip-wall fix) ────────────────────────────────────────
-
-  test("city dropdown #citySel is visible and has ≥ 25 options", async ({ page }) => {
-    await page.goto("/nv-housing-map.html");
-    // Wait for data to load (filters are built after hydrate())
-    await expect
-      .poll(() => leadingCount(page), { timeout: 15_000 })
-      .toBeGreaterThan(0);
-    const citySel = page.locator("#citySel");
-    await expect(citySel).toBeVisible();
-    const optionCount = await citySel.locator("option").count();
-    expect(optionCount).toBeGreaterThanOrEqual(25); // ~30 cities + "All cities" option
-  });
-
   // ── Leaflet markers render ───────────────────────────────────────────────
 
   test("markers render on default load", async ({ page }) => {
@@ -86,11 +74,12 @@ test.describe("nv-housing-map.html — hybrid map regression lock", () => {
     expect(markerCount).toBeGreaterThan(0);
   });
 
-  // ── Mobile stacking @mobile ──────────────────────────────────────────────
-  // Pixel 5 viewport: 393 × 851. The responsive CSS stacks .map-col ABOVE
-  // .list-col on mobile (map-col has order:-1 / comes first in DOM flex column).
+  // ── Mobile: map fills the width @mobile ──────────────────────────────────
+  // Phase 2-A removed the list rail, so the map is a single full-width column
+  // at every breakpoint. There's no more stacking to assert; instead confirm
+  // the map column spans (≈) the full viewport width on a phone-sized screen.
 
-  test("stacks map above list on mobile @mobile", async ({ page }) => {
+  test("map fills the viewport width on mobile @mobile", async ({ page }) => {
     // Pixel 5 logical dimensions (same as devices["Pixel 5"]).
     await page.setViewportSize({ width: 393, height: 851 });
     await page.goto("/nv-housing-map.html");
@@ -99,10 +88,48 @@ test.describe("nv-housing-map.html — hybrid map regression lock", () => {
       .toBeGreaterThan(0);
 
     const mapBox = await page.locator(".map-col").boundingBox();
-    const listBox = await page.locator(".list-col").boundingBox();
     expect(mapBox).not.toBeNull();
-    expect(listBox).not.toBeNull();
-    // map-col must render above (smaller Y) than list-col
-    expect(mapBox!.y).toBeLessThan(listBox!.y);
+    // Full-bleed: the map column spans (nearly) the full 393px viewport width.
+    expect(mapBox!.width).toBeGreaterThanOrEqual(380);
+  });
+});
+
+// ── React-driven integration: /discover?view=map → postMessage ────────────
+// Proves the Phase 2-A collapse end-to-end: the React parent owns the filter
+// chips and drives the iframe map via the 'frank:filters' postMessage (NO
+// iframe reload). Clicking the React "Available now" chip must narrow the
+// map's #count to 17 without touching the iframe src.
+test.describe("discover map — React postMessage integration", () => {
+  test("React 'Available now' chip narrows map #count to 17 via postMessage", async ({
+    page,
+  }) => {
+    await page.goto("/discover?view=map");
+
+    const frame = page.frameLocator('[data-testid="discover-map-iframe"]');
+
+    // Wait for the iframe map to hydrate (its #count gets a leading integer).
+    await expect
+      .poll(
+        async () => {
+          const text = await frame.locator("#count").innerText().catch(() => "0");
+          return Number(text.match(/^(\d+)/)?.[1] ?? "0");
+        },
+        { timeout: 20_000 },
+      )
+      .toBeGreaterThanOrEqual(300);
+
+    // Click the React-owned "Available now" chip in the PARENT page.
+    await page.getByTestId("chip-available-now").click();
+
+    // The postMessage path must narrow the map to exactly 17 — no reload.
+    await expect
+      .poll(
+        async () => {
+          const text = await frame.locator("#count").innerText().catch(() => "0");
+          return Number(text.match(/^(\d+)/)?.[1] ?? "0");
+        },
+        { timeout: 15_000 },
+      )
+      .toBe(17);
   });
 });

--- a/client-tenant/public/nv-housing-map.html
+++ b/client-tenant/public/nv-housing-map.html
@@ -42,57 +42,26 @@
   .eyebrow{margin-left:auto;font-family:var(--display);font-weight:700;font-size:12px;
     letter-spacing:.04em;text-transform:uppercase;color:var(--accent);}
 
-  /* Layout — header-height-agnostic: body is a flex column, .body fills the rest */
-  .body{display:grid;grid-template-columns:minmax(360px,440px) 1fr;flex:1 1 auto;min-height:0;}
-  .list-col{overflow-y:auto;padding:18px 18px 40px;border-right:1px solid var(--border);}
-  .map-col{position:relative;}
+  /* Layout — header-height-agnostic: body is a flex column, .body fills the rest.
+     Phase 2-A: the map is now a near-pure render surface (React owns filters via
+     postMessage), so the body is a single full-width map column — no more list
+     rail. */
+  .body{position:relative;flex:1 1 auto;min-height:0;}
+  .map-col{position:absolute;inset:0;}
   #map{position:absolute;inset:0;}
   /* warm the OSM tiles toward cream */
   .leaflet-tile-pane{filter:sepia(.18) saturate(.85) brightness(1.04) contrast(.96);}
   .leaflet-container{background:#e6ddc8;font-family:var(--body);}
 
-  /* Filter chips */
-  .filters{display:flex;gap:7px;flex-wrap:wrap;margin-bottom:14px;}
-  .chip{display:inline-flex;align-items:center;gap:5px;padding:6px 12px;border-radius:999px;
-    font-family:var(--body);font-weight:600;font-size:12.5px;cursor:pointer;
-    background:var(--paper);color:var(--ink2);border:1px solid var(--border);
-    box-shadow:var(--sh-xs);transition:all .12s;white-space:nowrap;}
-  .chip:hover{border-color:var(--borderHi);}
-  .chip.active{background:var(--ink);color:var(--paper);border-color:var(--ink);}
-  .chip.group-accent.active{background:var(--accent);border-color:var(--accent);}
-  .filter-label{font-family:var(--display);font-weight:700;font-size:10.5px;letter-spacing:.05em;
-    text-transform:uppercase;color:var(--ink3);width:100%;margin:6px 0 -4px;}
-  /* City has 30 values statewide — a select keeps the rail compact instead of
-     spilling into a chip wall. */
-  .filter-select{flex:1 1 100%;appearance:none;-webkit-appearance:none;margin-top:2px;
-    padding:8px 32px 8px 12px;border-radius:10px;border:1px solid var(--border);
-    background:var(--paper) url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%238a8170' stroke-width='3'%3E%3Cpath d='M6 9l6 6 6-6'/%3E%3C/svg%3E") no-repeat right 12px center;
-    font-family:var(--body);font-weight:600;font-size:13px;color:var(--ink2);cursor:pointer;
-    box-shadow:var(--sh-xs);transition:border-color .12s;}
-  .filter-select:hover{border-color:var(--borderHi);}
-
-  .count{font-family:var(--display);font-weight:800;font-size:20px;margin:2px 0 14px;}
-  .count small{font-family:var(--body);font-weight:500;font-size:13px;color:var(--ink3);}
-
-  /* Cards */
-  .card{background:var(--paper);border:1px solid var(--border);border-radius:14px;
-    box-shadow:var(--sh-xs);padding:14px 16px;margin-bottom:12px;cursor:pointer;transition:all .12s;}
-  .card:hover,.card.hot{border-color:var(--accentHi);box-shadow:var(--sh-md);transform:translateY(-1px);}
-  .card h3{font-family:var(--display);font-weight:700;font-size:15.5px;margin:0;color:var(--ink);
-    overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
-  .card .addr{font-size:12.5px;color:var(--ink3);margin:3px 0 0;}
-  .tags{display:flex;gap:6px;flex-wrap:wrap;margin-top:10px;}
-  .tag{display:inline-flex;align-items:center;gap:4px;padding:3px 9px;border-radius:7px;
-    font-size:11.5px;font-weight:600;border:1px solid;}
-  .tag.neutral{background:var(--cream);color:var(--ink2);border-color:var(--border);}
-  .tag.accent{background:var(--accentLo);color:var(--accentInk);border-color:#F3D7CB;}
-  .tag.sage{background:var(--sageLo);color:#3D5535;border-color:#D2DDC9;}
-  .tag.warn{background:var(--warnLo);color:#6B4A11;border-color:#E8D6A8;}
-  .card .meta{margin-top:11px;padding-top:11px;border-top:1px solid var(--border);
-    display:flex;justify-content:space-between;align-items:baseline;}
-  .card .units{font-family:var(--display);font-weight:700;font-size:16px;color:var(--ink);}
-  .card .units small{font-family:var(--body);font-weight:500;font-size:11.5px;color:var(--ink3);margin-left:3px;}
-  .card .restricted{font-size:11.5px;color:var(--ink3);}
+  /* Count overlay pill — warm-paper, top-left of the map. React owns the
+     filter rail now; this is the only chrome the map keeps. Its innerText must
+     start with the visible-count integer ("17 of 352") — an e2e regex parses
+     ^(\d+) as the count regression lock. */
+  .count{position:absolute;top:16px;left:16px;z-index:600;background:var(--paper);
+    border-radius:999px;box-shadow:var(--sh-sm);padding:8px 14px;
+    font-family:var(--display);font-weight:800;font-size:14px;color:var(--ink);
+    display:inline-flex;align-items:center;gap:4px;}
+  .count small{font-family:var(--body);font-weight:500;font-size:12px;color:var(--ink3);}
 
   /* Pins */
   .pin{width:34px;height:34px;}
@@ -140,20 +109,14 @@
     color:var(--ink2);display:flex;gap:14px;align-items:center;}
   .legend i{width:9px;height:9px;border-radius:99px;display:inline-block;margin-right:5px;vertical-align:middle;}
 
-  /* Mobile: stack the 2-col layout so the map gets full width instead of a
-     crushed sliver. Map on top (bounded height), filters + cards scroll below.
-     The 360px min-width on the desktop grid is what squeezed the map at narrow
-     widths; below 768px we drop the grid entirely. */
+  /* Mobile: the map is already full-bleed (single column), so we only trim the
+     header and overlay chrome. No list rail to stack anymore. */
   @media (max-width:768px){
     header.app{padding:11px 16px;gap:10px;}
     header.app .brand{font-size:15px;}
-    header.app .eyebrow{display:none;} /* the "335 statewide" count lives in .count below */
-    .body{display:flex;flex-direction:column;}
-    .map-col{order:-1;flex:none;height:46vh;min-height:280px;}
-    .list-col{flex:1 1 auto;min-height:0;border-right:none;border-top:1px solid var(--border);
-      padding:14px 14px 28px;}
+    header.app .eyebrow{display:none;}
     .legend{bottom:12px;left:12px;gap:11px;padding:7px 12px;font-size:11.5px;}
-    .count{font-size:18px;}
+    .count{top:12px;left:12px;font-size:13px;padding:7px 12px;}
   }
 </style>
 </head>
@@ -165,13 +128,9 @@
 </header>
 
 <div class="body">
-  <aside class="list-col">
-    <div class="filters" id="filters"></div>
-    <div class="count" id="count"></div>
-    <div id="cards"></div>
-  </aside>
   <div class="map-col">
     <div id="map"></div>
+    <div class="count" id="count"></div>
     <div class="legend">
       <span><i style="background:#C9492A"></i>Family</span>
       <span><i style="background:#5C7A4F"></i>Senior</span>
@@ -191,10 +150,11 @@ function slugify(name){
 let PROPS = [];
 PROPS.forEach((p,i)=>p._id=i);
 
-const TYPES = ['Family','Senior','Mixed'];
-let CITIES = [...new Set(PROPS.map(p=>p.city).filter(Boolean))].sort();
-let FUNDS  = [...new Set(PROPS.flatMap(p=>p.funding))].sort();
-
+// Filter state. React (the parent /discover page) is the source of truth and
+// drives these via the 'frank:filters' postMessage; initFiltersFromURL seeds
+// them for direct-nav / deep-link first paint. fFund stays 'all' (Funding was
+// dropped from the React filter UI in Phase 2-A) but is kept in matches() +
+// ctaQuery() so the popup-href logic is unchanged.
 let fType='all', fCity='all', fFund='all', fAvail=false;
 
 // Hydrate initial filter state from the URL the parent /discover page forwards
@@ -279,23 +239,6 @@ function popupHTML(p){
     + `<a class="pop-cta" href="/property/${slugify(p.name)}${ctaQuery()}" target="_top">${ctaLabel}</a></div>`;
 }
 
-// ---- Cards -----------------------------------------------------------
-function tag(cls,txt){return `<span class="tag ${cls}">${txt}</span>`;}
-function cardHTML(p){
-  const typeCls = p.type==='Senior'?'sage':p.type==='Mixed'?'warn':'accent';
-  const amiTags = p.amiTiers.slice(0,3).map(t=>tag('neutral',t)).join('');
-  const fundTags = p.funding.slice(0,2).map(f=>tag('neutral',f)).join('');
-  return `<div class="card" data-id="${p._id}">
-    <h3>${p.name}</h3>
-    <div class="addr">${p.address}</div>
-    <div class="tags">${tag(typeCls,p.type)}${amiTags}${fundTags}</div>
-    <div class="meta">
-      <div class="units">${p.totalUnits??'—'}<small>units</small></div>
-      <div class="restricted">${p.restrictedUnits!=null?p.restrictedUnits+' restricted':''}</div>
-    </div>
-  </div>`;
-}
-
 // ---- Filters ---------------------------------------------------------
 function matches(p){
   // Only the GPMG availability layer carries availableUnits. Statewide-coverage
@@ -307,71 +250,51 @@ function matches(p){
       && (fFund==='all'||p.funding.includes(fFund))
       && availOk;
 }
-function buildFilters(){
-  const el=document.getElementById('filters');
-  const seg=(label,items,cur,grp)=>{
-    let h=`<div class="filter-label">${label}</div>`;
-    h+=`<span class="chip ${grp} ${cur==='all'?'active':''}" data-grp="${grp}" data-val="all">All</span>`;
-    items.forEach(it=>{h+=`<span class="chip ${grp} ${cur===it?'active':''}" data-grp="${grp}" data-val="${it}">${it}</span>`;});
-    return h;
-  };
-  const citySel = `<div class="filter-label">City</div>`
-    + `<select class="filter-select" id="citySel">`
-    + `<option value="all"${fCity==='all'?' selected':''}>All cities (${CITIES.length})</option>`
-    + CITIES.map(c=>`<option value="${c}"${fCity===c?' selected':''}>${c}</option>`).join('')
-    + `</select>`;
-  el.innerHTML = seg('Type',TYPES,fType,'group-accent')
-               + citySel
-               + seg('Funding',FUNDS,fFund,'group-fund')
-               + `<div class="filter-label">Availability</div>`
-               + `<span class="chip group-accent ${fAvail?'active':''}" data-grp="group-avail" data-val="available_now">Available now</span>`;
-  el.querySelectorAll('.chip').forEach(c=>c.onclick=()=>{
-    const g=c.dataset.grp, v=c.dataset.val;
-    if(g==='group-accent') fType=v;
-    else if(g==='group-fund') fFund=v;
-    else if(g==='group-avail') fAvail=!fAvail;   // toggle
-    render();
-  });
-  const csEl=document.getElementById('citySel');
-  if(csEl) csEl.onchange=()=>{ fCity=csEl.value; render(); };
+
+// ---- postMessage: React is the single source of filter truth -----------
+// The parent /discover page (PropertyList.tsx) owns the Type / City /
+// Availability chips. It pushes filter changes down here WITHOUT reloading the
+// iframe. We accept messages only from our own origin and ignore anything
+// malformed. On boot we post 'frank:ready' up so React knows when to send the
+// current state (handshake — avoids a race where React posts before this
+// script is listening).
+function applyFilters(f){
+  if(!f || typeof f !== 'object') return;
+  // type: lowercase GPMGType ('family'|'senior'|'mixed'|'all'|null) → map's
+  // capitalized fType. Anything unrecognized resets to 'all'.
+  const t = String(f.type||'all').toLowerCase();
+  fType = t==='family' ? 'Family' : t==='senior' ? 'Senior' : t==='mixed' ? 'Mixed' : 'all';
+  // city: a string matches 1:1; 'all'/falsy clears it.
+  fCity = (typeof f.city === 'string' && f.city && f.city !== 'all') ? f.city : 'all';
+  // availability: only 'available_now' flips the flag.
+  fAvail = f.availability === 'available_now';
+  render();
 }
+window.addEventListener('message', (event)=>{
+  if(event.origin !== window.location.origin) return;
+  const d = event.data;
+  if(!d || typeof d !== 'object' || d.type !== 'frank:filters') return;
+  applyFilters(d.filters);
+});
 
 // ---- Render ----------------------------------------------------------
 function render(){
   const shown = PROPS.filter(matches);
 
-  // cards
-  document.getElementById('cards').innerHTML = shown.map(cardHTML).join('') ||
-    '<p style="color:var(--ink3);font-size:14px;">No communities match these filters.</p>';
+  // count overlay pill — leading integer is the count regression lock.
   document.getElementById('count').innerHTML =
-    `${shown.length} communities <small>of ${PROPS.length}${fAvail?' available now':''}</small>`;
+    `${shown.length} <small>of ${PROPS.length}${fAvail?' available now':''}</small>`;
   document.getElementById('eyebrow').textContent =
     `${PROPS.length} affordable communities`;
 
   // markers
   cluster.clearLayers();
-  const shownIds = new Set(shown.map(p=>p._id));
   Object.keys(markers).forEach(k=>delete markers[k]);
   shown.forEach(p=>{
     const m = L.marker([p.lat,p.lng],{icon:icon(p.type,false)});
     m.bindPopup(popupHTML(p));
-    m.on('mouseover',()=>hotCard(p._id,true));
-    m.on('mouseout',()=>hotCard(p._id,false));
     markers[p._id]=m;
     cluster.addLayer(m);
-  });
-
-  // card interactions
-  document.querySelectorAll('.card').forEach(card=>{
-    const id=+card.dataset.id;
-    card.onmouseenter=()=>hotPin(id,true);
-    card.onmouseleave=()=>hotPin(id,false);
-    card.onclick=()=>{
-      const p=PROPS[id], m=markers[id];
-      if(!m) return;
-      map.flyTo([p.lat,p.lng], Math.max(map.getZoom(),15), {duration:.6});
-      cluster.zoomToShowLayer(m, ()=>m.openPopup());
-    };
   });
 
   // fit bounds on first/filtered render
@@ -380,26 +303,15 @@ function render(){
     map.fitBounds(b,{padding:[40,40], maxZoom:14});
   }
 }
-function hotCard(id,on){
-  const c=document.querySelector(`.card[data-id="${id}"]`);
-  if(c){c.classList.toggle('hot',on); if(on) c.scrollIntoView({block:'nearest',behavior:'smooth'});}
-}
-function hotPin(id,on){
-  const m=markers[id];
-  if(m && m._icon){m._icon.classList.toggle('hot',on);}
-}
 
 function boot(){
   if(!PROPS.length){
-    document.getElementById('cards').innerHTML =
-      '<p style="color:var(--ink3);font-size:14px;">No communities to show yet.</p>';
-    document.getElementById('count').innerHTML = '0 communities <small>statewide Nevada</small>';
+    document.getElementById('count').innerHTML = '0 <small>statewide Nevada</small>';
     return;
   }
-  buildFilters();
   render();
-  // Container may have just been laid out (esp. the mobile stacked map-col);
-  // recompute size so the basemap fills it and fitBounds frames correctly.
+  // Container may have just been laid out; recompute size so the basemap fills
+  // it and fitBounds frames correctly.
   setTimeout(()=>map.invalidateSize(), 60);
 }
 
@@ -430,9 +342,10 @@ function hydrate(rows){
     funding: Array.isArray(p.funding) ? p.funding : [],
     _id: i,
   })).filter(p=>Number.isFinite(p.lat) && Number.isFinite(p.lng));
-  CITIES = [...new Set(PROPS.map(p=>p.city).filter(Boolean))].sort();
-  FUNDS  = [...new Set(PROPS.flatMap(p=>p.funding))].sort();
   boot();
+  // Handshake: tell the parent /discover page we're listening so it can push
+  // the current filter state down. Guarded to our own origin.
+  try{ window.parent?.postMessage({type:'frank:ready'}, window.location.origin); }catch(e){}
 }
 // Hybrid load: a real-availability layer (live DB rows if present, else the
 // bundled GPMG snapshot) merged with the statewide coverage snapshot. The
@@ -455,8 +368,6 @@ Promise.all([
   if(!merged.length) throw new Error('no data');
   hydrate(merged);
 }).catch(()=>{
-  document.getElementById('cards').innerHTML =
-    '<p style="color:var(--accentInk);font-size:14px;">Could not load properties. Please try again later.</p>';
   document.getElementById('count').innerHTML = '— <small>could not load</small>';
 });
 </script>

--- a/client-tenant/src/pages/discover/PropertyList.tsx
+++ b/client-tenant/src/pages/discover/PropertyList.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { fetchUnits } from '@/api/units';
@@ -99,6 +99,86 @@ function ChipButton({
     >
       {children}
     </button>
+  );
+}
+
+/** Uppercase eyebrow label shared by every filter row (list + map views). */
+function FilterRowLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <span
+      style={{
+        fontSize: 12,
+        color: HF.ink3,
+        textTransform: 'uppercase',
+        letterSpacing: '0.04em',
+        fontWeight: 700,
+        minWidth: 36,
+      }}
+    >
+      {children}
+    </span>
+  );
+}
+
+/**
+ * Type / City / Availability chip rows. Map view reuses this (Phase 2-A
+ * collapse) so the map's own filter rail can be deleted — React is now the
+ * single source of filter truth for both views. Bedroom is intentionally NOT
+ * here: the map has no bedroom dimension, and list view renders Bedroom
+ * separately (it sits between City and Availability there).
+ */
+function TypeCityAvailabilityFilters({
+  t,
+  typeFilter,
+  cityFilter,
+  availableNow,
+  updateParam,
+}: {
+  t: (key: string) => string;
+  typeFilter: TypeFilter;
+  cityFilter: CityFilter;
+  availableNow: boolean;
+  updateParam: (key: string, value: string | null) => void;
+}) {
+  return (
+    <>
+      <div className="flex items-center gap-2 overflow-x-auto">
+        <FilterRowLabel>{t('filter.type')}</FilterRowLabel>
+        {(Object.keys(TYPE_LABELS) as TypeFilter[]).map((k) => (
+          <ChipButton
+            key={k}
+            active={typeFilter === k}
+            onClick={() => updateParam('type', k === 'all' ? null : k)}
+          >
+            {TYPE_LABELS[k]}
+          </ChipButton>
+        ))}
+      </div>
+      <div className="flex items-center gap-2 overflow-x-auto">
+        <FilterRowLabel>{t('filter.city')}</FilterRowLabel>
+        {(Object.keys(CITY_LABELS) as CityFilter[]).map((k) => (
+          <ChipButton
+            key={k}
+            active={cityFilter === k}
+            onClick={() => updateParam('city', k === 'all' ? null : k)}
+          >
+            {CITY_LABELS[k]}
+          </ChipButton>
+        ))}
+      </div>
+      <div className="flex items-center gap-2 overflow-x-auto">
+        <FilterRowLabel>{t('filter.availability')}</FilterRowLabel>
+        <ChipButton
+          active={availableNow}
+          testId="chip-available-now"
+          onClick={() =>
+            updateParam('availability', availableNow ? null : 'available_now')
+          }
+        >
+          {t('filter.availableNow')}
+        </ChipButton>
+      </div>
+    </>
   );
 }
 
@@ -258,6 +338,68 @@ export function PropertyList() {
     }
     setParams(next, { replace: true });
   };
+
+  // ── Map view: React is the single source of filter truth ────────────────
+  //
+  // Phase 2-A collapses the duplicated filter rail. In map view the React
+  // chips above drive the map; the map itself is a near-pure render surface.
+  // We push filter changes into the iframe via postMessage (NOT by changing
+  // src — that would reload the whole Leaflet map). The iframe still boots
+  // from its src querystring (initFiltersFromURL) so deep-links + hard reloads
+  // paint the right slice on first render; postMessage only handles
+  // subsequent in-session changes.
+  const iframeRef = useRef<HTMLIFrameElement | null>(null);
+
+  // The iframe `src` is computed once at mount and never changed thereafter
+  // (changing it remounts the iframe). We capture the filters present at first
+  // entry into map view; later changes flow over postMessage. Recomputing this
+  // on every render is fine because React diffs the string — it only differs
+  // from the live DOM attribute if the component fully remounts.
+  const initialMapSrc = useMemo(() => {
+    const mapParams = new URLSearchParams(params);
+    mapParams.delete('view');
+    const qs = mapParams.toString();
+    return qs ? `/nv-housing-map.html?${qs}` : '/nv-housing-map.html';
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []); // intentionally mount-only — see comment above
+
+  // Post the current filters down to the iframe. Same-origin only — we always
+  // pass an explicit targetOrigin (never '*').
+  const postFiltersToMap = () => {
+    const win = iframeRef.current?.contentWindow;
+    if (!win) return;
+    win.postMessage(
+      {
+        type: 'frank:filters',
+        filters: {
+          type: typeFilter,
+          city: cityFilter,
+          availability: availableNow ? 'available_now' : null,
+        },
+      },
+      window.location.origin,
+    );
+  };
+
+  // Handshake + change propagation. The iframe posts 'frank:ready' once its
+  // script is listening; we (re)send the current filters then, which closes
+  // the race where React posts before the iframe wired its listener. We also
+  // resend whenever the filter dimensions change while in map view.
+  useEffect(() => {
+    if (viewMode !== 'map') return;
+    const onMessage = (event: MessageEvent) => {
+      if (event.origin !== window.location.origin) return;
+      const d = event.data;
+      if (!d || typeof d !== 'object' || d.type !== 'frank:ready') return;
+      postFiltersToMap();
+    };
+    window.addEventListener('message', onMessage);
+    // Also push immediately in case the iframe was already ready (e.g. a
+    // re-render after the handshake already fired).
+    postFiltersToMap();
+    return () => window.removeEventListener('message', onMessage);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [viewMode, typeFilter, cityFilter, availableNow]);
 
   useEffect(() => {
     // Authed users still get the live catalog warm-fetched so cached
@@ -466,27 +608,44 @@ export function PropertyList() {
         )}
 
         {viewMode === 'map' ? (
-          <iframe
-            // Forward the active discover filters so the map renders the same
-            // slice the list does (it reads these from its own location.search).
-            // `view` is stripped — it's the parent's tab state, meaningless to
-            // the iframe — so the map URL only carries real filter dimensions.
-            src={(() => {
-              const mapParams = new URLSearchParams(params);
-              mapParams.delete('view');
-              const qs = mapParams.toString();
-              return qs ? `/nv-housing-map.html?${qs}` : '/nv-housing-map.html';
-            })()}
-            title="Nevada affordable housing map"
-            data-testid="discover-map-iframe"
-            className="w-full h-[86vh] md:h-[72vh]"
-            style={{
-              border: 'none',
-              borderRadius: HF.r.md,
-              boxShadow: '0 1px 3px rgba(31,26,18,.10)',
-              background: HF.paper,
-            }}
-          />
+          <>
+            {/* React owns the filter rail (Phase 2-A). These chips drive the
+                map below via postMessage — the map no longer has its own
+                interactive rail. Type / City / Availability only: the map has
+                no Bedroom dimension, and Funding was dropped from the UI. */}
+            <div
+              className="-mx-4 px-4 py-3 sm:-mx-6 sm:px-6 mb-3"
+              style={{ background: HF.cream, borderBottom: `1px solid ${HF.border}` }}
+            >
+              <div className="flex flex-col gap-2">
+                <TypeCityAvailabilityFilters
+                  t={t}
+                  typeFilter={typeFilter}
+                  cityFilter={cityFilter}
+                  availableNow={availableNow}
+                  updateParam={updateParam}
+                />
+              </div>
+            </div>
+            <iframe
+              ref={iframeRef}
+              // Initial src carries the current filters so a deep-link / hard
+              // reload paints the right slice via the map's initFiltersFromURL.
+              // We never mutate src on filter change — that reloads the iframe.
+              // Subsequent changes ride the 'frank:filters' postMessage.
+              // `view` is stripped — it's the parent's tab state.
+              src={initialMapSrc}
+              title="Nevada affordable housing map"
+              data-testid="discover-map-iframe"
+              className="w-full h-[86vh] md:h-[72vh]"
+              style={{
+                border: 'none',
+                borderRadius: HF.r.md,
+                boxShadow: '0 1px 3px rgba(31,26,18,.10)',
+                background: HF.paper,
+              }}
+            />
+          </>
         ) : (
           <>
         <div


### PR DESCRIPTION
## The collapse

Phase 2-A of the `/discover` map optimization. Before this, the map view had **two** filter rails: React hid its chips and the iframe rendered its own interactive rail + card list. This kills the duplication.

**React is now the single source of filter truth.** The map (`nv-housing-map.html`) becomes a near-pure render surface: React's Type/City/Availability chips sit above a full-bleed iframe and push filter changes down over a same-origin `postMessage` channel — **without reloading the iframe**. The URL stays the React source of truth (`updateParam`); postMessage is just the transport.

## postMessage protocol

- **React → map:** `{ type: 'frank:filters', filters: { type, city, availability } }` where `type` is lowercase GPMGType (`'family'|'senior'|'all'`), `city` is a string or `'all'`, `availability` is `'available_now'` or `null`.
- **Map → React:** `{ type: 'frank:ready' }` posted to `window.parent` once the map's script is listening. This **handshake** closes the race where React posts before the iframe wired its listener — React (re)sends current filters on receipt.
- **Origin safety:** both sides verify `event.origin === window.location.origin` on receipt and always pass an explicit `targetOrigin` (`window.location.origin`, never `'*'`). Malformed messages are ignored defensively.

## Files

**`client-tenant/public/nv-housing-map.html`**
- Removed the `.list-col` aside, `buildFilters()`, `cardHTML()`, card click/hover, `#citySel`, `hotCard`/`hotPin`, and dead `TYPES`/`CITIES`/`FUNDS` chip builders. Map is full-width at every breakpoint.
- `#count` is now a warm-paper overlay pill on the map (top-left, `.legend` style); keeps a leading integer so the e2e `^(\d+)` lock still parses.
- Added the `frank:filters` listener + `frank:ready` boot handshake.
- `initFiltersFromURL`, `matches()`, the hybrid 3-source load + offline fallback, and the **Phase 1 popup** (availability badge, AMI chips, Apply-now CTA, filter-forwarding href) are all unchanged.

**`client-tenant/src/pages/discover/PropertyList.tsx`**
- Map view renders Type/City/Availability chips (shared `TypeCityAvailabilityFilters` sub-component) above the iframe.
- iframe gets a `ref`; `src` computed once at mount (deep-link/reload first paint), never mutated on filter change.
- Effect listens for `frank:ready` and posts filters down; reposts on `type`/`city`/`availability` change.

**`client-tenant/e2e/scenarios/discover-map.spec.ts`**
- **Kept:** URL-driven count tests (≥300 / 17 / 4 / 13) + markers test (still boot via `initFiltersFromURL`).
- **Removed:** `#citySel` test (city filter gone from map) and the mobile `.list-col` stacking test (no list-col).
- **Added:** mobile map-fills-width assertion, and a React-driven integration test — `goto /discover?view=map`, poll the iframe `#count`, click the React "Available now" chip, assert the frame `#count` narrows to **17** (proves the postMessage path end-to-end).

## Decisions / deviations
- **Count overlay:** kept `#count` as a small map overlay pill (id + leading-integer preserved) per spec, so the count regression lock survives.
- **Funding dropped** from the map UI (it was map-only/secondary). `fFund` stays in the map's `matches()`/`ctaQuery()` (always `'all'`) so the popup-href logic is unchanged.
- No new i18n keys — map view reuses existing `filter.*` keys (EN/ES already at parity).

## Local results
- `client-tenant` build (`tsc -b` + `vite build`): **green**.
- `vitest`: **244/244 passed**.
- Full `tenant-e2e` harness needs Docker/Postgres which is **unavailable in this sandbox** — it was **NOT run** here; relying on CI. The iframe side it depends on was verified with a standalone Playwright harness against the static map: default **352**, `available_now`→**17**, `family`+avail→**4**, malformed-ignored (stays 4), reset→**352**, `frank:ready` handshake **fires**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)