### PR TITLE
perf(discover): PropertyDetail first-paint + mobile tap targets (Phase 4)

### DIFF
--- a/client-tenant/e2e/scenarios/discover-map.spec.ts
+++ b/client-tenant/e2e/scenarios/discover-map.spec.ts
@@ -22,6 +22,33 @@ async function leadingCount(page: import("@playwright/test").Page): Promise<numb
   return Number(text.match(/^(\d+)/)?.[1] ?? "0");
 }
 
+/**
+ * Decluster the markercluster group so an individual `.pin` divIcon renders.
+ * Uses the e2e-exposed Leaflet handles (window.map / window.cluster) to zoom
+ * to and spider out the first marker — deterministic, viewport-independent.
+ */
+async function declusterFirstPin(page: import("@playwright/test").Page): Promise<void> {
+  await page.evaluate(() => {
+    const w = window as unknown as {
+      map?: { setView: (ll: unknown, z: number) => void };
+      cluster?: {
+        getLayers: () => Array<{ getLatLng: () => unknown }>;
+        zoomToShowLayer: (m: unknown, cb: () => void) => void;
+      };
+    };
+    const cluster = w.cluster;
+    const map = w.map;
+    if (!cluster || !map) return;
+    const layers = cluster.getLayers();
+    if (!layers.length) return;
+    const first = layers[0];
+    map.setView(first.getLatLng(), 19);
+    cluster.zoomToShowLayer(first, () => {});
+  });
+  // Give Leaflet a beat to render the declustered marker(s).
+  await page.waitForTimeout(600);
+}
+
 test.describe("nv-housing-map.html — hybrid map regression lock", () => {
   // ── Default view (no filter) ─────────────────────────────────────────────
 
@@ -91,6 +118,85 @@ test.describe("nv-housing-map.html — hybrid map regression lock", () => {
     expect(mapBox).not.toBeNull();
     // Full-bleed: the map column spans (nearly) the full 393px viewport width.
     expect(mapBox!.width).toBeGreaterThanOrEqual(380);
+  });
+
+  // ── Phase 4: touch tap targets ≥ 44×44 (Apple HIG) @mobile ────────────────
+  // On a coarse-pointer (touch) device the map pin must be ≥44px and the
+  // popup Apply-now CTA must be a ≥44px-tall tappable target. We open a
+  // dedicated touch+mobile context (isMobile/hasTouch ⇒ pointer:coarse) so the
+  // map's `(pointer:coarse)` branch (44px divIcon + .pin.touch) is exercised —
+  // without adding a new Playwright project. The single-pin assertion zooms in
+  // so a cluster declusters into individual `.leaflet-marker-icon.pin` markers.
+  const TOUCH_TARGET_MIN = 44;
+
+  test("map pin is a ≥44px tap target on touch devices @mobile", async ({
+    browser,
+  }) => {
+    const ctx = await browser.newContext({
+      viewport: { width: 390, height: 844 }, // iPhone 12/13/14 logical size
+      isMobile: true,
+      hasTouch: true,
+    });
+    const tp = await ctx.newPage();
+    try {
+      // available_now view = 17 markers; zoom in so they decluster into pins.
+      await tp.goto("/nv-housing-map.html?availability=available_now");
+      await expect
+        .poll(() => leadingCount(tp), { timeout: 15_000 })
+        .toBeGreaterThan(0);
+
+      // Confirm the coarse-pointer branch is actually active in this context.
+      const coarse = await tp.evaluate(
+        () => window.matchMedia("(pointer:coarse)").matches,
+      );
+      expect(coarse).toBe(true);
+
+      // Decluster the first marker so an individual .pin divIcon renders.
+      await declusterFirstPin(tp);
+
+      const pin = tp.locator(".leaflet-marker-icon.pin").first();
+      await expect(pin).toBeVisible({ timeout: 10_000 });
+      const box = await pin.boundingBox();
+      expect(box).not.toBeNull();
+      expect(box!.width).toBeGreaterThanOrEqual(TOUCH_TARGET_MIN);
+      expect(box!.height).toBeGreaterThanOrEqual(TOUCH_TARGET_MIN);
+    } finally {
+      await ctx.close();
+    }
+  });
+
+  test("popup Apply-now CTA is a ≥44px-tall tap target on touch devices @mobile", async ({
+    browser,
+  }) => {
+    const ctx = await browser.newContext({
+      viewport: { width: 390, height: 844 },
+      isMobile: true,
+      hasTouch: true,
+    });
+    const tp = await ctx.newPage();
+    try {
+      await tp.goto("/nv-housing-map.html?availability=available_now");
+      await expect
+        .poll(() => leadingCount(tp), { timeout: 15_000 })
+        .toBeGreaterThan(0);
+
+      await declusterFirstPin(tp);
+
+      const pin = tp.locator(".leaflet-marker-icon.pin").first();
+      await expect(pin).toBeVisible({ timeout: 10_000 });
+      await pin.click();
+
+      // Phase 1 content lock: the CTA verb on an available property is
+      // "Apply now". We only assert its tappable size here.
+      const cta = tp.locator(".pop .pop-cta").first();
+      await expect(cta).toBeVisible({ timeout: 10_000 });
+      await expect(cta).toContainText("Apply now");
+      const box = await cta.boundingBox();
+      expect(box).not.toBeNull();
+      expect(box!.height).toBeGreaterThanOrEqual(TOUCH_TARGET_MIN);
+    } finally {
+      await ctx.close();
+    }
   });
 });
 

--- a/client-tenant/public/nv-housing-map.html
+++ b/client-tenant/public/nv-housing-map.html
@@ -64,7 +64,7 @@
   .count small{font-family:var(--body);font-weight:500;font-size:12px;color:var(--ink3);}
 
   /* Pins */
-  .pin{width:34px;height:34px;}
+  .pin{width:34px;height:34px;position:relative;}
   .pin svg{display:block;width:100%;height:100%;
     filter:drop-shadow(0 3px 5px rgba(31,26,18,.5));}
   .pin svg path{stroke:#fff;stroke-width:1.3;paint-order:stroke fill;}
@@ -74,6 +74,15 @@
   .pin.hot{z-index:1000 !important;}
   .pin.hot svg{transform:scale(1.35);transform-origin:bottom center;
     filter:drop-shadow(0 4px 6px rgba(201,73,42,.5));}
+  /* Touch tap-target (Apple HIG ≥44×44). On coarse pointers the divIcon is
+     built at 44×44 with a matching iconAnchor (see icon() in JS) so the pin
+     tip still lands exactly on the coordinate. This `.pin.touch` rule sizes
+     the box and keeps the visible teardrop SVG pinned to the bottom-center so
+     the desktop look is preserved — only the clickable box grows. */
+  .pin.touch{width:44px;height:44px;}
+  .pin.touch svg{position:absolute;left:50%;bottom:0;width:34px;height:34px;
+    transform:translateX(-50%);}
+  .pin.touch.hot svg{transform:translateX(-50%) scale(1.35);}
 
   /* Cluster bubbles */
   .marker-cluster{background:rgba(201,73,42,.3);width:46px !important;height:46px !important;}
@@ -88,9 +97,13 @@
   .pop .addr{font-size:12px;color:var(--ink3);margin:0 0 9px;}
   .pop .row{font-size:12.5px;color:var(--ink2);margin:3px 0;}
   .pop .row b{color:var(--ink);}
-  .pop .pop-cta{display:inline-block;margin-top:10px;padding:7px 14px;border-radius:999px;
+  /* Apply-now CTA — comfortably tappable on mobile: >=44px min-height with
+     centered label (Apple HIG). Content/verb unchanged from Phase 1. */
+  .pop .pop-cta{display:inline-flex;align-items:center;justify-content:center;
+    min-height:44px;margin-top:10px;padding:9px 18px;border-radius:999px;
     background:var(--accent);color:#fff;font-family:var(--display);font-weight:700;
-    font-size:12.5px;text-decoration:none;box-shadow:var(--sh-xs);transition:background .12s;}
+    font-size:13px;line-height:1.1;text-decoration:none;box-shadow:var(--sh-xs);
+    transition:background .12s;}
   .pop .pop-cta:hover{background:var(--accentHi);}
   /* Availability urgency badge — sage/ok green, sits under the title */
   .pop .pop-avail{display:inline-flex;align-items:center;gap:5px;margin:0 0 8px;
@@ -173,6 +186,9 @@ let fType='all', fCity='all', fFund='all', fAvail=false;
 
 // ---- Map -------------------------------------------------------------
 const map = L.map('map',{zoomControl:false});
+// Expose the Leaflet instance for e2e harnesses (Phase 4 @mobile tap-target
+// tests drive map.setZoom to decluster pins). Harmless in prod — read-only handle.
+window.map = map;
 L.control.zoom({position:'topright'}).addTo(map);
 L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',{
   maxZoom:19, attribution:'&copy; OpenStreetMap'
@@ -191,15 +207,24 @@ window.addEventListener('resize', ()=>{
 });
 
 const pinSVG = `<svg width="26" height="26" viewBox="0 0 24 24"><path d="M12 0C7 0 3 4 3 9c0 6 9 15 9 15s9-9 9-15c0-5-4-9-9-9z"/><circle cx="12" cy="9" r="3.4" fill="#fff"/></svg>`;
+// Coarse-pointer (touch) devices get a 44×44 tap target per Apple HIG; the
+// teardrop SVG stays 34px and bottom-anchored (see `.pin.touch` CSS) so the
+// desktop appearance is unchanged. iconAnchor scales with the box so the pin
+// tip still lands exactly on the geographic coordinate (no marker drift).
+const COARSE = typeof window!=='undefined' && window.matchMedia
+  && window.matchMedia('(pointer:coarse)').matches;
+const PIN_SIZE = COARSE ? 44 : 34;
 function icon(type,hot){
-  return L.divIcon({html:pinSVG, className:`pin ${type.toLowerCase()}${hot?' hot':''}`,
-    iconSize:[34,34], iconAnchor:[17,34], popupAnchor:[0,-32]});
+  return L.divIcon({html:pinSVG,
+    className:`pin ${type.toLowerCase()}${COARSE?' touch':''}${hot?' hot':''}`,
+    iconSize:[PIN_SIZE,PIN_SIZE], iconAnchor:[PIN_SIZE/2,PIN_SIZE], popupAnchor:[0,-(PIN_SIZE-2)]});
 }
 
 const cluster = L.markerClusterGroup({
   maxClusterRadius:30, spiderfyOnMaxZoom:true, showCoverageOnHover:false,
 });
 map.addLayer(cluster);
+window.cluster = cluster; // e2e handle (Phase 4 tap-target tests decluster via zoomToShowLayer)
 
 const markers = {};   // _id -> marker
 // Normalize an AMI tier label to the compact "60%" form. The two snapshots

--- a/client-tenant/src/pages/discover/PropertyDetail.tsx
+++ b/client-tenant/src/pages/discover/PropertyDetail.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { Link, useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { ArrowLeft } from 'lucide-react';
 import { useTranslation, Trans } from 'react-i18next';
@@ -80,7 +81,9 @@ export function PropertyDetail() {
   const navigate = useNavigate();
   const [params] = useSearchParams();
   const { t } = useTranslation('discover');
-  const prop = findGPMGBySlug(slug);
+  // Fixture lookup is an array scan — memoize on slug so i18n-namespace loads
+  // and searchParams churn don't re-scan the catalog on every render.
+  const prop = useMemo(() => findGPMGBySlug(slug), [slug]);
 
   // Preserve a deep-linked amiTier when bouncing to /apply so the W0 funnel
   // continues to know the applicant's tier. Validated against the same set
@@ -90,6 +93,34 @@ export function PropertyDetail() {
     amiTierRaw && VALID_AMI_TIERS.has(amiTierRaw as AmiTier)
       ? (amiTierRaw as AmiTier)
       : null;
+
+  // All per-property derivations are pure functions of `prop`. Memoizing the
+  // whole block on the fixture identity means the availability/pricing/AMI
+  // rollups (small loops, but several of them) run once per navigation rather
+  // than on every render (i18n suspense resolve, searchParams update, etc.).
+  // Computed before the early return to keep hook order stable when `prop` is
+  // undefined; the values are simply unused in the not-found branch.
+  const derived = useMemo(() => {
+    if (!prop) return null;
+    // Wedge #9 — rent range + AMI disclosure. `rentBuckets` drives the per-
+    // bedroom table; `propertySetAside` is "60% AMI" for every GPMG fixture
+    // today. Distinct from the URL `amiTier` deep-link (applicant's tier).
+    const rentRange = propertyRentRange(prop.name);
+    const rentBuckets = populatedBuckets(rentRange);
+    const propertySetAside = propertyAmiTier(prop.name);
+    const countyKey = cityToCountyKey(prop.city);
+    const setAsideTier = parseSetAsideTier(propertySetAside);
+    return {
+      est: rentEstimate(prop),
+      availability: getPropertyAvailability(prop.name),
+      rentBuckets,
+      propertySetAside,
+      countyKey,
+      setAsideTier,
+      countyMsa: countyKey ? LIMITS_2026[countyKey].msa : '',
+      showAmiDisclosure: !!propertySetAside && rentBuckets.length > 0,
+    };
+  }, [prop]);
 
   if (!prop) {
     return (
@@ -119,25 +150,19 @@ export function PropertyDetail() {
     );
   }
 
-  const est = rentEstimate(prop);
-  const availability = getPropertyAvailability(prop.name);
+  // `derived` is non-null here: it returns null only when `prop` is falsy,
+  // and that path already returned above.
+  const {
+    est,
+    availability,
+    rentBuckets,
+    propertySetAside,
+    countyKey,
+    setAsideTier,
+    countyMsa,
+    showAmiDisclosure,
+  } = derived!;
   const hasAvailability = availability.availableCount > 0;
-
-  // Wedge #9 — rent range + AMI disclosure. `rentBuckets` drives the per-
-  // bedroom table; `propertySetAside` is "60% AMI" for every GPMG fixture
-  // today (the mirror in utils/pricing.ts returns null for non-fixture
-  // properties so the section is suppressed for any future off-catalog case).
-  // Distinct from the URL `amiTier` deep-link (applicant's tier from W0).
-  const rentRange = propertyRentRange(prop.name);
-  const rentBuckets = populatedBuckets(rentRange);
-  const propertySetAside = propertyAmiTier(prop.name);
-  // County-aware official 2026 limits. Resolve the property's county from its
-  // city; a null county = not-yet-ingested → "coming soon" rather than stale
-  // numbers. setAsideTier is the numeric tier ("60") parsed from "60% AMI".
-  const countyKey = cityToCountyKey(prop.city);
-  const setAsideTier = parseSetAsideTier(propertySetAside);
-  const countyMsa = countyKey ? LIMITS_2026[countyKey].msa : '';
-  const showAmiDisclosure = !!propertySetAside && rentBuckets.length > 0;
 
   const onApply = () => {
     // Apply requires auth; bounce unauthed users through /login with a return.
@@ -663,6 +688,10 @@ export function PropertyDetail() {
               borderRadius: HF.r.md,
               padding: 16,
               boxShadow: HF.shadow.xs,
+              // Below-fold: skip render/layout work until scrolled near.
+              // containIntrinsicSize reserves the box so there's no shift.
+              contentVisibility: 'auto',
+              containIntrinsicSize: '0 200px',
             }}
           >
             <h2
@@ -705,7 +734,14 @@ export function PropertyDetail() {
             </dl>
           </section>
 
-          <section style={{ marginTop: 24 }}>
+          <section
+            style={{
+              marginTop: 24,
+              // Always below the fold — defer its paint to keep first paint cheap.
+              contentVisibility: 'auto',
+              containIntrinsicSize: '0 180px',
+            }}
+          >
             <h2
               style={{
                 fontFamily: HF.display,


### PR DESCRIPTION
Phase 4 — the final polish pass on the `/discover` map flow. Two parts.

## Part 1 — PropertyDetail first-paint
`client-tenant/src/pages/discover/PropertyDetail.tsx`

**Profiling finding:** there is no async data fetch on this route. `findGPMGBySlug` and the pricing/availability/AMI rollups are all synchronous fixture derivations, so the page paints fully on first render — there is nothing to skeleton/optimistic-shell. The first-paint jank is pure render + layout cost. No hero layout shift either: it's a local SVG CSS background with `aspect-[16/9]` already reserving space.

Concrete, low-risk changes:
- **Memoize the fixture lookup** (an array scan) on `slug`.
- **Group every per-property derivation** (rent range, availability rollup, AMI/county resolution, estimate) into a single `useMemo` keyed on the fixture identity, so they run once per navigation instead of on every render (i18n suspense resolve, `searchParams` churn). The hooks run before the not-found early return so hook order stays stable.
- **`content-visibility:auto` + `containIntrinsicSize`** on the below-fold Contact and Amenities sections so the browser skips their render/layout during first paint, with reserved intrinsic boxes so there's no layout shift.

Data contract and routing unchanged.

## Part 2 — Mobile tap targets
`client-tenant/public/nv-housing-map.html`

- **Pin (was 34×34, below the 44px HIG minimum):** on coarse-pointer (touch) devices the `divIcon` is built at 44×44 with a matching `iconAnchor` so the pin tip still lands exactly on the coordinate (no marker drift). The visible teardrop SVG stays 34px and is bottom-anchored via a `.pin.touch` rule, so the **desktop appearance is unchanged**.
- **Popup Apply-now CTA:** `min-height:44px` + flex-centered label + roomier padding. Popup content **structure is untouched** — same AMI chips, `● N available now` badge, and `Apply now →` verb as Phase 1.
- Exposed `window.map` / `window.cluster` as read-only e2e handles (harmless in prod) so tests can decluster a pin deterministically.

## Tests (no new Playwright project)
Extended `client-tenant/e2e/scenarios/discover-map.spec.ts` with two `@mobile` tests in a touch context (iPhone 390×844, `isMobile`/`hasTouch` ⇒ `pointer:coarse`) asserting via `boundingBox()` that the pin is ≥44×44 and the Apply-now CTA is ≥44px tall.

## Verification (local)
- `npx tsc --noEmit` — PASS
- `npm run build` — PASS
- `npx vitest run .../PropertyDetail.test.tsx` — PASS (11/11)
- New `@mobile` e2e: pin tap-target test PASS, CTA tap-target test PASS (each passes in isolation). A flaky local backend (a sibling session's uncommitted `src/modules/payment/refunds.ts` TS2322) can crash the dev `api` server and tear down the shared static server mid-run; that file is **not** on this branch, so CI's clean checkout is unaffected. CI runs the full `tenant-e2e` + `pm-console-e2e` gates.

## Count lock
Untouched. No JSON data file or `#count` logic was changed — the 352 / 17 / 4 / 13 counts remain a pure function of the committed JSON + the count badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)