### PR TITLE
fix(qa): operator viewer 500s — add qa_bundle_read enum + drop non-UUID resourceId

### DIFF
--- a/src/__tests__/qa-routes-proxy.test.ts
+++ b/src/__tests__/qa-routes-proxy.test.ts
@@ -220,8 +220,7 @@ describe("GET /api/qa/bundles/:stem/png — streaming proxy", () => {
         actorId: regionalManager.id,
         actorRole: regionalManager.role,
         resourceType: "qa_bundle",
-        resourceId: STEM,
-        details: { artifact: "png" },
+        details: { artifact: "png", bundle: STEM },
       })
     );
   });
@@ -255,7 +254,7 @@ describe("GET /api/qa/bundles/:stem/sidecar — streaming proxy", () => {
     expect(mockWriteAuditLog).toHaveBeenCalledWith(
       expect.objectContaining({
         action: "qa_bundle_read",
-        details: { artifact: "sidecar" },
+        details: { artifact: "sidecar", bundle: STEM },
       })
     );
   });
@@ -293,7 +292,7 @@ describe("GET /api/qa/bundles/:stem/replay — streaming proxy", () => {
     expect(mockWriteAuditLog).toHaveBeenCalledWith(
       expect.objectContaining({
         action: "qa_bundle_read",
-        details: { artifact: "replay" },
+        details: { artifact: "replay", bundle: STEM },
       })
     );
   });

--- a/src/db/migrations/2026-05-30-qa-bundle-read-audit-action.sql
+++ b/src/db/migrations/2026-05-30-qa-bundle-read-audit-action.sql
@@ -1,0 +1,19 @@
+-- QA/demo bundle audit-action gap (surfaced by the first live operator-side
+-- demo-session replay). The audit-gated proxy endpoints in src/modules/qa/routes.ts
+-- write audit_log.action = 'qa_bundle_read' before streaming each artifact, but
+-- that value was never added to the audit_action enum. Result: every artifact
+-- fetch (/api/qa/bundles/:stem/{png,sidecar,replay} and
+-- /api/qa/demo/:runId/file/:name) throws `invalid input value for enum
+-- audit_action: "qa_bundle_read"`. writeAuditLog re-throws by design, so the
+-- handler returns 500 and the operator viewer can never load a replay. The QA
+-- proxy unit tests mock writeAuditLog, so the gap was invisible until a live read.
+--
+-- Companion code fix (same change): the two writeAuditLog calls passed a
+-- non-UUID resourceId (the bundle stem / `demo/{runId}`) into the UUID-typed
+-- audit_log.resource_id column, which also threw. Those now carry the
+-- identifier in details (JSONB) and leave resource_id NULL.
+--
+-- ADD VALUE IF NOT EXISTS is idempotent (Postgres 12+) and runs in autocommit
+-- (each ALTER TYPE ... ADD VALUE cannot run inside a transaction block).
+
+ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'qa_bundle_read';

--- a/src/modules/qa/routes.ts
+++ b/src/modules/qa/routes.ts
@@ -376,8 +376,9 @@ export function qaRouter(): Router {
           actorId: req.user?.id,
           actorRole: req.user?.role,
           resourceType: "qa_bundle",
-          resourceId: stem,
-          details: { artifact: kind },
+          // resource_id is a UUID column; the bundle stem isn't one, so carry
+          // the identifier in details (JSONB) instead of resourceId.
+          details: { artifact: kind, bundle: stem },
           ipAddress: (req.ip || req.socket.remoteAddress) as string | undefined,
           userAgent: req.headers["user-agent"] as string | undefined,
         });
@@ -553,8 +554,9 @@ export function qaRouter(): Router {
           actorId: req.user?.id,
           actorRole: req.user?.role,
           resourceType: "qa_bundle",
-          resourceId: `demo/${runId}`,
-          details: { artifact: name },
+          // resource_id is a UUID column; the runId isn't one, so carry the
+          // identifier in details (JSONB) instead of resourceId.
+          details: { artifact: name, runId },
           ipAddress: (req.ip || req.socket.remoteAddress) as string | undefined,
           userAgent: req.headers["user-agent"] as string | undefined,
         });


### PR DESCRIPTION
## Problem
The #168 demo-session **operator viewer is fully broken in prod** — every artifact fetch returns **HTTP 500**:
- `/api/qa/bundles/:stem/{png,sidecar,replay}`
- `/api/qa/demo/:runId/file/:name`

Surfaced during the first live operator-side replay (the "live demo walkthrough verification" of #168). List/detail endpoints work; only the audited artifact reads 500.

## Root cause — two audit-write bugs, both invisible to CI
The QA proxy audits **before** streaming bytes, and `writeAuditLog` **re-throws by design**, so an audit-insert failure becomes a 500.

1. **Missing enum value** — handlers write `audit_log.action = 'qa_bundle_read'`, but that value was never added to the `audit_action` Postgres enum → `invalid input value for enum audit_action: "qa_bundle_read"`.
2. **Non-UUID resourceId** — the two `writeAuditLog` calls passed the bundle stem / `demo/{runId}` into the **UUID-typed** `audit_log.resource_id` column → INSERT throws on cast.

The proxy unit tests **mock `writeAuditLog`**, so neither gap was caught (same class as the `2026-05-27-bp08-audit-action-enum` precedent).

## Fix
- **Migration** `2026-05-30-qa-bundle-read-audit-action.sql`: `ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'qa_bundle_read'` (idempotent, autocommit).
- **Code**: fold the identifier into `details` (JSONB) — `{ artifact, bundle }` / `{ artifact, runId }` — and leave `resource_id` NULL.
- **Tests**: proxy assertions updated to the corrected audit shape (10 + 54 related tests green locally).

## Deploy notes
- Apply the enum migration to prod **before** deploying the api (additive, safe).
- Canonical `src/db/schema.ts` DDL should also gain the value for fresh-DB bootstrap (follow-up; file owned by another active session — does not affect CI, which mocks the DB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)