### PR TITLE
test(pm-console): harden flaky applications-detail detail-shell spec

### DIFF
--- a/client/e2e/scenarios/applications-detail.spec.ts
+++ b/client/e2e/scenarios/applications-detail.spec.ts
@@ -28,7 +28,16 @@ test.describe("Application detail — rendering", () => {
   test("opening a row from the list renders the detail shell", async ({ adminPage }) => {
     await adminPage.goto("/applications");
     const main = adminPage.getByRole("main");
-    await main.getByRole("button", { name: "View details" }).first().click();
+    // The list is seeded async — wait for the row's trigger to actually render
+    // before clicking, so `.first()` doesn't resolve against a not-yet-painted list.
+    const viewDetails = main.getByRole("button", { name: "View details" }).first();
+    await expect(viewDetails).toBeVisible();
+    await viewDetails.click();
+
+    // The list→detail transition is a client-side route change followed by a
+    // data fetch. Gate on the URL flipping to /applications/:id first — asserting
+    // on the detail tree before the route changed was the flake source.
+    await adminPage.waitForURL(/\/applications\/[^/]+$/);
 
     await expect(adminPage.getByRole("button", { name: /Back to Applications/i })).toBeVisible();
     await expect(adminPage.getByRole("heading", { name: /Applicant Information/i })).toBeVisible();


### PR DESCRIPTION
## Problem
`applications-detail.spec.ts:28` ("opening a row from the list renders the detail shell") intermittently reddens `pm-console-e2e`. It clicked **View details** and immediately asserted the detail tree (Back to Applications button, etc.). The list→detail transition is a client-side route change followed by a data fetch, so the assertions sometimes ran before the route flipped.

## Fix (test-only, standard Playwright auto-wait)
- Wait for the **View details** trigger to be visible before clicking, so `.first()` can't resolve against a not-yet-painted seeded list.
- `await page.waitForURL(/\/applications\/[^/]+$/)` after the click — gate on the route actually changing before asserting on the detail shell.

No product code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)