### PR TITLE
fix(seo): sitemap property URLs → /property/{slug} (dead /discover/ links)

### DIFF
--- a/client-tenant/public/sitemap.xml
+++ b/client-tenant/public/sitemap.xml
@@ -2,121 +2,121 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://frank-pilot-tenant.vercel.app/</loc>
-    <lastmod>2026-05-22</lastmod>
+    <lastmod>2026-05-24</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://frank-pilot-tenant.vercel.app/discover</loc>
-    <lastmod>2026-05-22</lastmod>
+    <lastmod>2026-05-24</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://frank-pilot-tenant.vercel.app/apply</loc>
-    <lastmod>2026-05-22</lastmod>
+    <lastmod>2026-05-24</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://frank-pilot-tenant.vercel.app/discover/aldene-kline-barlow-senior-apartments</loc>
-    <lastmod>2026-05-22</lastmod>
+    <loc>https://frank-pilot-tenant.vercel.app/property/aldene-kline-barlow-senior-apartments</loc>
+    <lastmod>2026-05-24</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://frank-pilot-tenant.vercel.app/discover/david-j-hoggard-family-community</loc>
-    <lastmod>2026-05-22</lastmod>
+    <loc>https://frank-pilot-tenant.vercel.app/property/david-j-hoggard-family-community</loc>
+    <lastmod>2026-05-24</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://frank-pilot-tenant.vercel.app/discover/donna-louise-apartments</loc>
-    <lastmod>2026-05-22</lastmod>
+    <loc>https://frank-pilot-tenant.vercel.app/property/donna-louise-apartments</loc>
+    <lastmod>2026-05-24</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://frank-pilot-tenant.vercel.app/discover/donna-louise-apartments-2</loc>
-    <lastmod>2026-05-22</lastmod>
+    <loc>https://frank-pilot-tenant.vercel.app/property/donna-louise-apartments-2</loc>
+    <lastmod>2026-05-24</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://frank-pilot-tenant.vercel.app/discover/luther-mack-jr-senior-apartments</loc>
-    <lastmod>2026-05-22</lastmod>
+    <loc>https://frank-pilot-tenant.vercel.app/property/luther-mack-jr-senior-apartments</loc>
+    <lastmod>2026-05-24</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://frank-pilot-tenant.vercel.app/discover/dr-paul-meacham-senior-community</loc>
-    <lastmod>2026-05-22</lastmod>
+    <loc>https://frank-pilot-tenant.vercel.app/property/dr-paul-meacham-senior-community</loc>
+    <lastmod>2026-05-24</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://frank-pilot-tenant.vercel.app/discover/ethel-mae-fletcher-apartments</loc>
-    <lastmod>2026-05-22</lastmod>
+    <loc>https://frank-pilot-tenant.vercel.app/property/ethel-mae-fletcher-apartments</loc>
+    <lastmod>2026-05-24</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://frank-pilot-tenant.vercel.app/discover/ethel-mae-robinson-senior-apartments</loc>
-    <lastmod>2026-05-22</lastmod>
+    <loc>https://frank-pilot-tenant.vercel.app/property/ethel-mae-robinson-senior-apartments</loc>
+    <lastmod>2026-05-24</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://frank-pilot-tenant.vercel.app/discover/mike-o-callaghan-legacy-apartments</loc>
-    <lastmod>2026-05-22</lastmod>
+    <loc>https://frank-pilot-tenant.vercel.app/property/mike-o-callaghan-legacy-apartments</loc>
+    <lastmod>2026-05-24</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://frank-pilot-tenant.vercel.app/discover/juan-garcia-garden-apartments</loc>
-    <lastmod>2026-05-22</lastmod>
+    <loc>https://frank-pilot-tenant.vercel.app/property/juan-garcia-garden-apartments</loc>
+    <lastmod>2026-05-24</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://frank-pilot-tenant.vercel.app/discover/louise-shell-senior-apartments</loc>
-    <lastmod>2026-05-22</lastmod>
+    <loc>https://frank-pilot-tenant.vercel.app/property/louise-shell-senior-apartments</loc>
+    <lastmod>2026-05-24</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://frank-pilot-tenant.vercel.app/discover/owens-senior-housing</loc>
-    <lastmod>2026-05-22</lastmod>
+    <loc>https://frank-pilot-tenant.vercel.app/property/owens-senior-housing</loc>
+    <lastmod>2026-05-24</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://frank-pilot-tenant.vercel.app/discover/sarann-knight-apartments</loc>
-    <lastmod>2026-05-22</lastmod>
+    <loc>https://frank-pilot-tenant.vercel.app/property/sarann-knight-apartments</loc>
+    <lastmod>2026-05-24</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://frank-pilot-tenant.vercel.app/discover/senator-harry-reid-senior-apartments</loc>
-    <lastmod>2026-05-22</lastmod>
+    <loc>https://frank-pilot-tenant.vercel.app/property/senator-harry-reid-senior-apartments</loc>
+    <lastmod>2026-05-24</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://frank-pilot-tenant.vercel.app/discover/senator-richard-bryan-senior-apartments</loc>
-    <lastmod>2026-05-22</lastmod>
+    <loc>https://frank-pilot-tenant.vercel.app/property/senator-richard-bryan-senior-apartments</loc>
+    <lastmod>2026-05-24</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://frank-pilot-tenant.vercel.app/discover/smith-williams-senior-apartments</loc>
-    <lastmod>2026-05-22</lastmod>
+    <loc>https://frank-pilot-tenant.vercel.app/property/smith-williams-senior-apartments</loc>
+    <lastmod>2026-05-24</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://frank-pilot-tenant.vercel.app/discover/yale-keyes-senior-apartments</loc>
-    <lastmod>2026-05-22</lastmod>
+    <loc>https://frank-pilot-tenant.vercel.app/property/yale-keyes-senior-apartments</loc>
+    <lastmod>2026-05-24</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>

--- a/client-tenant/scripts/generate-sitemap.mjs
+++ b/client-tenant/scripts/generate-sitemap.mjs
@@ -6,7 +6,7 @@
  * and emits a sitemap covering:
  *   - /              (Welcome)               priority 1.0, monthly
  *   - /discover      (browse)                priority 0.9, daily
- *   - /discover/{slug} for every property    priority 0.8, daily
+ *   - /property/{slug} for every property    priority 0.8, daily
  *   - /apply                                 priority 0.5, monthly
  *
  * Wired into the `build` npm script so the file regenerates pre-`vite build`.
@@ -124,7 +124,7 @@ export function buildSitemapXml({ fixtures, slugify, siteUrl, lastmod }) {
     const slug = slugify(p.name);
     lines.push(
       urlBlock({
-        loc: `${siteUrl}/discover/${slug}`,
+        loc: `${siteUrl}/property/${slug}`,
         lastmod,
         changefreq: PROPERTY_CHANGEFREQ,
         priority: PROPERTY_PRIORITY,

--- a/client-tenant/src/__tests__/generate-sitemap.test.ts
+++ b/client-tenant/src/__tests__/generate-sitemap.test.ts
@@ -48,11 +48,14 @@ describe('generate-sitemap', () => {
     expect(applyBlock[0]).toContain('<changefreq>monthly</changefreq>');
   });
 
-  it('includes every GPMG property slug at /discover/{slug}', () => {
+  it('includes every GPMG property slug at /property/{slug}', () => {
+    // Must match the React route (App.tsx `/property/:slug`) and the in-app
+    // PropertyList card link — `/discover/{slug}` has no route and redirects
+    // logged-out crawlers to /login, dropping the listing JSON-LD from the index.
     expect(GPMG_FIXTURES.length).toBe(17); // safety net for the fixture contract
     for (const p of GPMG_FIXTURES) {
       const slug = slugify(p.name);
-      expect(xml).toContain(`<loc>${SITE_URL}/discover/${slug}</loc>`);
+      expect(xml).toContain(`<loc>${SITE_URL}/property/${slug}</loc>`);
     }
   });
 
@@ -60,7 +63,7 @@ describe('generate-sitemap', () => {
     const sampleSlug = slugify(GPMG_FIXTURES[0]!.name);
     const block = xml.match(
       new RegExp(
-        `<url>\\s*<loc>https://[^/]+/discover/${sampleSlug}</loc>[\\s\\S]*?</url>`
+        `<url>\\s*<loc>https://[^/]+/property/${sampleSlug}</loc>[\\s\\S]*?</url>`
       )
     )!;
     expect(block[0]).toContain('<priority>0.8</priority>');

--- a/docs/demo-runbook.md
+++ b/docs/demo-runbook.md
@@ -50,12 +50,13 @@ The full applicant journey. Use this for operator demos.
 ### Setup
 
 - Browser at 1280×900 (matches CI smoke baseline). Fresh incognito session so the cookie banner fires.
-- Have `https://frank-pilot-tenant.vercel.app/` loaded in tab 1, `https://gpmglv.com/` loaded in tab 2.
+- Have `https://frank-pilot-tenant.vercel.app/welcome` loaded in tab 1, `https://gpmglv.com/` loaded in tab 2.
+  - ⚠️ Start on **`/welcome`**, NOT bare `/`. The root path is an auth gate — a cold (logged-out) visitor on `/` is redirected to `/login`. The AMI-calculator welcome lives at `/welcome`.
 - One real email you can receive — the magic-link is real (Resend wired in PR #53).
 
 ### The click path
 
-1. **Land on `/`** — Welcome page with the AMI calculator above-the-fold.
+1. **Land on `/welcome`** — Welcome page with the AMI calculator above-the-fold. (Bare `/` redirects logged-out visitors to `/login` — always open `/welcome` directly.)
    - Talking point: "Affordable housing applicants traditionally waste 20+ minutes filling out applications to find out at the end they're income-disqualified. We tell them in 10 seconds."
    - Punch in: household size `2`, gross annual income `$36,000`.
    - Output: `60% AMI` tier with green confirmation.
@@ -66,7 +67,7 @@ The full applicant journey. Use this for operator demos.
    - Sticky chip bar: `Type` (Family / Senior / Workforce), `City` (Las Vegas / etc.), `Studio`, `1BR`, `2BR`, `3BR`, `Available now`.
    - Each tile: photo placeholder, name, **rent range** (`Studio $747 · 1BR $995 · 2BR $1,194 · 3BR $1,380`), **`60% AMI` chip**, **availability badge** (`3 available` or `Fully leased`).
    - Talking point: "Their cards have a name and a photo. Ours surface rent and availability publicly — eligibility-disqualified applicants self-select out before they ever call the leasing office."
-   - Click into any tile (recommended: **Meacham Cove** or **Decatur Pines** — these have the cleanest 2BR availability for the 60% tier).
+   - Click into any tile (recommended: **Dr. Paul Meacham Senior Community** or **David J. Hoggard Family Community** — real GPMG fixture names; the prior "Meacham Cove"/"Decatur Pines" labels do not exist in the dataset).
    - **Optional map beat (`/discover?view=map`):** toggle the map view — ~352 clustered pins covering the whole state (335 statewide coverage + 17 live-availability properties). Click a pin → popup shows **AMI set-asides as chips** (e.g. `60%` `50%`) for 271 of the 352 markers, up from zero before the 2026-05-23 enrichment. On the 17 live-availability pins the popup also shows a green **`● N available now` badge** and the CTA flips to **`Apply now →`** (coverage-only pins stay `View / Apply →`); the CTA carries your active map filters through into the property page. Talking point: "Even properties we don't have live availability for, we surface their AMI set-aside tiers — statewide coverage, not just our 17 active listings."
 
 3. **PropertyDetail** — the disclosure beat.


### PR DESCRIPTION
## What

The sitemap advertised every property at `/discover/{slug}`, but the React route (`App.tsx`) and the in-app PropertyList card link are both **`/property/:slug`**. `/discover/{slug}` matches no route → SPA catch-all → logged-out crawlers get redirected to `/login`. Result: **all 17 property URLs in the sitemap were dead ends**, and Google never saw the `RealEstateListing` JSON-LD.

Surfaced during the GPMG demo dry run (the runbook's SEO beat opens `sitemap.xml`).

## Changes

- `client-tenant/scripts/generate-sitemap.mjs` — `/discover/${slug}` → `/property/${slug}` (+ header doc line)
- `client-tenant/src/__tests__/generate-sitemap.test.ts` — assert `/property/{slug}` (the test had encoded the bug); added a comment tying the path to the route + in-app link
- `client-tenant/public/sitemap.xml` — regenerated (`build` also regenerates via `npm run sitemap`, so prod self-heals on next deploy regardless)
- `docs/demo-runbook.md` — start URL is `/welcome` (bare `/` is an auth gate → `/login`); corrected recommended property names to real fixtures ("Dr. Paul Meacham Senior Community" / "David J. Hoggard Family Community")

## Verification

- `node scripts/generate-sitemap.mjs` → "17 properties + 3 static routes"; grep confirms **17 `/property/` URLs, zero stale `/discover/{slug}`**.
- Dry run confirmed `/property/dr-paul-meacham-senior-community` renders rent table + AMI disclosure + 1 JSON-LD block; `/discover/<slug>` does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)