### PR TITLE
feat(tenant): location mini-map on each property listing

### DIFF
--- a/client-tenant/public/property-minimap.html
+++ b/client-tenant/public/property-minimap.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Property location</title>
+<!--
+  Single-pin mini-map embedded as an iframe on the property detail page.
+  Deliberately self-contained (no build step, no shared JS) and matches the
+  /discover map (nv-housing-map.html): same pinned Leaflet 1.9.4 + warmed OSM
+  tiles. Reads the location from the query string so React stays the source of
+  truth for which property's coords to show:
+    property-minimap.html?lat=36.18&lng=-115.15&label=Name&type=family
+  Scroll-wheel zoom is OFF so scrolling the page over the map doesn't zoom it.
+-->
+<link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="" />
+<style>
+  :root{
+    --cream:#FBF7F0; --ink:#1F1A12; --ink3:#807866;
+    --accent:#C9492A; --sage:#5C7A4F; --warn:#9C6A18;
+    --body:'Inter',system-ui,-apple-system,Segoe UI,Roboto,sans-serif;
+  }
+  html,body{margin:0;height:100%;}
+  body{background:var(--cream);}
+  #map{position:absolute;inset:0;}
+  /* warm the OSM tiles toward cream so it reads as one piece with the app */
+  .leaflet-tile-pane{filter:sepia(.18) saturate(.85) brightness(1.04) contrast(.96);}
+  .leaflet-container{background:#e6ddc8;font-family:var(--body);}
+  /* teardrop pin, mirrors nv-housing-map.html */
+  .pin svg{display:block;width:100%;height:100%;
+    filter:drop-shadow(0 3px 5px rgba(31,26,18,.5));}
+  .pin svg path{stroke:#fff;stroke-width:1.3;paint-order:stroke fill;fill:var(--accent);}
+  .pin.senior svg path{fill:var(--sage);}
+  .pin.mixed  svg path{fill:var(--warn);}
+  .leaflet-popup-content-wrapper{border-radius:12px;}
+  .leaflet-popup-content{margin:9px 12px;font-family:var(--body);font-size:12.5px;color:var(--ink);}
+  .leaflet-popup-content b{display:block;font-weight:800;margin-bottom:2px;}
+  .leaflet-control-attribution{font-size:10px;background:rgba(251,247,240,.8);}
+</style>
+</head>
+<body>
+<div id="map"></div>
+<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
+<script>
+  var q = new URLSearchParams(location.search);
+  var lat = parseFloat(q.get('lat'));
+  var lng = parseFloat(q.get('lng'));
+  var label = q.get('label') || '';
+  var type = (q.get('type') || 'family').toLowerCase();
+
+  if (!isFinite(lat) || !isFinite(lng)) {
+    // No coords — leave the iframe blank; React only mounts it when coords exist.
+    document.getElementById('map').style.display = 'none';
+  } else {
+    var map = L.map('map', {
+      zoomControl: true,
+      scrollWheelZoom: false,   // don't hijack page scroll
+      attributionControl: true,
+    }).setView([lat, lng], 15);
+
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      maxZoom: 19, attribution: '&copy; OpenStreetMap'
+    }).addTo(map);
+
+    var pinSVG = '<svg width="34" height="34" viewBox="0 0 24 24"><path d="M12 0C7 0 3 4 3 9c0 6 9 15 9 15s9-9 9-15c0-5-4-9-9-9z"/><circle cx="12" cy="9" r="3.4" fill="#fff"/></svg>';
+    var icon = L.divIcon({
+      html: pinSVG, className: 'pin ' + type,
+      iconSize: [34, 34], iconAnchor: [17, 34], popupAnchor: [0, -32],
+    });
+    var marker = L.marker([lat, lng], { icon: icon }).addTo(map);
+    if (label) {
+      marker.bindPopup('<b>' + label.replace(/</g, '&lt;') + '</b>Approximate location', { closeButton: false });
+    }
+  }
+</script>
+</body>
+</html>

--- a/client-tenant/src/pages/discover/PropertyDetail.tsx
+++ b/client-tenant/src/pages/discover/PropertyDetail.tsx
@@ -1,8 +1,8 @@
-import { useMemo } from 'react';
+import { useMemo, useState, useEffect } from 'react';
 import { Link, useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { ArrowLeft } from 'lucide-react';
 import { useTranslation, Trans } from 'react-i18next';
-import { findGPMGBySlug, rentEstimate } from '@/api/gpmg-fixtures';
+import { findGPMGBySlug, rentEstimate, slugify } from '@/api/gpmg-fixtures';
 import { CTA } from '@/components/primitives';
 import { getToken } from '@/api/client';
 import { placeholderFor } from '@/utils/unitPlaceholder';
@@ -84,6 +84,35 @@ export function PropertyDetail() {
   // Fixture lookup is an array scan — memoize on slug so i18n-namespace loads
   // and searchParams churn don't re-scan the catalog on every render.
   const prop = useMemo(() => findGPMGBySlug(slug), [slug]);
+
+  // Coordinates for the location mini-map. The GPMG fixtures don't carry
+  // lat/lng — coords live in nv-gpmg-map-props.json, the same dataset the
+  // /discover map uses (single source of truth), keyed by slug. Fetched once
+  // per slug; the map section only renders when a match is found.
+  const [coords, setCoords] = useState<{ lat: number; lng: number } | null>(null);
+  useEffect(() => {
+    if (!slug) return;
+    let cancelled = false;
+    fetch('/nv-gpmg-map-props.json')
+      .then((r) => (r.ok ? r.json() : Promise.reject(r.status)))
+      .then((rows: Array<{ slug?: string; name?: string; lat?: number; lng?: number }>) => {
+        if (cancelled) return;
+        const hit = rows.find(
+          (r) => r.slug === slug || (r.name != null && slugify(r.name) === slug),
+        );
+        if (hit && typeof hit.lat === 'number' && typeof hit.lng === 'number') {
+          setCoords({ lat: hit.lat, lng: hit.lng });
+        } else {
+          setCoords(null);
+        }
+      })
+      .catch(() => {
+        /* dataset unavailable → no map, no error surfaced */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [slug]);
 
   // Preserve a deep-linked amiTier when bouncing to /apply so the W0 funnel
   // continues to know the applicant's tier. Validated against the same set
@@ -297,6 +326,84 @@ export function PropertyDetail() {
               </span>
             </div>
           </header>
+
+          {/* Location mini-map. Renders only when we have coords for this slug
+              (from nv-gpmg-map-props.json). Embedded as an iframe — same Leaflet
+              + warmed-OSM stack as the /discover map, no map dep in the bundle.
+              "Approximate location" + a directions link keep it honest. */}
+          {coords && (
+            <section
+              data-testid="property-minimap"
+              style={{
+                marginTop: 24,
+                background: HF.paper,
+                border: `1px solid ${HF.border}`,
+                borderRadius: HF.r.md,
+                overflow: 'hidden',
+                boxShadow: HF.shadow.xs,
+              }}
+            >
+              <div
+                style={{
+                  display: 'flex',
+                  alignItems: 'baseline',
+                  justifyContent: 'space-between',
+                  gap: 12,
+                  padding: '14px 16px 10px',
+                }}
+              >
+                <h2
+                  style={{
+                    fontFamily: HF.display,
+                    fontWeight: 700,
+                    fontSize: 14,
+                    color: HF.ink2,
+                    textTransform: 'uppercase',
+                    letterSpacing: '0.05em',
+                    margin: 0,
+                  }}
+                >
+                  Location
+                </h2>
+                <a
+                  href={`https://www.google.com/maps/search/?api=1&query=${coords.lat},${coords.lng}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  style={{
+                    fontSize: 13,
+                    fontWeight: 700,
+                    color: HF.accent,
+                    textDecoration: 'none',
+                    whiteSpace: 'nowrap',
+                  }}
+                >
+                  Directions ↗
+                </a>
+              </div>
+              <iframe
+                title={`Map of ${prop.name}`}
+                src={`/property-minimap.html?lat=${coords.lat}&lng=${coords.lng}&type=${prop.type}&label=${encodeURIComponent(prop.name)}`}
+                loading="lazy"
+                style={{
+                  display: 'block',
+                  width: '100%',
+                  height: 200,
+                  border: 'none',
+                }}
+              />
+              <p
+                style={{
+                  margin: 0,
+                  padding: '8px 16px 12px',
+                  fontSize: 12,
+                  color: HF.ink3,
+                  fontFamily: HF.body,
+                }}
+              >
+                {prop.addr} · {prop.city}, NV {prop.zip} · approximate location
+              </p>
+            </section>
+          )}
 
           {/* Wedge #9 — Rent & AMI disclosure (the gpmglv differentiator).
               Honest, public, per-bedroom rent figures + the 60% AMI set-


### PR DESCRIPTION
## What
Adds a single-pin **location mini-map** to each property detail page, slotted between the photo hero and the Rent & AMI disclosure.

## How
- **`public/property-minimap.html`** — self-contained single-pin map reusing the `/discover` stack exactly: Leaflet 1.9.4 + warmed OSM tiles, same cream sepia filter and teardrop pin. Embedded as an iframe, so **no map dependency enters the tenant bundle**. Reads `?lat=&lng=&label=&type=` from the query string (React stays the source of truth for *which* property).
- **PropertyDetail** looks up coords by slug from `nv-gpmg-map-props.json` — the same dataset the discover map uses (single source of truth; the GPMG fixtures themselves carry no lat/lng). Section renders **only on a coord match**, so off-catalog properties degrade to no-map rather than an empty frame.

## Honest by design
- Scroll-wheel zoom disabled → scrolling the page over the map doesn't hijack into a zoom.
- Pin popup + caption both read **"approximate location"**.
- **"Directions ↗"** link opens the coordinates in Google Maps.

## Verify
- `tsc --noEmit` clean; 244 vitest tests green.
- Screenshotted David J. Hoggard Family Community: pin centered on W Monroe Ave, cream-warmed tiles matching the app, LOCATION header + Directions link + address caption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)