### PR TITLE
feat(discover): mini-map on list cards + representative photo in map popup

### DIFF
--- a/client-tenant/public/nv-housing-map.html
+++ b/client-tenant/public/nv-housing-map.html
@@ -93,6 +93,13 @@
   /* Popup */
   .leaflet-popup-content-wrapper{border-radius:14px;box-shadow:var(--sh-md);}
   .leaflet-popup-content{margin:14px 16px;font-family:var(--body);min-width:210px;}
+  /* Representative photo banner — full-bleed to the popup edges, rounded to
+     match the wrapper's top corners. The negative margins cancel the
+     .leaflet-popup-content 14/16px padding. */
+  .pop .pop-photo{position:relative;height:104px;margin:-14px -16px 11px;border-radius:14px 14px 0 0;
+    background:var(--sageLo) center/cover no-repeat;}
+  .pop .pop-photo-tag{position:absolute;left:8px;bottom:8px;padding:2px 7px;border-radius:6px;
+    background:rgba(31,26,18,.6);color:#fff;font-size:9.5px;font-weight:600;letter-spacing:.01em;}
   .pop h4{font-family:var(--display);font-weight:800;font-size:15px;margin:0 0 2px;color:var(--ink);}
   .pop .addr{font-size:12px;color:var(--ink3);margin:0 0 9px;}
   .pop .row{font-size:12.5px;color:var(--ink2);margin:3px 0;}
@@ -158,6 +165,16 @@
 // kebab-case a property name into a URL slug (matches gpmg-fixtures.ts slugify).
 function slugify(name){
   return String(name||'').toLowerCase().replace(/[^a-z0-9]+/g,'-').replace(/^-+|-+$/g,'');
+}
+// Representative photos — mirror src/utils/unitPlaceholder.ts (same set + FNV-1a
+// pick on the slug) so a property shows the SAME fallback image here, on the
+// /discover cards, and on its detail page. Labelled "Representative photo".
+var PROPERTY_PLACEHOLDERS=['/property-placeholders/building-01.jpg','/property-placeholders/building-02.jpg','/property-placeholders/building-03.jpg','/property-placeholders/building-04.jpg','/property-placeholders/building-05.jpg','/property-placeholders/building-06.jpg'];
+function placeholderFor(seed){
+  if(seed==null||seed==='') return PROPERTY_PLACEHOLDERS[0];
+  var s=String(seed),h=2166136261;
+  for(var i=0;i<s.length;i++){h^=s.charCodeAt(i);h=Math.imul(h,16777619);}
+  return PROPERTY_PLACEHOLDERS[(h>>>0)%PROPERTY_PLACEHOLDERS.length];
 }
 // Populated live from /api/applicants/properties/map at boot.
 let PROPS = [];
@@ -252,7 +269,8 @@ function popupHTML(p){
     : '<b>—</b>';
   const fund = p.funding.length ? p.funding.join(', ') : 'Not specified';
   const ctaLabel = hasAvail ? 'Apply now &rarr;' : 'View / Apply &rarr;';
-  return `<div class="pop"><h4>${p.name}</h4>`
+  const photo = placeholderFor(p.slug || slugify(p.name));
+  return `<div class="pop"><div class="pop-photo" style="background-image:url('${photo}')"><span class="pop-photo-tag">Representative photo</span></div><h4>${p.name}</h4>`
     + (hasAvail?`<div class="pop-avail">&#9679; <b>${p.availableUnits}</b> available now</div>`:'')
     + (p.aka?`<div class="addr">aka ${p.aka}</div>`:'')
     + `<div class="addr">${p.address}</div>`

--- a/client-tenant/public/property-minimap.html
+++ b/client-tenant/public/property-minimap.html
@@ -47,16 +47,26 @@
   var lng = parseFloat(q.get('lng'));
   var label = q.get('label') || '';
   var type = (q.get('type') || 'family').toLowerCase();
+  // ui=min: a static, non-interactive thumbnail for the /discover cards. All
+  // gestures + the zoom control are off so the surrounding card stays a single
+  // tap-target (the card also sets pointer-events:none on the iframe). OSM
+  // attribution stays on — it's required by the tile usage policy.
+  var minimal = (q.get('ui') || '').toLowerCase() === 'min';
 
   if (!isFinite(lat) || !isFinite(lng)) {
     // No coords — leave the iframe blank; React only mounts it when coords exist.
     document.getElementById('map').style.display = 'none';
   } else {
     var map = L.map('map', {
-      zoomControl: true,
+      zoomControl: !minimal,
       scrollWheelZoom: false,   // don't hijack page scroll
       attributionControl: true,
-    }).setView([lat, lng], 15);
+      dragging: !minimal,
+      doubleClickZoom: !minimal,
+      boxZoom: !minimal,
+      keyboard: !minimal,
+      touchZoom: !minimal,
+    }).setView([lat, lng], minimal ? 14 : 15);
 
     L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
       maxZoom: 19, attribution: '&copy; OpenStreetMap'
@@ -68,7 +78,7 @@
       iconSize: [34, 34], iconAnchor: [17, 34], popupAnchor: [0, -32],
     });
     var marker = L.marker([lat, lng], { icon: icon }).addTo(map);
-    if (label) {
+    if (label && !minimal) {
       marker.bindPopup('<b>' + label.replace(/</g, '&lt;') + '</b>Approximate location', { closeButton: false });
     }
   }

--- a/client-tenant/src/pages/discover/PropertyList.tsx
+++ b/client-tenant/src/pages/discover/PropertyList.tsx
@@ -401,6 +401,36 @@ export function PropertyList() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [viewMode, typeFilter, cityFilter, availableNow]);
 
+  // Card mini-maps: a single fetch of the committed coords snapshot (the same
+  // /nv-gpmg-map-props.json the map iframe reads), keyed by slug, so each list
+  // card can render a small non-interactive locator without a per-card request.
+  // Cards whose slug has no coords simply omit the map.
+  const [coordsBySlug, setCoordsBySlug] = useState<
+    Record<string, { lat: number; lng: number }>
+  >({});
+  useEffect(() => {
+    let alive = true;
+    fetch('/nv-gpmg-map-props.json')
+      .then((r) => (r.ok ? r.json() : Promise.reject(r.status)))
+      .then(
+        (rows: Array<{ slug?: string; name?: string; lat?: number; lng?: number }>) => {
+          if (!alive) return;
+          const m: Record<string, { lat: number; lng: number }> = {};
+          for (const row of rows) {
+            if (typeof row.lat !== 'number' || typeof row.lng !== 'number') continue;
+            const coords = { lat: row.lat, lng: row.lng };
+            if (row.slug) m[row.slug] = coords;
+            if (row.name) m[slugify(row.name)] = coords;
+          }
+          setCoordsBySlug(m);
+        },
+      )
+      .catch(() => {});
+    return () => {
+      alive = false;
+    };
+  }, []);
+
   useEffect(() => {
     // Authed users still get the live catalog warm-fetched so cached
     // responses are ready for downstream pages (intent/pick).
@@ -758,7 +788,7 @@ export function PropertyList() {
 
         <ul className="grid grid-cols-1 gap-4 sm:grid-cols-2" data-testid="property-grid">
           {filtered.map((p) => (
-            <PropertyTile key={p.name} prop={p} />
+            <PropertyTile key={p.name} prop={p} coords={coordsBySlug[p.slug]} />
           ))}
         </ul>
           </>
@@ -810,7 +840,13 @@ function AvailabilityBadge({ availableCount }: { availableCount: number }) {
   );
 }
 
-function PropertyTile({ prop }: { prop: TileSource }) {
+function PropertyTile({
+  prop,
+  coords,
+}: {
+  prop: TileSource;
+  coords?: { lat: number; lng: number };
+}) {
   const { t } = useTranslation('discover');
   const { slug, availability, rentRange, amiTier } = prop;
 
@@ -843,6 +879,27 @@ function PropertyTile({ prop }: { prop: TileSource }) {
             }}
             aria-hidden="true"
           />
+          {coords && (
+            <iframe
+              title={`Map — ${prop.name}`}
+              loading="lazy"
+              src={`/property-minimap.html?lat=${coords.lat}&lng=${coords.lng}&type=${prop.type}&label=${encodeURIComponent(
+                prop.name,
+              )}&ui=min`}
+              data-testid={`property-tile-minimap-${slug}`}
+              style={{
+                display: 'block',
+                width: '100%',
+                height: 116,
+                border: 'none',
+                borderTop: `1px solid ${HF.border}`,
+                // Non-interactive: clicks/drags fall through to the card Link so
+                // the whole tile stays one tap-target (map is a locator only).
+                pointerEvents: 'none',
+              }}
+              aria-hidden="true"
+            />
+          )}
           <div style={{ padding: 16 }}>
             <h2
               style={{

--- a/client-tenant/src/pages/discover/PropertyList.tsx
+++ b/client-tenant/src/pages/discover/PropertyList.tsx
@@ -886,7 +886,7 @@ function PropertyTile({
               src={`/property-minimap.html?lat=${coords.lat}&lng=${coords.lng}&type=${prop.type}&label=${encodeURIComponent(
                 prop.name,
               )}&ui=min`}
-              data-testid={`property-tile-minimap-${slug}`}
+              data-testid={`minimap-${slug}`}
               style={{
                 display: 'block',
                 width: '100%',


### PR DESCRIPTION
## What
Two discover-surface parity additions requested back-to-back:

1. **Mini-map on each list card** (`/discover?view=list`) — under the representative building photo, every card now shows a small location locator.
2. **Representative photo in the map-view marker popup** (`/discover?view=map`) — the popup gains the same building photo banner the cards/detail page use.

## How (zero new bundle deps — reuses self-hosted assets)
- **Cards:** coords come from a *single* fetch of the committed `/nv-gpmg-map-props.json` (keyed by slug) at the list level — no per-card request. Cards without coords omit the map. The locator reuses `property-minimap.html` with a new `?ui=min` variant (drag/zoom/scroll gestures + zoom control off) and `pointer-events:none`, so the whole card stays a single tap-target to the detail page. `loading="lazy"` defers offscreen maps.
- **Popup:** photo selection mirrors `src/utils/unitPlaceholder.ts` (same 6-image set + FNV-1a pick on the slug), so a property shows the **identical** fallback image across cards, popup, and detail page. Banner is labelled **"Representative photo"** (fair-housing honesty, same as the other surfaces).

## Verify
- `tsc --noEmit` clean, `vite build` clean, discover vitest 36/36 pass.
- Local preview screenshots confirmed: cards render photo + sage/accent pin locator; map popup renders the photo banner.
- OSM attribution kept on the `ui=min` thumbnail (tile usage policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)