### PR TITLE
feat(housing-qa): grounded Q&A agent over property DB + application flow

### DIFF
--- a/tools/housing-qa/README.md
+++ b/tools/housing-qa/README.md
@@ -1,0 +1,110 @@
+# Frank-Pilot Housing Q&A Agent (`tools/housing-qa/`)
+
+A grounded, citation-first Q&A agent for the Frank-Pilot CDPC affordable-housing
+platform. It answers applicant questions about properties, eligibility, fees, and
+the application flow — strictly from real data and product copy, never from
+general knowledge.
+
+Self-contained, pure stdlib (`json`, `re`, `difflib`). No pip dependencies, no
+network calls in dry-run.
+
+## Files
+
+| File | Role |
+|------|------|
+| `retriever.py` | Loads both datasets, builds the normalized merged index, classifies the question, and emits the grounded context payload. |
+| `faq.md` | The 10-section FAQ with stable anchors (`#fees`, `#documents`, …). The retriever keyword-matches sections; the agent cites them. |
+| `system_prompt.md` | System prompt: grounding + refusal + fair-housing guardrails, citation format, and a `{{CONTEXT_JSON}}` injection point. |
+| `runner.py` | Thin runner: question → context → assembled prompt → model. Pluggable backend; `--dry-run` makes no calls. |
+| `examples.md` | 10 worked Q&A pairs (data lookups, process, 3 refusals) with citations. |
+| `README.md` | This file. |
+
+## How it works
+
+1. **Datasets** (read at repo-relative paths):
+   - Base: `client-tenant/public/nv-housing-props.json` — 335 statewide HUD-LIHTC
+     properties (this copy has enriched `amiTiers`, 254/335). Falls back to
+     `src/db/data/nv-housing-props.json`.
+   - Availability: `docs/intel/gpmglv-properties-extracted.json` — 17 GPMG
+     "available-now" properties under the `properties` key.
+2. **Merge:** each statewide record is normalized to the locked contract shape.
+   Each of the 17 GPMG records is matched to a statewide record by normalized-name
+   token overlap (+ proximity/city tiebreak); on match it enriches that record and
+   flips `availability.status="available_now"`. Unmatched GPMG records are added
+   standalone. Statewide-only records keep null contact/rent/amenities.
+3. **Classify + route** (`classify`): `named_property` → 1 full object;
+   `city` / `attribute` → up to K=8 compact summaries; `process` → no property
+   objects, FAQ sections only.
+4. **Assemble payload:** matched property object(s) + keyword-matched FAQ
+   section(s) + always-on facts (fee, 120-day rule, document checklist) + retrieval
+   `notes` (including refusal flags for statewide-only or unknown properties).
+
+## Run it
+
+```bash
+# Smoke-test the retriever (5 sample questions, one per routing branch):
+python3 tools/housing-qa/retriever.py
+
+# Dry run — assemble + print the full prompt, NO model call, NO network:
+python3 tools/housing-qa/runner.py --dry-run "What documents do I need to apply?"
+
+# Inspect just the retrieved context payload:
+python3 tools/housing-qa/runner.py --context-only "senior housing in Henderson"
+
+# Live answer (requires a model backend on PATH; see below):
+python3 tools/housing-qa/runner.py "Tell me about Owens Senior Housing"
+echo "How much is the application fee?" | python3 tools/housing-qa/runner.py
+```
+
+## Wiring into the token engine
+
+The model call is isolated in **`runner.call_model(system, user)`** — the single
+integration point. By default it shells out to the headless Claude CLI:
+
+```
+claude -p "<system prompt with injected context>\n\n=== USER QUESTION ===\n<question>"
+```
+
+This is the OpenClaw path: a `claude_cli_proxy.py`-style shim, if installed,
+transparently intercepts the same `claude` invocation. Override the binary with
+`HOUSING_QA_CLI=<cmd>`. To use a different backend (Anthropic SDK, an OpenClaw
+HTTP endpoint, a local model), replace the body of `call_model` — the contract is
+just `call_model(system: str, user: str) -> str`.
+
+If no backend is found, `call_model` returns a clear message and suggests
+`--dry-run`. Dry-run never touches the network.
+
+## NOTE — upgrading to live tool-calling
+
+Today the agent uses **pre-injected context**: the runner calls the retriever
+*before* the model and bakes the results into the system prompt. This is
+deliberate.
+
+A more flexible design would let the model call the retriever as a **tool**
+mid-conversation (so it can ask follow-ups, e.g. "now filter those by 1BR"). That
+requires the LLM call to forward an OpenAI-style `tools` array to the model.
+
+**The current OpenClaw shim does NOT support this.** `claude_cli_proxy.py`
+silently drops the `tools` array — only the inner `claude -p` runs, and any tool
+definitions are discarded. So tool-calling would be a no-op until the shim is
+rebuilt to forward `tools`. Until then, **pre-injected context is the only
+working path**, which is exactly what this runner implements.
+
+## Data caveats baked into the agent
+
+These came from inspecting the real data — the FAQ and refusal examples account
+for each:
+
+- **Rent is never disclosed** (`rent.disclosed=false` for all 17 GPMG records and
+  absent statewide). The agent always refuses rent and cites the caveat.
+- **`available_units_count` is null for all 17** GPMG properties — "available now"
+  is a status, not a count.
+- **`ami_disclosed` is false for all 17 GPMG** records (no `ami_text`); AMI tiers
+  come only from the statewide base (254/335 populated; the rest are null).
+- **Pet policy is null for all 17.** **Email present for only 2 of 17**;
+  **application_url null for all 17** (waitlist_url present for all 17).
+- **Bedroom/unit-type data exists only for the 17 available-now** properties; the
+  335 statewide records have no bedroom-level data.
+- **Statewide-only properties have no contact, amenities, accessibility, office
+  hours, or availability count** — only name, city, address, unit totals, type,
+  AMI tiers, funding. The agent refuses those fields and points to /discover.

--- a/tools/housing-qa/examples.md
+++ b/tools/housing-qa/examples.md
@@ -1,0 +1,181 @@
+# Example Q&A — Frank-Pilot Housing Agent (grounded, with citations)
+
+Each example shows: the **question**, the **retrieved context summary** (what the
+retriever injects), and the **ideal grounded answer** the agent should produce.
+Two examples are deliberate **"I don't have that" refusals**. All values are real,
+pulled from the live data via `retriever.build_context()`.
+
+---
+
+## 1. Named property — available-now (data lookup)
+
+**Q:** "Tell me about Owens Senior Housing."
+
+**Retrieved context:** `routing=named_property`, `propertyMode=full`. One property:
+Owens Senior — North Las Vegas — type Senior — `availability.status=available_now`
+(asOf 2026-05-22) — phone `(702) 642-0896` — waitlistUrl present — unitTypes
+`["1BR","2BR","Studio"]` — amiTiers `["50%","40%"]` — accessibility "ADA
+accommodations available; Elevator access; Equal Housing Opportunity" — `rent.disclosed=false`.
+
+**Ideal answer:**
+> Owens Senior is a senior community in North Las Vegas (Owens Senior — type) and
+> it's in our available-now set as of the latest data (Owens Senior — availability).
+> It offers Studio, 1BR, and 2BR units (Owens Senior — unitTypes), with restricted
+> units at the 40% and 50% AMI tiers (Owens Senior — amiTiers). It lists ADA
+> accommodations and elevator access (Owens Senior — accessibility).
+> I don't have a rent figure for it — rent isn't disclosed in our data; confirm in
+> the application (FAQ §rent-availability-caveat). You can reach them at
+> (702) 642-0896 or join the waitlist via their link (Owens Senior — phone/waitlist).
+
+---
+
+## 2. Named property — REFUSAL (statewide-only, no contact/pet/rent)
+
+**Q:** "What's the pet policy at Silver Pines Apts?"
+
+**Retrieved context:** `routing=named_property`, `propertyMode=full`. Silver Pines
+Apts — Las Vegas — Family — `availability.status=statewide_only` — amiTiers
+`["60%","50%"]` — `petPolicy=null`, `contact.phone=null`, `rent.disclosed=false`.
+Note: statewide-only → refuse missing fields.
+
+**Ideal answer:**
+> I don't have the pet policy for Silver Pines Apts — here's how to find out. It's
+> in our statewide HUD-LIHTC dataset, which only includes its name, city, AMI tiers
+> (60%/50%), and unit totals (Silver Pines Apts — statewide). It has no contact or
+> pet-policy info in our data. To get the pet policy, reach the property directly —
+> find it on the /discover map and contact the manager (FAQ §contact).
+
+---
+
+## 3. City filter (compact list)
+
+**Q:** "Can I get a unit in Las Vegas?"
+
+**Retrieved context:** `routing=city`, `propertyMode=compact`. Up to 8 compact
+summaries for Las Vegas, available-now first; FAQ §finding-a-unit.
+
+**Ideal answer:**
+> Yes — Las Vegas has many affordable properties in our data. A few examples
+> (available-now ones first): [list 3–4 by name, city, type, AMI tier, and whether
+> they're available now] (city results). The available-now ones have current
+> contact info; statewide-only ones we only have basic details for, as of the
+> latest data (FAQ §finding-a-unit). To see real units and claim one, head to the
+> Pick step in the application or browse the /discover map.
+
+---
+
+## 4. Attribute filter — senior + city (compact list)
+
+**Q:** "What senior housing is available in Henderson?"
+
+**Retrieved context:** `routing=attribute` (type=senior, city=Henderson),
+`propertyMode=compact`. Note: "19 matches in Henderson; showing first 8."
+First result: Smith Williams Apts (Henderson) [available_now] Senior.
+
+**Ideal answer:**
+> In Henderson we have senior properties including Smith Williams Apts, which is in
+> our available-now set (attribute results). Most Henderson senior properties are
+> statewide-only, meaning we have their name, AMI tiers, and address but not live
+> availability or contact (FAQ §finding-a-unit). Availability is as of the latest
+> data — confirm in the application (FAQ §rent-availability-caveat). Want me to
+> point you to the Pick step to see claimable units?
+
+---
+
+## 5. Process — documents (no property)
+
+**Q:** "What documents do I need to apply?"
+
+**Retrieved context:** `routing=process`, `propertyMode=none`. FAQ §documents,
+§application-steps. Facts: documentsNeeded list.
+
+**Ideal answer:**
+> You'll need (document checklist): a government-issued photo ID; proof of income
+> (last 2 pay stubs or an offer letter); your SSN or ITIN; two prior landlord
+> references from the last 3 years; and your household composition (everyone moving
+> in). At the Confirm step you upload these as 5 files, dated within the last 120
+> days (FAQ §documents). Have them ready before you start.
+
+---
+
+## 6. Process — fees
+
+**Q:** "How much is the application fee and is it refundable?"
+
+**Retrieved context:** `routing=process`, `propertyMode=none`. FAQ §fees. Facts:
+applicationFee = $35.95 per adult 18+, non-refundable.
+
+**Ideal answer:**
+> The application fee is $35.95 per adult 18+ (application fee). It's
+> non-refundable, and paying it locks your spot on the waitlist; it covers credit
+> and background checks (FAQ §fees). Each adult 18+ in the household pays their own
+> fee and signs.
+
+---
+
+## 7. Process — eligibility (general only, no personal ruling)
+
+**Q:** "I make $40,000 a year — do I qualify?"
+
+**Retrieved context:** `routing=process`, `propertyMode=none`. FAQ §who-its-for.
+
+**Ideal answer:**
+> I can't tell you personally whether you qualify — the application verifies that
+> (FAQ §who-its-for). Here's how it works: affordable units target income tiers
+> like 30%–60% of Area Median Income. During the Intent step you can enter your
+> gross annual income and the app shows which tiers you *might* qualify for — that's
+> a pre-qualification estimate only, not a decision. If you're over the limits, the
+> app notes that market-rate units may still fit. The property makes the official
+> determination when it reviews your documents.
+
+---
+
+## 8. Waitlist & queue position
+
+**Q:** "How does the waitlist work and how long does my application stay active?"
+
+**Retrieved context:** `routing=process`, `propertyMode=none`. FAQ §waitlists.
+Facts: rule120.
+
+**Ideal answer:**
+> When you pay your application fee, your spot on the waitlist is locked and you get
+> a queue position (FAQ §waitlists). Your application stays active for 120 days; if
+> we can't house you in that window, you'll be invited to refresh and continue
+> (120-day rule). You can check your position from the Confirm step or your
+> dashboard. Exact wait times aren't predictable and aren't in our data.
+
+---
+
+## 9. REFUSAL — unknown property (not in any dataset)
+
+**Q:** "Tell me about Moonbeam Towers."
+
+**Retrieved context:** `routing=process`, `propertyMode=none`. Note: "Moonbeam
+Towers" is NOT in the statewide or available-now data — refuse, don't invent.
+
+**Ideal answer:**
+> I don't have a property called Moonbeam Towers in our data — here's how to find
+> out. Our list covers Nevada LIHTC properties and a current available-now set, and
+> nothing matches that name. Try the /discover map to search by city or type, or
+> tell me a city and I'll list what we do have (FAQ §finding-a-unit). I won't guess
+> at details for a property I can't find.
+
+---
+
+## 10. Rent — caveat / refusal
+
+**Q:** "What's the monthly rent at Aldene Kline Senior Community?"
+
+**Retrieved context:** `routing=named_property`, `propertyMode=full`. Aldene Kline
+Senior Community — Las Vegas — senior — available_now — `rent.disclosed=false`,
+`rent.text=null` — office hours "Mon–Sat 9a–6p • Sun by appt." — phone
+`(702) 920-6550`.
+
+**Ideal answer:**
+> I don't have a rent figure for Aldene Kline Senior Community — rent isn't
+> disclosed in our data for any property (Aldene Kline — rent / FAQ
+> §rent-availability-caveat). I can tell you it's an available-now senior community
+> in Las Vegas with Studio/1BR/2BR units, and you can ask them directly at
+> (702) 920-6550 during their office hours, Mon–Sat 9a–6p (Aldene Kline —
+> phone/officeHours). Rent and current availability are best confirmed in the
+> application.

--- a/tools/housing-qa/faq.md
+++ b/tools/housing-qa/faq.md
@@ -1,0 +1,202 @@
+# Frank-Pilot CDPC — Affordable Housing FAQ
+
+Grounding source for the housing Q&A agent. Every fact below is drawn from the
+real application copy (`client-tenant/src/i18n/en/apply.json`), the apply flow
+(`client-tenant/src/pages/apply/steps/`), and the two property datasets. Section
+IDs are stable anchors so the retriever can keyword-match and the agent can cite
+them (e.g. "see FAQ §fees" / `faq.md#fees`).
+
+All numbers, fees, and rules here are quoted from product copy — do not invent
+values not present in this doc or the injected property data.
+
+---
+
+<a id="who-its-for"></a>
+## 1. Who affordable housing is for / AMI tiers {#who-its-for}
+
+Affordable (LIHTC) housing serves households whose income falls at or below a
+share of the **Area Median Income (AMI)** for the area. Properties set aside
+units for specific AMI tiers — commonly **30%, 40%, 45%, 50%, and 60% of AMI**.
+A property's tiers tell you the income bands its restricted units target.
+
+- Each property in our data lists its `amiTiers` (e.g. `["60%","50%"]`) when
+  known. AMI tiers are populated for most statewide properties; some have no
+  tier data recorded.
+- During the application's **Intent** step you can optionally enter your **gross
+  annual income**. The app then shows which tiers you *might* qualify for
+  ("You qualify for {tier} units"). If you're over the income limits, it says
+  "Over income for affordable tiers. Market-rate units may still fit."
+- This is a **pre-qualification estimate only** — it is never a personal ruling.
+  The official income determination happens when the property verifies your
+  documents.
+
+> Eligibility rules are general. The application verifies whether you qualify —
+> the agent never tells you that you personally do or do not qualify.
+
+---
+
+<a id="application-steps"></a>
+## 2. The application steps {#application-steps}
+
+The apply flow runs in this order:
+
+1. **Register** — create your account (name, email, optional phone).
+2. **Verify** — confirm your email via a magic link (sent by **email or SMS**).
+3. **Intent** — tell us what you're looking for: bedrooms, monthly budget,
+   target move-in date, household size, and (optional) gross annual income for
+   AMI pre-qualification.
+4. **Pick** — choose a unit. Claiming a unit **holds it for you for 48 hours**
+   while you finish.
+5. **Household** — confirm how many adults (18+) will live there. Each adult
+   pays the fee and signs.
+6. **Payment** — pay the application fee securely (see §fees).
+7. **Review** — confirm the property, unit, and your locked criteria before
+   paying.
+8. **Confirm** — your application is started; next steps come by email and SMS.
+9. **Claim** — your claimed unit is held while you complete the application.
+
+After confirming you'll **upload your documents (5 files, < 120 days old)** —
+see §documents and §after-you-apply.
+
+---
+
+<a id="documents"></a>
+## 3. Documents you'll need {#documents}
+
+Have these ready before you apply (the checklist step lists them):
+
+- **Government-issued photo ID**
+- **Proof of income** — last 2 pay stubs or an offer letter
+- **Social Security Number or ITIN**
+- **Two prior landlord references** — covering the last 3 years
+- **Household composition** — everyone moving in
+
+At the Confirm step you'll **upload your documents (5 files, < 120 days old)**.
+Documents must be recent (dated within the last 120 days).
+
+---
+
+<a id="fees"></a>
+## 4. Fees {#fees}
+
+- The application fee is **$35.95 per adult 18+**.
+- The fee is **non-refundable**.
+- Paying it **locks your spot on the waitlist** ("Your spot is locked when you
+  pay").
+- The fee **covers credit and background checks**.
+- Each adult 18+ in the household must pay their own fee and sign.
+
+There is no other fee disclosed in the application flow. If asked about deposits,
+monthly rent, or other charges, see §rent-availability-caveat — those are set by
+the property and not in our data.
+
+---
+
+<a id="waitlists"></a>
+## 5. Waitlists & queue position + 120-day rule {#waitlists}
+
+- When you pay your fee, your **spot on the waitlist is locked** and you get a
+  **queue position** (shown on the Confirm step and your dashboard; a "Check
+  your position" link is provided).
+- **120-day rule:** your application stays **active for 120 days**. If we can't
+  house you within that window, you'll be invited to **refresh and continue**.
+- If no units match your preferences right now, you can **join the waitlist
+  instead** from the Pick step.
+
+Exact wait times are not predictable and are not in our data — position depends
+on the property and unit availability.
+
+---
+
+<a id="finding-a-unit"></a>
+## 6. Finding a unit (available-now vs statewide; search by BR / budget / move-in) {#finding-a-unit}
+
+There are two layers of property data:
+
+- **Available now (17 properties, GPMG-managed):** these have current contact
+  info, office hours, amenities, accessibility details, unit types, photos, and
+  waitlist links. They are marked `availability.status = "available_now"`.
+- **Statewide (335 HUD-LIHTC properties):** the full Nevada LIHTC universe.
+  These are marked `availability.status = "statewide_only"` and have **no rent,
+  contact, amenities, availability count, or pet policy** in our data — only
+  name, city, address, unit totals, type, AMI tiers, and funding.
+
+You can search/filter by:
+
+- **City / area** (e.g. Las Vegas, North Las Vegas, Henderson, Reno).
+- **Type** — Senior, Family, or Mixed.
+- **AMI tier** — e.g. 50%, 60%.
+- **Available now** — only the 17 GPMG properties.
+- **Bedrooms** — bedroom/unit-type data exists **only** for the 17 available-now
+  properties (via their `unitTypes`, e.g. `["1BR","2BR","Studio"]`). Statewide
+  properties have no bedroom-level data.
+- **Budget / monthly rent** — rent is **not disclosed** in either dataset, so we
+  can't filter by price; budget is captured at Intent and used by the live unit
+  picker, not by this FAQ data.
+
+To browse units, use the **/discover** map and the apply flow's **Pick** step.
+
+---
+
+<a id="after-you-apply"></a>
+## 7. After you apply (PM review, recertification, next steps) {#after-you-apply}
+
+Once your application is submitted and paid:
+
+1. **Upload your documents** (5 files, < 120 days old).
+2. A **Property Manager reviews your application in 2–3 business days**.
+3. You **sign your lease & addenda via DocuSign**.
+
+**Recertification:** affordable-housing tenants are periodically re-checked
+against income limits. Our platform enforces a **140% AMI ceiling** at recert —
+if a household's income rises above 140% of the AMI limit for their unit, the
+unit may need to convert (e.g. to market rent). This is a compliance rule for
+existing tenants, not part of the initial application. The application/recert
+process verifies the numbers — the agent never issues a personal ruling.
+
+---
+
+<a id="rent-availability-caveat"></a>
+## 8. Rent & availability caveat {#rent-availability-caveat}
+
+- **Rent is not disclosed** in our property data (`rent.disclosed = false` for
+  all properties). We cannot quote a monthly rent for any property. Confirm rent
+  directly with the property or in the application.
+- **Availability is "as of the latest data."** The available-now set reflects a
+  snapshot (see each property's `availability.asOf` date). Availability changes —
+  always **confirm current availability in the application** or with the
+  property.
+
+> Standard caveat to attach to any rent/availability answer: "This is as of the
+> latest data; confirm in the application."
+
+---
+
+<a id="accessibility"></a>
+## 9. Accessibility / senior / ADA {#accessibility}
+
+- **Senior properties** (`type = "Senior"`) are age-restricted communities. Many
+  available-now senior properties note **ADA accommodations, elevator access,
+  and Equal Housing Opportunity** in their accessibility details.
+- Accessibility details (ADA accommodations, elevator access, etc.) are recorded
+  **only for the 17 available-now properties**. Statewide-only properties have no
+  accessibility field in our data — confirm with the property.
+- We describe what a property offers from its own listing. We never infer or ask
+  about a person's disability, age, or any other protected characteristic, and
+  we never steer applicants toward or away from any property based on protected
+  class. (Fair-housing neutral.)
+
+---
+
+<a id="contact"></a>
+## 10. Contacting a property / getting help {#contact}
+
+- **Available-now (GPMG) properties** have a **phone number, office hours, and a
+  waitlist link** in our data; a couple also list an email. Use those to reach
+  the property directly.
+- **Statewide-only properties** have **no contact info** in our data — we have
+  only their name, city, and address. To reach them, search for the property
+  manager or use the **/discover** map.
+- To get help with your application, continue through the apply flow or go to
+  your **dashboard** ("Go to my dashboard"). Next steps are also sent by email
+  and SMS after you apply.

--- a/tools/housing-qa/retriever.py
+++ b/tools/housing-qa/retriever.py
@@ -1,0 +1,743 @@
+#!/usr/bin/env python3
+"""
+retriever.py — Grounded retrieval for the frank-pilot CDPC housing Q&A agent.
+
+Loads two datasets, builds a normalized merged index per the LOCKED grounding
+contract, and assembles a compact context payload for any question string.
+
+Datasets (relative to repo root):
+  1. STATEWIDE HUD-LIHTC base : client-tenant/public/nv-housing-props.json (335 records,
+     enriched amiTiers 254/335). Falls back to src/db/data/nv-housing-props.json.
+  2. AVAILABLE-NOW (GPMG)     : docs/intel/gpmglv-properties-extracted.json
+     (dict; property list under "properties", 17 records).
+
+Pure stdlib only (json, re, difflib). No pip deps. No network.
+
+Context payload assembled per question =
+  (a) matched property object(s)        -> full (named) or compact (city/attribute)
+  (b) keyword-matched FAQ section(s)    -> ids + titles + anchors from faq.md
+  (c) always-on facts block             -> fee, 120-day rule, document checklist
+
+Routing branches:
+  - named property      -> fuzzy match name/aka/slug -> 1 FULL normalized object
+  - city/area           -> filter by city            -> COMPACT summaries, cap K=8
+  - attribute filter    -> filter index (BR/senior|family/AMI tier/available now)
+                                                     -> COMPACT summaries, cap K=8
+  - process/eligibility -> NO property objects; FAQ sections only
+"""
+
+import json
+import os
+import re
+import difflib
+
+# --------------------------------------------------------------------------- #
+# Paths
+# --------------------------------------------------------------------------- #
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+_REPO_ROOT = os.path.abspath(os.path.join(_THIS_DIR, "..", ".."))
+
+_STATEWIDE_PRIMARY = os.path.join(_REPO_ROOT, "client-tenant", "public", "nv-housing-props.json")
+_STATEWIDE_FALLBACK = os.path.join(_REPO_ROOT, "src", "db", "data", "nv-housing-props.json")
+_GPMG_PATH = os.path.join(_REPO_ROOT, "docs", "intel", "gpmglv-properties-extracted.json")
+_FAQ_PATH = os.path.join(_THIS_DIR, "faq.md")
+
+K_COMPACT = 8  # cap on compact summaries injected
+
+# --------------------------------------------------------------------------- #
+# Normalization helpers
+# --------------------------------------------------------------------------- #
+_STOPWORDS = {
+    "apartments", "apartment", "apts", "apt", "community", "communities",
+    "senior", "family", "the", "at", "of", "housing", "homes", "home",
+    "village", "court", "courts", "place", "gardens", "garden",
+}
+
+
+def _norm_name(s):
+    """Lowercase, strip punctuation, collapse whitespace. Keeps stopwords."""
+    if not s:
+        return ""
+    s = s.lower()
+    s = re.sub(r"[^a-z0-9\s]", " ", s)
+    s = re.sub(r"\s+", " ", s).strip()
+    return s
+
+
+def _name_tokens(s):
+    """Significant tokens (stopwords removed) for overlap scoring."""
+    return {t for t in _norm_name(s).split() if t and t not in _STOPWORDS}
+
+
+def _slug_to_name(slug):
+    return _norm_name(slug.replace("-", " ")) if slug else ""
+
+
+def _haversine_km(a_lat, a_lng, b_lat, b_lng):
+    import math
+    r = 6371.0
+    p1, p2 = math.radians(a_lat), math.radians(b_lat)
+    dphi = math.radians(b_lat - a_lat)
+    dlmb = math.radians(b_lng - a_lng)
+    h = math.sin(dphi / 2) ** 2 + math.cos(p1) * math.cos(p2) * math.sin(dlmb / 2) ** 2
+    return 2 * r * math.asin(math.sqrt(h))
+
+
+# --------------------------------------------------------------------------- #
+# Data loading
+# --------------------------------------------------------------------------- #
+def _load_statewide():
+    path = _STATEWIDE_PRIMARY if os.path.exists(_STATEWIDE_PRIMARY) else _STATEWIDE_FALLBACK
+    with open(path, "r") as f:
+        return json.load(f), path
+
+
+def _load_gpmg():
+    if not os.path.exists(_GPMG_PATH):
+        return [], None
+    with open(_GPMG_PATH, "r") as f:
+        d = json.load(f)
+    props = d.get("properties", []) if isinstance(d, dict) else d
+    snapshot = d.get("source_snapshot") if isinstance(d, dict) else None
+    return props, snapshot
+
+
+# --------------------------------------------------------------------------- #
+# Normalized index construction (LOCKED contract shape)
+# --------------------------------------------------------------------------- #
+def _blank_normalized(rec):
+    """Build a statewide-only normalized object from a HUD-LIHTC record."""
+    return {
+        "id": _norm_name(rec.get("name", "")).replace(" ", "-") or "unknown",
+        "name": rec.get("name") or None,
+        "city": rec.get("city") or None,
+        "address": rec.get("address") or None,
+        "type": rec.get("type") or None,
+        "totalUnits": rec.get("totalUnits"),
+        "restrictedUnits": rec.get("restrictedUnits"),
+        "amiTiers": rec.get("amiTiers") if rec.get("amiTiers") else None,
+        "funding": rec.get("funding") or None,
+        "availability": {
+            "status": "statewide_only",
+            "availableUnitsCount": None,
+            "asOf": None,
+        },
+        "rent": {"disclosed": False, "text": None},
+        "contact": {
+            "phone": None, "email": None, "officeHours": None,
+            "waitlistUrl": None, "applicationUrl": None,
+        },
+        "amenities": None,
+        "accessibility": None,
+        "petPolicy": None,
+        "unitTypes": None,
+        "_source": {"base": "HUD-LIHTC statewide", "availability": None},
+        # internal-only (not part of emitted shape; stripped before injection)
+        "_lat": rec.get("lat"),
+        "_lng": rec.get("lng"),
+        "_aka": rec.get("aka") or "",
+    }
+
+
+def _gpmg_to_normalized(g, snapshot):
+    """Build a normalized object for an unmatched-but-available GPMG record."""
+    addr = g.get("address") or {}
+    parts = [addr.get("line1"), addr.get("city"), addr.get("state"), addr.get("zip")]
+    address = ", ".join([p for p in parts if p]) or None
+    accessibility = g.get("accessibility")
+    if isinstance(accessibility, list):
+        accessibility = "; ".join(accessibility) if accessibility else None
+    return {
+        "id": g.get("slug") or _norm_name(g.get("name", "")).replace(" ", "-"),
+        "name": g.get("name") or None,
+        "city": addr.get("city") or None,
+        "address": address,
+        "type": g.get("property_type") or None,
+        "totalUnits": None,
+        "restrictedUnits": None,
+        "amiTiers": None,
+        "funding": None,
+        "availability": {
+            "status": "available_now",
+            "availableUnitsCount": g.get("available_units_count"),
+            "asOf": snapshot,
+        },
+        "rent": {
+            "disclosed": bool(g.get("rent_disclosed")),
+            "text": g.get("rent_text"),
+        },
+        "contact": {
+            "phone": g.get("phone"),
+            "email": g.get("email") or g.get("manager_email"),
+            "officeHours": g.get("office_hours"),
+            "waitlistUrl": g.get("waitlist_url"),
+            "applicationUrl": g.get("application_url"),
+        },
+        "amenities": g.get("amenities") or None,
+        "accessibility": accessibility,
+        "petPolicy": g.get("pet_policy"),
+        "unitTypes": g.get("unit_types") or None,
+        "_source": {"base": "HUD-LIHTC statewide", "availability": f"GPMG {snapshot}" if snapshot else "GPMG"},
+        "_lat": None,
+        "_lng": None,
+        "_aka": "",
+    }
+
+
+def _enrich_with_gpmg(norm, g, snapshot):
+    """Overlay GPMG fields onto a matched statewide record + flip availability."""
+    addr = g.get("address") or {}
+    accessibility = g.get("accessibility")
+    if isinstance(accessibility, list):
+        accessibility = "; ".join(accessibility) if accessibility else None
+
+    norm["availability"] = {
+        "status": "available_now",
+        "availableUnitsCount": g.get("available_units_count"),
+        "asOf": snapshot,
+    }
+    norm["rent"] = {
+        "disclosed": bool(g.get("rent_disclosed")),
+        "text": g.get("rent_text"),
+    }
+    norm["contact"] = {
+        "phone": g.get("phone"),
+        "email": g.get("email") or g.get("manager_email"),
+        "officeHours": g.get("office_hours"),
+        "waitlistUrl": g.get("waitlist_url"),
+        "applicationUrl": g.get("application_url"),
+    }
+    norm["amenities"] = g.get("amenities") or None
+    norm["accessibility"] = accessibility
+    norm["petPolicy"] = g.get("pet_policy")
+    norm["unitTypes"] = g.get("unit_types") or None
+    # type: prefer the statewide canonical type if present, else GPMG
+    if not norm.get("type"):
+        norm["type"] = g.get("property_type") or None
+    norm["_source"]["availability"] = f"GPMG {snapshot}" if snapshot else "GPMG"
+    return norm
+
+
+def _match_gpmg_to_statewide(g, statewide_norms):
+    """
+    Match a GPMG record to a statewide normalized record.
+    Strategy: token overlap on significant name tokens; tie-break by proximity
+    when both have coords. Returns the best statewide norm or None.
+    """
+    g_name = g.get("name") or _slug_to_name(g.get("slug", ""))
+    g_tokens = _name_tokens(g_name)
+    g_full = _norm_name(g_name)
+    addr = g.get("address") or {}
+    g_city = _norm_name(addr.get("city", ""))
+
+    best = None
+    best_score = 0.0
+    for s in statewide_norms:
+        s_name = s.get("name") or ""
+        s_tokens = _name_tokens(s_name) | _name_tokens(s.get("_aka", ""))
+        if not g_tokens or not s_tokens:
+            # fall back to full-string ratio
+            ratio = difflib.SequenceMatcher(None, g_full, _norm_name(s_name)).ratio()
+            score = ratio
+        else:
+            overlap = len(g_tokens & s_tokens) / len(g_tokens | s_tokens)
+            ratio = difflib.SequenceMatcher(None, g_full, _norm_name(s_name)).ratio()
+            score = 0.7 * overlap + 0.3 * ratio
+        # require same city if both known (avoids cross-city name collisions)
+        if g_city and s.get("city") and _norm_name(s["city"]) != g_city:
+            score *= 0.5
+        if score > best_score:
+            best_score, best = score, s
+    # threshold: meaningful name overlap
+    if best is not None and best_score >= 0.45:
+        return best
+    return None
+
+
+class HousingIndex:
+    """Builds and holds the normalized merged index + name lookup tables."""
+
+    def __init__(self):
+        statewide_raw, self._statewide_path = _load_statewide()
+        gpmg_raw, self._gpmg_snapshot = _load_gpmg()
+
+        # 1. Build statewide normalized records
+        self.records = [_blank_normalized(r) for r in statewide_raw]
+
+        # 2. Match each GPMG record -> enrich, or include as standalone available
+        matched_ids = set()
+        for g in gpmg_raw:
+            target = _match_gpmg_to_statewide(g, self.records)
+            if target is not None and id(target) not in matched_ids:
+                _enrich_with_gpmg(target, g, self._gpmg_snapshot)
+                matched_ids.add(id(target))
+            else:
+                # unmatched-but-available -> include as its own record
+                self.records.append(_gpmg_to_normalized(g, self._gpmg_snapshot))
+
+        # 3. Lookup helpers
+        self._by_norm_name = {}
+        for r in self.records:
+            self._by_norm_name.setdefault(_norm_name(r.get("name", "")), r)
+
+        self.gpmg_count = len(gpmg_raw)
+        self.statewide_count = len(statewide_raw)
+        self.available_now_count = sum(
+            1 for r in self.records if r["availability"]["status"] == "available_now"
+        )
+
+    # ----------------------------------------------------------------- #
+    # Matching primitives
+    # ----------------------------------------------------------------- #
+    def fuzzy_property(self, query):
+        """Return best single normalized record matching a property name, or None."""
+        q_full = _norm_name(query)
+        q_tokens = _name_tokens(query)
+        best, best_score = None, 0.0
+        for r in self.records:
+            cand_names = [r.get("name") or "", r.get("_aka") or "", r.get("id") or ""]
+            local_best = 0.0
+            for cand in cand_names:
+                c_full = _norm_name(cand.replace("-", " "))
+                if not c_full:
+                    continue
+                ratio = difflib.SequenceMatcher(None, q_full, c_full).ratio()
+                c_tokens = _name_tokens(cand.replace("-", " "))
+                overlap = (len(q_tokens & c_tokens) / len(q_tokens | c_tokens)) if (q_tokens and c_tokens) else 0.0
+                # reward substring containment of the query in the candidate
+                contains = 1.0 if (q_full and q_full in c_full) else 0.0
+                score = max(ratio, 0.6 * overlap + 0.4 * ratio, contains * 0.95)
+                local_best = max(local_best, score)
+            if local_best > best_score:
+                best_score, best = local_best, r
+        if best is not None and best_score >= 0.6:
+            return best, best_score
+        return None, best_score
+
+    def by_city(self, city):
+        c = _norm_name(city)
+        return [r for r in self.records if _norm_name(r.get("city", "")) == c]
+
+    def all_cities(self):
+        return sorted({r.get("city") for r in self.records if r.get("city")})
+
+    def filter_attributes(self, *, ptype=None, ami_tier=None, available_now=False,
+                          bedrooms=None, city=None):
+        out = []
+        cnorm = _norm_name(city) if city else None
+        for r in self.records:
+            if cnorm and _norm_name(r.get("city", "")) != cnorm:
+                continue
+            if ptype:
+                rt = _norm_name(r.get("type", ""))
+                if _norm_name(ptype) not in rt:
+                    continue
+            if ami_tier:
+                tiers = r.get("amiTiers") or []
+                norm_tiers = {t.replace("%", "").strip() for t in tiers}
+                if ami_tier.replace("%", "").strip() not in norm_tiers:
+                    continue
+            if available_now and r["availability"]["status"] != "available_now":
+                continue
+            if bedrooms:
+                ut = r.get("unitTypes") or []
+                joined = " ".join(ut).lower()
+                if bedrooms.lower() not in joined:
+                    continue
+            out.append(r)
+        return out
+
+
+# --------------------------------------------------------------------------- #
+# FAQ section index (parsed from faq.md anchors)
+# --------------------------------------------------------------------------- #
+# Stable section ids -> (title, keyword triggers). Mirrors faq.md anchors.
+FAQ_SECTIONS = [
+    ("who-its-for", "Who affordable housing is for / AMI tiers",
+     ["who", "qualify", "eligib", "ami", "income", "area median", "tier", "low income", "afford"]),
+    ("application-steps", "The application steps",
+     ["step", "how do i apply", "how to apply", "process", "register", "verify",
+      "magic link", "intent", "pick", "review", "confirm", "claim", "stages", "apply"]),
+    ("documents", "Documents you'll need",
+     ["document", "paperwork", "id", "pay stub", "paystub", "proof of income",
+      "ssn", "itin", "reference", "landlord", "bring", "need to apply", "upload"]),
+    ("fees", "Fees",
+     ["fee", "cost", "pay", "price", "charge", "35", "$35", "refund", "non-refund", "money"]),
+    ("waitlists", "Waitlists & queue position + 120-day rule",
+     ["waitlist", "queue", "position", "120", "spot", "wait", "how long", "active"]),
+    ("finding-a-unit", "Finding a unit (available-now vs statewide; search by BR/budget/move-in)",
+     ["find", "available", "search", "unit", "bedroom", "br", "budget", "move-in",
+      "move in", "vacancy", "open", "now", "list", "show me"]),
+    ("after-you-apply", "After you apply (PM review, recertification, next steps)",
+     ["after", "next", "review", "property manager", "pm", "recertif", "recert",
+      "lease", "docusign", "sign", "approved", "decision", "140%", "what happens"]),
+    ("rent-availability-caveat", "Rent & availability caveat",
+     ["rent", "how much", "monthly", "price", "availability", "still available", "current"]),
+    ("accessibility", "Accessibility / senior / ADA",
+     ["accessib", "ada", "senior", "elder", "disab", "wheelchair", "elevator", "55", "62"]),
+    ("contact", "Contacting a property / getting help",
+     ["contact", "phone", "call", "email", "reach", "office hours", "help",
+      "talk to", "speak", "manager", "get in touch"]),
+]
+
+
+def _match_faq_sections(question, cap=3):
+    q = question.lower()
+    scored = []
+    for sid, title, kws in FAQ_SECTIONS:
+        hits = sum(1 for kw in kws if kw in q)
+        if hits:
+            scored.append((hits, sid, title))
+    scored.sort(reverse=True)
+    return [{"id": s[1], "title": s[2], "anchor": f"faq.md#{s[1]}"} for s in scored[:cap]]
+
+
+# --------------------------------------------------------------------------- #
+# Always-on facts block (grounded in apply.json copy)
+# --------------------------------------------------------------------------- #
+ALWAYS_ON_FACTS = {
+    "applicationFee": {
+        "amount": "$35.95",
+        "per": "per adult 18+",
+        "refundable": False,
+        "note": "Non-refundable. Locks your spot on the waitlist. Covers credit and background checks.",
+        "source": "apply.json checklist.fee / household.disclaimer",
+    },
+    "rule120": {
+        "days": 120,
+        "note": "Your application stays active for 120 days. If you can't be housed in that window, you're invited to refresh and continue.",
+        "source": "apply.json checklist.rule120",
+    },
+    "documentsNeeded": [
+        "Government-issued photo ID",
+        "Proof of income (last 2 pay stubs or offer letter)",
+        "Social Security Number or ITIN",
+        "Two prior landlord references (last 3 years)",
+        "Household composition (everyone moving in)",
+    ],
+    "documentsNote": "Upload your documents (5 files, < 120 days old).",
+    "documentsSource": "apply.json checklist.items / confirm.nextSteps",
+}
+
+
+# --------------------------------------------------------------------------- #
+# Question classification + routing
+# --------------------------------------------------------------------------- #
+_AMI_RE = re.compile(r"(\d{2,3})\s*%")
+_BR_RE = re.compile(r"\b(studio|\d\s*br|\d\s*bed(room)?s?|\d-bed)\b", re.I)
+
+
+def _detect_ami_tier(q):
+    m = _AMI_RE.search(q)
+    return f"{m.group(1)}%" if m else None
+
+
+def _detect_bedrooms(q):
+    ql = q.lower()
+    if "studio" in ql:
+        return "studio"
+    m = re.search(r"\b(\d)\s*(?:br|bed)", ql)
+    if m:
+        return f"{m.group(1)}br"
+    return None
+
+
+def _detect_type(q):
+    ql = q.lower()
+    if re.search(r"\bsenior(s)?\b|\belder|\b55\+|\b62\+", ql):
+        return "senior"
+    if re.search(r"\bfamily\b|\bfamilies\b", ql):
+        return "family"
+    return None
+
+
+def _wants_available_now(q):
+    ql = q.lower()
+    return bool(re.search(r"available\s*now|available today|right now|currently available|"
+                          r"open now|move in now|vacan", ql))
+
+
+def _strip_internal(rec):
+    """Remove internal-only keys (_lat/_lng/_aka) from emitted objects."""
+    return {k: v for k, v in rec.items() if not k.startswith("_") or k == "_source"}
+
+
+def _compact(rec):
+    """Compact summary shape for city/attribute results."""
+    return {
+        "name": rec.get("name"),
+        "city": rec.get("city"),
+        "availability": rec["availability"]["status"],
+        "amiTiers": rec.get("amiTiers"),
+        "type": rec.get("type"),
+    }
+
+
+_PROCESS_HINTS = (
+    "document", "fee", "cost", "apply", "application", "qualify", "eligib",
+    "waitlist", "queue", "income", "ami", "rent", "how", "what", "when",
+    "where", "who", "need", "step", "recertif", "help", "contact", "available",
+)
+
+
+def _extract_property_phrase(q):
+    """
+    Strip leading question/preposition lead-ins ('tell me about', 'what is the
+    pet policy at', 'do you have', ...) to isolate a candidate property-name
+    phrase. Returns the phrase (may be the whole question if nothing stripped).
+    """
+    s = q.strip().rstrip("?.!")
+    # progressively strip known lead-in patterns
+    patterns = [
+        r"^(?:can you )?tell me (?:about|more about)\s+",
+        r"^(?:what(?:'s| is| are)?)\s+(?:the\s+)?(?:[\w\s/-]+?)\s+(?:at|for|of)\s+",
+        r"^(?:do|does)\s+(?:you|they)\s+(?:have|offer|allow)\s+",
+        r"^(?:what about|how about|info on|information (?:about|on)|details (?:about|on))\s+",
+        r"^(?:is|are)\s+(?:there\s+)?",
+        r"^(?:i(?:'m| am)?\s+(?:looking|interested)\s+(?:for|in)\s+)",
+    ]
+    for p in patterns:
+        new = re.sub(p, "", s, flags=re.I)
+        if new != s:
+            s = new.strip()
+            break
+    # trailing "at/in <city>" — drop it so the name stands alone
+    return s.strip()
+
+
+def _looks_like_unknown_property(q, prop, score):
+    """
+    Heuristic: the question likely names a property we don't have if it contains
+    a proper-noun-ish phrase ('about X', 'X Apartments') and no decent match.
+    Returns the suspected property name or None.
+    """
+    if prop is not None and score >= 0.6:
+        return None
+    ql = q.lower()
+    # explicit ask-about pattern
+    m = re.search(r"\b(?:about|at|for|regarding|tell me about)\s+([A-Z][\w'.-]+(?:\s+[A-Z][\w'.-]+){0,4})", q)
+    if m:
+        return m.group(1).strip()
+    # "<Name> Apartments/Towers/Village..." pattern
+    m = re.search(r"\b([A-Z][\w'.-]+(?:\s+[A-Z][\w'.-]+){0,3}\s+"
+                  r"(?:Apartments?|Apts?|Towers?|Village|Court|Place|Community|Homes?))\b", q)
+    if m:
+        return m.group(1).strip()
+    return None
+
+
+def classify(question, index=None):
+    """
+    Classify a question into one of:
+      'named_property' | 'city' | 'attribute' | 'process'
+    Returns (branch, detail_dict).
+    """
+    index = index or _shared_index()
+    q = question.strip()
+    ql = q.lower()
+
+    # 1. Named property? Try fuzzy match on both the raw question and a
+    #    lead-in-stripped property phrase; keep the stronger match.
+    prop, score = index.fuzzy_property(q)
+    phrase = _extract_property_phrase(q)
+    if phrase and phrase.lower() != ql:
+        p2, s2 = index.fuzzy_property(phrase)
+        if p2 is not None and s2 > score:
+            prop, score = p2, s2
+    # Avoid treating a bare city name as a property
+    cities_lower = {c.lower() for c in index.all_cities()}
+    looks_like_city_only = ql in cities_lower or _norm_name(phrase) in cities_lower
+
+    # 2. City mention
+    city_hit = None
+    for c in index.all_cities():
+        if re.search(r"\b" + re.escape(c.lower()) + r"\b", ql):
+            city_hit = c
+            break
+
+    # 3. Attribute signals
+    ami = _detect_ami_tier(q)
+    br = _detect_bedrooms(q)
+    ptype = _detect_type(q)
+    avail = _wants_available_now(q)
+
+    # Decision order: a confident specific-property name wins unless it's just a city.
+    if prop is not None and score >= 0.72 and not looks_like_city_only:
+        return "named_property", {"record": prop, "score": score}
+
+    if (ami or br or ptype or avail) and not (prop is not None and score >= 0.78):
+        return "attribute", {"ami": ami, "bedrooms": br, "type": ptype,
+                             "available_now": avail, "city": city_hit}
+
+    if city_hit:
+        return "city", {"city": city_hit}
+
+    # Medium-confidence property name with no other signal -> still named
+    if prop is not None and score >= 0.62 and not looks_like_city_only:
+        return "named_property", {"record": prop, "score": score}
+
+    # Looks like it names a property (capitalized multi-word, not process keywords)
+    # but we couldn't match it -> unknown-property refusal signal.
+    unknown_prop = _looks_like_unknown_property(q, prop, score)
+    return "process", {"unknownProperty": unknown_prop}
+
+
+# --------------------------------------------------------------------------- #
+# Main entry point
+# --------------------------------------------------------------------------- #
+_INDEX_SINGLETON = None
+
+
+def _shared_index():
+    global _INDEX_SINGLETON
+    if _INDEX_SINGLETON is None:
+        _INDEX_SINGLETON = HousingIndex()
+    return _INDEX_SINGLETON
+
+
+def build_context(question, index=None):
+    """
+    Take a question string, return the assembled context payload per the
+    LOCKED grounding contract:
+      {
+        "question": ...,
+        "routing": "named_property|city|attribute|process",
+        "properties": [ <full normalized obj> ]            (named)
+                    or [ {name,city,availability,amiTiers,type} ]  (compact)
+                    or []                                   (process),
+        "propertyMode": "full|compact|none",
+        "faqSections": [ {id,title,anchor} ],
+        "facts": <always-on facts block>,
+        "notes": [ ... optional retrieval notes ... ]
+      }
+    """
+    index = index or _shared_index()
+    branch, detail = classify(question, index)
+    notes = []
+    properties = []
+    mode = "none"
+
+    if branch == "named_property":
+        rec = detail["record"]
+        properties = [_strip_internal(rec)]
+        mode = "full"
+        if rec["availability"]["status"] == "statewide_only":
+            notes.append(
+                f"'{rec.get('name')}' is in the statewide HUD-LIHTC dataset only "
+                f"(no available-now feed). Rent, contact, amenities, pet policy, "
+                f"office hours are NOT in the data — refuse + point to next step."
+            )
+    elif branch == "city":
+        recs = index.by_city(detail["city"])
+        # surface available-now first within the city
+        recs.sort(key=lambda r: 0 if r["availability"]["status"] == "available_now" else 1)
+        properties = [_compact(r) for r in recs[:K_COMPACT]]
+        mode = "compact"
+        if len(recs) > K_COMPACT:
+            notes.append(f"{len(recs)} properties in {detail['city']}; showing first {K_COMPACT}.")
+        if not recs:
+            notes.append(f"No properties found for city '{detail['city']}' in the data.")
+    elif branch == "attribute":
+        recs = index.filter_attributes(
+            ptype=detail.get("type"),
+            ami_tier=detail.get("ami"),
+            available_now=detail.get("available_now"),
+            bedrooms=detail.get("bedrooms"),
+            city=detail.get("city"),
+        )
+        recs.sort(key=lambda r: 0 if r["availability"]["status"] == "available_now" else 1)
+        properties = [_compact(r) for r in recs[:K_COMPACT]]
+        mode = "compact"
+        scope = f" in {detail['city']}" if detail.get("city") else ""
+        if len(recs) > K_COMPACT:
+            notes.append(f"{len(recs)} matches{scope}; showing first {K_COMPACT}.")
+        if not recs:
+            notes.append("No properties match those attributes in the data.")
+        if detail.get("bedrooms"):
+            notes.append(
+                "Bedroom counts are only known for the 17 available-now (GPMG) "
+                "properties via unitTypes; statewide-only records have no bedroom data."
+            )
+    else:  # process
+        properties = []
+        mode = "none"
+        unknown = detail.get("unknownProperty")
+        if unknown:
+            notes.append(
+                f"The question appears to name a property ('{unknown}') that is NOT "
+                f"in the statewide HUD-LIHTC or available-now data. Refuse: say you "
+                f"don't have a property by that name and point to /discover or "
+                f"contacting GPMG. Do NOT invent details."
+            )
+
+    faq = _match_faq_sections(question)
+    if not faq:
+        # Always give the agent something to ground process answers in.
+        faq = [{"id": "application-steps",
+                "title": "The application steps",
+                "anchor": "faq.md#application-steps"}]
+
+    return {
+        "question": question,
+        "routing": branch,
+        "propertyMode": mode,
+        "properties": properties,
+        "faqSections": faq,
+        "facts": ALWAYS_ON_FACTS,
+        "notes": notes,
+        "_meta": {
+            "statewideRecords": index.statewide_count,
+            "gpmgRecords": index.gpmg_count,
+            "availableNowRecords": index.available_now_count,
+            "totalIndexRecords": len(index.records),
+            "dataAsOf": index._gpmg_snapshot,
+        },
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Smoke harness
+# --------------------------------------------------------------------------- #
+if __name__ == "__main__":
+    idx = _shared_index()
+    print("=" * 72)
+    print(f"INDEX BUILT: {idx.statewide_count} statewide + {idx.gpmg_count} GPMG "
+          f"-> {len(idx.records)} total records "
+          f"({idx.available_now_count} available_now)")
+    print(f"  statewide source: {idx._statewide_path}")
+    print(f"  data as of: {idx._gpmg_snapshot}")
+    print("=" * 72)
+
+    samples = [
+        ("Tell me about Silver Pines Apts",          "named_property"),
+        ("What senior housing is available in Henderson?", "city/attribute"),
+        ("Show me available-now senior units",       "attribute"),
+        ("What documents do I need to apply?",        "process"),
+        ("Tell me about Moonbeam Towers",             "named_property->unknown(refusal)"),
+    ]
+
+    for q, expected in samples:
+        ctx = build_context(q, idx)
+        print(f"\nQ: {q}")
+        print(f"  expected branch ~ {expected}")
+        print(f"  ROUTED -> {ctx['routing']}  (propertyMode={ctx['propertyMode']})")
+        if ctx["propertyMode"] == "full" and ctx["properties"]:
+            p = ctx["properties"][0]
+            print(f"    property: {p['name']} | city={p['city']} | type={p['type']} | "
+                  f"amiTiers={p['amiTiers']} | avail={p['availability']['status']} | "
+                  f"phone={p['contact']['phone']}")
+        elif ctx["propertyMode"] == "compact":
+            print(f"    {len(ctx['properties'])} compact summaries:")
+            for p in ctx["properties"][:4]:
+                print(f"      - {p['name']} ({p['city']}) [{p['availability']}] "
+                      f"type={p['type']} ami={p['amiTiers']}")
+            if not ctx["properties"]:
+                print("      (none)")
+        else:
+            print("    (no property objects injected)")
+        print(f"    FAQ sections: {[s['id'] for s in ctx['faqSections']]}")
+        if ctx["notes"]:
+            for n in ctx["notes"]:
+                print(f"    NOTE: {n}")
+    print("\n" + "=" * 72)
+    print("Smoke harness complete.")

--- a/tools/housing-qa/runner.py
+++ b/tools/housing-qa/runner.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""
+runner.py — Thin runner for the Frank-Pilot housing Q&A agent.
+
+Pipeline:
+  1. Take a question (CLI arg or stdin).
+  2. retriever.build_context(question) -> grounded context payload.
+  3. Load system_prompt.md, inject the context JSON at {{CONTEXT_JSON}}.
+  4. Send (system, user=question) through the model via call_model().
+
+Model backend is PLUGGABLE (see call_model below). Defaults to shelling out to
+`claude -p` (the OpenClaw / headless Claude CLI) if it's on PATH. With
+--dry-run, it makes NO network calls and just prints the fully assembled prompt.
+
+Usage:
+  python3 runner.py "What documents do I need to apply?"
+  python3 runner.py --dry-run "Tell me about Owens Senior Housing"
+  echo "How much is the application fee?" | python3 runner.py
+  python3 runner.py --context-only "senior housing in Henderson"   # dump payload
+
+Pure stdlib. No pip deps.
+"""
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, _THIS_DIR)
+
+import retriever  # noqa: E402
+
+_SYSTEM_PROMPT_PATH = os.path.join(_THIS_DIR, "system_prompt.md")
+_CONTEXT_PLACEHOLDER = "{{CONTEXT_JSON}}"
+
+# Which CLI to shell out to for the live backend. `claude -p <prompt>` runs
+# headless. This is the OpenClaw shim integration point (see README).
+_DEFAULT_CLI = os.environ.get("HOUSING_QA_CLI", "claude")
+
+
+# --------------------------------------------------------------------------- #
+# Prompt assembly
+# --------------------------------------------------------------------------- #
+def load_system_prompt():
+    with open(_SYSTEM_PROMPT_PATH, "r") as f:
+        return f.read()
+
+
+def assemble_prompt(question):
+    """Return (system_text, user_text, context_payload)."""
+    ctx = retriever.build_context(question)
+    ctx_json = json.dumps(ctx, indent=2, ensure_ascii=False)
+    system_text = load_system_prompt().replace(_CONTEXT_PLACEHOLDER, ctx_json)
+    return system_text, question, ctx
+
+
+# --------------------------------------------------------------------------- #
+# Model backend — PLUGGABLE INTEGRATION POINT
+# --------------------------------------------------------------------------- #
+def call_model(system, user):
+    """
+    Send the prompt to the model and return the text response.
+
+    >>> INTEGRATION POINT <<<
+    Default implementation shells out to the headless Claude CLI:
+        claude -p "<combined prompt>"
+    (the OpenClaw `claude_cli_proxy.py`-style shim, if configured, intercepts
+    this same `claude` invocation transparently).
+
+    To wire a different backend (Anthropic SDK, OpenClaw HTTP endpoint, a local
+    model, etc.), replace the body of this function. The contract is simply:
+        def call_model(system: str, user: str) -> str
+
+    NOTE: this runner PRE-INJECTS context into the system prompt. It does not
+    rely on tool-calling, because the current OpenClaw shim drops the OpenAI
+    `tools` array (see README). Pre-injection is the supported path today.
+    """
+    cli = shutil.which(_DEFAULT_CLI)
+    if not cli:
+        return (
+            f"[no model backend] '{_DEFAULT_CLI}' not found on PATH.\n"
+            f"Re-run with --dry-run to inspect the assembled prompt, or wire a "
+            f"backend in runner.call_model()."
+        )
+
+    # `claude -p` takes a single prompt string. Some shims separate system vs
+    # user; here we concatenate with a clear delimiter so the system prompt is
+    # honored even by a plain headless invocation.
+    combined = f"{system}\n\n=== USER QUESTION ===\n{user}\n"
+    try:
+        proc = subprocess.run(
+            [cli, "-p", combined],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+    except Exception as e:  # noqa: BLE001
+        return f"[backend error] {type(e).__name__}: {e}"
+    if proc.returncode != 0:
+        return f"[backend exit {proc.returncode}] {proc.stderr.strip() or proc.stdout.strip()}"
+    return proc.stdout.strip()
+
+
+# --------------------------------------------------------------------------- #
+# CLI
+# --------------------------------------------------------------------------- #
+def _read_question(args):
+    if args.question:
+        return " ".join(args.question).strip()
+    if not sys.stdin.isatty():
+        return sys.stdin.read().strip()
+    return ""
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description="Frank-Pilot housing Q&A runner (grounded, pluggable backend)."
+    )
+    ap.add_argument("question", nargs="*", help="The question (or pipe via stdin).")
+    ap.add_argument("--dry-run", action="store_true",
+                    help="Print the assembled prompt; make NO model/network call.")
+    ap.add_argument("--context-only", action="store_true",
+                    help="Print only the retrieved context payload (JSON) and exit.")
+    args = ap.parse_args()
+
+    question = _read_question(args)
+    if not question:
+        ap.error("No question provided (pass as arg or via stdin).")
+
+    system_text, user_text, ctx = assemble_prompt(question)
+
+    if args.context_only:
+        print(json.dumps(ctx, indent=2, ensure_ascii=False))
+        return
+
+    if args.dry_run:
+        print("=" * 78)
+        print("DRY RUN — assembled prompt (no model call, no network)")
+        print("=" * 78)
+        print(f"ROUTING: {ctx['routing']}  |  propertyMode: {ctx['propertyMode']}  "
+              f"|  properties: {len(ctx['properties'])}  "
+              f"|  faq: {[s['id'] for s in ctx['faqSections']]}")
+        if ctx["notes"]:
+            print("RETRIEVAL NOTES:")
+            for n in ctx["notes"]:
+                print(f"  - {n}")
+        print("\n----- SYSTEM PROMPT (with injected context) -----\n")
+        print(system_text)
+        print("\n----- USER -----\n")
+        print(user_text)
+        print("\n" + "=" * 78)
+        print("End dry run.")
+        return
+
+    answer = call_model(system_text, user_text)
+    print(answer)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/housing-qa/system_prompt.md
+++ b/tools/housing-qa/system_prompt.md
@@ -1,0 +1,104 @@
+# System Prompt — Frank-Pilot CDPC Housing Q&A Agent
+
+You are the housing assistant for **Frank-Pilot CDPC**, an affordable-housing
+(LIHTC) application platform serving Nevada. You help prospective applicants
+understand affordable housing, find properties, and complete their application.
+
+You answer **only** from the context injected below. You do not have general web
+knowledge about specific properties, rents, or availability — if it is not in the
+injected context, you do not know it.
+
+---
+
+## GROUNDING RULES (non-negotiable)
+
+1. **Ground every factual claim in the injected data.** For each fact you state,
+   it must come from either (a) an injected property object, (b) an injected FAQ
+   section, or (c) the always-on facts block. Do not state property facts that
+   are not in the context.
+
+2. **Cite your source inline.** Use one of these citation forms:
+   - Property data: `(Silver Pines Apts — amiTiers)` or `(Owens Senior — phone)`
+   - FAQ section: `(FAQ §fees)` / `(FAQ §application-steps)`
+   - Always-on facts: `(application fee)`, `(120-day rule)`, `(document checklist)`
+   Keep citations short and natural — one per fact is enough.
+
+3. **If it's not in the context, say so.** Use this exact spirit:
+   > "I don't have that — here's how to find out: …"
+   Then point to the next step (the application's Pick step, the /discover map,
+   or contacting the property). Never guess, never invent a value (no made-up
+   rent, phone number, pet policy, amenity, or availability).
+
+4. **A `null` field means "not in our data" — not "no" or "free."** If a
+   property's `rent.disclosed` is false, you cannot quote rent. If `contact.phone`
+   is null, you don't have a phone number. Say you don't have it.
+
+---
+
+## ELIGIBILITY & FAIR-HOUSING RULES (non-negotiable)
+
+5. **General eligibility only.** Explain how AMI tiers and income limits work in
+   general. **Never tell a user they personally qualify or do not qualify.** Say:
+   "the application verifies this" / "the property determines eligibility when it
+   reviews your documents." The income field at the Intent step is a
+   **pre-qualification estimate only**, never a ruling.
+
+6. **Fair-housing safe.** Stay neutral. Never steer an applicant toward or away
+   from any property. Never reference, ask about, or infer **protected classes**
+   (race, color, national origin, religion, sex, familial status, disability).
+   You may describe a property's own listed features (e.g. "this is a senior
+   community", "this property lists ADA accommodations") — but never connect them
+   to a person's characteristics or assume anything about the applicant.
+
+7. **Rent & availability are time-sensitive.** Whenever you mention rent or
+   availability, attach: *"as of the latest data; confirm in the application."*
+   Rent is not disclosed in our data for any property — do not quote a rent.
+
+---
+
+## STYLE
+
+- Short, plain-language answers. Lead with the answer. No filler.
+- Offer the **next step** when relevant (a CTA or link): continue the
+  application, use the /discover map, call the property, check your dashboard.
+- Use the applicant's framing; don't lecture. A couple of sentences plus a next
+  step is usually enough.
+- When listing multiple properties, a short bulleted list is fine; don't dump
+  every field — surface name, city, availability, type, and AMI tier.
+
+---
+
+## INJECTED CONTEXT
+
+The runner injects a JSON context payload below. Its shape:
+
+```jsonc
+{
+  "question": "...",
+  "routing": "named_property | city | attribute | process",
+  "propertyMode": "full | compact | none",
+  "properties": [ ... ],     // full normalized object(s), compact summaries, or []
+  "faqSections": [ {id,title,anchor} ],   // which FAQ sections to ground in
+  "facts": { applicationFee, rule120, documentsNeeded, ... },  // always-on
+  "notes": [ ... ],          // retrieval hints, incl. refusal flags — OBEY THESE
+  "_meta": { ... }           // dataset counts + data-as-of date
+}
+```
+
+- **`properties` with `propertyMode: "full"`** → one property; answer in detail,
+  but only from fields present (null = unknown → refuse that field).
+- **`propertyMode: "compact"`** → a filtered list; summarize the matches.
+- **`propertyMode: "none"`** (process/eligibility) → answer from `faqSections`
+  and `facts` only; do not name specific properties.
+- **`notes`** → these are retrieval instructions. If a note says a property is
+  statewide-only (no rent/contact/amenities) or that the named property is
+  unknown, you MUST follow it: refuse the missing fields and point to the next
+  step.
+- Use `_meta.dataAsOf` as the "as of" date for availability statements.
+
+--- BEGIN CONTEXT ---
+{{CONTEXT_JSON}}
+--- END CONTEXT ---
+
+Answer the user's question grounded strictly in the context above, with
+citations, following all rules.


### PR DESCRIPTION
Self-contained, grounded Q&A agent that answers prospective-applicant questions strictly from the housing dataset and apply-funnel copy — no invented values. Lives in `tools/housing-qa/`, pure stdlib, no network, no pip deps, nothing touched outside the directory.

## What it does
Merges the two property universes into one grounded index and answers questions against it with cite-or-refuse discipline.

| File | Role |
|---|---|
| `retriever.py` | Merges **335** statewide HUD-LIHTC + **17** GPMG available-now → **341**-record normalized index (16 enriched to `available_now`); classifies a question (named-property / city / attribute / process) and emits a context payload = matched properties + keyword-matched FAQ sections + always-on facts |
| `faq.md` | 10 anchored sections grounded in real `apply.json` copy (fees, 120-day rule, document checklist, AMI tiers, waitlist, etc.) |
| `system_prompt.md` | Guardrails + concrete citation format + `{{CONTEXT_JSON}}` injection point |
| `runner.py` | Pluggable `call_model()` (defaults to `claude -p`), `--dry-run`, `--context-only` |
| `examples.md` | 10 worked Q&A pairs incl. **3** "I don't have that" refusals |
| `README.md` | Token-engine wiring + the OpenClaw shim limitation note |

## Guardrails (baked into the system prompt)
- Ground every claim in injected data; cite source (`property — field` or `FAQ §section`). Not in context → "I don't have that — here's how to find out."
- General eligibility only — never tells a user they personally qualify; "the application verifies this."
- Fair-housing neutral; no steering; never references protected classes.
- Rent & availability are "as of the latest data; confirm in the application."

## Grounded against real-data sparseness (refuses rather than invents)
- **Rent** never disclosed (all 17 GPMG `rent_disclosed=false`, absent statewide) → always refuses rent.
- **`available_units_count`** null for all 17 → availability is a *status*, not a count.
- **Bedroom/unitTypes** exist only for the 17 available-now → statewide queries get a "not in our data" note.
- Pet policy null all 17; email only 2/17; application_url null all 17 (waitlist_url present).

## Validation
- `python3 tools/housing-qa/retriever.py` — 5-branch smoke harness, all route correctly (incl. unknown-property refusal).
- `python3 tools/housing-qa/runner.py --dry-run "What documents do I need to apply?"` — assembles a coherent grounded prompt.

## Note
Live tool-calling (agent invokes the retriever mid-conversation instead of pre-injecting context) stays blocked until the OpenClaw shim forwards the `tools` array — today `claude_cli_proxy.py` silently drops it, so only pre-injected context works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)