### PR TITLE
feat(discover): honest-by-design neutral brand placeholders (drop stock photos)

### DIFF
--- a/client-tenant/src/api/properties.ts
+++ b/client-tenant/src/api/properties.ts
@@ -132,16 +132,10 @@ export const DL2_FIXTURE: PropertyDetail = {
   neighborhood: 'East Las Vegas',
   description:
     'Family-oriented community in East Las Vegas, walking distance to Garcia Elementary and Sunrise Hospital. Three-story building with elevator, on-site laundry, gated parking, and a courtyard with playground equipment. Section 8 vouchers welcome.',
-  // Representative placeholder gallery — seeded per index so the carousel shows
-  // variety rather than five identical frames. Labeled "Representative photo" in
-  // the UI; not images of the actual building.
-  photos: [
-    placeholderFor('donna-louise-2-0'),
-    placeholderFor('donna-louise-2-1'),
-    placeholderFor('donna-louise-2-2'),
-    placeholderFor('donna-louise-2-3'),
-    placeholderFor('donna-louise-2-4'),
-  ],
+  // Single neutral brand placeholder (no real photos for this building). A
+  // multi-frame carousel of near-identical placeholder panels adds nothing, so
+  // we show one; PhotoCarousel hides its dots/arrows at count === 1.
+  photos: [placeholderFor('donna-louise-2', 'Donna Louise 2')],
   amenities: [
     'Pool',
     'Elevator',

--- a/client-tenant/src/pages/discover/PropertyDetail.tsx
+++ b/client-tenant/src/pages/discover/PropertyDetail.tsx
@@ -277,32 +277,14 @@ export function PropertyDetail() {
             className="aspect-[16/9] w-full"
             style={{
               background: HF.sageLo,
-              backgroundImage: `url(${placeholderFor(slug)})`,
+              backgroundImage: `url(${placeholderFor(slug, prop.name)})`,
               backgroundSize: 'cover',
               backgroundPosition: 'center',
             }}
             aria-hidden="true"
           />
-          {/* The hero uses a generic stock exterior, not a photo of this building.
-              Label it so the listing can't be read as misrepresenting the property
-              (fair-housing / advertising hygiene). */}
-          <span
-            style={{
-              position: 'absolute',
-              right: 12,
-              bottom: 12,
-              padding: '3px 8px',
-              borderRadius: HF.r.pill,
-              background: 'rgba(0,0,0,0.55)',
-              color: '#fff',
-              fontFamily: HF.body,
-              fontSize: 11,
-              lineHeight: 1.2,
-              backdropFilter: 'blur(2px)',
-            }}
-          >
-            Representative photo
-          </span>
+          {/* Hero is a generated neutral brand placeholder (gradient + glyph +
+              property name), not a photo — so no "photo" label is needed. */}
           <Link
             to="/discover"
             aria-label="Back"

--- a/client-tenant/src/pages/discover/PropertyList.tsx
+++ b/client-tenant/src/pages/discover/PropertyList.tsx
@@ -873,7 +873,7 @@ function PropertyTile({
             className="aspect-[16/9] w-full"
             style={{
               background: `${HF.sageLo}`,
-              backgroundImage: `url(${placeholderFor(slug)})`,
+              backgroundImage: `url(${placeholderFor(slug, prop.name)})`,
               backgroundSize: 'cover',
               backgroundPosition: 'center',
             }}

--- a/client-tenant/src/utils/__tests__/unitPlaceholder.test.ts
+++ b/client-tenant/src/utils/__tests__/unitPlaceholder.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import {
+  nameWord,
+  placeholderFor,
+  getUnitPhoto,
+  isPlaceholder,
+  UNIT_PLACEHOLDER,
+} from '../unitPlaceholder';
+
+/** Decode a `data:image/svg+xml,...` URI back to its SVG source. */
+function svgOf(dataUri: string): string {
+  const comma = dataUri.indexOf(',');
+  return decodeURIComponent(dataUri.slice(comma + 1));
+}
+
+describe('nameWord', () => {
+  it('picks the distinctive proper noun, stripping generic words', () => {
+    expect(nameWord('David J. Hoggard Family Community')).toBe('HOGGARD');
+    expect(nameWord('Owens Senior Housing')).toBe('OWENS');
+    expect(nameWord('Donna Louise 2')).toBe('LOUISE');
+  });
+
+  it('returns empty string for no usable label', () => {
+    expect(nameWord('')).toBe('');
+    expect(nameWord(null)).toBe('');
+    expect(nameWord('2')).toBe('');
+  });
+
+  it('clamps to 10 characters', () => {
+    expect(nameWord('Sunnyvalemeadowsbrook').length).toBeLessThanOrEqual(10);
+  });
+});
+
+describe('placeholderFor', () => {
+  it('returns a decodable data:image/svg+xml URI containing an <svg>', () => {
+    const uri = placeholderFor('owens-senior-housing', 'Owens Senior Housing');
+    expect(uri.startsWith('data:image/svg+xml,')).toBe(true);
+    expect(svgOf(uri)).toContain('<svg');
+  });
+
+  it('is deterministic — same seed yields the identical URI', () => {
+    const a = placeholderFor('owens-senior-housing', 'Owens Senior Housing');
+    const b = placeholderFor('owens-senior-housing', 'Owens Senior Housing');
+    expect(a).toBe(b);
+  });
+
+  it('varies the gradient across different seeds', () => {
+    const a = placeholderFor('aaa');
+    const b = placeholderFor('zzz-different-seed');
+    expect(a).not.toBe(b);
+  });
+
+  it('renders the name word when a label is given', () => {
+    const svg = svgOf(placeholderFor('x', 'David J. Hoggard Family Community'));
+    expect(svg).toContain('<text');
+    expect(svg).toContain('HOGGARD');
+  });
+
+  it('is glyph-only (no <text>) when no label is given', () => {
+    const svg = svgOf(placeholderFor('some-unit-uuid'));
+    expect(svg).not.toContain('<text');
+  });
+
+  it('never emits an unescaped paren in the URI (CSS url() safety)', () => {
+    const uri = placeholderFor('weird', 'The (Old) Mill Apartments');
+    expect(uri.includes('(')).toBe(false);
+    expect(uri.includes(')')).toBe(false);
+  });
+});
+
+describe('getUnitPhoto', () => {
+  it('prefers a real photo URL when present', () => {
+    expect(getUnitPhoto('/uploads/real.jpg', 'seed')).toBe('/uploads/real.jpg');
+  });
+
+  it('falls back to a generated placeholder otherwise', () => {
+    expect(getUnitPhoto(null, 'seed').startsWith('data:image/svg+xml,')).toBe(true);
+  });
+});
+
+describe('isPlaceholder', () => {
+  it('recognises generated data-URIs', () => {
+    expect(isPlaceholder(placeholderFor('s', 'Owens'))).toBe(true);
+    expect(isPlaceholder(UNIT_PLACEHOLDER)).toBe(true);
+  });
+
+  it('still recognises legacy asset paths (static map / OG back-compat)', () => {
+    expect(isPlaceholder('/property-placeholders/building-01.jpg')).toBe(true);
+    expect(isPlaceholder('/unit-placeholder.svg')).toBe(true);
+  });
+
+  it('treats null/empty as a placeholder and real uploads as not', () => {
+    expect(isPlaceholder(null)).toBe(true);
+    expect(isPlaceholder('')).toBe(true);
+    expect(isPlaceholder('/uploads/real.jpg')).toBe(false);
+  });
+});

--- a/client-tenant/src/utils/unitPlaceholder.ts
+++ b/client-tenant/src/utils/unitPlaceholder.ts
@@ -1,41 +1,26 @@
 /**
  * Placeholder imagery for properties/units that have no uploaded photo.
  *
- * We self-host a small set of generic apartment-exterior photos (see
- * `public/property-placeholders/`) rather than hotlinking a third-party service —
- * this avoids the flakiness and rate-limiting of placeholder services (e.g.
- * picsum.photos) and keeps the imagery licensing-safe (Pexels License, credited in
- * `property-placeholders/CREDITS.md`).
+ * Rather than show a real-but-not-the-actual-building stock photo (a
+ * misrepresentation risk on a fair-housing site, even when labelled), we
+ * generate an honest-by-design **neutral brand placeholder**: a warm brand
+ * gradient + a geometric building glyph + the property's short name. It is
+ * self-evidently not a photograph, carries no licensing, and needs no network
+ * request (inline `data:image/svg+xml` URI).
  *
- * Selection is deterministic on a caller-supplied `seed` (property slug/id, unit id)
- * so a given listing always renders the same photo across reloads and surfaces, while
- * a list of listings shows variety. Callers should pass a stable seed.
+ * Selection is deterministic on a caller-supplied `seed` (property slug/id, unit
+ * id) so a given listing always renders the same panel across reloads and
+ * surfaces, while a list of listings shows on-brand variety (the gradient is
+ * picked from the seed). An optional `label` (the property name) drives the
+ * name word; with no label the panel is glyph-only.
  *
- * Because these are *representative* photos and not the actual building, any surface
- * that renders a placeholder must label it — use `isPlaceholder()` to drive a
- * "Representative photo" badge, shown only on the fallback, never on a real photo.
+ * NOTE: the legacy static map (`public/nv-housing-map.html`) and the social OG
+ * tags still reference the old `/property-placeholders/*.jpg` and
+ * `/unit-placeholder.svg` assets directly — those files are intentionally kept.
+ * `isPlaceholder()` therefore still recognises them for back-compat.
  */
 
-export const PROPERTY_PLACEHOLDERS: string[] = [
-  '/property-placeholders/building-01.jpg',
-  '/property-placeholders/building-02.jpg',
-  '/property-placeholders/building-03.jpg',
-  '/property-placeholders/building-04.jpg',
-  '/property-placeholders/building-05.jpg',
-  '/property-placeholders/building-06.jpg',
-];
-
-/** Ultimate fallback if the photo set is ever unavailable. */
-export const UNIT_PLACEHOLDER_SVG = '/unit-placeholder.svg';
-
-/**
- * Back-compat alias for the old single-asset export. Existing call sites that
- * don't pass a seed get a stable default photo.
- * @deprecated prefer `getUnitPhoto(photoUrl, seed)` with a stable seed.
- */
-export const UNIT_PLACEHOLDER = PROPERTY_PLACEHOLDERS[0];
-
-/** Small stable string hash (FNV-1a style) → non-negative int. */
+/** Small stable string hash (FNV-1a style) → non-negative int. Mirrors propertyProfile.ts. */
 function hashSeed(seed: string): number {
   let h = 2166136261;
   for (let i = 0; i < seed.length; i++) {
@@ -45,32 +30,144 @@ function hashSeed(seed: string): number {
   return h >>> 0;
 }
 
-/** Pick a deterministic placeholder photo from the set for a given seed. */
-export function placeholderFor(seed?: string | number | null): string {
-  if (seed === undefined || seed === null || seed === '') {
-    return PROPERTY_PLACEHOLDERS[0];
+/** On-brand 2-stop gradients (dark enough for white text). Ported from HF tokens. */
+const GRADIENTS: ReadonlyArray<readonly [string, string]> = [
+  ['#C9492A', '#7A2A18'], // terracotta — accent → accentInk
+  ['#5C7A4F', '#3A4F31'], // sage
+  ['#4A4338', '#1F1A12'], // cocoa — ink2 → ink
+  ['#B0673E', '#7A3A1F'], // warm clay
+];
+
+/** Generic words stripped when deriving the name word, so the proper noun wins. */
+const STOPWORDS = new Set([
+  'family', 'community', 'communities', 'senior', 'seniors', 'housing',
+  'apartments', 'apartment', 'homes', 'home', 'the', 'villas', 'villa',
+  'manor', 'estates', 'estate', 'gardens', 'garden', 'place', 'residences',
+  'residence', 'at', 'of', 'and', 'court', 'courts', 'village', 'terrace',
+  'towers', 'tower', 'plaza', 'commons', 'lofts', 'square',
+]);
+
+/**
+ * Derive a single prominent short name word from a property name.
+ * "David J. Hoggard Family Community" → "HOGGARD", "Owens Senior Housing" →
+ * "OWENS", "Donna Louise 2" → "LOUISE". Empty string when no usable word.
+ */
+export function nameWord(label?: string | null): string {
+  if (!label) return '';
+  const tokens = label
+    .replace(/[^A-Za-z0-9]+/g, ' ')
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean);
+  const candidates = tokens.filter(
+    (tok) => tok.length >= 2 && !/^\d+$/.test(tok) && !STOPWORDS.has(tok.toLowerCase()),
+  );
+  const pool = candidates.length ? candidates : tokens.filter((t) => t.length >= 2);
+  if (!pool.length) return '';
+  // Longest wins (most distinctive); first on a tie.
+  const best = pool.reduce((a, b) => (b.length > a.length ? b : a));
+  return best.toUpperCase().slice(0, 10);
+}
+
+/** SVG-escape text content (property names are user-facing strings). */
+function esc(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+/** Build the inline SVG (1200×675, 16:9) for a given seed + optional name word. */
+function buildPlaceholderSvg(seed: string, label?: string | null): string {
+  const h = hashSeed(seed);
+  const [from, to] = GRADIENTS[h % GRADIENTS.length];
+  const id = `g${h % 100000}`;
+  const word = nameWord(label);
+
+  // Geometric building glyph — a tower with a window grid, white at low opacity.
+  // Centred horizontally, sitting in the upper-middle so the name word reads below.
+  const bx = 510;
+  const by = 150;
+  const bw = 180;
+  const bh = 250;
+  let windows = '';
+  const cols = 3;
+  const rows = 5;
+  const ww = 28;
+  const wh = 28;
+  const gapX = (bw - cols * ww) / (cols + 1);
+  const gapY = (bh - rows * wh) / (rows + 1);
+  for (let r = 0; r < rows; r++) {
+    for (let c = 0; c < cols; c++) {
+      const wx = bx + gapX + c * (ww + gapX);
+      const wy = by + gapY + r * (wh + gapY);
+      windows += `<rect x="${wx.toFixed(0)}" y="${wy.toFixed(0)}" width="${ww}" height="${wh}" rx="3" fill="#FFFFFF" opacity="0.16"/>`;
+    }
   }
-  const idx = hashSeed(String(seed)) % PROPERTY_PLACEHOLDERS.length;
-  return PROPERTY_PLACEHOLDERS[idx];
+  const glyph =
+    `<rect x="${bx}" y="${by}" width="${bw}" height="${bh}" rx="8" fill="#FFFFFF" opacity="0.12"/>` +
+    windows;
+
+  // Name word — clamp size to length so long names still fit.
+  const fontSize = word.length <= 6 ? 132 : word.length <= 8 ? 108 : 88;
+  const text = word
+    ? `<text x="600" y="540" text-anchor="middle" font-family="Manrope, -apple-system, system-ui, sans-serif" font-weight="800" font-size="${fontSize}" letter-spacing="4" fill="#FFFFFF" fill-opacity="0.92">${esc(word)}</text>`
+    : '';
+
+  const svg =
+    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 675" width="1200" height="675">` +
+    `<defs><linearGradient id="${id}" x1="0" y1="0" x2="1" y2="1">` +
+    `<stop offset="0" stop-color="${from}"/><stop offset="1" stop-color="${to}"/>` +
+    `</linearGradient></defs>` +
+    `<rect width="1200" height="675" fill="url(#${id})"/>` +
+    glyph +
+    text +
+    `</svg>`;
+
+  // Encode for use in both CSS `url(...)` and `<img src>`. encodeURIComponent
+  // leaves ( ) ' unescaped — escape parens too so CSS `url()` never breaks.
+  const encoded = encodeURIComponent(svg).replace(/\(/g, '%28').replace(/\)/g, '%29');
+  return `data:image/svg+xml,${encoded}`;
 }
 
 /**
- * Returns the real photo URL if present, otherwise a deterministic placeholder
- * chosen from `seed`. With no seed, returns a stable default photo.
+ * Deterministic neutral brand placeholder for a given seed. Pass the property
+ * name as `label` to render its short name word; omit it for a glyph-only panel.
+ */
+export function placeholderFor(
+  seed?: string | number | null,
+  label?: string | null,
+): string {
+  const s = seed === undefined || seed === null ? '' : String(seed);
+  return buildPlaceholderSvg(s, label);
+}
+
+/**
+ * Returns the real photo URL if present, otherwise a deterministic neutral
+ * placeholder generated from `seed` (+ optional `label`).
  */
 export function getUnitPhoto(
   photoUrl: string | null | undefined,
   seed?: string | number | null,
+  label?: string | null,
 ): string {
-  return photoUrl || placeholderFor(seed);
+  return photoUrl || placeholderFor(seed, label);
 }
 
-/** True when the given URL is one of our placeholders (drives the "Representative photo" label). */
+/**
+ * Back-compat alias for the old single-asset export.
+ * @deprecated prefer `placeholderFor(seed, label)` with a stable seed.
+ */
+export const UNIT_PLACEHOLDER = placeholderFor('');
+
+/** Legacy asset paths still referenced by the static map + OG tags (kept for back-compat detection). */
+const LEGACY_PLACEHOLDER_PREFIXES = ['/property-placeholders/', '/unit-placeholder.svg'];
+
+/** True when the given URL is one of our placeholders (real photo ⇒ false). */
 export function isPlaceholder(url: string | null | undefined): boolean {
   if (!url) return true;
   return (
-    url === UNIT_PLACEHOLDER_SVG ||
-    PROPERTY_PLACEHOLDERS.includes(url) ||
-    url.startsWith('/property-placeholders/')
+    url.startsWith('data:image/svg+xml') ||
+    LEGACY_PLACEHOLDER_PREFIXES.some((p) => url === p || url.startsWith(p))
   );
 }


### PR DESCRIPTION
## Why
The `/discover` cards + detail hero (and apply-flow unit cards) fell back to **6 shared royalty-free Pexels building photos** labelled "Representative photo" (#179). On a **compliance / fair-housing** surface, a real-but-not-the-actual-building photo is a misrepresentation risk even when labelled — so we replace them with an **honest-by-design generated placeholder**: an on-brand gradient + building glyph + the property's short name. Self-evidently not a photo, no licensing, zero external image requests.

## What
- **`unitPlaceholder.ts`** — rewrite to emit a deterministic inline `data:image/svg+xml` URI seeded on slug/id (FNV-1a). 4 on-brand gradients (terracotta/sage/cocoa/clay); `nameWord()` derives the distinctive proper noun (stopword-stripped, e.g. `David J. Hoggard Family Community → HOGGARD`). Parens escaped for CSS `url()` safety. Public signatures unchanged; `isPlaceholder()` matches the data-URIs **and** legacy asset paths (back-compat).
- **Discover cards + detail hero** — pass `prop.name` so the wordmark renders.
- **Detail hero** — remove the now-misleading "Representative photo" label.
- **DL2 fixture** — collapse 5 near-identical placeholder frames to one.
- **Apply-flow unit cards** — inherit glyph-only placeholders automatically (no edits).
- **14 new tests** — determinism, `nameWord`, data-URI shape, glyph-only, paren-escaping, `isPlaceholder`.

Legacy `public/property-placeholders/*.jpg` + `public/unit-placeholder.svg` are **kept intentionally** — the static `nv-housing-map.html` and OG meta tags still reference them directly.

## Verification
- `tsc --noEmit` clean · `vitest` 52/52 (14 new + discover suites) · visual grid render confirms centered glyph + wordmark across all 4 gradients.

🤖 Generated with [Claude Code](https://claude.com/claude-code)