### PR TITLE
feat(housing-qa): grounded property/application chat widget on tenant site

### DIFF
--- a/client-tenant/src/App.tsx
+++ b/client-tenant/src/App.tsx
@@ -22,6 +22,7 @@ import { WaitlistFasterList } from '@/pages/waitlist/FasterList';
 import { MagicLinkSent } from '@/pages/apply/MagicLinkSent';
 import { ScreenshotButton } from '@/components/dev/ScreenshotButton';
 import { DemoStuckButton } from '@/components/dev/DemoStuckButton';
+import { HousingChatWidget } from '@/components/HousingChatWidget';
 import { CookieBanner } from '@/components/CookieBanner';
 import { SiteFooter } from '@/components/SiteFooter';
 import { PrivacyPolicy } from '@/pages/legal/PrivacyPolicy';
@@ -85,6 +86,7 @@ export default function App() {
     <CookieBanner />
     <ScreenshotButton />
     <DemoStuckButton />
+    <HousingChatWidget />
     </>
   );
 }

--- a/client-tenant/src/api/client.ts
+++ b/client-tenant/src/api/client.ts
@@ -95,3 +95,14 @@ export const api = {
     request<T>(path, { method: 'PATCH', body: body ? JSON.stringify(body) : undefined }),
   del: <T>(path: string) => request<T>(path, { method: 'DELETE' }),
 };
+
+/**
+ * Ask the grounded housing Q&A assistant a question. Public endpoint — no auth
+ * required (the chat widget is shown to pre-registration visitors). Routes
+ * through the shared request() wrapper so demo-token / base-URL handling stays
+ * consistent. Backend: POST /api/housing-qa (non-streaming, returns the full
+ * answer in one response).
+ */
+export function askHousingQa(question: string): Promise<{ answer: string }> {
+  return api.post<{ answer: string }>('/housing-qa', { question });
+}

--- a/client-tenant/src/components/HousingChatWidget.tsx
+++ b/client-tenant/src/components/HousingChatWidget.tsx
@@ -343,6 +343,7 @@ export function HousingChatWidget() {
           onKeyDown={onInputKeyDown}
           placeholder={t('input.placeholder')}
           aria-label={t('input.placeholder')}
+          maxLength={1000}
           disabled={loading}
           style={{
             flex: 1,

--- a/client-tenant/src/components/HousingChatWidget.tsx
+++ b/client-tenant/src/components/HousingChatWidget.tsx
@@ -1,0 +1,373 @@
+/**
+ * HousingChatWidget — Intercom-style floating chat for grounded housing Q&A.
+ *
+ * A floating bubble (bottom-right) expands into a chat panel. Mostly seen by
+ * pre-registration visitors asking about NV affordable-housing properties and
+ * the application process. Backed by the public, grounded POST /api/housing-qa
+ * endpoint (non-streaming) via askHousingQa().
+ *
+ * Styling uses the repo's shared brand tokens (HF) + the CTA primitive — no new
+ * styling system. Accessible: focus management on open, Esc to close, aria
+ * labels, scrollable history, "typing…" indicator, and an error state.
+ */
+import { useEffect, useRef, useState, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import { HF } from '@/styles/tokens';
+import { CTA } from '@/components/primitives/CTA';
+import { askHousingQa } from '@/api/client';
+
+interface ChatMessage {
+  id: string;
+  role: 'user' | 'assistant';
+  text: string;
+}
+
+let _seq = 0;
+const nextId = () => `m${Date.now()}-${_seq++}`;
+
+export function HousingChatWidget() {
+  const { t } = useTranslation('chat');
+  const [open, setOpen] = useState(false);
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [input, setInput] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(false);
+
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const listEndRef = useRef<HTMLDivElement | null>(null);
+  const bubbleRef = useRef<HTMLButtonElement | null>(null);
+
+  // Focus the input when the panel opens; return focus to the bubble on close.
+  useEffect(() => {
+    if (open) {
+      // defer so the element is mounted
+      const id = window.setTimeout(() => inputRef.current?.focus(), 0);
+      return () => window.clearTimeout(id);
+    }
+    bubbleRef.current?.focus();
+  }, [open]);
+
+  // Esc closes the panel.
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation();
+        setOpen(false);
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open]);
+
+  // Auto-scroll history to the latest message.
+  useEffect(() => {
+    listEndRef.current?.scrollIntoView({ behavior: 'smooth', block: 'end' });
+  }, [messages, loading]);
+
+  const send = useCallback(async () => {
+    const question = input.trim();
+    if (!question || loading) return;
+    setError(false);
+    setInput('');
+    const userMsg: ChatMessage = { id: nextId(), role: 'user', text: question };
+    setMessages((prev) => [...prev, userMsg]);
+    setLoading(true);
+    try {
+      const { answer } = await askHousingQa(question);
+      setMessages((prev) => [
+        ...prev,
+        { id: nextId(), role: 'assistant', text: answer },
+      ]);
+    } catch {
+      setError(true);
+    } finally {
+      setLoading(false);
+      inputRef.current?.focus();
+    }
+  }, [input, loading]);
+
+  const onInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      void send();
+    }
+  };
+
+  // ── Bubble (collapsed) ──────────────────────────────────────────────
+  if (!open) {
+    return (
+      <button
+        ref={bubbleRef}
+        type="button"
+        aria-label={t('bubble.label')}
+        title={t('bubble.label')}
+        onClick={() => setOpen(true)}
+        style={{
+          position: 'fixed',
+          right: 20,
+          bottom: 20,
+          zIndex: 1000,
+          width: 56,
+          height: 56,
+          borderRadius: HF.r.pill,
+          background: HF.accent,
+          color: HF.paper,
+          border: 'none',
+          boxShadow: HF.shadow.lg,
+          cursor: 'pointer',
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          fontFamily: HF.body,
+        }}
+      >
+        <svg
+          width="26"
+          height="26"
+          viewBox="0 0 24 24"
+          fill="none"
+          aria-hidden="true"
+        >
+          <path
+            d="M4 5.5A2.5 2.5 0 0 1 6.5 3h11A2.5 2.5 0 0 1 20 5.5v8A2.5 2.5 0 0 1 17.5 16H9l-4 4v-4H6.5"
+            stroke="currentColor"
+            strokeWidth="1.8"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      </button>
+    );
+  }
+
+  // ── Panel (expanded) ────────────────────────────────────────────────
+  return (
+    <div
+      ref={panelRef}
+      role="dialog"
+      aria-modal="false"
+      aria-label={t('panel.title')}
+      style={{
+        position: 'fixed',
+        right: 20,
+        bottom: 20,
+        zIndex: 1000,
+        width: 'min(380px, calc(100vw - 32px))',
+        height: 'min(560px, calc(100vh - 40px))',
+        display: 'flex',
+        flexDirection: 'column',
+        background: HF.paper,
+        border: `1px solid ${HF.border}`,
+        borderRadius: HF.r.lg,
+        boxShadow: HF.shadow.lg,
+        overflow: 'hidden',
+        fontFamily: HF.body,
+        color: HF.ink,
+      }}
+    >
+      {/* Header */}
+      <div
+        style={{
+          background: HF.accent,
+          color: HF.paper,
+          padding: '12px 14px',
+          display: 'flex',
+          alignItems: 'flex-start',
+          justifyContent: 'space-between',
+          gap: 8,
+        }}
+      >
+        <div>
+          <div
+            style={{
+              fontFamily: HF.display,
+              fontWeight: 700,
+              fontSize: 15,
+            }}
+          >
+            {t('panel.title')}
+          </div>
+          <div style={{ fontSize: 11.5, opacity: 0.92, marginTop: 4, lineHeight: 1.35 }}>
+            {t('panel.greeting')}
+          </div>
+        </div>
+        <button
+          type="button"
+          aria-label={t('panel.close')}
+          onClick={() => setOpen(false)}
+          style={{
+            flexShrink: 0,
+            background: 'transparent',
+            border: 'none',
+            color: HF.paper,
+            cursor: 'pointer',
+            fontSize: 20,
+            lineHeight: 1,
+            padding: 2,
+          }}
+        >
+          ×
+        </button>
+      </div>
+
+      {/* Message list */}
+      <div
+        aria-live="polite"
+        style={{
+          flex: 1,
+          overflowY: 'auto',
+          padding: '14px',
+          background: HF.cream,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 10,
+        }}
+      >
+        {messages.length === 0 && (
+          <div style={{ color: HF.ink3, fontSize: 13, lineHeight: 1.45 }}>
+            {t('empty.hint')}
+          </div>
+        )}
+
+        {messages.map((m) => {
+          const isUser = m.role === 'user';
+          return (
+            <div
+              key={m.id}
+              style={{
+                alignSelf: isUser ? 'flex-end' : 'flex-start',
+                maxWidth: '85%',
+              }}
+            >
+              <div
+                style={{
+                  fontSize: 10.5,
+                  color: HF.ink3,
+                  marginBottom: 3,
+                  textAlign: isUser ? 'right' : 'left',
+                }}
+              >
+                {isUser ? t('message.you') : t('message.assistant')}
+              </div>
+              <div
+                style={{
+                  background: isUser ? HF.accent : HF.paper,
+                  color: isUser ? HF.paper : HF.ink,
+                  border: isUser ? 'none' : `1px solid ${HF.border}`,
+                  borderRadius: HF.r.md,
+                  padding: '8px 11px',
+                  fontSize: 13.5,
+                  lineHeight: 1.45,
+                  whiteSpace: 'pre-wrap',
+                  wordBreak: 'break-word',
+                  boxShadow: HF.shadow.xs,
+                }}
+              >
+                {m.text}
+              </div>
+            </div>
+          );
+        })}
+
+        {loading && (
+          <div
+            aria-label={t('status.typing')}
+            style={{
+              alignSelf: 'flex-start',
+              background: HF.paper,
+              border: `1px solid ${HF.border}`,
+              borderRadius: HF.r.md,
+              padding: '8px 11px',
+              fontSize: 13,
+              color: HF.ink3,
+              fontStyle: 'italic',
+            }}
+          >
+            {t('status.typing')}
+          </div>
+        )}
+
+        {error && (
+          <div
+            role="alert"
+            style={{
+              alignSelf: 'flex-start',
+              maxWidth: '85%',
+              background: HF.errLo,
+              color: HF.err,
+              border: `1px solid ${HF.err}`,
+              borderRadius: HF.r.md,
+              padding: '8px 11px',
+              fontSize: 13,
+            }}
+          >
+            {t('error.generic')}{' '}
+            <button
+              type="button"
+              onClick={() => void send()}
+              style={{
+                background: 'transparent',
+                border: 'none',
+                color: HF.err,
+                textDecoration: 'underline',
+                cursor: 'pointer',
+                padding: 0,
+                font: 'inherit',
+              }}
+            >
+              {t('error.retry')}
+            </button>
+          </div>
+        )}
+
+        <div ref={listEndRef} />
+      </div>
+
+      {/* Input row */}
+      <div
+        style={{
+          display: 'flex',
+          gap: 8,
+          padding: 10,
+          borderTop: `1px solid ${HF.border}`,
+          background: HF.paper,
+        }}
+      >
+        <input
+          ref={inputRef}
+          type="text"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={onInputKeyDown}
+          placeholder={t('input.placeholder')}
+          aria-label={t('input.placeholder')}
+          disabled={loading}
+          style={{
+            flex: 1,
+            border: `1px solid ${HF.border}`,
+            borderRadius: HF.r.sm,
+            padding: '9px 11px',
+            fontSize: 13.5,
+            fontFamily: HF.body,
+            color: HF.ink,
+            background: HF.paperHi,
+            outline: 'none',
+          }}
+        />
+        <CTA
+          tone="primary"
+          size="md"
+          onClick={() => void send()}
+          disabled={loading || input.trim().length === 0}
+          aria-label={t('input.sendLabel')}
+        >
+          {t('input.send')}
+        </CTA>
+      </div>
+    </div>
+  );
+}
+
+export default HousingChatWidget;

--- a/client-tenant/src/i18n/en/chat.json
+++ b/client-tenant/src/i18n/en/chat.json
@@ -1,0 +1,15 @@
+{
+  "bubble.label": "Ask about housing",
+  "panel.title": "Housing assistant",
+  "panel.greeting": "Ask about NV affordable housing & applying. I answer from our latest data — confirm details in the application.",
+  "panel.close": "Close chat",
+  "message.you": "You",
+  "message.assistant": "Assistant",
+  "input.placeholder": "Ask a question…",
+  "input.send": "Send",
+  "input.sendLabel": "Send message",
+  "status.typing": "Assistant is typing…",
+  "error.generic": "Something went wrong. Please try again.",
+  "error.retry": "Try again",
+  "empty.hint": "Try: “What documents do I need?” or “Senior housing in Henderson”."
+}

--- a/client-tenant/src/i18n/es/chat.json
+++ b/client-tenant/src/i18n/es/chat.json
@@ -1,0 +1,15 @@
+{
+  "bubble.label": "Pregunta sobre vivienda",
+  "panel.title": "Asistente de vivienda",
+  "panel.greeting": "Pregunta sobre vivienda asequible en NV y cómo solicitarla. Respondo según nuestros datos más recientes; confirma los detalles en la solicitud.",
+  "panel.close": "Cerrar el chat",
+  "message.you": "Tú",
+  "message.assistant": "Asistente",
+  "input.placeholder": "Escribe tu pregunta…",
+  "input.send": "Enviar",
+  "input.sendLabel": "Enviar mensaje",
+  "status.typing": "El asistente está escribiendo…",
+  "error.generic": "Algo salió mal. Inténtalo de nuevo.",
+  "error.retry": "Reintentar",
+  "empty.hint": "Prueba: «¿Qué documentos necesito?» o «Vivienda para personas mayores en Henderson»."
+}

--- a/client-tenant/src/i18n/index.ts
+++ b/client-tenant/src/i18n/index.ts
@@ -11,6 +11,7 @@ import enDiscover from './en/discover.json';
 import enLegal from './en/legal.json';
 import enSettings from './en/settings.json';
 import enLease from './en/lease.json';
+import enChat from './en/chat.json';
 
 import esCommon from './es/common.json';
 import esWelcome from './es/welcome.json';
@@ -20,8 +21,9 @@ import esDiscover from './es/discover.json';
 import esLegal from './es/legal.json';
 import esSettings from './es/settings.json';
 import esLease from './es/lease.json';
+import esChat from './es/chat.json';
 
-export const NS = ['common', 'welcome', 'apply', 'waitlist', 'discover', 'legal', 'settings', 'lease'] as const;
+export const NS = ['common', 'welcome', 'apply', 'waitlist', 'discover', 'legal', 'settings', 'lease', 'chat'] as const;
 
 const resources = {
   en: {
@@ -33,6 +35,7 @@ const resources = {
     legal: enLegal,
     settings: enSettings,
     lease: enLease,
+    chat: enChat,
   },
   es: {
     common: esCommon,
@@ -43,6 +46,7 @@ const resources = {
     legal: esLegal,
     settings: esSettings,
     lease: esLease,
+    chat: esChat,
   },
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,12 +8,14 @@
       "name": "frank-pilot-tenant-onboarding",
       "version": "1.0.0",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.98.0",
         "bcrypt": "^5.1.1",
         "commander": "^12.1.0",
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
         "express": "^5.2.1",
         "express-rate-limit": "^8.5.2",
+        "fuse.js": "^7.3.0",
         "helmet": "^7.1.0",
         "jsonwebtoken": "^9.0.2",
         "node-cron": "^4.2.1",
@@ -24,7 +26,7 @@
         "twilio": "^5.3.0",
         "uuid": "^10.0.0",
         "winston": "^3.15.0",
-        "zod": "4.4.3"
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@types/bcrypt": "^5.0.2",
@@ -46,6 +48,27 @@
         "ts-node": "^10.9.2",
         "typescript": "^5.6.0",
         "wait-on": "^8.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.98.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.98.0.tgz",
+      "integrity": "sha512-N7aXtCvC5g6T1Y4V29lJjceu/zTkVkIZF0jdBvagr0TRFHuKeImffalGWEfqZKrvjH+IQbzJWw6TmSmUzrlMgg==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/@babel/code-frame": {
@@ -507,6 +530,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -3201,6 +3233,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/fuse.js": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.3.0.tgz",
+      "integrity": "sha512-plz8RVjfcDedTGfVngWH1jmJvBvAwi1v2jecfDerbEnMcmOYUEEwKFTHbNoCiYyzaK2Ws8lABkTCcRSqCY1q4w==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/krisk"
+      }
+    },
     "node_modules/gauge": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
@@ -4371,6 +4416,19 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -6256,6 +6314,12 @@
       "engines": {
         "node": ">= 14.0.0"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
     },
     "node_modules/ts-jest": {
       "version": "29.4.11",

--- a/package.json
+++ b/package.json
@@ -16,12 +16,14 @@
     "e2e:up:once": "node scripts/e2e-up.mjs --once"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.98.0",
     "bcrypt": "^5.1.1",
     "commander": "^12.1.0",
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^5.2.1",
     "express-rate-limit": "^8.5.2",
+    "fuse.js": "^7.3.0",
     "helmet": "^7.1.0",
     "jsonwebtoken": "^9.0.2",
     "node-cron": "^4.2.1",

--- a/src/__tests__/housing-qa-retriever.test.ts
+++ b/src/__tests__/housing-qa-retriever.test.ts
@@ -1,0 +1,100 @@
+/**
+ * housing-qa-retriever.test.ts — unit tests for the grounded retriever.
+ *
+ * Ports the 5 smoke cases proven on the Python tool (tools/housing-qa).
+ * These are pure retrieval tests — NO model call — asserting on the assembled
+ * CONTEXT payload shape (routing, propertyMode, properties, faqSections, notes).
+ *
+ * They lock the grounding contract: process Qs inject no property objects,
+ * city+attribute Qs filter on both and cap at K=8, statewide-only named
+ * properties refuse rent (rent.disclosed=false → no rent value), and an
+ * unknown property name produces a refusal note with no invented data.
+ */
+import { buildContext } from "../modules/housing-qa/retriever";
+import { getHousingIndex } from "../modules/housing-qa/data";
+
+describe("housing-qa retriever — grounded context assembly", () => {
+  it("builds the merged index (335 statewide + 17 GPMG)", () => {
+    const idx = getHousingIndex();
+    expect(idx.statewideCount).toBe(335);
+    expect(idx.gpmgCount).toBe(17);
+    // every GPMG record is either merged into a statewide record or appended.
+    expect(idx.availableNowCount).toBeGreaterThan(0);
+    expect(idx.availableNowCount).toBeLessThanOrEqual(17);
+  });
+
+  it("(1) process question (fee) → FAQ-only, no property objects", () => {
+    const ctx = buildContext("How much is the application fee and is it refundable?");
+    expect(ctx.routing).toBe("process");
+    expect(ctx.propertyMode).toBe("none");
+    expect(ctx.properties).toHaveLength(0);
+    expect(ctx.faqSections.map((f) => f.id)).toContain("fees");
+    // always-on facts block is present so the agent can ground the answer.
+    expect(ctx.facts.applicationFee.amount).toBe("$35.95");
+    expect(ctx.facts.applicationFee.refundable).toBe(false);
+  });
+
+  it("(2) 'senior housing in Henderson' → city+attribute filter, compact, capped at K=8", () => {
+    const ctx = buildContext("What senior housing is available in Henderson?");
+    expect(ctx.routing).toBe("attribute");
+    expect(ctx.propertyMode).toBe("compact");
+    // capped
+    expect(ctx.properties.length).toBeLessThanOrEqual(8);
+    expect(ctx.properties.length).toBeGreaterThan(0);
+    // filtered by BOTH city (Henderson) and attribute (senior)
+    for (const p of ctx.properties) {
+      const cp = p as { city: string | null; type: string | null };
+      expect(cp.city).toBe("Henderson");
+      expect((cp.type || "").toLowerCase()).toContain("senior");
+    }
+    // compact shape — no full contact/rent object leaked
+    expect(ctx.properties[0]).not.toHaveProperty("contact");
+    expect(ctx.properties[0]).not.toHaveProperty("rent");
+  });
+
+  it("(3) named property rent → property matched, rent refused (rent.disclosed=false → no value)", () => {
+    const ctx = buildContext("What's the monthly rent at Silver Pines Apts?");
+    expect(ctx.routing).toBe("named_property");
+    expect(ctx.propertyMode).toBe("full");
+    expect(ctx.properties).toHaveLength(1);
+    const prop = ctx.properties[0] as {
+      name: string;
+      rent: { disclosed: boolean; text: string | null };
+      contact: { phone: string | null };
+    };
+    expect(prop.name).toBe("Silver Pines Apts");
+    // rent is NOT disclosed → no rent value, so the agent must refuse it.
+    expect(prop.rent.disclosed).toBe(false);
+    expect(prop.rent.text).toBeNull();
+    // statewide-only → no invented contact info + a refusal note.
+    expect(prop.contact.phone).toBeNull();
+    expect(ctx.notes.join(" ")).toMatch(/statewide HUD-LIHTC dataset only/i);
+  });
+
+  it("(4) unknown property 'Moonbeam Towers' → no match, no invented data, refusal note", () => {
+    const ctx = buildContext("Tell me about Moonbeam Towers");
+    expect(ctx.routing).toBe("process");
+    expect(ctx.propertyMode).toBe("none");
+    expect(ctx.properties).toHaveLength(0);
+    expect(ctx.notes.join(" ")).toMatch(/NOT in the statewide HUD-LIHTC or available-now data/i);
+    expect(ctx.notes.join(" ")).toMatch(/Moonbeam Towers/);
+  });
+
+  it("(5) AMI/eligibility question → FAQ section, no personal ruling, no property objects", () => {
+    const ctx = buildContext("I make $40,000 a year — do I qualify?");
+    expect(ctx.routing).toBe("process");
+    expect(ctx.propertyMode).toBe("none");
+    expect(ctx.properties).toHaveLength(0);
+    expect(ctx.faqSections.map((f) => f.id)).toContain("who-its-for");
+  });
+
+  it("emitted full-property objects never expose internal-only fields", () => {
+    const ctx = buildContext("Tell me about Silver Pines Apts");
+    const prop = ctx.properties[0] as Record<string, unknown>;
+    expect(prop).not.toHaveProperty("_lat");
+    expect(prop).not.toHaveProperty("_lng");
+    expect(prop).not.toHaveProperty("_aka");
+    // provenance _source is intentionally retained
+    expect(prop).toHaveProperty("_source");
+  });
+});

--- a/src/__tests__/housing-qa-routes.test.ts
+++ b/src/__tests__/housing-qa-routes.test.ts
@@ -1,0 +1,142 @@
+/**
+ * housing-qa-routes.test.ts — route tests for POST /api/housing-qa.
+ *
+ * Mocks @anthropic-ai/sdk (no real network). Asserts:
+ *   - empty / oversized question → 400
+ *   - valid question → 200 { answer }, AND the system prompt passed to the SDK
+ *     contains the injected grounded context
+ *   - missing ANTHROPIC_API_KEY → 503 (clean, no crash)
+ */
+import express from "express";
+import request from "supertest";
+
+// Capture the system prompt the route passes to the SDK so we can assert the
+// grounded context is injected.
+const createMock = jest.fn();
+
+jest.mock("@anthropic-ai/sdk", () => {
+  return {
+    __esModule: true,
+    default: jest.fn().mockImplementation(() => ({
+      messages: { create: createMock },
+    })),
+  };
+});
+
+jest.mock("../utils/logger", () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+import { housingQaRouter } from "../modules/housing-qa/routes";
+
+function makeApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/api/housing-qa", housingQaRouter());
+  return app;
+}
+
+const ORIGINAL_KEY = process.env.ANTHROPIC_API_KEY;
+
+beforeEach(() => {
+  createMock.mockReset();
+  process.env.ANTHROPIC_API_KEY = "test-key-123";
+});
+
+afterAll(() => {
+  if (ORIGINAL_KEY === undefined) delete process.env.ANTHROPIC_API_KEY;
+  else process.env.ANTHROPIC_API_KEY = ORIGINAL_KEY;
+});
+
+describe("POST /api/housing-qa — validation", () => {
+  it("rejects an empty question with 400", async () => {
+    const res = await request(makeApp())
+      .post("/api/housing-qa")
+      .send({ question: "" });
+    expect(res.status).toBe(400);
+    expect(createMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a missing question body with 400", async () => {
+    const res = await request(makeApp()).post("/api/housing-qa").send({});
+    expect(res.status).toBe(400);
+    expect(createMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects an oversized question (>1000 chars) with 400", async () => {
+    const res = await request(makeApp())
+      .post("/api/housing-qa")
+      .send({ question: "a".repeat(1001) });
+    expect(res.status).toBe(400);
+    expect(createMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /api/housing-qa — grounded answer", () => {
+  it("returns 200 { answer } and injects grounded context into the system prompt", async () => {
+    createMock.mockResolvedValueOnce({
+      content: [{ type: "text", text: "The application fee is $35.95 per adult." }],
+    });
+
+    const res = await request(makeApp())
+      .post("/api/housing-qa")
+      .send({ question: "How much is the application fee?" });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      answer: "The application fee is $35.95 per adult.",
+    });
+
+    expect(createMock).toHaveBeenCalledTimes(1);
+    const callArg = createMock.mock.calls[0][0];
+    // model + user message wired correctly
+    expect(callArg.model).toContain("haiku");
+    expect(callArg.messages).toEqual([
+      { role: "user", content: "How much is the application fee?" },
+    ]);
+    // The system prompt must carry the guardrails AND the injected context.
+    expect(callArg.system).toMatch(/GROUNDING RULES \(non-negotiable\)/);
+    expect(callArg.system).toMatch(/BEGIN CONTEXT/);
+    expect(callArg.system).toMatch(/"routing": "process"/);
+    // always-on facts injected so the answer can be grounded
+    expect(callArg.system).toMatch(/\$35\.95/);
+  });
+
+  it("injects a refusal note for an unknown property", async () => {
+    createMock.mockResolvedValueOnce({
+      content: [{ type: "text", text: "I don't have that property." }],
+    });
+
+    const res = await request(makeApp())
+      .post("/api/housing-qa")
+      .send({ question: "Tell me about Moonbeam Towers" });
+
+    expect(res.status).toBe(200);
+    const callArg = createMock.mock.calls[0][0];
+    expect(callArg.system).toMatch(/Moonbeam Towers/);
+    expect(callArg.system).toMatch(/NOT in the statewide HUD-LIHTC or available-now data/);
+  });
+
+  it("returns 502 when the model call throws", async () => {
+    createMock.mockRejectedValueOnce(new Error("upstream boom"));
+    const res = await request(makeApp())
+      .post("/api/housing-qa")
+      .send({ question: "How much is the fee?" });
+    expect(res.status).toBe(502);
+    expect(res.body.error).toBeDefined();
+    // the raw upstream error is never echoed to the client
+    expect(JSON.stringify(res.body)).not.toMatch(/upstream boom/);
+  });
+});
+
+describe("POST /api/housing-qa — missing API key", () => {
+  it("returns 503 (clean) when ANTHROPIC_API_KEY is absent", async () => {
+    delete process.env.ANTHROPIC_API_KEY;
+    const res = await request(makeApp())
+      .post("/api/housing-qa")
+      .send({ question: "How much is the application fee?" });
+    expect(res.status).toBe(503);
+    expect(res.body.error).toMatch(/temporarily unavailable/i);
+    expect(createMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,7 @@ import messagesRoutes from "./modules/messages/routes";
 import tapeRoutes from "./modules/tape/routes";
 import { createTapeViewerRoutes } from "./modules/tape/routes-viewer";
 import { qaRouter } from "./modules/qa/routes";
+import { housingQaRouter } from "./modules/housing-qa/routes";
 import acquisitionRoutes from "./modules/acquisitions/routes";
 import { startScheduler } from "./scheduler";
 
@@ -128,6 +129,12 @@ app.use("/api/auth", authRoutes);
 
 // Applicant self-service (public register + auth'd apply)
 app.use("/api/applicants", applicantRoutes);
+
+// Grounded housing Q&A chat (PUBLIC, per-IP rate-limited — pre-registration
+// applicants ask about NV affordable-housing properties + the application
+// process; answers are grounded strictly in injected data). Degrades to 503
+// when ANTHROPIC_API_KEY is absent.
+app.use("/api/housing-qa", housingQaRouter());
 
 // BP-03b compliance tape beacons (HUD-928.1 page-view, welcome-accept).
 // Stub module — see src/modules/tape/index.ts. Replace with canonical BP-02

--- a/src/modules/housing-qa/data.ts
+++ b/src/modules/housing-qa/data.ts
@@ -1,0 +1,460 @@
+/**
+ * data.ts — Load + merge the two housing datasets into the normalized index.
+ *
+ * Ported from tools/housing-qa/retriever.py (HousingIndex + helpers). Keeps the
+ * LOCKED grounding contract: per-field provenance, `null` for any field absent
+ * in source — NEVER invent. The built index is cached in module scope (build
+ * once).
+ *
+ * Datasets (resolved relative to repo root):
+ *   1. STATEWIDE HUD-LIHTC base : client-tenant/public/nv-housing-props.json
+ *      (335 records). Falls back to src/db/data/nv-housing-props.json.
+ *   2. AVAILABLE-NOW (GPMG)     : docs/intel/gpmglv-properties-extracted.json
+ *      (dict; property list under "properties", 17 records).
+ */
+
+import fs from "fs";
+import path from "path";
+
+// __dirname = src/modules/housing-qa -> repo root is three levels up.
+const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
+
+const STATEWIDE_PRIMARY = path.join(
+  REPO_ROOT,
+  "client-tenant",
+  "public",
+  "nv-housing-props.json"
+);
+const STATEWIDE_FALLBACK = path.join(
+  REPO_ROOT,
+  "src",
+  "db",
+  "data",
+  "nv-housing-props.json"
+);
+const GPMG_PATH = path.join(
+  REPO_ROOT,
+  "docs",
+  "intel",
+  "gpmglv-properties-extracted.json"
+);
+
+export const K_COMPACT = 8; // cap on compact summaries injected
+
+// --------------------------------------------------------------------------- //
+// Normalization helpers (mirror retriever.py)
+// --------------------------------------------------------------------------- //
+const STOPWORDS = new Set([
+  "apartments", "apartment", "apts", "apt", "community", "communities",
+  "senior", "family", "the", "at", "of", "housing", "homes", "home",
+  "village", "court", "courts", "place", "gardens", "garden",
+]);
+
+export function normName(s: string | null | undefined): string {
+  if (!s) return "";
+  let out = s.toLowerCase();
+  out = out.replace(/[^a-z0-9\s]/g, " ");
+  out = out.replace(/\s+/g, " ").trim();
+  return out;
+}
+
+export function nameTokens(s: string | null | undefined): Set<string> {
+  const out = new Set<string>();
+  for (const t of normName(s).split(" ")) {
+    if (t && !STOPWORDS.has(t)) out.add(t);
+  }
+  return out;
+}
+
+function slugToName(slug: string | null | undefined): string {
+  return slug ? normName(slug.replace(/-/g, " ")) : "";
+}
+
+/** Jaccard-style token overlap (|A∩B| / |A∪B|). */
+function tokenOverlap(a: Set<string>, b: Set<string>): number {
+  if (a.size === 0 || b.size === 0) return 0;
+  let inter = 0;
+  for (const t of a) if (b.has(t)) inter += 1;
+  const union = a.size + b.size - inter;
+  return union === 0 ? 0 : inter / union;
+}
+
+/**
+ * difflib.SequenceMatcher.ratio() equivalent (Ratcliff/Obershelp). Used as the
+ * full-string similarity component in GPMG↔statewide matching, mirroring
+ * retriever.py. Fuse.js is used for the user-facing fuzzy_property lookup in
+ * retriever.ts; this internal merge ratio stays faithful to the Python tool.
+ */
+export function seqRatio(a: string, b: string): number {
+  if (!a && !b) return 1;
+  if (!a || !b) return 0;
+  const matches = matchingBlocksTotal(a, b);
+  return (2 * matches) / (a.length + b.length);
+}
+
+function matchingBlocksTotal(a: string, b: string): number {
+  // Recursive longest-matching-block sum, as in difflib.
+  if (!a || !b) return 0;
+  let bestI = 0;
+  let bestJ = 0;
+  let bestSize = 0;
+  // j2len: length of longest match ending at b[j]
+  const bIndex = new Map<string, number[]>();
+  for (let j = 0; j < b.length; j++) {
+    const arr = bIndex.get(b[j]);
+    if (arr) arr.push(j);
+    else bIndex.set(b[j], [j]);
+  }
+  let j2len = new Map<number, number>();
+  for (let i = 0; i < a.length; i++) {
+    const newJ2len = new Map<number, number>();
+    const js = bIndex.get(a[i]);
+    if (js) {
+      for (const j of js) {
+        const k = (j > 0 ? j2len.get(j - 1) || 0 : 0) + 1;
+        newJ2len.set(j, k);
+        if (k > bestSize) {
+          bestI = i - k + 1;
+          bestJ = j - k + 1;
+          bestSize = k;
+        }
+      }
+    }
+    j2len = newJ2len;
+  }
+  if (bestSize === 0) return 0;
+  return (
+    bestSize +
+    matchingBlocksTotal(a.slice(0, bestI), b.slice(0, bestJ)) +
+    matchingBlocksTotal(a.slice(bestI + bestSize), b.slice(bestJ + bestSize))
+  );
+}
+
+// --------------------------------------------------------------------------- //
+// Types
+// --------------------------------------------------------------------------- //
+export interface Availability {
+  status: "statewide_only" | "available_now";
+  availableUnitsCount: number | null;
+  asOf: string | null;
+}
+
+export interface NormalizedProperty {
+  id: string;
+  name: string | null;
+  city: string | null;
+  address: string | null;
+  type: string | null;
+  totalUnits: number | null;
+  restrictedUnits: number | null;
+  amiTiers: string[] | null;
+  funding: string[] | null;
+  availability: Availability;
+  rent: { disclosed: boolean; text: string | null };
+  contact: {
+    phone: string | null;
+    email: string | null;
+    officeHours: string | null;
+    waitlistUrl: string | null;
+    applicationUrl: string | null;
+  };
+  amenities: string[] | null;
+  accessibility: string | null;
+  petPolicy: string | null;
+  unitTypes: string[] | null;
+  _source: { base: string; availability: string | null };
+  // internal-only (stripped before injection)
+  _lat: number | null;
+  _lng: number | null;
+  _aka: string;
+}
+
+interface StatewideRaw {
+  name?: string;
+  aka?: string;
+  city?: string;
+  address?: string;
+  lat?: number;
+  lng?: number;
+  totalUnits?: number;
+  restrictedUnits?: number;
+  type?: string;
+  amiTiers?: string[];
+  funding?: string[];
+}
+
+interface GpmgRaw {
+  slug?: string;
+  name?: string;
+  address?: { line1?: string; city?: string; state?: string; zip?: string };
+  phone?: string;
+  email?: string;
+  manager_email?: string;
+  property_type?: string;
+  amenities?: string[];
+  accessibility?: string[] | string;
+  pet_policy?: string | null;
+  office_hours?: string;
+  unit_types?: string[];
+  rent_disclosed?: boolean;
+  rent_text?: string | null;
+  available_units_count?: number | null;
+  waitlist_url?: string | null;
+  application_url?: string | null;
+}
+
+// --------------------------------------------------------------------------- //
+// Data loading
+// --------------------------------------------------------------------------- //
+function loadStatewide(): { raw: StatewideRaw[]; path: string } {
+  const p = fs.existsSync(STATEWIDE_PRIMARY)
+    ? STATEWIDE_PRIMARY
+    : STATEWIDE_FALLBACK;
+  const parsed = JSON.parse(fs.readFileSync(p, "utf8"));
+  const arr: StatewideRaw[] = Array.isArray(parsed)
+    ? parsed
+    : parsed.properties || parsed.records || [];
+  return { raw: arr, path: p };
+}
+
+function loadGpmg(): { raw: GpmgRaw[]; snapshot: string | null } {
+  if (!fs.existsSync(GPMG_PATH)) return { raw: [], snapshot: null };
+  const d = JSON.parse(fs.readFileSync(GPMG_PATH, "utf8"));
+  const props: GpmgRaw[] = Array.isArray(d) ? d : d.properties || [];
+  const snapshot: string | null = Array.isArray(d)
+    ? null
+    : d.source_snapshot || null;
+  return { raw: props, snapshot };
+}
+
+// --------------------------------------------------------------------------- //
+// Normalized record construction (LOCKED contract shape)
+// --------------------------------------------------------------------------- //
+function blankNormalized(rec: StatewideRaw): NormalizedProperty {
+  return {
+    id: normName(rec.name || "").replace(/ /g, "-") || "unknown",
+    name: rec.name || null,
+    city: rec.city || null,
+    address: rec.address || null,
+    type: rec.type || null,
+    totalUnits: rec.totalUnits ?? null,
+    restrictedUnits: rec.restrictedUnits ?? null,
+    amiTiers: rec.amiTiers && rec.amiTiers.length ? rec.amiTiers : null,
+    funding: rec.funding && rec.funding.length ? rec.funding : null,
+    availability: {
+      status: "statewide_only",
+      availableUnitsCount: null,
+      asOf: null,
+    },
+    rent: { disclosed: false, text: null },
+    contact: {
+      phone: null,
+      email: null,
+      officeHours: null,
+      waitlistUrl: null,
+      applicationUrl: null,
+    },
+    amenities: null,
+    accessibility: null,
+    petPolicy: null,
+    unitTypes: null,
+    _source: { base: "HUD-LIHTC statewide", availability: null },
+    _lat: rec.lat ?? null,
+    _lng: rec.lng ?? null,
+    _aka: rec.aka || "",
+  };
+}
+
+function normalizeAccessibility(
+  acc: string[] | string | undefined
+): string | null {
+  if (Array.isArray(acc)) return acc.length ? acc.join("; ") : null;
+  return acc || null;
+}
+
+function gpmgToNormalized(
+  g: GpmgRaw,
+  snapshot: string | null
+): NormalizedProperty {
+  const addr = g.address || {};
+  const parts = [addr.line1, addr.city, addr.state, addr.zip].filter(Boolean);
+  const address = parts.length ? parts.join(", ") : null;
+  return {
+    id: g.slug || normName(g.name || "").replace(/ /g, "-"),
+    name: g.name || null,
+    city: addr.city || null,
+    address,
+    type: g.property_type || null,
+    totalUnits: null,
+    restrictedUnits: null,
+    amiTiers: null,
+    funding: null,
+    availability: {
+      status: "available_now",
+      availableUnitsCount: g.available_units_count ?? null,
+      asOf: snapshot,
+    },
+    rent: { disclosed: Boolean(g.rent_disclosed), text: g.rent_text ?? null },
+    contact: {
+      phone: g.phone ?? null,
+      email: g.email || g.manager_email || null,
+      officeHours: g.office_hours ?? null,
+      waitlistUrl: g.waitlist_url ?? null,
+      applicationUrl: g.application_url ?? null,
+    },
+    amenities: g.amenities && g.amenities.length ? g.amenities : null,
+    accessibility: normalizeAccessibility(g.accessibility),
+    petPolicy: g.pet_policy ?? null,
+    unitTypes: g.unit_types && g.unit_types.length ? g.unit_types : null,
+    _source: {
+      base: "HUD-LIHTC statewide",
+      availability: snapshot ? `GPMG ${snapshot}` : "GPMG",
+    },
+    _lat: null,
+    _lng: null,
+    _aka: "",
+  };
+}
+
+function enrichWithGpmg(
+  norm: NormalizedProperty,
+  g: GpmgRaw,
+  snapshot: string | null
+): void {
+  norm.availability = {
+    status: "available_now",
+    availableUnitsCount: g.available_units_count ?? null,
+    asOf: snapshot,
+  };
+  norm.rent = { disclosed: Boolean(g.rent_disclosed), text: g.rent_text ?? null };
+  norm.contact = {
+    phone: g.phone ?? null,
+    email: g.email || g.manager_email || null,
+    officeHours: g.office_hours ?? null,
+    waitlistUrl: g.waitlist_url ?? null,
+    applicationUrl: g.application_url ?? null,
+  };
+  norm.amenities = g.amenities && g.amenities.length ? g.amenities : null;
+  norm.accessibility = normalizeAccessibility(g.accessibility);
+  norm.petPolicy = g.pet_policy ?? null;
+  norm.unitTypes = g.unit_types && g.unit_types.length ? g.unit_types : null;
+  if (!norm.type) norm.type = g.property_type || null;
+  norm._source.availability = snapshot ? `GPMG ${snapshot}` : "GPMG";
+}
+
+/**
+ * Match a GPMG record to a statewide normalized record. Strategy: token overlap
+ * on significant name tokens; full-string ratio fallback; penalize cross-city
+ * collisions. Returns the best statewide norm or null. Mirrors
+ * retriever._match_gpmg_to_statewide.
+ */
+function matchGpmgToStatewide(
+  g: GpmgRaw,
+  statewide: NormalizedProperty[]
+): NormalizedProperty | null {
+  const gName = g.name || slugToName(g.slug);
+  const gTokens = nameTokens(gName);
+  const gFull = normName(gName);
+  const addr = g.address || {};
+  const gCity = normName(addr.city || "");
+
+  let best: NormalizedProperty | null = null;
+  let bestScore = 0;
+  for (const s of statewide) {
+    const sName = s.name || "";
+    const sTokens = new Set<string>([
+      ...nameTokens(sName),
+      ...nameTokens(s._aka),
+    ]);
+    let score: number;
+    if (gTokens.size === 0 || sTokens.size === 0) {
+      score = seqRatio(gFull, normName(sName));
+    } else {
+      const overlap = tokenOverlap(gTokens, sTokens);
+      const ratio = seqRatio(gFull, normName(sName));
+      score = 0.7 * overlap + 0.3 * ratio;
+    }
+    if (gCity && s.city && normName(s.city) !== gCity) {
+      score *= 0.5;
+    }
+    if (score > bestScore) {
+      bestScore = score;
+      best = s;
+    }
+  }
+  if (best !== null && bestScore >= 0.45) return best;
+  return null;
+}
+
+// --------------------------------------------------------------------------- //
+// Index
+// --------------------------------------------------------------------------- //
+export interface HousingIndex {
+  records: NormalizedProperty[];
+  statewidePath: string;
+  gpmgSnapshot: string | null;
+  statewideCount: number;
+  gpmgCount: number;
+  availableNowCount: number;
+  allCities(): string[];
+  byCity(city: string): NormalizedProperty[];
+}
+
+function buildIndex(): HousingIndex {
+  const { raw: statewideRaw, path: statewidePath } = loadStatewide();
+  const { raw: gpmgRaw, snapshot } = loadGpmg();
+
+  const records: NormalizedProperty[] = statewideRaw.map(blankNormalized);
+
+  const matched = new Set<NormalizedProperty>();
+  for (const g of gpmgRaw) {
+    const target = matchGpmgToStatewide(g, records);
+    if (target !== null && !matched.has(target)) {
+      enrichWithGpmg(target, g, snapshot);
+      matched.add(target);
+    } else {
+      records.push(gpmgToNormalized(g, snapshot));
+    }
+  }
+
+  const availableNowCount = records.filter(
+    (r) => r.availability.status === "available_now"
+  ).length;
+
+  let citiesCache: string[] | null = null;
+
+  return {
+    records,
+    statewidePath,
+    gpmgSnapshot: snapshot,
+    statewideCount: statewideRaw.length,
+    gpmgCount: gpmgRaw.length,
+    availableNowCount,
+    allCities(): string[] {
+      if (citiesCache) return citiesCache;
+      const set = new Set<string>();
+      for (const r of records) if (r.city) set.add(r.city);
+      citiesCache = Array.from(set).sort();
+      return citiesCache;
+    },
+    byCity(city: string): NormalizedProperty[] {
+      const c = normName(city);
+      return records.filter((r) => normName(r.city) === c);
+    },
+  };
+}
+
+// Module-scope singleton — build once.
+let indexSingleton: HousingIndex | null = null;
+
+export function getHousingIndex(): HousingIndex {
+  if (indexSingleton === null) {
+    indexSingleton = buildIndex();
+  }
+  return indexSingleton;
+}
+
+/** Test-only: force a rebuild on next getHousingIndex(). */
+export function _resetIndex(): void {
+  indexSingleton = null;
+}

--- a/src/modules/housing-qa/faq.ts
+++ b/src/modules/housing-qa/faq.ts
@@ -1,0 +1,133 @@
+/**
+ * faq.ts — FAQ section index for the grounded housing Q&A agent.
+ *
+ * Ported from tools/housing-qa/faq.md. The 10 sections keep their stable
+ * anchors (e.g. `#fees`, `#documents`) so the agent can cite them and the
+ * retriever can keyword-match them. Mirrors retriever.py FAQ_SECTIONS.
+ */
+
+export interface FaqSection {
+  id: string;
+  title: string;
+  /** Keyword triggers for retrieval matching. */
+  keywords: string[];
+}
+
+export interface FaqMatch {
+  id: string;
+  title: string;
+  anchor: string;
+}
+
+// Stable section ids -> (title, keyword triggers). Mirrors faq.md anchors.
+export const FAQ_SECTIONS: FaqSection[] = [
+  {
+    id: "who-its-for",
+    title: "Who affordable housing is for / AMI tiers",
+    keywords: [
+      "who", "qualify", "eligib", "ami", "income", "area median", "tier",
+      "low income", "afford",
+    ],
+  },
+  {
+    id: "application-steps",
+    title: "The application steps",
+    keywords: [
+      "step", "how do i apply", "how to apply", "process", "register", "verify",
+      "magic link", "intent", "pick", "review", "confirm", "claim", "stages",
+      "apply",
+    ],
+  },
+  {
+    id: "documents",
+    title: "Documents you'll need",
+    keywords: [
+      "document", "paperwork", "id", "pay stub", "paystub", "proof of income",
+      "ssn", "itin", "reference", "landlord", "bring", "need to apply", "upload",
+    ],
+  },
+  {
+    id: "fees",
+    title: "Fees",
+    keywords: [
+      "fee", "cost", "pay", "price", "charge", "35", "$35", "refund",
+      "non-refund", "money",
+    ],
+  },
+  {
+    id: "waitlists",
+    title: "Waitlists & queue position + 120-day rule",
+    keywords: [
+      "waitlist", "queue", "position", "120", "spot", "wait", "how long",
+      "active",
+    ],
+  },
+  {
+    id: "finding-a-unit",
+    title:
+      "Finding a unit (available-now vs statewide; search by BR/budget/move-in)",
+    keywords: [
+      "find", "available", "search", "unit", "bedroom", "br", "budget",
+      "move-in", "move in", "vacancy", "open", "now", "list", "show me",
+    ],
+  },
+  {
+    id: "after-you-apply",
+    title: "After you apply (PM review, recertification, next steps)",
+    keywords: [
+      "after", "next", "review", "property manager", "pm", "recertif", "recert",
+      "lease", "docusign", "sign", "approved", "decision", "140%",
+      "what happens",
+    ],
+  },
+  {
+    id: "rent-availability-caveat",
+    title: "Rent & availability caveat",
+    keywords: [
+      "rent", "how much", "monthly", "price", "availability", "still available",
+      "current",
+    ],
+  },
+  {
+    id: "accessibility",
+    title: "Accessibility / senior / ADA",
+    keywords: [
+      "accessib", "ada", "senior", "elder", "disab", "wheelchair", "elevator",
+      "55", "62",
+    ],
+  },
+  {
+    id: "contact",
+    title: "Contacting a property / getting help",
+    keywords: [
+      "contact", "phone", "call", "email", "reach", "office hours", "help",
+      "talk to", "speak", "manager", "get in touch",
+    ],
+  },
+];
+
+/**
+ * Keyword-match FAQ sections against a question. Returns up to `cap` matches
+ * (id/title/anchor), highest keyword-hit count first. Mirrors
+ * retriever._match_faq_sections.
+ */
+export function matchFaqSections(question: string, cap = 3): FaqMatch[] {
+  const q = question.toLowerCase();
+  const scored: Array<{ hits: number; id: string; title: string }> = [];
+  for (const s of FAQ_SECTIONS) {
+    const hits = s.keywords.reduce(
+      (acc, kw) => acc + (q.includes(kw) ? 1 : 0),
+      0
+    );
+    if (hits > 0) {
+      scored.push({ hits, id: s.id, title: s.title });
+    }
+  }
+  // Sort by hits desc; preserve original section order for ties (stable sort).
+  scored.sort((a, b) => b.hits - a.hits);
+  return scored.slice(0, cap).map((s) => ({
+    id: s.id,
+    title: s.title,
+    anchor: `faq.md#${s.id}`,
+  }));
+}

--- a/src/modules/housing-qa/prompt.ts
+++ b/src/modules/housing-qa/prompt.ts
@@ -1,0 +1,126 @@
+/**
+ * prompt.ts — System prompt for the grounded housing Q&A agent.
+ *
+ * Ported VERBATIM from tools/housing-qa/system_prompt.md. The guardrails
+ * (cite-or-refuse, fair-housing-neutral, "the application verifies this",
+ * as-of-latest-data) are non-negotiable and must not be altered. The
+ * {{CONTEXT_JSON}} placeholder is where the retriever's assembled context
+ * payload is injected.
+ */
+
+export const CONTEXT_PLACEHOLDER = "{{CONTEXT_JSON}}";
+
+export const SYSTEM_PROMPT = `# System Prompt — Frank-Pilot CDPC Housing Q&A Agent
+
+You are the housing assistant for **Frank-Pilot CDPC**, an affordable-housing
+(LIHTC) application platform serving Nevada. You help prospective applicants
+understand affordable housing, find properties, and complete their application.
+
+You answer **only** from the context injected below. You do not have general web
+knowledge about specific properties, rents, or availability — if it is not in the
+injected context, you do not know it.
+
+---
+
+## GROUNDING RULES (non-negotiable)
+
+1. **Ground every factual claim in the injected data.** For each fact you state,
+   it must come from either (a) an injected property object, (b) an injected FAQ
+   section, or (c) the always-on facts block. Do not state property facts that
+   are not in the context.
+
+2. **Cite your source inline.** Use one of these citation forms:
+   - Property data: \`(Silver Pines Apts — amiTiers)\` or \`(Owens Senior — phone)\`
+   - FAQ section: \`(FAQ §fees)\` / \`(FAQ §application-steps)\`
+   - Always-on facts: \`(application fee)\`, \`(120-day rule)\`, \`(document checklist)\`
+   Keep citations short and natural — one per fact is enough.
+
+3. **If it's not in the context, say so.** Use this exact spirit:
+   > "I don't have that — here's how to find out: …"
+   Then point to the next step (the application's Pick step, the /discover map,
+   or contacting the property). Never guess, never invent a value (no made-up
+   rent, phone number, pet policy, amenity, or availability).
+
+4. **A \`null\` field means "not in our data" — not "no" or "free."** If a
+   property's \`rent.disclosed\` is false, you cannot quote rent. If \`contact.phone\`
+   is null, you don't have a phone number. Say you don't have it.
+
+---
+
+## ELIGIBILITY & FAIR-HOUSING RULES (non-negotiable)
+
+5. **General eligibility only.** Explain how AMI tiers and income limits work in
+   general. **Never tell a user they personally qualify or do not qualify.** Say:
+   "the application verifies this" / "the property determines eligibility when it
+   reviews your documents." The income field at the Intent step is a
+   **pre-qualification estimate only**, never a ruling.
+
+6. **Fair-housing safe.** Stay neutral. Never steer an applicant toward or away
+   from any property. Never reference, ask about, or infer **protected classes**
+   (race, color, national origin, religion, sex, familial status, disability).
+   You may describe a property's own listed features (e.g. "this is a senior
+   community", "this property lists ADA accommodations") — but never connect them
+   to a person's characteristics or assume anything about the applicant.
+
+7. **Rent & availability are time-sensitive.** Whenever you mention rent or
+   availability, attach: *"as of the latest data; confirm in the application."*
+   Rent is not disclosed in our data for any property — do not quote a rent.
+
+---
+
+## STYLE
+
+- Short, plain-language answers. Lead with the answer. No filler.
+- Offer the **next step** when relevant (a CTA or link): continue the
+  application, use the /discover map, call the property, check your dashboard.
+- Use the applicant's framing; don't lecture. A couple of sentences plus a next
+  step is usually enough.
+- When listing multiple properties, a short bulleted list is fine; don't dump
+  every field — surface name, city, availability, type, and AMI tier.
+
+---
+
+## INJECTED CONTEXT
+
+The runner injects a JSON context payload below. Its shape:
+
+\`\`\`jsonc
+{
+  "question": "...",
+  "routing": "named_property | city | attribute | process",
+  "propertyMode": "full | compact | none",
+  "properties": [ ... ],     // full normalized object(s), compact summaries, or []
+  "faqSections": [ {id,title,anchor} ],   // which FAQ sections to ground in
+  "facts": { applicationFee, rule120, documentsNeeded, ... },  // always-on
+  "notes": [ ... ],          // retrieval hints, incl. refusal flags — OBEY THESE
+  "_meta": { ... }           // dataset counts + data-as-of date
+}
+\`\`\`
+
+- **\`properties\` with \`propertyMode: "full"\`** → one property; answer in detail,
+  but only from fields present (null = unknown → refuse that field).
+- **\`propertyMode: "compact"\`** → a filtered list; summarize the matches.
+- **\`propertyMode: "none"\`** (process/eligibility) → answer from \`faqSections\`
+  and \`facts\` only; do not name specific properties.
+- **\`notes\`** → these are retrieval instructions. If a note says a property is
+  statewide-only (no rent/contact/amenities) or that the named property is
+  unknown, you MUST follow it: refuse the missing fields and point to the next
+  step.
+- Use \`_meta.dataAsOf\` as the "as of" date for availability statements.
+
+--- BEGIN CONTEXT ---
+${CONTEXT_PLACEHOLDER}
+--- END CONTEXT ---
+
+Answer the user's question grounded strictly in the context above, with
+citations, following all rules.
+`;
+
+/**
+ * Assemble the final system prompt by injecting the JSON-serialized context
+ * payload at the placeholder. Mirrors runner.assemble_prompt.
+ */
+export function buildSystemPrompt(contextPayload: unknown): string {
+  const ctxJson = JSON.stringify(contextPayload, null, 2);
+  return SYSTEM_PROMPT.replace(CONTEXT_PLACEHOLDER, ctxJson);
+}

--- a/src/modules/housing-qa/retriever.ts
+++ b/src/modules/housing-qa/retriever.ts
@@ -1,0 +1,544 @@
+/**
+ * retriever.ts — Grounded retrieval: classify → match → assemble context.
+ *
+ * Ported from tools/housing-qa/retriever.py. The two-layer data merge lives in
+ * data.ts; this module classifies a question into one of four routing branches
+ * and assembles the context payload per the LOCKED grounding contract.
+ *
+ * Fuse.js replaces difflib.SequenceMatcher for the user-facing property-name
+ * fuzzy match (fuzzy_property). The internal GPMG↔statewide merge ratio stays
+ * in data.ts (seqRatio) for faithfulness to the Python merge.
+ *
+ * Routing branches:
+ *   - named property      -> 1 FULL normalized object
+ *   - city/area           -> COMPACT summaries, cap K=8
+ *   - attribute filter    -> COMPACT summaries, cap K=8 (city+attribute = AND)
+ *   - process/eligibility -> NO property objects; FAQ sections only
+ */
+
+import Fuse from "fuse.js";
+import {
+  getHousingIndex,
+  HousingIndex,
+  NormalizedProperty,
+  normName,
+  nameTokens,
+  K_COMPACT,
+} from "./data";
+import { matchFaqSections, FaqMatch } from "./faq";
+
+// --------------------------------------------------------------------------- //
+// Always-on facts block (grounded in apply.json copy) — mirrors retriever.py
+// --------------------------------------------------------------------------- //
+export const ALWAYS_ON_FACTS = {
+  applicationFee: {
+    amount: "$35.95",
+    per: "per adult 18+",
+    refundable: false,
+    note:
+      "Non-refundable. Locks your spot on the waitlist. Covers credit and background checks.",
+    source: "apply.json checklist.fee / household.disclaimer",
+  },
+  rule120: {
+    days: 120,
+    note:
+      "Your application stays active for 120 days. If you can't be housed in that window, you're invited to refresh and continue.",
+    source: "apply.json checklist.rule120",
+  },
+  documentsNeeded: [
+    "Government-issued photo ID",
+    "Proof of income (last 2 pay stubs or offer letter)",
+    "Social Security Number or ITIN",
+    "Two prior landlord references (last 3 years)",
+    "Household composition (everyone moving in)",
+  ],
+  documentsNote: "Upload your documents (5 files, < 120 days old).",
+  documentsSource: "apply.json checklist.items / confirm.nextSteps",
+} as const;
+
+// --------------------------------------------------------------------------- //
+// Fuzzy property matching (Fuse.js — replaces difflib)
+// --------------------------------------------------------------------------- //
+interface FuseEntry {
+  rec: NormalizedProperty;
+  name: string;
+  aka: string;
+  idName: string;
+}
+
+const fuseCache = new WeakMap<HousingIndex, Fuse<FuseEntry>>();
+
+function getFuse(index: HousingIndex): Fuse<FuseEntry> {
+  let f = fuseCache.get(index);
+  if (f) return f;
+  const entries: FuseEntry[] = index.records.map((rec) => ({
+    rec,
+    name: normName(rec.name),
+    aka: normName((rec._aka || "").replace(/-/g, " ")),
+    idName: normName((rec.id || "").replace(/-/g, " ")),
+  }));
+  f = new Fuse(entries, {
+    includeScore: true,
+    threshold: 0.5,
+    ignoreLocation: true,
+    minMatchCharLength: 2,
+    keys: [
+      { name: "name", weight: 0.6 },
+      { name: "aka", weight: 0.2 },
+      { name: "idName", weight: 0.2 },
+    ],
+  });
+  fuseCache.set(index, f);
+  return f;
+}
+
+/**
+ * Return [best record, score in 0..1] matching a property name, or [null,
+ * bestScore]. Score is a blend of token overlap, substring containment, and
+ * Fuse similarity — kept on the same 0.6/0.72/0.78 thresholds the Python tool
+ * used. Mirrors HousingIndex.fuzzy_property.
+ */
+export function fuzzyProperty(
+  index: HousingIndex,
+  query: string
+): [NormalizedProperty | null, number] {
+  const qFull = normName(query);
+  const qTokens = nameTokens(query);
+  if (!qFull) return [null, 0];
+
+  const fuse = getFuse(index);
+  // Fuse for candidate ranking; we still compute the python-equivalent score
+  // on the top candidates so thresholds line up with the ported behavior.
+  const results = fuse.search(qFull, { limit: 25 });
+
+  let best: NormalizedProperty | null = null;
+  let bestScore = 0;
+
+  const candidates =
+    results.length > 0 ? results.map((r) => r.item) : [];
+  // If Fuse found nothing (rare for very short queries), fall back to scanning
+  // all records so we never silently miss a containment match.
+  const pool: FuseEntry[] =
+    candidates.length > 0
+      ? candidates
+      : index.records.map((rec) => ({
+          rec,
+          name: normName(rec.name),
+          aka: normName((rec._aka || "").replace(/-/g, " ")),
+          idName: normName((rec.id || "").replace(/-/g, " ")),
+        }));
+
+  for (const entry of pool) {
+    const candNames = [entry.name, entry.aka, entry.idName];
+    let localBest = 0;
+    for (const cFull of candNames) {
+      if (!cFull) continue;
+      const cTokens = nameTokens(cFull);
+      const overlap =
+        qTokens.size && cTokens.size
+          ? jaccard(qTokens, cTokens)
+          : 0;
+      const contains = qFull && cFull.includes(qFull) ? 1 : 0;
+      // Fuse-based ratio for this candidate string.
+      const ratio = stringSimilarity(qFull, cFull);
+      const score = Math.max(
+        ratio,
+        0.6 * overlap + 0.4 * ratio,
+        contains * 0.95
+      );
+      if (score > localBest) localBest = score;
+    }
+    if (localBest > bestScore) {
+      bestScore = localBest;
+      best = entry.rec;
+    }
+  }
+  if (best !== null && bestScore >= 0.6) return [best, bestScore];
+  return [null, bestScore];
+}
+
+function jaccard(a: Set<string>, b: Set<string>): number {
+  if (!a.size || !b.size) return 0;
+  let inter = 0;
+  for (const t of a) if (b.has(t)) inter += 1;
+  return inter / (a.size + b.size - inter);
+}
+
+/**
+ * Lightweight bigram Dice coefficient — a stable difflib.ratio()-style
+ * similarity for the single-candidate scoring above. (Fuse provides ranking;
+ * this provides the numeric score the thresholds were tuned against.)
+ */
+function stringSimilarity(a: string, b: string): number {
+  if (a === b) return 1;
+  if (a.length < 2 || b.length < 2) return 0;
+  const bigrams = (s: string) => {
+    const m = new Map<string, number>();
+    for (let i = 0; i < s.length - 1; i++) {
+      const bg = s.slice(i, i + 2);
+      m.set(bg, (m.get(bg) || 0) + 1);
+    }
+    return m;
+  };
+  const ma = bigrams(a);
+  const mb = bigrams(b);
+  let inter = 0;
+  for (const [bg, count] of ma) {
+    const other = mb.get(bg) || 0;
+    inter += Math.min(count, other);
+  }
+  return (2 * inter) / (a.length - 1 + (b.length - 1));
+}
+
+// --------------------------------------------------------------------------- //
+// Attribute detection — mirrors retriever.py detectors
+// --------------------------------------------------------------------------- //
+const AMI_RE = /(\d{2,3})\s*%/;
+
+function detectAmiTier(q: string): string | null {
+  const m = AMI_RE.exec(q);
+  return m ? `${m[1]}%` : null;
+}
+
+function detectBedrooms(q: string): string | null {
+  const ql = q.toLowerCase();
+  if (ql.includes("studio")) return "studio";
+  const m = /\b(\d)\s*(?:br|bed)/.exec(ql);
+  if (m) return `${m[1]}br`;
+  return null;
+}
+
+function detectType(q: string): string | null {
+  const ql = q.toLowerCase();
+  if (/\bsenior(s)?\b|\belder|\b55\+|\b62\+/.test(ql)) return "senior";
+  if (/\bfamily\b|\bfamilies\b/.test(ql)) return "family";
+  return null;
+}
+
+function wantsAvailableNow(q: string): boolean {
+  const ql = q.toLowerCase();
+  return /available\s*now|available today|right now|currently available|open now|move in now|vacan/.test(
+    ql
+  );
+}
+
+// --------------------------------------------------------------------------- //
+// Attribute filter — mirrors HousingIndex.filter_attributes
+// --------------------------------------------------------------------------- //
+function filterAttributes(
+  index: HousingIndex,
+  opts: {
+    ptype?: string | null;
+    amiTier?: string | null;
+    availableNow?: boolean;
+    bedrooms?: string | null;
+    city?: string | null;
+  }
+): NormalizedProperty[] {
+  const cnorm = opts.city ? normName(opts.city) : null;
+  const out: NormalizedProperty[] = [];
+  for (const r of index.records) {
+    if (cnorm && normName(r.city) !== cnorm) continue;
+    if (opts.ptype) {
+      const rt = normName(r.type);
+      if (!rt.includes(normName(opts.ptype))) continue;
+    }
+    if (opts.amiTier) {
+      const tiers = r.amiTiers || [];
+      const normTiers = new Set(
+        tiers.map((t) => t.replace(/%/g, "").trim())
+      );
+      if (!normTiers.has(opts.amiTier.replace(/%/g, "").trim())) continue;
+    }
+    if (opts.availableNow && r.availability.status !== "available_now")
+      continue;
+    if (opts.bedrooms) {
+      const ut = r.unitTypes || [];
+      const joined = ut.join(" ").toLowerCase();
+      if (!joined.includes(opts.bedrooms.toLowerCase())) continue;
+    }
+    out.push(r);
+  }
+  return out;
+}
+
+// --------------------------------------------------------------------------- //
+// Property-phrase extraction + unknown-property heuristic — mirror retriever.py
+// --------------------------------------------------------------------------- //
+function extractPropertyPhrase(q: string): string {
+  let s = q.trim().replace(/[?.!]+$/, "");
+  const patterns = [
+    /^(?:can you )?tell me (?:about|more about)\s+/i,
+    /^(?:what(?:'s| is| are)?)\s+(?:the\s+)?(?:[\w\s/-]+?)\s+(?:at|for|of)\s+/i,
+    /^(?:do|does)\s+(?:you|they)\s+(?:have|offer|allow)\s+/i,
+    /^(?:what about|how about|info on|information (?:about|on)|details (?:about|on))\s+/i,
+    /^(?:is|are)\s+(?:there\s+)?/i,
+    /^(?:i(?:'m| am)?\s+(?:looking|interested)\s+(?:for|in)\s+)/i,
+  ];
+  for (const p of patterns) {
+    const next = s.replace(p, "");
+    if (next !== s) {
+      s = next.trim();
+      break;
+    }
+  }
+  return s.trim();
+}
+
+function looksLikeUnknownProperty(
+  q: string,
+  prop: NormalizedProperty | null,
+  score: number
+): string | null {
+  if (prop !== null && score >= 0.6) return null;
+  let m = /\b(?:about|at|for|regarding|tell me about)\s+([A-Z][\w'.-]+(?:\s+[A-Z][\w'.-]+){0,4})/.exec(
+    q
+  );
+  if (m) return m[1].trim();
+  m = /\b([A-Z][\w'.-]+(?:\s+[A-Z][\w'.-]+){0,3}\s+(?:Apartments?|Apts?|Towers?|Village|Court|Place|Community|Homes?))\b/.exec(
+    q
+  );
+  if (m) return m[1].trim();
+  return null;
+}
+
+// --------------------------------------------------------------------------- //
+// Classification — mirrors retriever.classify
+// --------------------------------------------------------------------------- //
+export type Branch = "named_property" | "city" | "attribute" | "process";
+
+export interface ClassifyDetail {
+  record?: NormalizedProperty;
+  score?: number;
+  city?: string | null;
+  ami?: string | null;
+  bedrooms?: string | null;
+  type?: string | null;
+  available_now?: boolean;
+  unknownProperty?: string | null;
+}
+
+export function classify(
+  question: string,
+  index: HousingIndex = getHousingIndex()
+): [Branch, ClassifyDetail] {
+  const q = question.trim();
+  const ql = q.toLowerCase();
+
+  let [prop, score] = fuzzyProperty(index, q);
+  const phrase = extractPropertyPhrase(q);
+  if (phrase && phrase.toLowerCase() !== ql) {
+    const [p2, s2] = fuzzyProperty(index, phrase);
+    if (p2 !== null && s2 > score) {
+      prop = p2;
+      score = s2;
+    }
+  }
+
+  const citiesLower = new Set(index.allCities().map((c) => c.toLowerCase()));
+  const looksLikeCityOnly =
+    citiesLower.has(ql) || citiesLower.has(normName(phrase));
+
+  let cityHit: string | null = null;
+  for (const c of index.allCities()) {
+    const re = new RegExp(`\\b${escapeRegExp(c.toLowerCase())}\\b`);
+    if (re.test(ql)) {
+      cityHit = c;
+      break;
+    }
+  }
+
+  const ami = detectAmiTier(q);
+  const br = detectBedrooms(q);
+  const ptype = detectType(q);
+  const avail = wantsAvailableNow(q);
+
+  if (prop !== null && score >= 0.72 && !looksLikeCityOnly) {
+    return ["named_property", { record: prop, score }];
+  }
+
+  if (
+    (ami || br || ptype || avail) &&
+    !(prop !== null && score >= 0.78)
+  ) {
+    return [
+      "attribute",
+      {
+        ami,
+        bedrooms: br,
+        type: ptype,
+        available_now: avail,
+        city: cityHit,
+      },
+    ];
+  }
+
+  if (cityHit) {
+    return ["city", { city: cityHit }];
+  }
+
+  if (prop !== null && score >= 0.62 && !looksLikeCityOnly) {
+    return ["named_property", { record: prop, score }];
+  }
+
+  const unknownProp = looksLikeUnknownProperty(q, prop, score);
+  return ["process", { unknownProperty: unknownProp }];
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+// --------------------------------------------------------------------------- //
+// Emit helpers — mirror retriever._strip_internal / _compact
+// --------------------------------------------------------------------------- //
+type EmittedProperty = Omit<NormalizedProperty, "_lat" | "_lng" | "_aka">;
+
+function stripInternal(rec: NormalizedProperty): EmittedProperty {
+  const { _lat, _lng, _aka, ...rest } = rec;
+  void _lat;
+  void _lng;
+  void _aka;
+  return rest;
+}
+
+export interface CompactProperty {
+  name: string | null;
+  city: string | null;
+  availability: string;
+  amiTiers: string[] | null;
+  type: string | null;
+}
+
+function compact(rec: NormalizedProperty): CompactProperty {
+  return {
+    name: rec.name,
+    city: rec.city,
+    availability: rec.availability.status,
+    amiTiers: rec.amiTiers,
+    type: rec.type,
+  };
+}
+
+// --------------------------------------------------------------------------- //
+// Context assembly — mirrors retriever.build_context
+// --------------------------------------------------------------------------- //
+export interface HousingContext {
+  question: string;
+  routing: Branch;
+  propertyMode: "full" | "compact" | "none";
+  properties: Array<EmittedProperty | CompactProperty>;
+  faqSections: FaqMatch[];
+  facts: typeof ALWAYS_ON_FACTS;
+  notes: string[];
+  _meta: {
+    statewideRecords: number;
+    gpmgRecords: number;
+    availableNowRecords: number;
+    totalIndexRecords: number;
+    dataAsOf: string | null;
+  };
+}
+
+export function buildContext(
+  question: string,
+  index: HousingIndex = getHousingIndex()
+): HousingContext {
+  const [branch, detail] = classify(question, index);
+  const notes: string[] = [];
+  let properties: Array<EmittedProperty | CompactProperty> = [];
+  let mode: "full" | "compact" | "none" = "none";
+
+  if (branch === "named_property") {
+    const rec = detail.record!;
+    properties = [stripInternal(rec)];
+    mode = "full";
+    if (rec.availability.status === "statewide_only") {
+      notes.push(
+        `'${rec.name}' is in the statewide HUD-LIHTC dataset only (no available-now feed). Rent, contact, amenities, pet policy, office hours are NOT in the data — refuse + point to next step.`
+      );
+    }
+  } else if (branch === "city") {
+    const recs = index.byCity(detail.city!);
+    recs.sort(
+      (a, b) =>
+        (a.availability.status === "available_now" ? 0 : 1) -
+        (b.availability.status === "available_now" ? 0 : 1)
+    );
+    properties = recs.slice(0, K_COMPACT).map(compact);
+    mode = "compact";
+    if (recs.length > K_COMPACT) {
+      notes.push(
+        `${recs.length} properties in ${detail.city}; showing first ${K_COMPACT}.`
+      );
+    }
+    if (recs.length === 0) {
+      notes.push(`No properties found for city '${detail.city}' in the data.`);
+    }
+  } else if (branch === "attribute") {
+    const recs = filterAttributes(index, {
+      ptype: detail.type,
+      amiTier: detail.ami,
+      availableNow: detail.available_now,
+      bedrooms: detail.bedrooms,
+      city: detail.city,
+    });
+    recs.sort(
+      (a, b) =>
+        (a.availability.status === "available_now" ? 0 : 1) -
+        (b.availability.status === "available_now" ? 0 : 1)
+    );
+    properties = recs.slice(0, K_COMPACT).map(compact);
+    mode = "compact";
+    const scope = detail.city ? ` in ${detail.city}` : "";
+    if (recs.length > K_COMPACT) {
+      notes.push(`${recs.length} matches${scope}; showing first ${K_COMPACT}.`);
+    }
+    if (recs.length === 0) {
+      notes.push("No properties match those attributes in the data.");
+    }
+    if (detail.bedrooms) {
+      notes.push(
+        "Bedroom counts are only known for the 17 available-now (GPMG) properties via unitTypes; statewide-only records have no bedroom data."
+      );
+    }
+  } else {
+    // process
+    properties = [];
+    mode = "none";
+    const unknown = detail.unknownProperty;
+    if (unknown) {
+      notes.push(
+        `The question appears to name a property ('${unknown}') that is NOT in the statewide HUD-LIHTC or available-now data. Refuse: say you don't have a property by that name and point to /discover or contacting GPMG. Do NOT invent details.`
+      );
+    }
+  }
+
+  let faq = matchFaqSections(question);
+  if (faq.length === 0) {
+    faq = [
+      {
+        id: "application-steps",
+        title: "The application steps",
+        anchor: "faq.md#application-steps",
+      },
+    ];
+  }
+
+  return {
+    question,
+    routing: branch,
+    propertyMode: mode,
+    properties,
+    faqSections: faq,
+    facts: ALWAYS_ON_FACTS,
+    notes,
+    _meta: {
+      statewideRecords: index.statewideCount,
+      gpmgRecords: index.gpmgCount,
+      availableNowRecords: index.availableNowCount,
+      totalIndexRecords: index.records.length,
+      dataAsOf: index.gpmgSnapshot,
+    },
+  };
+}

--- a/src/modules/housing-qa/routes.ts
+++ b/src/modules/housing-qa/routes.ts
@@ -1,0 +1,117 @@
+/**
+ * routes.ts — Public, rate-limited housing Q&A endpoint.
+ *
+ * Mounted at /api/housing-qa (PUBLIC — no auth, per-IP rate-limited, mirrors
+ * the applicant register/legal public routes). POST / takes { question },
+ * runs the grounded retriever to assemble context, injects it into the ported
+ * system prompt, and calls the Anthropic SDK NON-STREAMING. Returns
+ * { answer: string }.
+ *
+ * Guardrails are enforced upstream (in the system prompt + grounded context);
+ * this layer only validates input, rate-limits, and degrades cleanly when the
+ * API key is absent (503, never a crash).
+ */
+
+import { Router, Request, Response } from "express";
+import { z } from "zod";
+import rateLimit, { ipKeyGenerator } from "express-rate-limit";
+import Anthropic from "@anthropic-ai/sdk";
+import { buildContext } from "./retriever";
+import { buildSystemPrompt } from "./prompt";
+import { logger } from "../../utils/logger";
+
+// Short, grounded answers → Haiku for cost. Locked by the brief.
+const MODEL = "claude-haiku-4-5-20251001";
+const MAX_QUESTION_CHARS = 1000;
+const MAX_TOKENS = 1024;
+
+const questionSchema = z.object({
+  question: z.string().trim().min(1).max(MAX_QUESTION_CHARS),
+});
+
+// Per-IP limiter — public endpoint, so we key on source IP (IPv6-safe via
+// express-rate-limit's ipKeyGenerator). ~20 requests / 10 min.
+const qaLimiter = rateLimit({
+  windowMs: 10 * 60 * 1000,
+  max: 20,
+  keyGenerator: (req) => ipKeyGenerator(req.ip ?? ""),
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: "Too many questions, please slow down and try again soon." },
+});
+
+// Lazily construct the SDK client so a missing key degrades to a 503 rather
+// than throwing at module load (which would crash the whole server boot).
+let cachedClient: Anthropic | null = null;
+function getClient(): Anthropic | null {
+  const key = process.env.ANTHROPIC_API_KEY;
+  if (!key) return null;
+  if (!cachedClient) cachedClient = new Anthropic({ apiKey: key });
+  return cachedClient;
+}
+
+export function housingQaRouter(): Router {
+  const router: Router = Router();
+
+  router.post("/", qaLimiter, async (req: Request, res: Response) => {
+    const parsed = questionSchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({
+        error: "A non-empty question (max 1000 characters) is required.",
+        details: parsed.error.issues,
+      });
+      return;
+    }
+    const { question } = parsed.data;
+
+    const client = getClient();
+    if (!client) {
+      logger.warn("housing-qa request rejected — ANTHROPIC_API_KEY not set");
+      res.status(503).json({
+        error:
+          "The housing assistant is temporarily unavailable. Please try again later.",
+      });
+      return;
+    }
+
+    try {
+      const context = buildContext(question);
+      const system = buildSystemPrompt(context);
+
+      const completion = await client.messages.create({
+        model: MODEL,
+        max_tokens: MAX_TOKENS,
+        system,
+        messages: [{ role: "user", content: question }],
+      });
+
+      const answer = completion.content
+        .filter(
+          (block): block is Anthropic.TextBlock => block.type === "text"
+        )
+        .map((block) => block.text)
+        .join("")
+        .trim();
+
+      if (!answer) {
+        res.status(502).json({
+          error: "The assistant returned an empty response. Please try again.",
+        });
+        return;
+      }
+
+      res.json({ answer });
+    } catch (err) {
+      // Never echo the upstream error (may embed prompt fragments); log name only.
+      const errName = err instanceof Error ? err.name : "UnknownError";
+      logger.error("housing-qa model call failed", { errorName: errName });
+      res.status(502).json({
+        error: "The housing assistant couldn't answer right now. Please try again.",
+      });
+    }
+  });
+
+  return router;
+}
+
+export default housingQaRouter;

--- a/src/modules/housing-qa/routes.ts
+++ b/src/modules/housing-qa/routes.ts
@@ -58,7 +58,6 @@ export function housingQaRouter(): Router {
     if (!parsed.success) {
       res.status(400).json({
         error: "A non-empty question (max 1000 characters) is required.",
-        details: parsed.error.issues,
       });
       return;
     }


### PR DESCRIPTION
Wires the standalone \`tools/housing-qa\` Q&A agent into the live tenant site.

## What
- **Backend** \`src/modules/housing-qa/\` — ports \`retriever.py\` to TypeScript (two-layer 335 HUD-LIHTC + 17 GPMG merge, classify→match→assemble context). Fuse.js replaces difflib for user-facing fuzzy matching; \`seqRatio\` ports difflib exactly for the internal GPMG↔statewide merge.
- **Endpoint** \`POST /api/housing-qa\` — public, per-IP rate-limited (20/10min), non-streaming \`@anthropic-ai/sdk\` (\`claude-haiku-4-5\`). Missing key → clean 503; upstream error → 502.
- **Frontend** — Intercom-style floating chat widget (\`HousingChatWidget.tsx\`) using shared \`CTA\` + brand tokens, mounted in \`App.tsx\`. \`askHousingQa()\` through the existing \`request()\` wrapper. New \`chat\` i18n namespace (EN+ES, parity-clean).

## Guardrails (ported verbatim from \`system_prompt.md\`)
cite-or-refuse · fair-housing-neutral · "the application verifies this" · "as of latest data". Behavior pressure-tested on the Python tool: rent refusal, unknown-property refusal, no personal-qualification rulings.

## Deps
\`@anthropic-ai/sdk\`, \`fuse.js\` (backend). \`express-rate-limit\` already present.

## Verify (subagent, all green)
- \`tsc --noEmit\` clean · 14 jest tests pass · i18n parity clean · \`vite build\` clean.

## Deploy
- **Requires \`ANTHROPIC_API_KEY\` on Railway \`api\`** (without it: 503 by design). No migration, no new frontend env var.

🤖 Generated with [Claude Code](https://claude.com/claude-code)