### PR TITLE
feat(saved): guest shortlist — ♥ save → guest session → magic-link convert

### DIFF
--- a/client-tenant/src/App.tsx
+++ b/client-tenant/src/App.tsx
@@ -17,6 +17,7 @@ import { Application } from '@/pages/Application';
 import { WelcomeShell } from '@/pages/welcome/WelcomeShell';
 import { PropertyList } from '@/pages/discover/PropertyList';
 import { PropertyDetail } from '@/pages/discover/PropertyDetail';
+import { Shortlist } from '@/pages/saved/Shortlist';
 import { WaitlistPosition } from '@/pages/waitlist/Position';
 import { WaitlistFasterList } from '@/pages/waitlist/FasterList';
 import { MagicLinkSent } from '@/pages/apply/MagicLinkSent';
@@ -55,6 +56,8 @@ export default function App() {
       <Route path="/apply/magic-link-sent" element={<MagicLinkSent />} />
       <Route path="/discover" element={<PropertyList />} />
       <Route path="/property/:slug" element={<PropertyDetail />} />
+      {/* feat/saved-shortlist — guest wishlist; public, NOT behind AuthGuard */}
+      <Route path="/saved" element={<Shortlist />} />
       <Route path="/auth/callback" element={<AuthCallback />} />
       <Route path="/verify-pending" element={<VerifyPending />} />
 

--- a/client-tenant/src/api/client.ts
+++ b/client-tenant/src/api/client.ts
@@ -42,7 +42,11 @@ async function request<T>(
   const baseUrl = (import.meta.env.VITE_API_BASE_URL as string | undefined)?.replace(/\/$/, '') ?? '';
   const fullPath = baseUrl ? `${baseUrl}${relativePath}` : relativePath;
 
-  const res = await fetch(fullPath, { ...options, headers });
+  // credentials:'include' so the httpOnly `uh_guest` cookie (guest shortlist)
+  // round-trips on every request — set by the backend on a guest's first save
+  // and read back on subsequent saves/reads + magic-link conversion. Harmless
+  // for the JWT-authed endpoints (they ignore the cookie).
+  const res = await fetch(fullPath, { ...options, headers, credentials: 'include' });
 
   // /auth/me is the probe endpoint — callers (AuthCallback, VerifyPending,
   // the Apply step='verify' poll) use it to discover auth state and handle
@@ -51,8 +55,29 @@ async function request<T>(
   const isAuthProbe =
     fullPath.includes('/auth/magic-link') || fullPath.includes('/auth/me');
   if (res.status === 401 && !isAuthProbe) {
+    // A stale/expired token in localStorage makes guest-allowed pages issue
+    // authed calls (e.g. discover warm-fetching /applicants/units) that 401.
+    // On a PUBLIC page that just means "treat me as a guest" — clear the dead
+    // token and let the caller fall back (discover renders from fixtures, the
+    // saved shortlist reads the guest cookie). Only hard-redirect to /login
+    // from auth-gated routes, where a 401 is a genuine session expiry.
+    const PUBLIC_PREFIXES = [
+      '/discover',
+      '/property',
+      '/saved',
+      '/welcome',
+      '/apply',
+      '/waitlist',
+      '/privacy',
+      '/cookies',
+    ];
+    const path = typeof window !== 'undefined' ? window.location.pathname : '';
+    const onPublicPage =
+      path === '/' || PUBLIC_PREFIXES.some((p) => path.startsWith(p));
     clearToken();
-    window.location.href = '/login';
+    if (!onPublicPage) {
+      window.location.href = '/login';
+    }
     throw new Error('Session expired');
   }
 

--- a/client-tenant/src/api/saved.ts
+++ b/client-tenant/src/api/saved.ts
@@ -1,0 +1,99 @@
+import { api } from './client';
+
+// ─── Saved-property shortlist (guest-first wishlist) ──────────────────────
+//
+// Backend mounted at /api/saved (src/modules/saved). A guest's saves are
+// keyed to an httpOnly `uh_guest` cookie that the shared `request()` helper
+// already round-trips (credentials:'include'). The cookie is set server-side
+// on a guest's first save and is migrated onto the user record on magic-link
+// conversion — so the same list survives the applicant→tenant transition.
+//
+// `propertyId` is a slug OR a uuid; /discover renders by slug (route
+// /property/:slug) so the UI always saves using the slug.
+
+export interface SavedItem {
+  id: string;
+  propertyId: string;
+  propertySlug: string;
+  listName: string;
+  alertEnabled: boolean;
+  createdAt: string;
+}
+
+export interface SavedListItem extends SavedItem {
+  name: string;
+  rentMin: number | null;
+  rentMax: number | null;
+  amiTier: string | null;
+  availableCount: number;
+}
+
+export interface SavedListGroup {
+  listName: string;
+  items: SavedListItem[];
+}
+
+export interface CompareProperty {
+  propertyId: string;
+  slug: string;
+  name: string;
+  city: string;
+  amiTier: string | null;
+  rentMin: number | null;
+  rentMax: number | null;
+  availableCount: number;
+}
+
+export interface ShortlistResponse {
+  lists: SavedListGroup[];
+  count: number;
+}
+
+/** Save a property to the guest's shortlist (sets the guest cookie on first save). */
+export async function saveProperty(
+  propertyId: string,
+  listName?: string,
+): Promise<SavedItem> {
+  const res = await api.post<{ saved: SavedItem }>('/saved', {
+    propertyId,
+    ...(listName ? { listName } : {}),
+  });
+  return res.saved;
+}
+
+/** Remove a property from the shortlist. Scoped to `listName` when given. */
+export async function unsaveProperty(
+  propertyId: string,
+  listName?: string,
+): Promise<{ ok: true; removed: number }> {
+  const qs = listName ? `?listName=${encodeURIComponent(listName)}` : '';
+  return api.del<{ ok: true; removed: number }>(
+    `/saved/${encodeURIComponent(propertyId)}${qs}`,
+  );
+}
+
+/** Load the full shortlist, grouped by list name, with the total count. */
+export async function getShortlist(): Promise<ShortlistResponse> {
+  return api.get<ShortlistResponse>('/saved');
+}
+
+/** Toggle the vacancy alert for a saved property. */
+export async function toggleAlert(
+  propertyId: string,
+  enabled: boolean,
+): Promise<SavedItem> {
+  const res = await api.patch<{ saved: SavedItem }>(
+    `/saved/${encodeURIComponent(propertyId)}/alert`,
+    { enabled },
+  );
+  return res.saved;
+}
+
+/** Fetch a comparison payload for a set of saved properties. */
+export async function compareSaved(ids: string[]): Promise<CompareProperty[]> {
+  const param = ids.map((id) => encodeURIComponent(id)).join(',');
+  const res = await api.get<{ properties: CompareProperty[] }>(
+    `/saved/compare?ids=${param}`,
+  );
+  return res.properties;
+}

--- a/client-tenant/src/components/SaveButton.tsx
+++ b/client-tenant/src/components/SaveButton.tsx
@@ -1,0 +1,141 @@
+import { useState } from 'react';
+import { Heart } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { useShortlist } from '@/state/shortlist';
+import { HF } from '@/styles/tokens';
+
+export interface SaveButtonProps {
+  /** Property slug — what /discover renders + saves by. */
+  slug: string;
+  /** Accessible name for the property (announced in the toggle label). */
+  propertyName?: string;
+  /** Diameter of the round hit-target. Defaults to 40 (mobile-friendly). */
+  size?: number;
+  /**
+   * Render with a translucent paper backdrop + shadow (for use over a photo
+   * hero). Off by default — bare heart for in-card placement.
+   */
+  floating?: boolean;
+  /** Extra className passthrough. */
+  className?: string;
+}
+
+/**
+ * SaveButton — the ♥ shortlist toggle. Filled terracotta heart when saved,
+ * outline when not. Optimistic via the shortlist store (so the heart and the
+ * header count badge stay in sync). Shows a brief "Saved to your shortlist"
+ * confirmation pill on save.
+ *
+ * No global toast system exists on this surface yet, so the confirmation is a
+ * self-contained `aria-live` pill that auto-dismisses. Reuses the welcome
+ * namespace string `savedShortlist` already shipped for this feature.
+ */
+export function SaveButton({
+  slug,
+  propertyName,
+  size = 40,
+  floating = false,
+  className = '',
+}: SaveButtonProps) {
+  const { t } = useTranslation('welcome');
+  const { isSaved, save, unsave } = useShortlist();
+  const saved = isSaved(slug);
+  const [busy, setBusy] = useState(false);
+  const [confirm, setConfirm] = useState(false);
+
+  const label = saved
+    ? t('save.remove', 'Remove from shortlist')
+    : t('save.add', 'Save to shortlist');
+
+  const onToggle = async (e: React.MouseEvent) => {
+    // SaveButton is frequently nested inside a card-level <Link>; never let the
+    // toggle navigate.
+    e.preventDefault();
+    e.stopPropagation();
+    if (busy) return;
+    setBusy(true);
+    if (saved) {
+      await unsave(slug);
+    } else {
+      const ok = await save(slug);
+      if (ok) {
+        setConfirm(true);
+        window.setTimeout(() => setConfirm(false), 1800);
+      }
+    }
+    setBusy(false);
+  };
+
+  const iconSize = Math.round(size * 0.5);
+
+  return (
+    <span
+      style={{ position: 'relative', display: 'inline-flex' }}
+      className={className}
+    >
+      <button
+        type="button"
+        onClick={onToggle}
+        disabled={busy}
+        aria-pressed={saved}
+        aria-label={propertyName ? `${label}: ${propertyName}` : label}
+        title={label}
+        data-testid={`save-button-${slug}`}
+        data-saved={saved}
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          height: size,
+          width: size,
+          borderRadius: HF.r.pill,
+          border: floating ? 'none' : `1px solid ${HF.border}`,
+          background: floating ? HF.paper : 'rgba(255,255,255,0.85)',
+          boxShadow: floating ? HF.shadow.sm : HF.shadow.xs,
+          cursor: busy ? 'default' : 'pointer',
+          opacity: busy ? 0.6 : 1,
+          transition: 'transform 120ms ease',
+          padding: 0,
+        }}
+      >
+        <Heart
+          width={iconSize}
+          height={iconSize}
+          style={{
+            color: saved ? HF.accent : HF.ink3,
+            fill: saved ? HF.accent : 'none',
+            transition: 'color 120ms ease, fill 120ms ease',
+          }}
+          aria-hidden="true"
+        />
+      </button>
+      {confirm && (
+        <span
+          role="status"
+          aria-live="polite"
+          data-testid={`save-confirm-${slug}`}
+          style={{
+            position: 'absolute',
+            top: '50%',
+            right: size + 8,
+            transform: 'translateY(-50%)',
+            whiteSpace: 'nowrap',
+            background: HF.ink,
+            color: HF.paper,
+            borderRadius: HF.r.pill,
+            padding: '4px 10px',
+            fontSize: 12,
+            fontWeight: 600,
+            fontFamily: HF.body,
+            boxShadow: HF.shadow.sm,
+            pointerEvents: 'none',
+          }}
+        >
+          {t('savedShortlist')}
+        </span>
+      )}
+    </span>
+  );
+}
+
+export default SaveButton;

--- a/client-tenant/src/i18n/en/discover.json
+++ b/client-tenant/src/i18n/en/discover.json
@@ -101,5 +101,18 @@
   "amenities.item.ac": "Air conditioning",
   "amenities.item.courtyard": "Courtyard",
   "amenities.item.playground": "Playground",
-  "amenities.item.pool": "Pool"
+  "amenities.item.pool": "Pool",
+  "saved.title": "Your shortlist",
+  "saved.viewShortlist": "View your saved homes ({{count}})",
+  "saved.count_one": "{{count}} saved home",
+  "saved.count_other": "{{count}} saved homes",
+  "saved.loading": "Loading your shortlist…",
+  "saved.empty.heading": "No saved homes yet",
+  "saved.empty.body": "Tap ♥ on any property to save it here.",
+  "saved.empty.cta": "Browse homes",
+  "saved.remove": "Remove {{name}} from your shortlist",
+  "saved.removeShort": "Remove from shortlist",
+  "saved.alertOn": "Vacancy alerts on",
+  "saved.alertOff": "Get vacancy alerts",
+  "saved.apply": "Apply"
 }

--- a/client-tenant/src/i18n/en/welcome.json
+++ b/client-tenant/src/i18n/en/welcome.json
@@ -23,6 +23,10 @@
   "help": "Help",
   "topMatch": "Top match",
   "savedShortlist": "Saved to your shortlist",
+  "save": {
+    "add": "Save to shortlist",
+    "remove": "Remove from shortlist"
+  },
   "vacancy": {
     "open": "Available now",
     "waitlist": "Waitlist open",

--- a/client-tenant/src/i18n/es/discover.json
+++ b/client-tenant/src/i18n/es/discover.json
@@ -101,5 +101,18 @@
   "amenities.item.ac": "Aire acondicionado",
   "amenities.item.courtyard": "Patio",
   "amenities.item.playground": "Área de juegos",
-  "amenities.item.pool": "Piscina"
+  "amenities.item.pool": "Piscina",
+  "saved.title": "Tu lista de favoritos",
+  "saved.viewShortlist": "Ver tus viviendas guardadas ({{count}})",
+  "saved.count_one": "{{count}} vivienda guardada",
+  "saved.count_other": "{{count}} viviendas guardadas",
+  "saved.loading": "Cargando tu lista…",
+  "saved.empty.heading": "Aún no tienes viviendas guardadas",
+  "saved.empty.body": "Toca ♥ en cualquier propiedad para guardarla aquí.",
+  "saved.empty.cta": "Explorar viviendas",
+  "saved.remove": "Quitar {{name}} de tu lista",
+  "saved.removeShort": "Quitar de la lista",
+  "saved.alertOn": "Alertas de disponibilidad activadas",
+  "saved.alertOff": "Recibir alertas de disponibilidad",
+  "saved.apply": "Solicitar"
 }

--- a/client-tenant/src/i18n/es/welcome.json
+++ b/client-tenant/src/i18n/es/welcome.json
@@ -23,6 +23,10 @@
   "help": "Ayuda",
   "topMatch": "Tu favorita",
   "savedShortlist": "Guardada en tu lista",
+  "save": {
+    "add": "Guardar en tu lista",
+    "remove": "Quitar de tu lista"
+  },
   "vacancy": {
     "open": "Disponible ahora",
     "waitlist": "Lista de espera abierta",

--- a/client-tenant/src/pages/discover/PropertyDetail.tsx
+++ b/client-tenant/src/pages/discover/PropertyDetail.tsx
@@ -16,6 +16,7 @@ import {
   type NearbyKind,
 } from '@/utils/propertyProfile';
 import { CTA } from '@/components/primitives';
+import { SaveButton } from '@/components/SaveButton';
 import { getToken } from '@/api/client';
 import { placeholderFor } from '@/utils/unitPlaceholder';
 import { HF } from '@/styles/tokens';
@@ -306,6 +307,10 @@ export function PropertyDetail() {
           >
             <ArrowLeft className="h-5 w-5" />
           </Link>
+          {/* ♥ shortlist toggle — mirrors the back button on the hero's right. */}
+          <div style={{ position: 'absolute', right: 12, top: 12 }}>
+            <SaveButton slug={slug} propertyName={prop.name} size={40} floating />
+          </div>
         </div>
 
         <div className="px-4 pb-32 pt-5 sm:px-6">

--- a/client-tenant/src/pages/discover/PropertyList.tsx
+++ b/client-tenant/src/pages/discover/PropertyList.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import { Heart } from 'lucide-react';
 import { fetchUnits } from '@/api/units';
 import { getToken } from '@/api/client';
 import {
@@ -18,6 +19,8 @@ import {
   type GPMGType,
 } from '@/api/gpmg-fixtures';
 import { Card } from '@/components/primitives';
+import { SaveButton } from '@/components/SaveButton';
+import { useShortlist } from '@/state/shortlist';
 import { placeholderFor } from '@/utils/unitPlaceholder';
 import { HF } from '@/styles/tokens';
 import {
@@ -311,6 +314,7 @@ function tileFromFixture(p: GPMGProperty): TileSource {
 
 export function PropertyList() {
   const { t } = useTranslation('discover');
+  const { count: savedCount } = useShortlist();
   const [params, setParams] = useSearchParams();
 
   // Single source of truth for filters: URL params. This is what lets the
@@ -536,21 +540,79 @@ export function PropertyList() {
       style={{ background: HF.cream, minHeight: '100vh', fontFamily: HF.body, color: HF.ink }}
     >
       <div className="mx-auto max-w-5xl p-4 sm:p-6">
-        <header className="mb-4">
-          <h1
+        <header className="mb-4 flex items-start justify-between" style={{ gap: 12 }}>
+          <div>
+            <h1
+              style={{
+                fontFamily: HF.display,
+                fontWeight: 800,
+                fontSize: 22,
+                color: HF.ink,
+                letterSpacing: '-0.01em',
+              }}
+            >
+              Find your home
+            </h1>
+            <p style={{ marginTop: 4, fontSize: 14, color: HF.ink3 }}>
+              Affordable communities across Nevada
+            </p>
+          </div>
+          {/* Saved-shortlist entry point — heart + live count badge. */}
+          <Link
+            to="/saved"
+            aria-label={t('saved.viewShortlist', { count: savedCount })}
+            data-testid="saved-shortlist-link"
             style={{
-              fontFamily: HF.display,
-              fontWeight: 800,
-              fontSize: 22,
-              color: HF.ink,
-              letterSpacing: '-0.01em',
+              position: 'relative',
+              display: 'inline-flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              height: 40,
+              width: 40,
+              flexShrink: 0,
+              borderRadius: HF.r.pill,
+              border: `1px solid ${HF.border}`,
+              background: HF.paper,
+              boxShadow: HF.shadow.xs,
+              color: savedCount > 0 ? HF.accent : HF.ink3,
+              textDecoration: 'none',
             }}
           >
-            Find your home
-          </h1>
-          <p style={{ marginTop: 4, fontSize: 14, color: HF.ink3 }}>
-            Affordable communities across Nevada
-          </p>
+            <Heart
+              width={20}
+              height={20}
+              style={{
+                color: savedCount > 0 ? HF.accent : HF.ink3,
+                fill: savedCount > 0 ? HF.accent : 'none',
+              }}
+              aria-hidden="true"
+            />
+            {savedCount > 0 && (
+              <span
+                data-testid="saved-count-badge"
+                style={{
+                  position: 'absolute',
+                  top: -6,
+                  right: -6,
+                  minWidth: 18,
+                  height: 18,
+                  padding: '0 5px',
+                  borderRadius: HF.r.pill,
+                  background: HF.accent,
+                  color: HF.paper,
+                  fontSize: 11,
+                  fontWeight: 700,
+                  fontFamily: HF.body,
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  lineHeight: 1,
+                }}
+              >
+                {savedCount}
+              </span>
+            )}
+          </Link>
         </header>
 
         <div
@@ -869,16 +931,26 @@ function PropertyTile({
         }}
       >
         <Card variant="mobile" padding={0} elevation="sm" style={{ overflow: 'hidden' }}>
-          <div
-            className="aspect-[16/9] w-full"
-            style={{
-              background: `${HF.sageLo}`,
-              backgroundImage: `url(${placeholderFor(slug, prop.name)})`,
-              backgroundSize: 'cover',
-              backgroundPosition: 'center',
-            }}
-            aria-hidden="true"
-          />
+          <div className="relative">
+            <div
+              className="aspect-[16/9] w-full"
+              style={{
+                background: `${HF.sageLo}`,
+                backgroundImage: `url(${placeholderFor(slug, prop.name)})`,
+                backgroundSize: 'cover',
+                backgroundPosition: 'center',
+              }}
+              aria-hidden="true"
+            />
+            {/* ♥ shortlist toggle — corner of the card photo. Stops propagation
+                so tapping the heart never follows the card's <Link>. */}
+            <div style={{ position: 'absolute', top: 8, right: 8 }}>
+              {/* No propertyName here on purpose: a name-bearing aria-label
+                  would collide with the card link in name-based queries
+                  (the card context already associates the heart). */}
+              <SaveButton slug={slug} size={36} />
+            </div>
+          </div>
           {coords && (
             <iframe
               title={`Map — ${prop.name}`}

--- a/client-tenant/src/pages/saved/Shortlist.tsx
+++ b/client-tenant/src/pages/saved/Shortlist.tsx
@@ -1,0 +1,458 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { ArrowLeft, Heart, Bell, BellOff } from 'lucide-react';
+import {
+  getShortlist,
+  toggleAlert,
+  type SavedListGroup,
+  type SavedListItem,
+} from '@/api/saved';
+import { unsave as unsaveSlug, refreshShortlist } from '@/state/shortlist';
+import { getToken } from '@/api/client';
+import { placeholderFor } from '@/utils/unitPlaceholder';
+import { HF } from '@/styles/tokens';
+
+/** "$900–$1,400" / "$900" / "" depending on which bounds are present. */
+function formatRentRange(min: number | null, max: number | null): string {
+  const fmt = (n: number) => `$${n.toLocaleString('en-US')}`;
+  if (min != null && max != null) {
+    return min === max ? fmt(min) : `${fmt(min)}–${fmt(max)}`;
+  }
+  if (min != null) return `${fmt(min)}+`;
+  if (max != null) return fmt(max);
+  return '';
+}
+
+export function Shortlist() {
+  const { t } = useTranslation('discover');
+  const navigate = useNavigate();
+  const [lists, setLists] = useState<SavedListGroup[]>([]);
+  const [count, setCount] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await getShortlist();
+      setLists(res.lists);
+      setCount(res.count);
+    } catch {
+      // A guest with no saves (no cookie yet) reads as an empty list, not an
+      // error — only surface real failures.
+      setLists([]);
+      setCount(0);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const onUnsave = async (item: SavedListItem) => {
+    // Optimistically drop from the local view; the store handles its own
+    // rollback if the API rejects.
+    setLists((prev) =>
+      prev
+        .map((g) =>
+          g.listName === item.listName
+            ? { ...g, items: g.items.filter((i) => i.propertySlug !== item.propertySlug) }
+            : g,
+        )
+        .filter((g) => g.items.length > 0),
+    );
+    setCount((c) => Math.max(0, c - 1));
+    const ok = await unsaveSlug(item.propertySlug, item.listName);
+    if (!ok) {
+      // Reconcile against the server on failure.
+      await load();
+      await refreshShortlist();
+    }
+  };
+
+  const onToggleAlert = async (item: SavedListItem) => {
+    const next = !item.alertEnabled;
+    // Optimistic flip.
+    setLists((prev) =>
+      prev.map((g) => ({
+        ...g,
+        items: g.items.map((i) =>
+          i.propertySlug === item.propertySlug && i.listName === item.listName
+            ? { ...i, alertEnabled: next }
+            : i,
+        ),
+      })),
+    );
+    try {
+      await toggleAlert(item.propertySlug, next);
+    } catch {
+      await load();
+    }
+  };
+
+  const onApply = (item: SavedListItem) => {
+    const qs = new URLSearchParams({ propertyId: item.propertySlug });
+    const target = `/apply?${qs.toString()}`;
+    navigate(getToken() ? target : `/login?return=${encodeURIComponent(target)}`);
+  };
+
+  return (
+    <div
+      style={{ background: HF.cream, minHeight: '100vh', fontFamily: HF.body, color: HF.ink }}
+    >
+      <div className="mx-auto max-w-3xl p-4 sm:p-6">
+        <Link
+          to="/discover"
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 6,
+            fontSize: 14,
+            color: HF.accent,
+            textDecoration: 'none',
+            fontWeight: 600,
+          }}
+        >
+          <ArrowLeft className="h-4 w-4" /> {t('detail.back')}
+        </Link>
+
+        <header className="mb-4" style={{ marginTop: 12 }}>
+          <h1
+            style={{
+              fontFamily: HF.display,
+              fontWeight: 800,
+              fontSize: 22,
+              color: HF.ink,
+              letterSpacing: '-0.01em',
+            }}
+          >
+            {t('saved.title')}
+          </h1>
+          {count > 0 && (
+            <p style={{ marginTop: 4, fontSize: 14, color: HF.ink3 }}>
+              {t('saved.count', { count })}
+            </p>
+          )}
+        </header>
+
+        {loading ? (
+          <p style={{ fontSize: 14, color: HF.ink3 }}>{t('saved.loading')}</p>
+        ) : error ? (
+          <p style={{ fontSize: 14, color: HF.err }}>{error}</p>
+        ) : count === 0 ? (
+          <EmptyState />
+        ) : (
+          <div className="flex flex-col" style={{ gap: 28 }}>
+            {lists.map((group) => (
+              <section key={group.listName} data-testid={`saved-list-${group.listName}`}>
+                {/* Show the list heading only when there's more than one list,
+                    or it isn't the default — keeps the single-list case clean. */}
+                {(lists.length > 1 || group.listName.toLowerCase() !== 'default') && (
+                  <h2
+                    style={{
+                      fontFamily: HF.display,
+                      fontWeight: 700,
+                      fontSize: 15,
+                      color: HF.ink2,
+                      margin: '0 0 10px',
+                    }}
+                  >
+                    {group.listName}
+                  </h2>
+                )}
+                <ul className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                  {group.items.map((item) => (
+                    <SavedCard
+                      key={`${group.listName}:${item.propertySlug}`}
+                      item={item}
+                      onUnsave={() => onUnsave(item)}
+                      onToggleAlert={() => onToggleAlert(item)}
+                      onApply={() => onApply(item)}
+                    />
+                  ))}
+                </ul>
+              </section>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function EmptyState() {
+  const { t } = useTranslation('discover');
+  return (
+    <div
+      data-testid="saved-empty"
+      style={{
+        background: HF.paper,
+        border: `1px solid ${HF.border}`,
+        borderRadius: HF.r.md,
+        padding: '40px 24px',
+        textAlign: 'center',
+        boxShadow: HF.shadow.xs,
+      }}
+    >
+      <Heart
+        width={32}
+        height={32}
+        aria-hidden="true"
+        style={{ color: HF.ink4, margin: '0 auto 12px', display: 'block' }}
+      />
+      <p style={{ fontSize: 15, fontWeight: 700, color: HF.ink, margin: 0 }}>
+        {t('saved.empty.heading')}
+      </p>
+      <p style={{ fontSize: 14, color: HF.ink3, margin: '6px 0 16px' }}>
+        {t('saved.empty.body')}
+      </p>
+      <Link
+        to="/discover"
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 6,
+          background: HF.accent,
+          color: HF.paper,
+          borderRadius: HF.r.md,
+          padding: '10px 16px',
+          fontSize: 14,
+          fontWeight: 600,
+          textDecoration: 'none',
+        }}
+      >
+        {t('saved.empty.cta')}
+      </Link>
+    </div>
+  );
+}
+
+function SavedCard({
+  item,
+  onUnsave,
+  onToggleAlert,
+  onApply,
+}: {
+  item: SavedListItem;
+  onUnsave: () => void;
+  onToggleAlert: () => void;
+  onApply: () => void;
+}) {
+  const { t } = useTranslation('discover');
+  const rent = formatRentRange(item.rentMin, item.rentMax);
+  const available = item.availableCount > 0;
+
+  return (
+    <li>
+      <div
+        data-testid={`saved-card-${item.propertySlug}`}
+        style={{
+          background: HF.paper,
+          border: `1px solid ${HF.border}`,
+          borderRadius: HF.r.md,
+          overflow: 'hidden',
+          boxShadow: HF.shadow.sm,
+          display: 'flex',
+          flexDirection: 'column',
+          height: '100%',
+        }}
+      >
+        <div className="relative">
+          <Link to={`/property/${item.propertySlug}`} aria-label={item.name}>
+            <div
+              className="aspect-[16/9] w-full"
+              style={{
+                background: HF.sageLo,
+                backgroundImage: `url(${placeholderFor(item.propertySlug)})`,
+                backgroundSize: 'cover',
+                backgroundPosition: 'center',
+              }}
+              aria-hidden="true"
+            />
+          </Link>
+          {/* Unsave (♥) — filled because everything on this page is saved. */}
+          <button
+            type="button"
+            onClick={onUnsave}
+            aria-label={t('saved.remove', { name: item.name })}
+            title={t('saved.removeShort')}
+            data-testid={`saved-unsave-${item.propertySlug}`}
+            style={{
+              position: 'absolute',
+              top: 8,
+              right: 8,
+              display: 'inline-flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              height: 36,
+              width: 36,
+              borderRadius: HF.r.pill,
+              border: 'none',
+              background: HF.paper,
+              boxShadow: HF.shadow.sm,
+              cursor: 'pointer',
+              padding: 0,
+            }}
+          >
+            <Heart
+              width={18}
+              height={18}
+              style={{ color: HF.accent, fill: HF.accent }}
+              aria-hidden="true"
+            />
+          </button>
+        </div>
+
+        <div style={{ padding: 16, display: 'flex', flexDirection: 'column', flex: 1 }}>
+          <Link
+            to={`/property/${item.propertySlug}`}
+            style={{ textDecoration: 'none', color: 'inherit' }}
+          >
+            <h3
+              style={{
+                fontFamily: HF.display,
+                fontWeight: 700,
+                fontSize: 16,
+                color: HF.ink,
+                margin: 0,
+                lineHeight: 1.25,
+              }}
+            >
+              {item.name}
+            </h3>
+          </Link>
+
+          <div className="flex items-center" style={{ gap: 6, marginTop: 8, flexWrap: 'wrap' }}>
+            {item.amiTier && (
+              <span
+                style={{
+                  background: HF.sageLo,
+                  color: HF.sage,
+                  border: `1px solid ${HF.border}`,
+                  borderRadius: HF.r.pill,
+                  padding: '2px 10px',
+                  fontSize: 11,
+                  fontWeight: 700,
+                }}
+              >
+                {t('amiDisclosure.chipLabel', { tier: item.amiTier })}
+              </span>
+            )}
+            <span
+              data-testid={`saved-availability-${item.propertySlug}`}
+              style={{
+                background: available ? HF.sageLo : HF.paper,
+                color: available ? HF.ink2 : HF.ink3,
+                border: `1px solid ${HF.border}`,
+                borderRadius: HF.r.pill,
+                padding: '2px 10px',
+                fontSize: 11,
+                fontWeight: 700,
+              }}
+            >
+              {available
+                ? t('badge.available', { count: item.availableCount })
+                : t('badge.fullyLeased')}
+            </span>
+          </div>
+
+          {rent && (
+            <p
+              style={{
+                marginTop: 10,
+                fontFamily: HF.display,
+                fontWeight: 700,
+                fontSize: 14,
+                color: HF.ink,
+              }}
+            >
+              {rent}
+              <span style={{ fontSize: 12, fontWeight: 500, color: HF.ink3 }}>
+                {t('pricing.suffix')}
+              </span>
+            </p>
+          )}
+
+          {/* Vacancy-alert toggle. */}
+          <button
+            type="button"
+            onClick={onToggleAlert}
+            aria-pressed={item.alertEnabled}
+            data-testid={`saved-alert-${item.propertySlug}`}
+            style={{
+              marginTop: 12,
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 8,
+              background: item.alertEnabled ? HF.accentLo : 'transparent',
+              color: item.alertEnabled ? HF.accentInk : HF.ink3,
+              border: `1px solid ${item.alertEnabled ? '#F3D7CB' : HF.border}`,
+              borderRadius: HF.r.pill,
+              padding: '6px 12px',
+              fontSize: 12,
+              fontWeight: 600,
+              fontFamily: HF.body,
+              cursor: 'pointer',
+              alignSelf: 'flex-start',
+            }}
+          >
+            {item.alertEnabled ? (
+              <Bell width={14} height={14} aria-hidden="true" />
+            ) : (
+              <BellOff width={14} height={14} aria-hidden="true" />
+            )}
+            {item.alertEnabled ? t('saved.alertOn') : t('saved.alertOff')}
+          </button>
+
+          <div style={{ flex: 1 }} />
+
+          <div className="flex items-center" style={{ gap: 8, marginTop: 14 }}>
+            <Link
+              to={`/property/${item.propertySlug}`}
+              data-testid={`saved-view-${item.propertySlug}`}
+              style={{
+                flex: 1,
+                textAlign: 'center',
+                background: HF.paper,
+                color: HF.ink,
+                border: `1px solid ${HF.border}`,
+                borderRadius: HF.r.md,
+                padding: '9px 12px',
+                fontSize: 13,
+                fontWeight: 600,
+                textDecoration: 'none',
+              }}
+            >
+              {t('list.viewDetails')}
+            </Link>
+            <button
+              type="button"
+              onClick={onApply}
+              data-testid={`saved-apply-${item.propertySlug}`}
+              style={{
+                flex: 1,
+                background: HF.accent,
+                color: HF.paper,
+                border: `1px solid ${HF.accent}`,
+                borderRadius: HF.r.md,
+                padding: '9px 12px',
+                fontSize: 13,
+                fontWeight: 600,
+                cursor: 'pointer',
+                fontFamily: HF.body,
+              }}
+            >
+              {t('saved.apply')}
+            </button>
+          </div>
+        </div>
+      </div>
+    </li>
+  );
+}
+
+export default Shortlist;

--- a/client-tenant/src/state/shortlist.ts
+++ b/client-tenant/src/state/shortlist.ts
@@ -1,0 +1,191 @@
+/**
+ * Shortlist store — the saved-property "wishlist" (feat/saved-shortlist).
+ *
+ * A guest's saves live server-side, keyed to an httpOnly `uh_guest` cookie
+ * (set on first save, migrated onto the user on magic-link conversion). This
+ * store is the in-memory mirror that keeps every UI affordance in sync:
+ *
+ *   - the ♥ SaveButton on each property card + the detail header
+ *   - the saved-count badge in the /discover header
+ *   - the /saved shortlist page
+ *
+ * Design mirrors `state/consent.ts`: a tiny pub/sub store consumed via
+ * `useSyncExternalStore`, no zustand. We track the set of saved *slugs* (what
+ * /discover renders by) so a heart can read its state in O(1) without
+ * re-fetching. The first `useShortlist()` consumer triggers a one-shot
+ * `GET /api/saved` load; saves/unsaves are optimistic and reconciled (or
+ * rolled back) against the API result.
+ */
+
+import { useEffect, useSyncExternalStore } from 'react';
+import {
+  getShortlist,
+  saveProperty,
+  unsaveProperty,
+} from '@/api/saved';
+
+interface ShortlistStoreState {
+  /** Set of saved property slugs — the source of truth for ♥ state. */
+  slugs: Set<string>;
+  /** True once the initial GET /api/saved has settled (success or failure). */
+  loaded: boolean;
+}
+
+let state: ShortlistStoreState = { slugs: new Set(), loaded: false };
+const listeners = new Set<() => void>();
+
+function emit(): void {
+  for (const l of listeners) l();
+}
+
+function setState(next: ShortlistStoreState): void {
+  state = next;
+  emit();
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+function getSnapshot(): ShortlistStoreState {
+  return state;
+}
+
+// Stable server snapshot for SSR / hydration (useSyncExternalStore contract).
+const SERVER_SNAPSHOT: ShortlistStoreState = {
+  slugs: new Set(),
+  loaded: false,
+};
+function getServerSnapshot(): ShortlistStoreState {
+  return SERVER_SNAPSHOT;
+}
+
+// ── One-shot load ─────────────────────────────────────────────────────
+let loadStarted = false;
+
+/**
+ * Load the shortlist once per session. Idempotent — repeated calls after the
+ * first are no-ops. Failures (e.g. no cookie yet, network) settle as an empty
+ * loaded list rather than throwing; the UI just shows no saves.
+ */
+export async function ensureShortlistLoaded(): Promise<void> {
+  if (loadStarted) return;
+  loadStarted = true;
+  try {
+    const res = await getShortlist();
+    const slugs = new Set<string>();
+    for (const group of res.lists) {
+      for (const item of group.items) slugs.add(item.propertySlug);
+    }
+    setState({ slugs, loaded: true });
+  } catch {
+    // No saves yet / unauthed guest with no cookie — treat as empty.
+    setState({ slugs: new Set(), loaded: true });
+  }
+}
+
+/** Force a re-fetch (used by the /saved page after destructive edits). */
+export async function refreshShortlist(): Promise<void> {
+  try {
+    const res = await getShortlist();
+    const slugs = new Set<string>();
+    for (const group of res.lists) {
+      for (const item of group.items) slugs.add(item.propertySlug);
+    }
+    setState({ slugs, loaded: true });
+  } catch {
+    setState({ slugs: new Set(), loaded: true });
+  }
+}
+
+// ── Optimistic mutations ──────────────────────────────────────────────
+
+function withSlug(slug: string, add: boolean): Set<string> {
+  const next = new Set(state.slugs);
+  if (add) next.add(slug);
+  else next.delete(slug);
+  return next;
+}
+
+/**
+ * Optimistically add `slug` to the shortlist, then call the API. On failure
+ * the optimistic add is rolled back. Returns true on success.
+ */
+export async function save(slug: string, listName?: string): Promise<boolean> {
+  if (state.slugs.has(slug)) return true;
+  setState({ ...state, slugs: withSlug(slug, true) });
+  try {
+    await saveProperty(slug, listName);
+    return true;
+  } catch {
+    setState({ ...state, slugs: withSlug(slug, false) });
+    return false;
+  }
+}
+
+/**
+ * Optimistically remove `slug`, then call the API. On failure the removal is
+ * rolled back. Returns true on success.
+ */
+export async function unsave(slug: string, listName?: string): Promise<boolean> {
+  if (!state.slugs.has(slug)) return true;
+  setState({ ...state, slugs: withSlug(slug, false) });
+  try {
+    await unsaveProperty(slug, listName);
+    return true;
+  } catch {
+    setState({ ...state, slugs: withSlug(slug, true) });
+    return false;
+  }
+}
+
+/** Test-only reset. */
+export function _resetForTests(): void {
+  loadStarted = false;
+  setState({ slugs: new Set(), loaded: false });
+}
+
+// ── React hook ─────────────────────────────────────────────────────────
+
+export interface UseShortlistResult {
+  /** Set of saved property slugs. */
+  savedSlugs: Set<string>;
+  /** Number of saved properties. */
+  count: number;
+  /** True once the initial load has settled. */
+  loaded: boolean;
+  /** Whether a given slug is currently saved. */
+  isSaved: (slug: string) => boolean;
+  /** Optimistic save — returns true on success, false on rollback. */
+  save: (slug: string, listName?: string) => Promise<boolean>;
+  /** Optimistic unsave — returns true on success, false on rollback. */
+  unsave: (slug: string, listName?: string) => Promise<boolean>;
+  /** Force a re-fetch from the server. */
+  refresh: () => Promise<void>;
+}
+
+export function useShortlist(): UseShortlistResult {
+  const snapshot = useSyncExternalStore(
+    subscribe,
+    getSnapshot,
+    getServerSnapshot,
+  );
+
+  // Kick the one-shot load on first mount of any consumer.
+  useEffect(() => {
+    void ensureShortlistLoaded();
+  }, []);
+
+  return {
+    savedSlugs: snapshot.slugs,
+    count: snapshot.slugs.size,
+    loaded: snapshot.loaded,
+    isSaved: (slug: string) => snapshot.slugs.has(slug),
+    save,
+    unsave,
+    refresh: refreshShortlist,
+  };
+}

--- a/src/__tests__/saved-properties.test.ts
+++ b/src/__tests__/saved-properties.test.ts
@@ -1,0 +1,448 @@
+/**
+ * Saved-property shortlist route + conversion tests.
+ *
+ * Covers:
+ *   POST   /saved                      (guest save mints uh_guest cookie; authed save)
+ *   DELETE /saved/:propertyId          (idempotent, owner-scoped)
+ *   GET    /saved                      (grouped by list_name; empty when no owner)
+ *   PATCH  /saved/:propertyId/alert    (vacancy-alert toggle)
+ *   GET    /saved/compare              (owner-scoped, order-preserving)
+ *   migrateGuestSavesToUser()          (guest → user conversion, idempotent)
+ *
+ * Strategy mirrors src/__tests__/waitlist-routes.test.ts: query()/transaction()
+ * are mocked and each test scripts the rows the handler will SELECT/INSERT/etc.
+ *
+ * Query ordering matters. The route's optional-auth helper issues a `SELECT id
+ * FROM users` ONLY when a Bearer token is present, so unauth (guest) tests skip
+ * that row. A guest WRITE resolves the property slug first, then the guest
+ * session, then the save insert (+ slug re-read).
+ */
+import type { QueryResult } from "pg";
+import express from "express";
+import request from "supertest";
+import { generateToken, AuthUser } from "../middleware/auth";
+
+function qr<T extends Record<string, unknown>>(rows: T[]): QueryResult<T> {
+  return { rows } as unknown as QueryResult<T>;
+}
+function qrWithCount<T extends Record<string, unknown>>(
+  rows: T[],
+  rowCount: number
+): QueryResult<T> {
+  return { rows, rowCount } as unknown as QueryResult<T>;
+}
+
+jest.mock("../config/database", () => ({
+  query: jest.fn(),
+  transaction: jest.fn(),
+}));
+jest.mock("../utils/logger", () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+import { query, transaction } from "../config/database";
+import savedRouter from "../modules/saved/routes";
+import {
+  migrateGuestSavesToUser,
+  hashGuestToken,
+} from "../modules/saved/service";
+
+const mockQuery = query as jest.MockedFunction<typeof query>;
+const mockTransaction = transaction as jest.MockedFunction<typeof transaction>;
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/saved", savedRouter);
+  return app;
+}
+const app = buildApp();
+
+const SLUG = "donna-louise-2";
+const PROPERTY_ID = "550e8400-e29b-41d4-a716-446655440099";
+const GUEST_SESSION_ID = "11111111-1111-1111-1111-111111111111";
+
+let __seq = 0;
+function makeUser(): AuthUser {
+  __seq += 1;
+  return {
+    id: `00000000-0000-0000-0000-${String(__seq).padStart(12, "0")}`,
+    email: `u${__seq}@x.com`,
+    role: "applicant",
+    firstName: "Ann",
+    lastName: "App",
+    propertyIds: [],
+    emailVerified: true,
+  };
+}
+
+describe("POST /saved (guest)", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("400 on missing propertyId", async () => {
+    const res = await request(app).post("/saved").send({});
+    expect(res.status).toBe(400);
+  });
+
+  it("404 when slug resolves to no property", async () => {
+    mockQuery.mockResolvedValueOnce(qr([])); // resolvePropertyIdBySlug → none
+    const res = await request(app).post("/saved").send({ propertyId: SLUG });
+    expect(res.status).toBe(404);
+  });
+
+  it("first guest save mints a uh_guest httpOnly cookie + returns the item", async () => {
+    // No Bearer → no users SELECT. Order:
+    mockQuery.mockResolvedValueOnce(qr([{ id: PROPERTY_ID }])); // resolve slug
+    mockQuery.mockResolvedValueOnce(qr([{ id: GUEST_SESSION_ID }])); // INSERT guest_sessions
+    mockQuery.mockResolvedValueOnce(
+      qr([
+        {
+          id: "saved-1",
+          property_id: PROPERTY_ID,
+          list_name: "My list",
+          alert_enabled: false,
+          created_at: new Date("2026-05-24T00:00:00Z"),
+        },
+      ])
+    ); // INSERT saved_properties RETURNING
+    mockQuery.mockResolvedValueOnce(qr([{ slug: SLUG }])); // resolveSlug
+
+    const res = await request(app).post("/saved").send({ propertyId: SLUG });
+    expect(res.status).toBe(201);
+    expect(res.body.saved).toMatchObject({
+      propertyId: PROPERTY_ID,
+      propertySlug: SLUG,
+      listName: "My list",
+      alertEnabled: false,
+    });
+    const setCookie = res.headers["set-cookie"];
+    expect(setCookie).toBeDefined();
+    const cookieStr = Array.isArray(setCookie) ? setCookie.join(";") : String(setCookie);
+    expect(cookieStr).toContain("uh_guest=");
+    expect(cookieStr).toContain("HttpOnly");
+    expect(cookieStr).toContain("SameSite=Lax");
+  });
+
+  it("existing guest cookie reuses the session — no new cookie", async () => {
+    const rawToken = "existing-guest-token-aaaaaaaaaaaaaaaaaaaa";
+    mockQuery.mockResolvedValueOnce(qr([{ id: PROPERTY_ID }])); // resolve slug
+    mockQuery.mockResolvedValueOnce(qr([{ id: GUEST_SESSION_ID }])); // UPDATE guest_sessions (found)
+    mockQuery.mockResolvedValueOnce(
+      qr([
+        {
+          id: "saved-2",
+          property_id: PROPERTY_ID,
+          list_name: "My list",
+          alert_enabled: false,
+          created_at: new Date("2026-05-24T00:00:00Z"),
+        },
+      ])
+    );
+    mockQuery.mockResolvedValueOnce(qr([{ slug: SLUG }]));
+
+    const res = await request(app)
+      .post("/saved")
+      .set("Cookie", `uh_guest=${rawToken}`)
+      .send({ propertyId: SLUG });
+    expect(res.status).toBe(201);
+    expect(res.headers["set-cookie"]).toBeUndefined();
+    // The guest session was resolved by token_hash, not the raw token.
+    const updateCall = mockQuery.mock.calls.find(
+      (c) => typeof c[0] === "string" && (c[0] as string).includes("UPDATE guest_sessions")
+    );
+    expect(updateCall![1]).toEqual([hashGuestToken(rawToken)]);
+  });
+});
+
+describe("POST /saved (authed user)", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("authed save scopes to user_id + uses the user-side conflict target", async () => {
+    const user = makeUser();
+    // POST resolves the property slug BEFORE the owner. So: slug SELECT, then
+    // the optional-auth users SELECT, then the save insert + slug re-read.
+    mockQuery.mockResolvedValueOnce(qr([{ id: PROPERTY_ID }])); // resolve slug
+    mockQuery.mockResolvedValueOnce(qr([{ id: user.id }])); // optional-auth users SELECT
+    mockQuery.mockResolvedValueOnce(
+      qr([
+        {
+          id: "saved-u1",
+          property_id: PROPERTY_ID,
+          list_name: "My list",
+          alert_enabled: false,
+          created_at: new Date("2026-05-24T00:00:00Z"),
+        },
+      ])
+    );
+    mockQuery.mockResolvedValueOnce(qr([{ slug: SLUG }]));
+
+    const token = generateToken(user);
+    const res = await request(app)
+      .post("/saved")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ propertyId: SLUG });
+    expect(res.status).toBe(201);
+    // No guest cookie for an authed save.
+    expect(res.headers["set-cookie"]).toBeUndefined();
+    const insertCall = mockQuery.mock.calls.find(
+      (c) =>
+        typeof c[0] === "string" && (c[0] as string).includes("INSERT INTO saved_properties")
+    );
+    expect(insertCall![0]).toContain("user_id");
+    // Partial-unique indexes can't be named as constraints; the upsert infers
+    // the user-side index by its columns + matching WHERE predicate.
+    expect(insertCall![0]).toContain("ON CONFLICT (user_id, property_id, list_name)");
+    expect(insertCall![0]).toContain("WHERE user_id IS NOT NULL");
+    expect(insertCall![1]![0]).toBe(user.id);
+  });
+});
+
+describe("DELETE /saved/:propertyId", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("idempotent ok=true with no owner cookie", async () => {
+    // resolvePropertyRef: UUID path → SELECT properties (found), then no owner.
+    mockQuery.mockResolvedValueOnce(qr([{ id: PROPERTY_ID }])); // properties SELECT (uuid)
+    // resolveOwnerForRead: no Bearer, no cookie → returns null, no query.
+    const res = await request(app).delete(`/saved/${PROPERTY_ID}`);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true, removed: 0 });
+  });
+
+  it("removes the guest's save (owner-scoped DELETE)", async () => {
+    const rawToken = "guest-del-token-bbbbbbbbbbbbbbbbbbbb";
+    mockQuery.mockResolvedValueOnce(qr([{ id: PROPERTY_ID }])); // resolve uuid
+    mockQuery.mockResolvedValueOnce(qr([{ id: GUEST_SESSION_ID }])); // resolveOwnerForRead UPDATE guest_sessions
+    mockQuery.mockResolvedValueOnce(qrWithCount([], 1)); // DELETE
+
+    const res = await request(app)
+      .delete(`/saved/${PROPERTY_ID}`)
+      .set("Cookie", `uh_guest=${rawToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true, removed: 1 });
+    const delCall = mockQuery.mock.calls.find(
+      (c) =>
+        typeof c[0] === "string" && (c[0] as string).includes("DELETE FROM saved_properties")
+    );
+    expect(delCall![0]).toContain("guest_session_id = $1");
+    expect(delCall![1]).toEqual([GUEST_SESSION_ID, PROPERTY_ID]);
+  });
+});
+
+describe("GET /saved", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("empty shortlist when there is no owner", async () => {
+    const res = await request(app).get("/saved");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ lists: [], count: 0 });
+  });
+
+  it("groups saves by list_name with property summary", async () => {
+    const rawToken = "guest-list-token-cccccccccccccccccccc";
+    mockQuery.mockResolvedValueOnce(qr([{ id: GUEST_SESSION_ID }])); // resolveOwnerForRead
+    mockQuery.mockResolvedValueOnce(
+      qr([
+        {
+          id: "s1",
+          property_id: PROPERTY_ID,
+          list_name: "My list",
+          alert_enabled: false,
+          created_at: new Date("2026-05-24T00:00:00Z"),
+          name: "Donna Louise 2",
+          slug: SLUG,
+          ami_set_aside: "60% AMI",
+          available_count: 3,
+          rent_min: 900,
+          rent_max: 1400,
+        },
+        {
+          id: "s2",
+          property_id: "650e8400-e29b-41d4-a716-446655440011",
+          list_name: "Dream homes",
+          alert_enabled: true,
+          created_at: new Date("2026-05-24T01:00:00Z"),
+          name: "Sunrise Villas",
+          slug: "sunrise-villas",
+          ami_set_aside: null,
+          available_count: 0,
+          rent_min: null,
+          rent_max: null,
+        },
+      ])
+    );
+
+    const res = await request(app).get("/saved").set("Cookie", `uh_guest=${rawToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body.count).toBe(2);
+    expect(res.body.lists).toHaveLength(2);
+    const myList = res.body.lists.find((l: { listName: string }) => l.listName === "My list");
+    expect(myList.items[0]).toMatchObject({
+      propertySlug: SLUG,
+      amiTier: "60",
+      availableCount: 3,
+      rentMin: 900,
+      rentMax: 1400,
+      walkScore: null,
+    });
+  });
+});
+
+describe("PATCH /saved/:propertyId/alert", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("400 on bad body", async () => {
+    const res = await request(app)
+      .patch(`/saved/${PROPERTY_ID}/alert`)
+      .send({ enabled: "yes" });
+    expect(res.status).toBe(400);
+  });
+
+  it("404 when the owner has no save for the property", async () => {
+    const rawToken = "guest-alert-token-dddddddddddddddddddd";
+    mockQuery.mockResolvedValueOnce(qr([{ id: PROPERTY_ID }])); // resolve uuid
+    mockQuery.mockResolvedValueOnce(qr([{ id: GUEST_SESSION_ID }])); // owner
+    mockQuery.mockResolvedValueOnce(qr([])); // UPDATE ... RETURNING → none
+    const res = await request(app)
+      .patch(`/saved/${PROPERTY_ID}/alert`)
+      .set("Cookie", `uh_guest=${rawToken}`)
+      .send({ enabled: true });
+    expect(res.status).toBe(404);
+  });
+
+  it("toggles the alert and returns the updated item", async () => {
+    const rawToken = "guest-alert-ok-token-eeeeeeeeeeeeeeee";
+    mockQuery.mockResolvedValueOnce(qr([{ id: PROPERTY_ID }])); // resolve uuid
+    mockQuery.mockResolvedValueOnce(qr([{ id: GUEST_SESSION_ID }])); // owner
+    mockQuery.mockResolvedValueOnce(
+      qr([
+        {
+          id: "s1",
+          property_id: PROPERTY_ID,
+          list_name: "My list",
+          alert_enabled: true,
+          created_at: new Date("2026-05-24T00:00:00Z"),
+        },
+      ])
+    ); // UPDATE RETURNING
+    mockQuery.mockResolvedValueOnce(qr([{ slug: SLUG }])); // resolveSlug
+
+    const res = await request(app)
+      .patch(`/saved/${PROPERTY_ID}/alert`)
+      .set("Cookie", `uh_guest=${rawToken}`)
+      .send({ enabled: true });
+    expect(res.status).toBe(200);
+    expect(res.body.saved.alertEnabled).toBe(true);
+  });
+});
+
+describe("GET /saved/compare", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("400 when ids missing", async () => {
+    const res = await request(app).get("/saved/compare");
+    expect(res.status).toBe(400);
+  });
+
+  it("empty when no owner", async () => {
+    const res = await request(app).get(`/saved/compare?ids=${PROPERTY_ID}`);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ properties: [] });
+  });
+
+  it("returns owner-scoped compare rows preserving request order", async () => {
+    const rawToken = "guest-cmp-token-ffffffffffffffffffff";
+    const idA = PROPERTY_ID;
+    const idB = "650e8400-e29b-41d4-a716-446655440011";
+    mockQuery.mockResolvedValueOnce(qr([{ id: GUEST_SESSION_ID }])); // owner
+    // resolvePropertyRef for each id (both UUIDs):
+    mockQuery.mockResolvedValueOnce(qr([{ id: idA }]));
+    mockQuery.mockResolvedValueOnce(qr([{ id: idB }]));
+    // getCompare query (returns out of order — handler must reorder to [A,B]):
+    mockQuery.mockResolvedValueOnce(
+      qr([
+        {
+          property_id: idB,
+          slug: "sunrise-villas",
+          name: "Sunrise Villas",
+          city: "Reno",
+          ami_set_aside: null,
+          available_count: 0,
+          rent_min: null,
+          rent_max: null,
+        },
+        {
+          property_id: idA,
+          slug: SLUG,
+          name: "Donna Louise 2",
+          city: "Las Vegas",
+          ami_set_aside: "60% AMI",
+          available_count: 3,
+          rent_min: 900,
+          rent_max: 1400,
+        },
+      ])
+    );
+
+    const res = await request(app)
+      .get(`/saved/compare?ids=${idA},${idB}`)
+      .set("Cookie", `uh_guest=${rawToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body.properties.map((p: { propertyId: string }) => p.propertyId)).toEqual([
+      idA,
+      idB,
+    ]);
+    expect(res.body.properties[0]).toMatchObject({ amiTier: "60", city: "Las Vegas" });
+  });
+});
+
+describe("migrateGuestSavesToUser (conversion)", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("no-op when there is no guest token", async () => {
+    const n = await migrateGuestSavesToUser(null, "user-1");
+    expect(n).toBe(0);
+    expect(mockTransaction).not.toHaveBeenCalled();
+  });
+
+  it("migrates guest saves onto the user, dropping collisions and stamping conversion", async () => {
+    const userId = "00000000-0000-0000-0000-000000000abc";
+    const clientQuery = jest
+      .fn()
+      // SELECT ... FOR UPDATE → un-converted session
+      .mockResolvedValueOnce({ rows: [{ id: GUEST_SESSION_ID, converted_user_id: null }] })
+      // UPDATE re-point (NOT EXISTS guard) → 2 rows migrated
+      .mockResolvedValueOnce({ rowCount: 2 })
+      // DELETE leftover colliding guest rows
+      .mockResolvedValueOnce({ rowCount: 1 })
+      // UPDATE guest_sessions stamp
+      .mockResolvedValueOnce({ rowCount: 1 });
+    mockTransaction.mockImplementation((async (fn: (c: { query: typeof clientQuery }) => unknown) =>
+      fn({ query: clientQuery })) as unknown as typeof transaction);
+
+    const n = await migrateGuestSavesToUser("raw-guest-token-zzzzzzzzzzzzzzzzzzzz", userId);
+    expect(n).toBe(2);
+    // Re-point flips owner columns.
+    const repoint = clientQuery.mock.calls.find(
+      (c) => typeof c[0] === "string" && c[0].includes("SET user_id = $2, guest_session_id = NULL")
+    );
+    expect(repoint).toBeDefined();
+    // Conversion is stamped.
+    const stamp = clientQuery.mock.calls.find(
+      (c) => typeof c[0] === "string" && c[0].includes("SET converted_user_id = $2")
+    );
+    expect(stamp).toBeDefined();
+  });
+
+  it("idempotent: already-converted session is a no-op", async () => {
+    const clientQuery = jest
+      .fn()
+      .mockResolvedValueOnce({ rows: [{ id: GUEST_SESSION_ID, converted_user_id: "someone" }] });
+    mockTransaction.mockImplementation((async (fn: (c: { query: typeof clientQuery }) => unknown) =>
+      fn({ query: clientQuery })) as unknown as typeof transaction);
+    const n = await migrateGuestSavesToUser("raw-token-already-converted-xxxx", "user-2");
+    expect(n).toBe(0);
+    // Only the SELECT FOR UPDATE ran — no re-point.
+    expect(clientQuery).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/db/migrations/2026-05-24-saved-properties-guest-shortlist.sql
+++ b/src/db/migrations/2026-05-24-saved-properties-guest-shortlist.sql
@@ -1,0 +1,65 @@
+-- Saved-property shortlist + server-side guest sessions — 2026-05-24
+--
+-- "Save property → temporary guest profile → Airbnb-style shortlist → convert
+-- to full account." Guests can't live in `users` (email/first_name/last_name
+-- are NOT NULL + email UNIQUE), so an anonymous saver gets a server-side
+-- `guest_sessions` row keyed by an opaque httpOnly cookie. On magic-link
+-- account creation the guest's saved list is re-pointed onto the real user.
+--
+-- A saved row belongs to EXACTLY ONE owner — a guest session OR a user, never
+-- both, never neither (CHECK below). On conversion we flip guest_session_id →
+-- user_id, so the same row migrates without being re-inserted.
+
+-- ── Guest sessions ──────────────────────────────────────────────────────────
+-- One row per anonymous browser. `token_hash` is sha256() of the opaque cookie
+-- token (the raw token is never stored). `converted_user_id` is stamped once
+-- the guest registers, so we can both audit the conversion and short-circuit
+-- re-migration (idempotent). `demo_run_id` mirrors users.demo_run_id so a
+-- `?demo=<TOKEN>` walkthrough's guest can be reaped by scripts/purge-demo-data.
+CREATE TABLE IF NOT EXISTS guest_sessions (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  token_hash VARCHAR(64) UNIQUE NOT NULL,
+  converted_user_id UUID NULL REFERENCES users(id) ON DELETE SET NULL,
+  demo_run_id TEXT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  last_seen_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_guest_sessions_converted_user
+  ON guest_sessions(converted_user_id);
+
+-- ── Saved properties (shortlist) ────────────────────────────────────────────
+-- Exactly one of (guest_session_id, user_id) is non-null — enforced by the
+-- CHECK. Both FKs cascade so deleting a guest session or a user reaps their
+-- shortlist. `list_name` gives Airbnb-style wishlists (default "My list").
+-- `alert_enabled` is the per-item vacancy-alert toggle.
+CREATE TABLE IF NOT EXISTS saved_properties (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  guest_session_id UUID NULL REFERENCES guest_sessions(id) ON DELETE CASCADE,
+  user_id UUID NULL REFERENCES users(id) ON DELETE CASCADE,
+  property_id UUID NOT NULL REFERENCES properties(id) ON DELETE CASCADE,
+  list_name TEXT NOT NULL DEFAULT 'My list',
+  alert_enabled BOOLEAN NOT NULL DEFAULT false,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT saved_properties_exactly_one_owner CHECK (
+    (guest_session_id IS NOT NULL AND user_id IS NULL)
+    OR (guest_session_id IS NULL AND user_id IS NOT NULL)
+  )
+);
+
+-- Partial-unique indexes: a given property can't be double-saved per owner per
+-- list. Two partials (one per owner column) because the owner is split across
+-- two nullable columns — a single composite unique over a coalesced owner isn't
+-- expressible without a generated column.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_saved_properties_guest
+  ON saved_properties(guest_session_id, property_id, list_name)
+  WHERE guest_session_id IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS uq_saved_properties_user
+  ON saved_properties(user_id, property_id, list_name)
+  WHERE user_id IS NOT NULL;
+
+-- Hot read paths: list a guest's or a user's shortlist.
+CREATE INDEX IF NOT EXISTS idx_saved_properties_guest
+  ON saved_properties(guest_session_id) WHERE guest_session_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_saved_properties_user
+  ON saved_properties(user_id) WHERE user_id IS NOT NULL;

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -496,6 +496,49 @@ CREATE INDEX idx_waitlist_entries_lane_created
 CREATE INDEX idx_waitlist_entries_user
   ON waitlist_entries(applicant_user_id);
 
+-- Saved-property shortlist + server-side guest sessions (2026-05-24).
+-- See migration 2026-05-24-saved-properties-guest-shortlist.sql. Guests can't
+-- live in the users table (NOT NULL email/name + UNIQUE email), so an anonymous
+-- saver gets a guest_sessions row keyed by an opaque httpOnly cookie; on magic-link
+-- account creation their saved list re-points onto the real user.
+CREATE TABLE guest_sessions (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  token_hash VARCHAR(64) UNIQUE NOT NULL,
+  converted_user_id UUID NULL REFERENCES users(id) ON DELETE SET NULL,
+  demo_run_id TEXT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  last_seen_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX idx_guest_sessions_converted_user
+  ON guest_sessions(converted_user_id);
+
+-- A saved row belongs to EXACTLY ONE owner (guest session OR user) — CHECK
+-- below. On conversion we flip guest_session_id → user_id so the row migrates
+-- in place. Partial-unique indexes block double-saving a property per owner+list.
+CREATE TABLE saved_properties (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  guest_session_id UUID NULL REFERENCES guest_sessions(id) ON DELETE CASCADE,
+  user_id UUID NULL REFERENCES users(id) ON DELETE CASCADE,
+  property_id UUID NOT NULL REFERENCES properties(id) ON DELETE CASCADE,
+  list_name TEXT NOT NULL DEFAULT 'My list',
+  alert_enabled BOOLEAN NOT NULL DEFAULT false,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT saved_properties_exactly_one_owner CHECK (
+    (guest_session_id IS NOT NULL AND user_id IS NULL)
+    OR (guest_session_id IS NULL AND user_id IS NOT NULL)
+  )
+);
+CREATE UNIQUE INDEX uq_saved_properties_guest
+  ON saved_properties(guest_session_id, property_id, list_name)
+  WHERE guest_session_id IS NOT NULL;
+CREATE UNIQUE INDEX uq_saved_properties_user
+  ON saved_properties(user_id, property_id, list_name)
+  WHERE user_id IS NOT NULL;
+CREATE INDEX idx_saved_properties_guest
+  ON saved_properties(guest_session_id) WHERE guest_session_id IS NOT NULL;
+CREATE INDEX idx_saved_properties_user
+  ON saved_properties(user_id) WHERE user_id IS NOT NULL;
+
 -- BP-02 Compliance Tape — append-only hash-chained audit ledger.
 -- One row per regulated event; UPDATE/DELETE/TRUNCATE rejected by trigger.
 -- Sequence is monotonic per scope (applicant_id, or global when NULL).

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,7 @@ import { createTapeViewerRoutes } from "./modules/tape/routes-viewer";
 import { qaRouter } from "./modules/qa/routes";
 import { housingQaRouter } from "./modules/housing-qa/routes";
 import acquisitionRoutes from "./modules/acquisitions/routes";
+import savedRoutes from "./modules/saved/routes";
 import { startScheduler } from "./scheduler";
 
 // Boot-time guardrails: in production, refuse to start without the secrets that
@@ -73,7 +74,13 @@ try {
   console.error((err as Error).message);
   process.exit(1);
 }
-app.use(cors({ origin: corsOrigins }));
+// credentials:true so the httpOnly `uh_guest` guest-shortlist cookie is
+// accepted on cross-origin XHR (Access-Control-Allow-Credentials). In prod the
+// client reaches the API through a same-origin Vercel rewrite, so the cookie is
+// first-party there; this keeps direct cross-origin calls working too. Note the
+// origin allow-list above is explicit (never "*"), which credentialed CORS
+// requires.
+app.use(cors({ origin: corsOrigins, credentials: true }));
 
 // BP-08 Stripe webhook — MUST be mounted before `express.json()` so the raw
 // request body survives intact for `stripe.webhooks.constructEvent`. Moving
@@ -135,6 +142,11 @@ app.use("/api/applicants", applicantRoutes);
 // process; answers are grounded strictly in injected data). Degrades to 503
 // when ANTHROPIC_API_KEY is absent.
 app.use("/api/housing-qa", housingQaRouter());
+
+// Saved-property shortlist (public — guests via uh_guest cookie OR authed users).
+// Guests save without an account; on magic-link conversion the saves migrate
+// onto the real user. See src/modules/saved/.
+app.use("/api/saved", savedRoutes);
 
 // BP-03b compliance tape beacons (HUD-928.1 page-view, welcome-accept).
 // Stub module — see src/modules/tape/index.ts. Replace with canonical BP-02

--- a/src/modules/auth/routes.ts
+++ b/src/modules/auth/routes.ts
@@ -6,8 +6,22 @@ import { authenticate, AuthRequest } from "../../middleware/auth";
 import { verifyTurnstile } from "../../middleware/verify-turnstile";
 import { logger } from "../../utils/logger";
 import { shouldReturnDevLink } from "../../utils/demo-link";
+import { GUEST_COOKIE_NAME, migrateGuestSavesToUser } from "../saved/service";
 
 const router: Router = Router();
+
+/** Read a single cookie value from the raw Cookie header (no cookie-parser). */
+function readCookie(cookieHeader: string | undefined, name: string): string | null {
+  if (!cookieHeader) return null;
+  for (const part of cookieHeader.split(";")) {
+    const eq = part.indexOf("=");
+    if (eq === -1) continue;
+    if (part.slice(0, eq).trim() === name) {
+      return decodeURIComponent(part.slice(eq + 1).trim());
+    }
+  }
+  return null;
+}
 
 const requestSchema = z.object({
   email: z.string().email(),
@@ -94,6 +108,28 @@ router.post("/magic-link/verify", async (req, res) => {
       res.status(401).json({ error: "Invalid or expired link" });
       return;
     }
+
+    // Conversion hook: if this browser carried a guest shortlist (uh_guest
+    // cookie), migrate those saves onto the now-verified user. Idempotent and
+    // best-effort — a migration failure must never block the login, so any
+    // error is logged and swallowed. "Your spot is already saved."
+    try {
+      const guestToken = readCookie(req.headers.cookie, GUEST_COOKIE_NAME);
+      if (guestToken && result.user?.id) {
+        const migrated = await migrateGuestSavesToUser(guestToken, result.user.id);
+        if (migrated > 0) {
+          logger.info("Migrated guest shortlist on conversion", {
+            userId: result.user.id,
+            migrated,
+          });
+        }
+      }
+    } catch (migrateErr) {
+      logger.error("Guest shortlist migration failed (non-fatal)", {
+        error: (migrateErr as Error).message,
+      });
+    }
+
     res.json(result);
   } catch (err) {
     logger.error("Magic-link verify failed", { error: (err as Error).message });

--- a/src/modules/saved/routes.ts
+++ b/src/modules/saved/routes.ts
@@ -1,0 +1,275 @@
+import { Router, Request, Response } from "express";
+import { z } from "zod";
+import jwt from "jsonwebtoken";
+import { query } from "../../config/database";
+import { logger } from "../../utils/logger";
+import { shouldReturnDevLink } from "../../utils/demo-link";
+import {
+  GUEST_COOKIE_NAME,
+  DEFAULT_LIST_NAME,
+  Owner,
+  hashGuestToken,
+  resolveOrCreateGuestSession,
+  saveProperty,
+  unsaveProperty,
+  getShortlist,
+  setAlert,
+  getCompare,
+  resolvePropertyIdBySlug,
+} from "./service";
+
+// ────────────────────────────────────────────────────────────────────────────
+// Saved-property shortlist routes (public — guests AND authed users).
+//
+// Owner resolution per request:
+//   - Authorization: Bearer <jwt> present + valid → user owner.
+//   - Else → guest owner, tracked by the httpOnly `uh_guest` cookie. The cookie
+//     is parsed from the raw Cookie header (no cookie-parser dependency) and
+//     set on the response (Set-Cookie) only when a NEW guest session is minted.
+//
+// Discover renders from slugs, so the API speaks slugs and resolves them to the
+// property UUID server-side. Reads never create a guest session (so a bot GET
+// can't spam guest rows); only a save (POST) mints one.
+// ────────────────────────────────────────────────────────────────────────────
+
+const router: Router = Router();
+
+const COOKIE_MAX_AGE_DAYS = 90;
+
+/** Parse a single cookie value out of the raw Cookie header. */
+function readCookie(req: Request, name: string): string | null {
+  const raw = req.headers.cookie;
+  if (!raw) return null;
+  for (const part of raw.split(";")) {
+    const eq = part.indexOf("=");
+    if (eq === -1) continue;
+    const k = part.slice(0, eq).trim();
+    if (k === name) {
+      return decodeURIComponent(part.slice(eq + 1).trim());
+    }
+  }
+  return null;
+}
+
+/** Set the guest cookie. httpOnly + SameSite=Lax; Secure in production. */
+function setGuestCookie(res: Response, token: string): void {
+  const parts = [
+    `${GUEST_COOKIE_NAME}=${encodeURIComponent(token)}`,
+    "Path=/",
+    "HttpOnly",
+    "SameSite=Lax",
+    `Max-Age=${COOKIE_MAX_AGE_DAYS * 24 * 60 * 60}`,
+  ];
+  if (process.env.NODE_ENV === "production") parts.push("Secure");
+  res.append("Set-Cookie", parts.join("; "));
+}
+
+/**
+ * Resolve the caller as a user (from a valid Bearer JWT) without paying the
+ * full authenticate() tax (which 401s on miss — we want graceful guest
+ * fallback). Mirrors the optional-auth pattern in applicants/routes.ts
+ * (waitlist-summary). Returns the user id or null.
+ */
+async function resolveOptionalUser(req: Request): Promise<string | null> {
+  const authHeader = req.headers.authorization;
+  if (!authHeader?.startsWith("Bearer ")) return null;
+  try {
+    const decoded = jwt.verify(
+      authHeader.substring(7),
+      process.env.JWT_SECRET || "dev-secret-change-me"
+    ) as { id?: string };
+    if (!decoded?.id) return null;
+    const u = await query("SELECT id FROM users WHERE id = $1 AND is_active = TRUE", [
+      decoded.id,
+    ]);
+    return u.rows.length > 0 ? u.rows[0].id : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve the owner for a WRITE request. A user takes precedence; otherwise we
+ * resolve (or create) a guest session and, when a new token was minted, set the
+ * cookie on the response. Demo guests are tagged with the run id the same way
+ * applicants/register tags users.demo_run_id.
+ */
+async function resolveOwnerForWrite(req: Request, res: Response): Promise<Owner> {
+  const userId = await resolveOptionalUser(req);
+  if (userId) return { kind: "user", userId };
+
+  const demoRunId = shouldReturnDevLink(req) ? req.header("x-demo-run") ?? null : null;
+  const rawToken = readCookie(req, GUEST_COOKIE_NAME);
+  const { guestSessionId, newToken } = await resolveOrCreateGuestSession(
+    rawToken,
+    demoRunId
+  );
+  if (newToken) setGuestCookie(res, newToken);
+  return { kind: "guest", guestSessionId };
+}
+
+/**
+ * Resolve the owner for a READ request. A user takes precedence; otherwise, if
+ * an existing guest cookie maps to a session, use it. We never CREATE a guest
+ * session on a read — returns null when there's no owner yet (empty shortlist).
+ */
+async function resolveOwnerForRead(req: Request): Promise<Owner | null> {
+  const userId = await resolveOptionalUser(req);
+  if (userId) return { kind: "user", userId };
+
+  const rawToken = readCookie(req, GUEST_COOKIE_NAME);
+  if (!rawToken) return null;
+  const res = await query(
+    `UPDATE guest_sessions SET last_seen_at = NOW() WHERE token_hash = $1 RETURNING id`,
+    [hashGuestToken(rawToken)]
+  );
+  if (res.rows.length === 0) return null;
+  return { kind: "guest", guestSessionId: res.rows[0].id };
+}
+
+const saveSchema = z.object({
+  propertyId: z.string().min(1).max(200), // slug or UUID — resolved below
+  listName: z.string().min(1).max(120).optional(),
+});
+
+/** Resolve an incoming `propertyId` (slug OR raw UUID) to a property UUID. */
+async function resolvePropertyRef(ref: string): Promise<string | null> {
+  if (/^[0-9a-f-]{36}$/i.test(ref)) {
+    const r = await query("SELECT id FROM properties WHERE id = $1", [ref]);
+    return r.rows.length > 0 ? r.rows[0].id : null;
+  }
+  return resolvePropertyIdBySlug(ref);
+}
+
+// POST /saved { propertyId (slug|uuid), listName? } → upsert, returns the item.
+// Sets uh_guest cookie if a new guest session was created.
+router.post("/", async (req: Request, res: Response): Promise<void> => {
+  try {
+    const parsed = saveSchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({ error: "Validation failed", details: parsed.error.issues });
+      return;
+    }
+    const propertyId = await resolvePropertyRef(parsed.data.propertyId);
+    if (!propertyId) {
+      res.status(404).json({ error: "Property not found" });
+      return;
+    }
+    const listName = parsed.data.listName?.trim() || DEFAULT_LIST_NAME;
+    const owner = await resolveOwnerForWrite(req, res);
+    const item = await saveProperty(owner, propertyId, listName);
+    res.status(201).json({ saved: item });
+  } catch (err) {
+    logger.error("Save property failed", { error: (err as Error).message });
+    res.status(500).json({ error: "Failed to save property" });
+  }
+});
+
+// DELETE /saved/:propertyId?listName= → unsave (idempotent).
+router.delete("/:propertyId", async (req: Request, res: Response): Promise<void> => {
+  try {
+    const propertyId = await resolvePropertyRef(String(req.params.propertyId ?? ""));
+    if (!propertyId) {
+      // Nothing to unsave if the property doesn't resolve — treat as idempotent.
+      res.json({ ok: true, removed: 0 });
+      return;
+    }
+    const listName =
+      typeof req.query.listName === "string" && req.query.listName.trim()
+        ? req.query.listName.trim()
+        : null;
+    // A read-style owner: no save can exist without an owner already, so don't
+    // mint a guest session on delete.
+    const owner = await resolveOwnerForRead(req);
+    if (!owner) {
+      res.json({ ok: true, removed: 0 });
+      return;
+    }
+    const removed = await unsaveProperty(owner, propertyId, listName);
+    res.json({ ok: true, removed });
+  } catch (err) {
+    logger.error("Unsave property failed", { error: (err as Error).message });
+    res.status(500).json({ error: "Failed to unsave property" });
+  }
+});
+
+// GET /saved → the owner's shortlist grouped by list_name (empty when no owner).
+router.get("/", async (req: Request, res: Response): Promise<void> => {
+  try {
+    const owner = await resolveOwnerForRead(req);
+    if (!owner) {
+      res.json({ lists: [], count: 0 });
+      return;
+    }
+    const lists = await getShortlist(owner);
+    const count = lists.reduce((n, l) => n + l.items.length, 0);
+    res.json({ lists, count });
+  } catch (err) {
+    logger.error("List shortlist failed", { error: (err as Error).message });
+    res.status(500).json({ error: "Failed to load shortlist" });
+  }
+});
+
+const alertSchema = z.object({ enabled: z.boolean() });
+
+// PATCH /saved/:propertyId/alert { enabled } → toggle vacancy alert.
+router.patch("/:propertyId/alert", async (req: Request, res: Response): Promise<void> => {
+  try {
+    const parsed = alertSchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({ error: "Validation failed", details: parsed.error.issues });
+      return;
+    }
+    const propertyId = await resolvePropertyRef(String(req.params.propertyId ?? ""));
+    if (!propertyId) {
+      res.status(404).json({ error: "Property not found" });
+      return;
+    }
+    const owner = await resolveOwnerForRead(req);
+    if (!owner) {
+      res.status(404).json({ error: "Not saved" });
+      return;
+    }
+    const item = await setAlert(owner, propertyId, parsed.data.enabled);
+    if (!item) {
+      res.status(404).json({ error: "Not saved" });
+      return;
+    }
+    res.json({ saved: item });
+  } catch (err) {
+    logger.error("Toggle alert failed", { error: (err as Error).message });
+    res.status(500).json({ error: "Failed to toggle alert" });
+  }
+});
+
+// GET /saved/compare?ids=<slug|uuid>,<...> → side-by-side compare data.
+router.get("/compare", async (req: Request, res: Response): Promise<void> => {
+  try {
+    const raw = typeof req.query.ids === "string" ? req.query.ids : "";
+    const refs = raw
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean);
+    if (refs.length === 0) {
+      res.status(400).json({ error: "ids query param is required" });
+      return;
+    }
+    const owner = await resolveOwnerForRead(req);
+    if (!owner) {
+      res.json({ properties: [] });
+      return;
+    }
+    const propertyIds: string[] = [];
+    for (const ref of refs) {
+      const id = await resolvePropertyRef(ref);
+      if (id) propertyIds.push(id);
+    }
+    const properties = await getCompare(owner, propertyIds);
+    res.json({ properties });
+  } catch (err) {
+    logger.error("Compare failed", { error: (err as Error).message });
+    res.status(500).json({ error: "Failed to compare properties" });
+  }
+});
+
+export default router;

--- a/src/modules/saved/service.ts
+++ b/src/modules/saved/service.ts
@@ -1,0 +1,423 @@
+import crypto from "crypto";
+import { query, transaction } from "../../config/database";
+
+// ────────────────────────────────────────────────────────────────────────────
+// Saved-property shortlist service.
+//
+// An owner is EITHER an authenticated user (user_id) OR an anonymous guest
+// session (guest_session_id), never both. The route layer resolves which one
+// the caller is (JWT → user; uh_guest cookie → guest) and hands us an `Owner`.
+// Every write/read here is scoped by that owner so a guest can only see/mutate
+// their own shortlist, and likewise for a user.
+// ────────────────────────────────────────────────────────────────────────────
+
+export const GUEST_COOKIE_NAME = "uh_guest";
+export const DEFAULT_LIST_NAME = "My list";
+
+export type Owner =
+  | { kind: "user"; userId: string }
+  | { kind: "guest"; guestSessionId: string };
+
+export function hashGuestToken(raw: string): string {
+  return crypto.createHash("sha256").update(raw).digest("hex");
+}
+
+/** Opaque, URL-safe random cookie token (32 bytes → 43 base64url chars). */
+export function generateGuestToken(): string {
+  return crypto.randomBytes(32).toString("base64url");
+}
+
+/**
+ * Resolve an existing guest session by its raw cookie token, or create a fresh
+ * one. Returns the session id plus a `newToken` when a session was created (the
+ * route sets the cookie only in that case). `demoRunId` tags demo-walkthrough
+ * guests the same way users.demo_run_id tags demo signups.
+ *
+ * `last_seen_at` is bumped on every resolve so stale guests can be reaped later.
+ */
+export async function resolveOrCreateGuestSession(
+  rawToken: string | null,
+  demoRunId: string | null
+): Promise<{ guestSessionId: string; newToken: string | null }> {
+  if (rawToken) {
+    const tokenHash = hashGuestToken(rawToken);
+    const existing = await query(
+      `UPDATE guest_sessions SET last_seen_at = NOW()
+        WHERE token_hash = $1
+        RETURNING id`,
+      [tokenHash]
+    );
+    if (existing.rows.length > 0) {
+      return { guestSessionId: existing.rows[0].id, newToken: null };
+    }
+    // Cookie present but unknown (purged session / forged value) — fall through
+    // and mint a fresh session + token so the caller still gets a shortlist.
+  }
+
+  const newToken = generateGuestToken();
+  const tokenHash = hashGuestToken(newToken);
+  const created = await query(
+    `INSERT INTO guest_sessions (token_hash, demo_run_id)
+     VALUES ($1, $2)
+     RETURNING id`,
+    [tokenHash, demoRunId]
+  );
+  return { guestSessionId: created.rows[0].id, newToken };
+}
+
+/** Owner predicate + param for parameterized WHERE clauses. */
+function ownerClause(owner: Owner, paramIndex: number): { sql: string; value: string } {
+  return owner.kind === "user"
+    ? { sql: `user_id = $${paramIndex}`, value: owner.userId }
+    : { sql: `guest_session_id = $${paramIndex}`, value: owner.guestSessionId };
+}
+
+export interface SavedItem {
+  id: string;
+  propertyId: string;
+  propertySlug: string;
+  listName: string;
+  alertEnabled: boolean;
+  createdAt: string;
+}
+
+/**
+ * Slug ↔ property lookup, identical normalization to
+ * applicants/routes.ts:resolvePropertyIdBySlug (LOWER → non-alnum→'-' → trim).
+ * Discover renders from slugs, so the save API speaks slugs and stores the
+ * resolved UUID. Returns null when the slug matches no property.
+ */
+export async function resolvePropertyIdBySlug(slug: string): Promise<string | null> {
+  const result = await query(
+    `SELECT id
+       FROM properties
+      WHERE trim(BOTH '-' FROM regexp_replace(LOWER(name), '[^a-z0-9]+', '-', 'g')) = $1
+      LIMIT 1`,
+    [slug]
+  );
+  return result.rows[0]?.id ?? null;
+}
+
+/** Derive the canonical slug for a property id (for response shapes). */
+function slugExpr(alias: string): string {
+  return `trim(BOTH '-' FROM regexp_replace(LOWER(${alias}.name), '[^a-z0-9]+', '-', 'g'))`;
+}
+
+/**
+ * Upsert a save for (owner, property, list). Idempotent: re-saving the same
+ * property to the same list is a no-op that returns the existing row (the
+ * partial-unique index backs the ON CONFLICT). Returns the saved item.
+ */
+export async function saveProperty(
+  owner: Owner,
+  propertyId: string,
+  listName: string
+): Promise<SavedItem> {
+  // The unique guards are PARTIAL indexes (one per owner kind), so ON CONFLICT
+  // must use index inference (columns + matching WHERE predicate) — naming the
+  // index as a constraint fails ("constraint ... does not exist").
+  const ownerCols =
+    owner.kind === "user"
+      ? { col: "user_id", val: owner.userId }
+      : { col: "guest_session_id", val: owner.guestSessionId };
+
+  const inserted = await query(
+    `INSERT INTO saved_properties (${ownerCols.col}, property_id, list_name)
+     VALUES ($1, $2, $3)
+     ON CONFLICT (${ownerCols.col}, property_id, list_name)
+       WHERE ${ownerCols.col} IS NOT NULL DO UPDATE
+        SET list_name = EXCLUDED.list_name
+     RETURNING id, property_id, list_name, alert_enabled, created_at`,
+    [ownerCols.val, propertyId, listName]
+  );
+
+  const row = inserted.rows[0];
+  const slugRes = await resolveSlug(row.property_id);
+  return rowToItem(row, slugRes);
+}
+
+async function resolveSlug(propertyId: string): Promise<string> {
+  const r = await query(
+    `SELECT ${slugExpr("p")} AS slug FROM properties p WHERE p.id = $1`,
+    [propertyId]
+  );
+  return r.rows[0]?.slug ?? "";
+}
+
+function rowToItem(row: Record<string, unknown>, slug: string): SavedItem {
+  return {
+    id: String(row.id),
+    propertyId: String(row.property_id),
+    propertySlug: slug,
+    listName: String(row.list_name),
+    alertEnabled: Boolean(row.alert_enabled),
+    createdAt: new Date(row.created_at as string).toISOString(),
+  };
+}
+
+/** Unsave a property for an owner. `listName` optional — when omitted, removes
+ *  the property from every list the owner has it in. Idempotent (no error if
+ *  nothing matched). Returns the number of rows removed. */
+export async function unsaveProperty(
+  owner: Owner,
+  propertyId: string,
+  listName: string | null
+): Promise<number> {
+  const o = ownerClause(owner, 1);
+  const params: unknown[] = [o.value, propertyId];
+  let sql = `DELETE FROM saved_properties WHERE ${o.sql} AND property_id = $2`;
+  if (listName) {
+    params.push(listName);
+    sql += ` AND list_name = $3`;
+  }
+  const res = await query(sql, params);
+  return res.rowCount ?? 0;
+}
+
+export interface SavedListGroup {
+  listName: string;
+  items: Array<
+    SavedItem & {
+      name: string;
+      rentMin: number | null;
+      rentMax: number | null;
+      amiTier: string | null;
+      availableCount: number;
+      walkScore: number | null;
+    }
+  >;
+}
+
+/**
+ * The owner's full shortlist, grouped by list_name, with a joined property
+ * summary (name, slug, rent range, AMI tier, live availability, walk score if
+ * present). `available_count` mirrors applicants/units (status='available' OR a
+ * stale hold). walk_score isn't a column on properties today → always null
+ * (kept in the shape so the compare table is forward-compatible).
+ */
+export async function getShortlist(owner: Owner): Promise<SavedListGroup[]> {
+  const o = ownerClause(owner, 1);
+  const result = await query(
+    `SELECT sp.id, sp.property_id, sp.list_name, sp.alert_enabled, sp.created_at,
+            p.name AS name,
+            ${slugExpr("p")} AS slug,
+            p.ami_set_aside AS ami_set_aside,
+            COALESCE(av.available_count, 0) AS available_count,
+            rr.rent_min AS rent_min,
+            rr.rent_max AS rent_max
+       FROM saved_properties sp
+       JOIN properties p ON p.id = sp.property_id
+       LEFT JOIN LATERAL (
+         SELECT COUNT(*)::int AS available_count
+           FROM units u
+          WHERE u.property_id = p.id
+            AND (u.status = 'available'
+                 OR (u.status = 'held' AND u.claim_expires_at < NOW()))
+       ) av ON true
+       LEFT JOIN LATERAL (
+         SELECT MIN(u.monthly_rent)::int AS rent_min,
+                MAX(u.monthly_rent)::int AS rent_max
+           FROM units u
+          WHERE u.property_id = p.id
+       ) rr ON true
+      WHERE ${o.sql}
+      ORDER BY sp.list_name ASC, sp.created_at ASC`,
+    [o.value]
+  );
+
+  const groups = new Map<string, SavedListGroup>();
+  for (const row of result.rows) {
+    const listName = String(row.list_name);
+    if (!groups.has(listName)) {
+      groups.set(listName, { listName, items: [] });
+    }
+    groups.get(listName)!.items.push({
+      ...rowToItem(row, String(row.slug ?? "")),
+      name: String(row.name),
+      rentMin: row.rent_min === null ? null : Number(row.rent_min),
+      rentMax: row.rent_max === null ? null : Number(row.rent_max),
+      amiTier: normalizeAmiTier(row.ami_set_aside as string | null),
+      availableCount: Number(row.available_count ?? 0),
+      walkScore: null,
+    });
+  }
+  return Array.from(groups.values());
+}
+
+/** "60% AMI" → "60"; null/market-rate → null. Mirrors properties/service. */
+function normalizeAmiTier(setAside: string | null): string | null {
+  if (!setAside) return null;
+  const digits = setAside.match(/^\d+/)?.[0];
+  return digits ?? null;
+}
+
+/** Toggle the per-item vacancy alert for a saved property. Returns the updated
+ *  item, or null if the owner has no save for that property. */
+export async function setAlert(
+  owner: Owner,
+  propertyId: string,
+  enabled: boolean
+): Promise<SavedItem | null> {
+  const o = ownerClause(owner, 1);
+  const res = await query(
+    `UPDATE saved_properties
+        SET alert_enabled = $2
+      WHERE ${o.sql} AND property_id = $3
+      RETURNING id, property_id, list_name, alert_enabled, created_at`,
+    [o.value, enabled, propertyId]
+  );
+  if (res.rows.length === 0) return null;
+  const slug = await resolveSlug(res.rows[0].property_id);
+  return rowToItem(res.rows[0], slug);
+}
+
+export interface CompareRow {
+  propertyId: string;
+  slug: string;
+  name: string;
+  city: string;
+  rentMin: number | null;
+  rentMax: number | null;
+  amiTier: string | null;
+  availableCount: number;
+  walkScore: number | null;
+}
+
+/**
+ * Compare-table data for a set of saved property ids, scoped to the owner so a
+ * caller can only compare what they've actually saved. Returns rows in the same
+ * order as the input ids (de-duped).
+ */
+export async function getCompare(
+  owner: Owner,
+  propertyIds: string[]
+): Promise<CompareRow[]> {
+  if (propertyIds.length === 0) return [];
+  const o = ownerClause(owner, 1);
+  const result = await query(
+    `SELECT DISTINCT p.id AS property_id,
+            ${slugExpr("p")} AS slug,
+            p.name AS name,
+            p.city AS city,
+            p.ami_set_aside AS ami_set_aside,
+            COALESCE(av.available_count, 0) AS available_count,
+            rr.rent_min AS rent_min,
+            rr.rent_max AS rent_max
+       FROM saved_properties sp
+       JOIN properties p ON p.id = sp.property_id
+       LEFT JOIN LATERAL (
+         SELECT COUNT(*)::int AS available_count
+           FROM units u
+          WHERE u.property_id = p.id
+            AND (u.status = 'available'
+                 OR (u.status = 'held' AND u.claim_expires_at < NOW()))
+       ) av ON true
+       LEFT JOIN LATERAL (
+         SELECT MIN(u.monthly_rent)::int AS rent_min,
+                MAX(u.monthly_rent)::int AS rent_max
+           FROM units u
+          WHERE u.property_id = p.id
+       ) rr ON true
+      WHERE ${o.sql} AND sp.property_id = ANY($2::uuid[])`,
+    [o.value, propertyIds]
+  );
+
+  const byId = new Map<string, CompareRow>();
+  for (const row of result.rows) {
+    byId.set(String(row.property_id), {
+      propertyId: String(row.property_id),
+      slug: String(row.slug ?? ""),
+      name: String(row.name),
+      city: String(row.city),
+      rentMin: row.rent_min === null ? null : Number(row.rent_min),
+      rentMax: row.rent_max === null ? null : Number(row.rent_max),
+      amiTier: normalizeAmiTier(row.ami_set_aside as string | null),
+      availableCount: Number(row.available_count ?? 0),
+      walkScore: null,
+    });
+  }
+  // Preserve request order; drop ids the owner doesn't actually own.
+  const seen = new Set<string>();
+  const out: CompareRow[] = [];
+  for (const id of propertyIds) {
+    if (seen.has(id)) continue;
+    seen.add(id);
+    const row = byId.get(id);
+    if (row) out.push(row);
+  }
+  return out;
+}
+
+/**
+ * Conversion hook — migrate a guest's shortlist onto a freshly-verified user.
+ *
+ * Called from the magic-link verify path with the raw uh_guest cookie token (if
+ * the registering browser carried one). Idempotent and safe to call on every
+ * verify:
+ *   - No cookie / unknown token / already-converted session → no-op.
+ *   - Re-points saved_properties.guest_session_id → the user, flipping the
+ *     owner columns so the rows migrate in place (no re-insert).
+ *   - Skips any property the user already saved to the same list (the user-side
+ *     partial-unique index would otherwise reject the flip) — dropping the
+ *     redundant guest row instead.
+ *   - Stamps guest_sessions.converted_user_id.
+ *
+ * Returns the number of saved rows migrated.
+ */
+export async function migrateGuestSavesToUser(
+  rawGuestToken: string | null,
+  userId: string
+): Promise<number> {
+  if (!rawGuestToken) return 0;
+  const tokenHash = hashGuestToken(rawGuestToken);
+
+  return transaction(async (client) => {
+    const sessionRes = await client.query(
+      `SELECT id, converted_user_id FROM guest_sessions
+        WHERE token_hash = $1
+        FOR UPDATE`,
+      [tokenHash]
+    );
+    if (sessionRes.rows.length === 0) return 0;
+    const session = sessionRes.rows[0];
+    // Already converted (idempotent re-verify, or a shared cookie) → no-op.
+    if (session.converted_user_id) return 0;
+    const guestSessionId = session.id;
+
+    // Re-point only guest rows that DON'T collide with an existing user save
+    // for the same (property, list). The NOT EXISTS guard is evaluated by the
+    // UPDATE itself, so it also covers a user save that lands concurrently
+    // between this migration's start and the re-point (the prior approach —
+    // a separate DELETE-then-blanket-UPDATE — left a window where such a save
+    // would make the UPDATE violate uq_saved_properties_user and abort the
+    // whole best-effort migration, silently dropping the guest's list).
+    const migrated = await client.query(
+      `UPDATE saved_properties g
+          SET user_id = $2, guest_session_id = NULL
+        WHERE g.guest_session_id = $1
+          AND NOT EXISTS (
+            SELECT 1 FROM saved_properties u
+             WHERE u.user_id = $2
+               AND u.property_id = g.property_id
+               AND u.list_name = g.list_name
+          )`,
+      [guestSessionId, userId]
+    );
+
+    // Whatever's still owned by the guest session collided with a user row the
+    // user already has — drop the redundant guest copies so the session is
+    // fully drained before it's marked converted.
+    await client.query(
+      `DELETE FROM saved_properties WHERE guest_session_id = $1`,
+      [guestSessionId]
+    );
+
+    await client.query(
+      `UPDATE guest_sessions SET converted_user_id = $2, last_seen_at = NOW()
+        WHERE id = $1`,
+      [guestSessionId, userId]
+    );
+
+    return migrated.rowCount ?? 0;
+  });
+}


### PR DESCRIPTION
Airbnb-style **save-property** flow for anonymous browsers, sibling to the unit-claim carrot. Guests save without an account; the list migrates onto a real user on magic-link conversion.

## Backend
- `guest_sessions` table — sha256 of httpOnly `uh_guest` cookie, `converted_user_id` FK, `demo_run_id`. Guests deliberately **not** in `users` (email/name NOT NULL).
- `saved_properties` — exactly-one-of `guest_session_id | user_id` (CHECK), partial unique indexes per owner kind, `property_id` FK, `list_name`, `alert_enabled`.
- Upsert uses `ON CONFLICT` **index-inference** (cols + `WHERE … IS NOT NULL`) — partial unique indexes can't be named as constraints.
- `migrateGuestSavesToUser` re-points guest saves → user on magic-link verify; idempotent, `FOR UPDATE`-locked.
- `src/modules/saved` routes + service; migration + 18 tests (all green).

## Frontend
- `SaveButton` (optimistic heart, aria-live pill), shortlist `useSyncExternalStore` store, `api/saved` client (`credentials:'include'`), public `/saved` Shortlist page (no AuthGuard).
- `SaveButton` wired onto discover cards + property-detail hero.
- **Fix:** `client.ts` 401 handler cleared the token *and* hard-redirected to `/login` on any non-probe 401, ejecting guests with a stale localStorage token off `/discover`. Now clears the dead token but only redirects from auth-gated routes; public allowlist stays put and falls back to guest rendering.

## Audit
Opus pre-merge audit: **PASS-WITH-CAVEATS, no blockers** — no IDOR (every op owner-scoped), parameterized SQL, cookie `HttpOnly/SameSite=Lax/Secure(prod)`, 32-byte random hashed at rest, CORS credentials with explicit origin allowlist.

Folded in from the audit: hardened the guest→user conversion against a concurrent-save race (re-point now `NOT EXISTS`-guarded + trailing cleanup, so a save landing mid-migration can't abort the whole list migration). Remaining caveats are follow-ups (DELETE `?listName` array semantics; `purge-demo-data` doesn't reap `guest_sessions`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)