### PR TITLE
fix(discover): wrap filter chip rows so "Henderson" stops clipping at ≤430px

### DIFF
--- a/client-tenant/src/pages/discover/PropertyList.tsx
+++ b/client-tenant/src/pages/discover/PropertyList.tsx
@@ -142,7 +142,7 @@ function TypeCityAvailabilityFilters({
 }) {
   return (
     <>
-      <div className="flex items-center gap-2 overflow-x-auto">
+      <div className="flex flex-wrap items-center gap-2">
         <FilterRowLabel>{t('filter.type')}</FilterRowLabel>
         {(Object.keys(TYPE_LABELS) as TypeFilter[]).map((k) => (
           <ChipButton
@@ -154,7 +154,7 @@ function TypeCityAvailabilityFilters({
           </ChipButton>
         ))}
       </div>
-      <div className="flex items-center gap-2 overflow-x-auto">
+      <div className="flex flex-wrap items-center gap-2">
         <FilterRowLabel>{t('filter.city')}</FilterRowLabel>
         {(Object.keys(CITY_LABELS) as CityFilter[]).map((k) => (
           <ChipButton
@@ -166,7 +166,7 @@ function TypeCityAvailabilityFilters({
           </ChipButton>
         ))}
       </div>
-      <div className="flex items-center gap-2 overflow-x-auto">
+      <div className="flex flex-wrap items-center gap-2">
         <FilterRowLabel>{t('filter.availability')}</FilterRowLabel>
         <ChipButton
           active={availableNow}
@@ -683,7 +683,7 @@ export function PropertyList() {
           style={{ background: HF.cream, borderBottom: `1px solid ${HF.border}` }}
         >
           <div className="flex flex-col gap-2">
-            <div className="flex items-center gap-2 overflow-x-auto">
+            <div className="flex flex-wrap items-center gap-2">
               <span
                 style={{
                   fontSize: 12,
@@ -706,7 +706,7 @@ export function PropertyList() {
                 </ChipButton>
               ))}
             </div>
-            <div className="flex items-center gap-2 overflow-x-auto">
+            <div className="flex flex-wrap items-center gap-2">
               <span
                 style={{
                   fontSize: 12,
@@ -730,7 +730,7 @@ export function PropertyList() {
               ))}
             </div>
             <div
-              className="flex items-center gap-2 overflow-x-auto"
+              className="flex flex-wrap items-center gap-2"
               data-testid="bedroom-filter-row"
             >
               <span
@@ -756,7 +756,7 @@ export function PropertyList() {
                 </ChipButton>
               ))}
             </div>
-            <div className="flex items-center gap-2 overflow-x-auto">
+            <div className="flex flex-wrap items-center gap-2">
               <span
                 style={{
                   fontSize: 12,


### PR DESCRIPTION
## Bug
Mobile-QA bug #1: on `/discover`, the **CITY filter chip row clipped "Henderson"** at ≤430px. The TYPE/CITY/BEDS/availability rows used `overflow-x-auto`, so on mobile the row scrolled horizontally with no visible affordance and the 4th CITY chip got cut at the right edge.

## Fix
Switch all **7 chip rows** to `flex flex-wrap` — the shared map-view `TypeCityAvailabilityFilters` (Type/City/Availability) **and** the 4 list-view rows (Type/City/Bedroom/Availability). Chips now wrap to the next line, so every option stays fully visible at any width. `gap-2` already supplies row + column spacing when wrapped. Desktop is unaffected (single row at width).

## Verification
- **375 / 430px** (vite preview build): Henderson chip fully within viewport (right edge 115px), row no longer scrolls, `flex-wrap` active. Screenshot shows CITY wrapping cleanly: All / Las Vegas / N. Las Vegas → Henderson / Reno / Sparks → Carson City / Elko.
- `tsc --noEmit` clean.
- 38 discover unit tests pass (`vitest run src/pages/discover`).
- tenant-e2e clicks the chip via `getByRole("button", {name:"Henderson"})`, which auto-scrolls into view — layout change is safe; map counts (352/17/4/13) untouched.

CSS-only layout change, no copy added → no i18n keys, no Vercel/Railway deploy needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)