### PR TITLE
fix(discover): wrap CITY filter chips so Henderson stays visible on mobile

### DIFF
--- a/client-tenant/src/pages/discover/PropertyList.tsx
+++ b/client-tenant/src/pages/discover/PropertyList.tsx
@@ -154,7 +154,7 @@ function TypeCityAvailabilityFilters({
           </ChipButton>
         ))}
       </div>
-      <div className="flex items-center gap-2 overflow-x-auto">
+      <div className="flex items-center gap-2 flex-wrap">
         <FilterRowLabel>{t('filter.city')}</FilterRowLabel>
         {(Object.keys(CITY_LABELS) as CityFilter[]).map((k) => (
           <ChipButton
@@ -706,7 +706,7 @@ export function PropertyList() {
                 </ChipButton>
               ))}
             </div>
-            <div className="flex items-center gap-2 overflow-x-auto">
+            <div className="flex items-center gap-2 flex-wrap">
               <span
                 style={{
                   fontSize: 12,


### PR DESCRIPTION
## What
The `/discover` CITY filter row used `overflow-x-auto`, so at ≤430px the 4th chip (**Henderson**) scrolled out of view and read as clipped (mobile-QA bug #1).

## Fix
Change the two CITY chip rows from `overflow-x-auto` → `flex-wrap`. With only 4 city options, they fit on one or two lines with no horizontal scroll — every city is visible without interaction. `gap-2` already supplies the vertical gap for the wrapped row.

TYPE / availability rows keep `overflow-x-auto` (longer chip sets benefit from horizontal scroll).

## Scope
- `client-tenant/src/pages/discover/PropertyList.tsx` — 2 className changes, no logic touched.
- No new copy → no i18n keys added.
- Henderson e2e (`discover-filters.spec.ts`) clicks by role+name, unaffected (chip is now more reliably visible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)