### PR TITLE
feat(housing-qa): keyless CLI fallback for public Q&A endpoint

### DIFF
--- a/src/__tests__/housing-qa-routes.test.ts
+++ b/src/__tests__/housing-qa-routes.test.ts
@@ -27,6 +27,31 @@ jest.mock("../utils/logger", () => ({
   logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
 }));
 
+// Mock child_process so the CLI-fallback path never spawns a real `claude`.
+const spawnMock = jest.fn();
+jest.mock("child_process", () => ({
+  spawn: (...args: unknown[]) => spawnMock(...args),
+}));
+
+import { EventEmitter } from "events";
+
+// Build a fake ChildProcess that emits `stdout` then `close` on next tick.
+function fakeChild(stdout: string, code = 0) {
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+    kill: jest.Mock;
+  };
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.kill = jest.fn();
+  setImmediate(() => {
+    if (stdout) child.stdout.emit("data", Buffer.from(stdout));
+    child.emit("close", code);
+  });
+  return child;
+}
+
 import { housingQaRouter } from "../modules/housing-qa/routes";
 
 function makeApp() {
@@ -37,15 +62,20 @@ function makeApp() {
 }
 
 const ORIGINAL_KEY = process.env.ANTHROPIC_API_KEY;
+const ORIGINAL_CLI_FLAG = process.env.HOUSING_QA_CLI_FALLBACK;
 
 beforeEach(() => {
   createMock.mockReset();
+  spawnMock.mockReset();
   process.env.ANTHROPIC_API_KEY = "test-key-123";
+  delete process.env.HOUSING_QA_CLI_FALLBACK;
 });
 
 afterAll(() => {
   if (ORIGINAL_KEY === undefined) delete process.env.ANTHROPIC_API_KEY;
   else process.env.ANTHROPIC_API_KEY = ORIGINAL_KEY;
+  if (ORIGINAL_CLI_FLAG === undefined) delete process.env.HOUSING_QA_CLI_FALLBACK;
+  else process.env.HOUSING_QA_CLI_FALLBACK = ORIGINAL_CLI_FLAG;
 });
 
 describe("POST /api/housing-qa — validation", () => {
@@ -138,5 +168,84 @@ describe("POST /api/housing-qa — missing API key", () => {
     expect(res.status).toBe(503);
     expect(res.body.error).toMatch(/temporarily unavailable/i);
     expect(createMock).not.toHaveBeenCalled();
+    // No key + no flag → never shells out.
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /api/housing-qa — CLI fallback (keyless)", () => {
+  it("does NOT spawn the CLI when an API key is present (SDK path wins)", async () => {
+    process.env.HOUSING_QA_CLI_FALLBACK = "1";
+    createMock.mockResolvedValueOnce({
+      content: [{ type: "text", text: "SDK answer." }],
+    });
+    const res = await request(makeApp())
+      .post("/api/housing-qa")
+      .send({ question: "How much is the application fee?" });
+    expect(res.status).toBe(200);
+    expect(res.body.answer).toBe("SDK answer.");
+    expect(createMock).toHaveBeenCalledTimes(1);
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it("answers via the CLI when no key is set AND the flag is on", async () => {
+    delete process.env.ANTHROPIC_API_KEY;
+    process.env.HOUSING_QA_CLI_FALLBACK = "1";
+    spawnMock.mockImplementationOnce(() => fakeChild("CLI grounded answer"));
+
+    const res = await request(makeApp())
+      .post("/api/housing-qa")
+      .send({ question: "How much is the application fee?" });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ answer: "CLI grounded answer" });
+    expect(createMock).not.toHaveBeenCalled();
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes the question behind a `--` separator as the final positional (no arg injection)", async () => {
+    delete process.env.ANTHROPIC_API_KEY;
+    process.env.HOUSING_QA_CLI_FALLBACK = "1";
+    spawnMock.mockImplementationOnce(() => fakeChild("ok"));
+
+    // A question that would be a dangerous CLI flag if not guarded by `--`.
+    const payload = "--dangerously-skip-permissions";
+    await request(makeApp()).post("/api/housing-qa").send({ question: payload });
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    const [bin, args] = spawnMock.mock.calls[0] as [string, string[]];
+    expect(bin).toBe("claude");
+    // `--` must precede the question, and the question must be the LAST arg —
+    // otherwise commander parses the leading `--` payload as a real flag.
+    expect(args[args.length - 2]).toBe("--");
+    expect(args[args.length - 1]).toBe(payload);
+    // tools stay disabled
+    expect(args).toContain("--allowed-tools");
+  });
+
+  it("does NOT spawn when no key is set and the flag is off → 503", async () => {
+    delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.HOUSING_QA_CLI_FALLBACK;
+    const res = await request(makeApp())
+      .post("/api/housing-qa")
+      .send({ question: "How much is the application fee?" });
+    expect(res.status).toBe(503);
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 502 (clean) when the CLI exits non-zero, without leaking stderr", async () => {
+    delete process.env.ANTHROPIC_API_KEY;
+    process.env.HOUSING_QA_CLI_FALLBACK = "1";
+    spawnMock.mockImplementationOnce(() => {
+      const child = fakeChild("", 1);
+      // emit some stderr that must never reach the client
+      setImmediate(() => child.stderr.emit("data", Buffer.from("secret stderr boom")));
+      return child;
+    });
+    const res = await request(makeApp())
+      .post("/api/housing-qa")
+      .send({ question: "How much is the application fee?" });
+    expect(res.status).toBe(502);
+    expect(JSON.stringify(res.body)).not.toMatch(/secret stderr boom/);
   });
 });

--- a/src/modules/housing-qa/routes.ts
+++ b/src/modules/housing-qa/routes.ts
@@ -16,6 +16,8 @@ import { Router, Request, Response } from "express";
 import { z } from "zod";
 import rateLimit, { ipKeyGenerator } from "express-rate-limit";
 import Anthropic from "@anthropic-ai/sdk";
+import { spawn } from "child_process";
+import os from "os";
 import { buildContext } from "./retriever";
 import { buildSystemPrompt } from "./prompt";
 import { logger } from "../../utils/logger";
@@ -50,6 +52,47 @@ function getClient(): Anthropic | null {
   return cachedClient;
 }
 
+// LOCAL/keyless fallback: shell out to the `claude` CLI (uses the operator's
+// OAuth login) instead of the SDK. OPT-IN via HOUSING_QA_CLI_FALLBACK=1 so a
+// server never spawns a subprocess by surprise — prod with an API key uses the
+// SDK path above and never reaches here. Constrained to a clean single-shot:
+// --system-prompt fully overrides the agent prompt, no tools are allowed, and
+// cwd is a temp dir so no CLAUDE.md is auto-discovered. The question is passed
+// as a spawn arg (array form, no shell) so it cannot inject.
+function cliFallbackEnabled(): boolean {
+  return process.env.HOUSING_QA_CLI_FALLBACK === "1";
+}
+
+function callViaCli(system: string, question: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(
+      "claude",
+      [
+        "-p",
+        question,
+        "--system-prompt",
+        system,
+        "--model",
+        MODEL,
+        "--allowed-tools",
+        "",
+        "--output-format",
+        "text",
+      ],
+      { cwd: os.tmpdir(), timeout: 60_000 }
+    );
+    let out = "";
+    let err = "";
+    child.stdout.on("data", (d) => (out += d.toString()));
+    child.stderr.on("data", (d) => (err += d.toString()));
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code === 0) resolve(out.trim());
+      else reject(new Error(`claude CLI exited ${code}: ${err.slice(0, 200)}`));
+    });
+  });
+}
+
 export function housingQaRouter(): Router {
   const router: Router = Router();
 
@@ -64,7 +107,8 @@ export function housingQaRouter(): Router {
     const { question } = parsed.data;
 
     const client = getClient();
-    if (!client) {
+    const useCli = !client && cliFallbackEnabled();
+    if (!client && !useCli) {
       logger.warn("housing-qa request rejected — ANTHROPIC_API_KEY not set");
       res.status(503).json({
         error:
@@ -77,20 +121,25 @@ export function housingQaRouter(): Router {
       const context = buildContext(question);
       const system = buildSystemPrompt(context);
 
-      const completion = await client.messages.create({
-        model: MODEL,
-        max_tokens: MAX_TOKENS,
-        system,
-        messages: [{ role: "user", content: question }],
-      });
-
-      const answer = completion.content
-        .filter(
-          (block): block is Anthropic.TextBlock => block.type === "text"
-        )
-        .map((block) => block.text)
-        .join("")
-        .trim();
+      let answer: string;
+      if (client) {
+        const completion = await client.messages.create({
+          model: MODEL,
+          max_tokens: MAX_TOKENS,
+          system,
+          messages: [{ role: "user", content: question }],
+        });
+        answer = completion.content
+          .filter(
+            (block): block is Anthropic.TextBlock => block.type === "text"
+          )
+          .map((block) => block.text)
+          .join("")
+          .trim();
+      } else {
+        // CLI fallback (local, keyless) — see callViaCli.
+        answer = await callViaCli(system, question);
+      }
 
       if (!answer) {
         res.status(502).json({

--- a/src/modules/housing-qa/routes.ts
+++ b/src/modules/housing-qa/routes.ts
@@ -63,13 +63,21 @@ function cliFallbackEnabled(): boolean {
   return process.env.HOUSING_QA_CLI_FALLBACK === "1";
 }
 
+// Bound concurrent subprocesses process-wide. The per-IP rate limit doesn't
+// cap fan-out across many IPs, so cap the CLI path here and 503 when saturated.
+const MAX_CONCURRENT_CLI = 3;
+let activeCliCalls = 0;
+
+// Cap captured output so a runaway / injection-induced huge response can't
+// balloon node's heap (the CLI path has no MAX_TOKENS equivalent).
+const MAX_CLI_OUTPUT_BYTES = 256 * 1024;
+
 function callViaCli(system: string, question: string): Promise<string> {
   return new Promise((resolve, reject) => {
     const child = spawn(
       "claude",
       [
         "-p",
-        question,
         "--system-prompt",
         system,
         "--model",
@@ -78,17 +86,40 @@ function callViaCli(system: string, question: string): Promise<string> {
         "",
         "--output-format",
         "text",
+        // `--` ends option parsing: the attacker-controlled question is the
+        // final positional and can never be interpreted as a CLI flag (e.g.
+        // `--dangerously-skip-permissions`). Required — `-p` is a boolean flag,
+        // not an option that consumes the next token.
+        "--",
+        question,
       ],
-      { cwd: os.tmpdir(), timeout: 60_000 }
+      { cwd: os.tmpdir(), timeout: 60_000, killSignal: "SIGKILL" }
     );
     let out = "";
     let err = "";
-    child.stdout.on("data", (d) => (out += d.toString()));
-    child.stderr.on("data", (d) => (err += d.toString()));
-    child.on("error", reject);
+    let settled = false;
+    const finish = (fn: () => void) => {
+      if (settled) return;
+      settled = true;
+      fn();
+    };
+    child.stdout.on("data", (d) => {
+      out += d.toString();
+      if (out.length > MAX_CLI_OUTPUT_BYTES) {
+        child.kill("SIGKILL");
+        finish(() => reject(new Error("claude CLI output exceeded cap")));
+      }
+    });
+    child.stderr.on("data", (d) => {
+      // Keep only the tail; full stderr is never returned to the client.
+      err = (err + d.toString()).slice(-200);
+    });
+    child.on("error", (e) => finish(() => reject(e)));
     child.on("close", (code) => {
-      if (code === 0) resolve(out.trim());
-      else reject(new Error(`claude CLI exited ${code}: ${err.slice(0, 200)}`));
+      finish(() => {
+        if (code === 0) resolve(out.trim());
+        else reject(new Error(`claude CLI exited ${code}: ${err}`));
+      });
     });
   });
 }
@@ -137,8 +168,21 @@ export function housingQaRouter(): Router {
           .join("")
           .trim();
       } else {
-        // CLI fallback (local, keyless) — see callViaCli.
-        answer = await callViaCli(system, question);
+        // CLI fallback (local, keyless) — see callViaCli. Bound concurrency so
+        // many IPs can't fan out into unbounded subprocesses.
+        if (activeCliCalls >= MAX_CONCURRENT_CLI) {
+          res.status(503).json({
+            error:
+              "The housing assistant is busy right now. Please try again in a moment.",
+          });
+          return;
+        }
+        activeCliCalls++;
+        try {
+          answer = await callViaCli(system, question);
+        } finally {
+          activeCliCalls--;
+        }
       }
 
       if (!answer) {


### PR DESCRIPTION
## What

Adds an **opt-in, key-priority** fallback to the public `/api/housing-qa` endpoint that answers via the local `claude` CLI (operator's OAuth login) when no `ANTHROPIC_API_KEY` is set. Lets the grounded housing-Q&A widget run end-to-end with **zero API key and zero cost** for local demos.

## Why

The widget (merged in #185/#188) is live on Vercel but the backend has no `ANTHROPIC_API_KEY` on Railway yet, so it degrades to 503. This unblocks a fully working local demo without provisioning a key.

## How it branches

```
key present?  → SDK path (unchanged, prod default)
no key + flag → CLI path (claude -p, local only)
no key, no flag→ 503 (unchanged)
```

The SDK path is untouched and takes priority. The CLI branch fires **only** when there's no key AND `HOUSING_QA_CLI_FALLBACK=1` is explicitly set — so a production server (no key, no flag) never spawns a subprocess; it still returns 503. Drop a key into Railway and the endpoint uses the SDK; the CLI code is never reached.

## Hardening

- Question passed as a **spawn arg (array form, no shell)** — no command injection
- `--system-prompt` fully overrides the agent prompt; `--allowed-tools ""` disables all tools
- cwd is `os.tmpdir()` so no `CLAUDE.md` is auto-discovered into the prompt
- 60s timeout; stderr truncated to 200 chars in the error path
- Still behind the existing per-IP rate limit (20 req / 10 min) + zod 1000-char cap

## Verified locally (CLI path, no key)

Booted backend with `HOUSING_QA_CLI_FALLBACK=1` + no key, frontend proxied to it, exercised the real widget request path. Grounding contract held on all cases:
- **Data Q** → real available properties, "not disclosed" where AMI absent
- **Process Q** → grounded in FAQ (5 steps, docs, \$35.95 fee, 120-day rule)
- **Rent Q** → refused + cited provenance + gave property phone
- **Unknown property** → refused, no fabrication, offered real alternatives
- **Mixed Q** → answered grounded half, refused the part not in data

🤖 Generated with [Claude Code](https://claude.com/claude-code)