### PR TITLE
fix(chat): hide chat FAB while cookie banner is showing (mobile consent collision)

### DIFF
--- a/client-tenant/src/components/HousingChatWidget.tsx
+++ b/client-tenant/src/components/HousingChatWidget.tsx
@@ -15,6 +15,7 @@ import { useTranslation } from 'react-i18next';
 import { HF } from '@/styles/tokens';
 import { CTA } from '@/components/primitives/CTA';
 import { askHousingQa } from '@/api/client';
+import { useConsent } from '@/state/consent';
 
 interface ChatMessage {
   id: string;
@@ -27,6 +28,13 @@ const nextId = () => `m${Date.now()}-${_seq++}`;
 
 export function HousingChatWidget() {
   const { t } = useTranslation('chat');
+  // While the cookie-consent banner is showing (needsChoice === true), the
+  // bottom-fixed banner stacks its Customize / Reject buttons full-width on
+  // mobile. The collapsed chat bubble (bottom-right, higher z-index) would
+  // otherwise overlap and intercept taps on those buttons. Hide the collapsed
+  // bubble until the visitor has recorded a consent choice; it reappears the
+  // instant the banner is dismissed.
+  const { needsChoice } = useConsent();
   const [open, setOpen] = useState(false);
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState('');
@@ -97,6 +105,9 @@ export function HousingChatWidget() {
 
   // ── Bubble (collapsed) ──────────────────────────────────────────────
   if (!open) {
+    // Yield to the cookie-consent banner so it doesn't cover the
+    // Customize / Reject buttons (see needsChoice note above).
+    if (needsChoice) return null;
     return (
       <button
         ref={bubbleRef}


### PR DESCRIPTION
## Problem (mobile UI QA finding)
The floating chat FAB (`HousingChatWidget`, `position:fixed; bottom:20 right:20; zIndex:1000`) rendered **on top of** the cookie-consent banner (`CookieBanner`, `fixed inset-x-0 bottom-0 z-50`). On mobile the banner stacks its **Customize** and **Reject non-essential** buttons full-width, so the higher-z-index FAB both visually covered and **intercepted taps** on the right edge of those buttons. A first-time mobile visitor couldn't reliably tap Customize/Reject — only "Accept all" was fully clear, steering users toward Accept (a consent-quality / GDPR concern).

Reproduced at **375px and 430px** (also 390px). Global — the widget is mounted in `App.tsx` on every route.

## Fix
Both components already share the `useConsent()` store. Gate the **collapsed** bubble on `needsChoice` (true exactly while the banner is showing, i.e. `recordedAt === null`): the bubble `return null`s while consent is undecided and reappears the instant the banner is dismissed. The placement is after all hooks, so no Rules-of-Hooks issue. No i18n keys, no token changes — single-file, +11 lines.

## Before / after probe (built `dist`, mobile emulation, localStorage cleared)
| viewport | banner showing (before consent) | after "Accept all" |
|---|---|---|
| 375px | `fabPresent: false`; Customize **tappable:true**, Reject non-essential **tappable:true** | `fabPresent: true` |
| 430px | `fabPresent: false`; Customize **tappable:true**, Reject non-essential **tappable:true** | `fabPresent: true` |

`tappable` is a hit-test: the topmost element at each button's center is the button itself (no FAB interception). Screenshots in QA artifacts (`FIX-before-{375,430}.png`, `FIX-after-{375,430}.png`).

## Local checks
- `npx tsc --noEmit -p tsconfig.json` — clean (exit 0)
- `vitest` CookieBanner — 5/5 pass; consent-related — 20 pass, 0 fail
- `npm run build` — succeeds (pre-existing chunk-size + demoCapture warnings only)

## Notes
- Does not touch `CookieBanner.tsx`, `state/consent.ts`, `PropertyList.tsx`, minimap HTML, or backend.
- No discover map-count changes, so `tenant-e2e` harness counts (352/17/4/13) are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)