### PR TITLE
feat(discover): city-named SEO landing pages (wedge Play 1)

### DIFF
--- a/client-tenant/public/sitemap.xml
+++ b/client-tenant/public/sitemap.xml
@@ -2,122 +2,140 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://frank-pilot-tenant.vercel.app/</loc>
-    <lastmod>2026-05-24</lastmod>
+    <lastmod>2026-05-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://frank-pilot-tenant.vercel.app/discover</loc>
-    <lastmod>2026-05-24</lastmod>
+    <lastmod>2026-05-25</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://frank-pilot-tenant.vercel.app/apply</loc>
-    <lastmod>2026-05-24</lastmod>
+    <lastmod>2026-05-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://frank-pilot-tenant.vercel.app/property/aldene-kline-barlow-senior-apartments</loc>
-    <lastmod>2026-05-24</lastmod>
+    <lastmod>2026-05-25</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://frank-pilot-tenant.vercel.app/property/david-j-hoggard-family-community</loc>
-    <lastmod>2026-05-24</lastmod>
+    <lastmod>2026-05-25</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://frank-pilot-tenant.vercel.app/property/donna-louise-apartments</loc>
-    <lastmod>2026-05-24</lastmod>
+    <lastmod>2026-05-25</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://frank-pilot-tenant.vercel.app/property/donna-louise-apartments-2</loc>
-    <lastmod>2026-05-24</lastmod>
+    <lastmod>2026-05-25</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://frank-pilot-tenant.vercel.app/property/luther-mack-jr-senior-apartments</loc>
-    <lastmod>2026-05-24</lastmod>
+    <lastmod>2026-05-25</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://frank-pilot-tenant.vercel.app/property/dr-paul-meacham-senior-community</loc>
-    <lastmod>2026-05-24</lastmod>
+    <lastmod>2026-05-25</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://frank-pilot-tenant.vercel.app/property/ethel-mae-fletcher-apartments</loc>
-    <lastmod>2026-05-24</lastmod>
+    <lastmod>2026-05-25</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://frank-pilot-tenant.vercel.app/property/ethel-mae-robinson-senior-apartments</loc>
-    <lastmod>2026-05-24</lastmod>
+    <lastmod>2026-05-25</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://frank-pilot-tenant.vercel.app/property/mike-o-callaghan-legacy-apartments</loc>
-    <lastmod>2026-05-24</lastmod>
+    <lastmod>2026-05-25</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://frank-pilot-tenant.vercel.app/property/juan-garcia-garden-apartments</loc>
-    <lastmod>2026-05-24</lastmod>
+    <lastmod>2026-05-25</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://frank-pilot-tenant.vercel.app/property/louise-shell-senior-apartments</loc>
-    <lastmod>2026-05-24</lastmod>
+    <lastmod>2026-05-25</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://frank-pilot-tenant.vercel.app/property/owens-senior-housing</loc>
-    <lastmod>2026-05-24</lastmod>
+    <lastmod>2026-05-25</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://frank-pilot-tenant.vercel.app/property/sarann-knight-apartments</loc>
-    <lastmod>2026-05-24</lastmod>
+    <lastmod>2026-05-25</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://frank-pilot-tenant.vercel.app/property/senator-harry-reid-senior-apartments</loc>
-    <lastmod>2026-05-24</lastmod>
+    <lastmod>2026-05-25</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://frank-pilot-tenant.vercel.app/property/senator-richard-bryan-senior-apartments</loc>
-    <lastmod>2026-05-24</lastmod>
+    <lastmod>2026-05-25</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://frank-pilot-tenant.vercel.app/property/smith-williams-senior-apartments</loc>
-    <lastmod>2026-05-24</lastmod>
+    <lastmod>2026-05-25</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://frank-pilot-tenant.vercel.app/property/yale-keyes-senior-apartments</loc>
-    <lastmod>2026-05-24</lastmod>
+    <lastmod>2026-05-25</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://frank-pilot-tenant.vercel.app/discover/city/las-vegas</loc>
+    <lastmod>2026-05-25</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://frank-pilot-tenant.vercel.app/discover/city/north-las-vegas</loc>
+    <lastmod>2026-05-25</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://frank-pilot-tenant.vercel.app/discover/city/henderson</loc>
+    <lastmod>2026-05-25</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
   </url>
 </urlset>

--- a/client-tenant/scripts/generate-sitemap.mjs
+++ b/client-tenant/scripts/generate-sitemap.mjs
@@ -46,6 +46,29 @@ const ROUTES = [
 const PROPERTY_PRIORITY = '0.8';
 const PROPERTY_CHANGEFREQ = 'daily';
 
+// City landing pages (/discover/city/{slug}) — one per city with ≥1 property.
+// Slightly below /discover (0.9) and individual listings (0.8): they're real
+// crawl targets for city-search intent but their content turns over slower
+// than per-listing availability, hence weekly.
+const CITY_PRIORITY = '0.7';
+const CITY_CHANGEFREQ = 'weekly';
+
+/**
+ * Unique cities present in the fixtures, in first-seen order, each with its
+ * URL slug. Derived here (rather than importing GPMG_CITIES) so buildSitemapXml
+ * stays self-contained on just {fixtures, slugify}.
+ */
+function citiesFromFixtures(fixtures, slugify) {
+  const seen = new Set();
+  const cities = [];
+  for (const p of fixtures) {
+    if (seen.has(p.city)) continue;
+    seen.add(p.city);
+    cities.push({ name: p.city, slug: slugify(p.city) });
+  }
+  return cities;
+}
+
 /**
  * Load `GPMG_FIXTURES` + `slugify` from the canonical TS source by
  * transpiling it through esbuild into a temp ESM module, then dynamically
@@ -128,6 +151,17 @@ export function buildSitemapXml({ fixtures, slugify, siteUrl, lastmod }) {
         lastmod,
         changefreq: PROPERTY_CHANGEFREQ,
         priority: PROPERTY_PRIORITY,
+      })
+    );
+  }
+
+  for (const city of citiesFromFixtures(fixtures, slugify)) {
+    lines.push(
+      urlBlock({
+        loc: `${siteUrl}/discover/city/${city.slug}`,
+        lastmod,
+        changefreq: CITY_CHANGEFREQ,
+        priority: CITY_PRIORITY,
       })
     );
   }

--- a/client-tenant/src/App.tsx
+++ b/client-tenant/src/App.tsx
@@ -17,6 +17,7 @@ import { Application } from '@/pages/Application';
 import { WelcomeShell } from '@/pages/welcome/WelcomeShell';
 import { PropertyList } from '@/pages/discover/PropertyList';
 import { PropertyDetail } from '@/pages/discover/PropertyDetail';
+import { CityLanding } from '@/pages/discover/CityLanding';
 import { Shortlist } from '@/pages/saved/Shortlist';
 import { WaitlistPosition } from '@/pages/waitlist/Position';
 import { WaitlistFasterList } from '@/pages/waitlist/FasterList';
@@ -55,6 +56,8 @@ export default function App() {
       <Route path="/apply" element={<Apply />} />
       <Route path="/apply/magic-link-sent" element={<MagicLinkSent />} />
       <Route path="/discover" element={<PropertyList />} />
+      {/* discover wedge — city-named SEO landing pages (one per GPMG city) */}
+      <Route path="/discover/city/:city" element={<CityLanding />} />
       <Route path="/property/:slug" element={<PropertyDetail />} />
       {/* feat/saved-shortlist — guest wishlist; public, NOT behind AuthGuard */}
       <Route path="/saved" element={<Shortlist />} />

--- a/client-tenant/src/__tests__/generate-sitemap.test.ts
+++ b/client-tenant/src/__tests__/generate-sitemap.test.ts
@@ -2,10 +2,15 @@
 import { describe, it, expect } from 'vitest';
 // @ts-expect-error — .mjs build script; no .d.ts shipped, imported by URL.
 import { buildSitemapXml } from '../../scripts/generate-sitemap.mjs';
-import { GPMG_FIXTURES, slugify } from '@/api/gpmg-fixtures';
+import { GPMG_FIXTURES, GPMG_CITIES, slugify } from '@/api/gpmg-fixtures';
 
 const SITE_URL = 'https://frank-pilot.vercel.app';
 const LASTMOD = '2026-05-22';
+
+// 3 static routes + one /property/{slug} per fixture + one /discover/city/{slug}
+// per city with ≥1 property.
+const STATIC_ROUTES = 3;
+const EXPECTED_URLS = STATIC_ROUTES + GPMG_FIXTURES.length + GPMG_CITIES.length;
 
 describe('generate-sitemap', () => {
   const xml = buildSitemapXml({
@@ -70,19 +75,38 @@ describe('generate-sitemap', () => {
     expect(block[0]).toContain('<changefreq>daily</changefreq>');
   });
 
+  it('includes every GPMG city at /discover/city/{slug}', () => {
+    // City landing pages are the SEO wedge — one crawlable page per city with
+    // inventory, keyed off GPMG_CITIES (derived from the fixtures).
+    expect(GPMG_CITIES.length).toBeGreaterThan(0);
+    for (const c of GPMG_CITIES) {
+      expect(xml).toContain(`<loc>${SITE_URL}/discover/city/${c.slug}</loc>`);
+    }
+  });
+
+  it('marks city pages priority 0.7 weekly', () => {
+    const sampleCity = GPMG_CITIES[0]!.slug;
+    const block = xml.match(
+      new RegExp(
+        `<url>\\s*<loc>https://[^/]+/discover/city/${sampleCity}</loc>[\\s\\S]*?</url>`
+      )
+    )!;
+    expect(block[0]).toContain('<priority>0.7</priority>');
+    expect(block[0]).toContain('<changefreq>weekly</changefreq>');
+  });
+
   it('stamps every <url> with the provided lastmod (ISO YYYY-MM-DD)', () => {
     const lastmodMatches = xml.match(/<lastmod>[^<]+<\/lastmod>/g) ?? [];
-    // 3 static routes + 17 properties = 20 url entries.
-    expect(lastmodMatches.length).toBe(20);
+    expect(lastmodMatches.length).toBe(EXPECTED_URLS);
     lastmodMatches.forEach((m) => {
       expect(m).toBe(`<lastmod>${LASTMOD}</lastmod>`);
     });
   });
 
-  it('contains exactly 20 <url> entries (3 static + 17 properties)', () => {
+  it('contains the expected <url> count (static + properties + cities)', () => {
     const urlOpenCount = (xml.match(/<url>/g) ?? []).length;
     const urlCloseCount = (xml.match(/<\/url>/g) ?? []).length;
-    expect(urlOpenCount).toBe(20);
-    expect(urlCloseCount).toBe(20);
+    expect(urlOpenCount).toBe(EXPECTED_URLS);
+    expect(urlCloseCount).toBe(EXPECTED_URLS);
   });
 });

--- a/client-tenant/src/api/__tests__/gpmg-city.test.ts
+++ b/client-tenant/src/api/__tests__/gpmg-city.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import {
+  GPMG_FIXTURES,
+  GPMG_CITIES,
+  citySlug,
+  findCityBySlug,
+  propertiesInCity,
+  slugify,
+} from '../gpmg-fixtures';
+
+describe('GPMG city helpers', () => {
+  it('derives one entry per distinct fixture city', () => {
+    const distinct = new Set(GPMG_FIXTURES.map((p) => p.city));
+    expect(GPMG_CITIES.length).toBe(distinct.size);
+    for (const c of GPMG_CITIES) {
+      expect(distinct.has(c.name)).toBe(true);
+    }
+  });
+
+  it('counts add up to the full fixture set (every property lands in a city)', () => {
+    const total = GPMG_CITIES.reduce((sum, c) => sum + c.count, 0);
+    expect(total).toBe(GPMG_FIXTURES.length);
+  });
+
+  it('each city count matches its actual fixture membership', () => {
+    for (const c of GPMG_CITIES) {
+      expect(c.count).toBe(propertiesInCity(c.name).length);
+    }
+  });
+
+  it('sorts by count desc then name asc (Las Vegas leads)', () => {
+    for (let i = 1; i < GPMG_CITIES.length; i++) {
+      const prev = GPMG_CITIES[i - 1]!;
+      const cur = GPMG_CITIES[i]!;
+      expect(
+        prev.count > cur.count ||
+          (prev.count === cur.count && prev.name <= cur.name),
+      ).toBe(true);
+    }
+    // Today's catalog: Las Vegas has the most inventory.
+    expect(GPMG_CITIES[0]!.name).toBe('Las Vegas');
+  });
+
+  it('citySlug matches slugify (kebab-case, no trailing dashes)', () => {
+    expect(citySlug('North Las Vegas')).toBe('north-las-vegas');
+    expect(citySlug('Las Vegas')).toBe(slugify('Las Vegas'));
+  });
+
+  it('findCityBySlug round-trips every city slug to its canonical entry', () => {
+    for (const c of GPMG_CITIES) {
+      const hit = findCityBySlug(c.slug);
+      expect(hit).toBeDefined();
+      expect(hit!.name).toBe(c.name);
+    }
+  });
+
+  it('findCityBySlug returns undefined for an unknown slug', () => {
+    expect(findCityBySlug('reno')).toBeUndefined();
+    expect(findCityBySlug('')).toBeUndefined();
+    expect(findCityBySlug('not-a-city')).toBeUndefined();
+  });
+
+  it('propertiesInCity returns only fixtures for that exact city', () => {
+    const lv = propertiesInCity('Las Vegas');
+    expect(lv.length).toBeGreaterThan(0);
+    expect(lv.every((p) => p.city === 'Las Vegas')).toBe(true);
+    expect(propertiesInCity('Nowhere')).toEqual([]);
+  });
+});

--- a/client-tenant/src/api/gpmg-fixtures.ts
+++ b/client-tenant/src/api/gpmg-fixtures.ts
@@ -67,6 +67,46 @@ export function findGPMGBySlug(slug: string): GPMGProperty | undefined {
   return GPMG_FIXTURES.find((p) => slugify(p.name) === slug);
 }
 
+/** A city that has at least one GPMG property — the unit of a city landing page. */
+export interface GPMGCity {
+  /** Canonical display name, e.g. "Las Vegas". */
+  name: string;
+  /** URL slug, e.g. "las-vegas". */
+  slug: string;
+  /** How many fixtures sit in this city. */
+  count: number;
+}
+
+/** kebab-case a city name into a URL slug (same rules as {@link slugify}). */
+export function citySlug(city: string): string {
+  return slugify(city);
+}
+
+/**
+ * Every city with ≥1 GPMG property, derived from the fixtures so it stays
+ * correct if the catalog changes. Sorted by property count (desc) then name —
+ * the order city landing pages and the sitemap iterate in.
+ */
+export const GPMG_CITIES: readonly GPMGCity[] = (() => {
+  const counts = new Map<string, number>();
+  for (const p of GPMG_FIXTURES) {
+    counts.set(p.city, (counts.get(p.city) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .map(([name, count]) => ({ name, slug: citySlug(name), count }))
+    .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name));
+})();
+
+/** Resolve a URL city slug back to its canonical {@link GPMGCity}, or undefined. */
+export function findCityBySlug(slug: string): GPMGCity | undefined {
+  return GPMG_CITIES.find((c) => c.slug === slug);
+}
+
+/** All fixtures in a given canonical city name. */
+export function propertiesInCity(city: string): GPMGProperty[] {
+  return GPMG_FIXTURES.filter((p) => p.city === city);
+}
+
 /**
  * Rough "from $X/mo" estimate — GPMG publishes ranges only via PDFs and the
  * catalog doesn't expose per-unit rent, so we surface a conservative number

--- a/client-tenant/src/components/CityJsonLd.tsx
+++ b/client-tenant/src/components/CityJsonLd.tsx
@@ -1,0 +1,82 @@
+/**
+ * City landing page structured data — a schema.org `CollectionPage` whose
+ * `mainEntity` is an `ItemList` of the city's properties, each pointing at its
+ * `/property/{slug}` detail page (which carries its own `Apartment` JSON-LD).
+ *
+ * Same effect-based injection as {@link PropertyJsonLd} (no react-helmet on the
+ * dep tree): append one `<script data-jsonld-city>` to <head> while mounted,
+ * remove on unmount. Keeps Google's view of a city page aligned with the
+ * crawlable list the user sees.
+ */
+
+import { useEffect } from 'react';
+import { GPMG_FIXTURES, slugify, type GPMGProperty } from '@/api/gpmg-fixtures';
+
+interface Props {
+  /** Canonical city name, e.g. "Las Vegas". */
+  city: string;
+  /** Properties shown on the page (already filtered to the city). */
+  properties: readonly GPMGProperty[];
+  /** Absolute origin for building canonical item URLs. */
+  origin: string;
+}
+
+/** Build the CollectionPage + ItemList payload. Exported for unit testing. */
+export function buildCityJsonLd(
+  city: string,
+  properties: readonly GPMGProperty[],
+  origin: string,
+): Record<string, unknown> {
+  const itemListElement = properties.map((p, i) => ({
+    '@type': 'ListItem',
+    position: i + 1,
+    url: `${origin}/property/${slugify(p.name)}`,
+    name: p.name,
+  }));
+
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'CollectionPage',
+    name: `Affordable housing in ${city}, NV`,
+    about: {
+      '@type': 'Place',
+      address: {
+        '@type': 'PostalAddress',
+        addressLocality: city,
+        addressRegion: 'NV',
+        addressCountry: 'US',
+      },
+    },
+    mainEntity: {
+      '@type': 'ItemList',
+      numberOfItems: properties.length,
+      itemListElement,
+    },
+  };
+}
+
+const SCRIPT_ATTR = 'data-jsonld-city';
+
+export function CityJsonLd({ city, properties, origin }: Props) {
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+
+    const payload = buildCityJsonLd(city, properties, origin);
+    const script = document.createElement('script');
+    script.type = 'application/ld+json';
+    script.setAttribute(SCRIPT_ATTR, '');
+    script.textContent = JSON.stringify(payload);
+    document.head.appendChild(script);
+
+    return () => {
+      if (script.parentNode) {
+        script.parentNode.removeChild(script);
+      }
+    };
+  }, [city, properties, origin]);
+
+  return null;
+}
+
+/** Re-export so callers can map the route param without importing fixtures twice. */
+export { GPMG_FIXTURES };

--- a/client-tenant/src/components/__tests__/CityJsonLd.test.tsx
+++ b/client-tenant/src/components/__tests__/CityJsonLd.test.tsx
@@ -1,0 +1,66 @@
+// @vitest-environment jsdom
+import { describe, expect, it, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { CityJsonLd, buildCityJsonLd } from '../CityJsonLd';
+import { propertiesInCity, slugify } from '@/api/gpmg-fixtures';
+
+const ORIGIN = 'https://frank-pilot-tenant.vercel.app';
+const CITY = 'Las Vegas';
+const PROPS = propertiesInCity(CITY);
+
+describe('CityJsonLd', () => {
+  beforeEach(() => {
+    document
+      .querySelectorAll('script[type="application/ld+json"]')
+      .forEach((n) => n.remove());
+  });
+
+  it('injects a single ld+json CollectionPage into <head>', () => {
+    render(<CityJsonLd city={CITY} properties={PROPS} origin={ORIGIN} />);
+    const scripts = document.head.querySelectorAll(
+      'script[type="application/ld+json"]',
+    );
+    expect(scripts.length).toBe(1);
+    const parsed = JSON.parse(scripts[0]!.textContent || '{}');
+    expect(parsed['@context']).toBe('https://schema.org');
+    expect(parsed['@type']).toBe('CollectionPage');
+  });
+
+  it('removes the script on unmount', () => {
+    const { unmount } = render(
+      <CityJsonLd city={CITY} properties={PROPS} origin={ORIGIN} />,
+    );
+    expect(
+      document.head.querySelectorAll('script[type="application/ld+json"]').length,
+    ).toBe(1);
+    unmount();
+    expect(
+      document.head.querySelectorAll('script[type="application/ld+json"]').length,
+    ).toBe(0);
+  });
+
+  it('builds an ItemList with one ListItem per property pointing at /property/{slug}', () => {
+    const payload = buildCityJsonLd(CITY, PROPS, ORIGIN);
+    const list = payload.mainEntity as Record<string, unknown>;
+    expect(list['@type']).toBe('ItemList');
+    expect(list.numberOfItems).toBe(PROPS.length);
+
+    const items = list.itemListElement as Array<Record<string, unknown>>;
+    expect(items.length).toBe(PROPS.length);
+    items.forEach((item, i) => {
+      expect(item['@type']).toBe('ListItem');
+      expect(item.position).toBe(i + 1);
+      expect(item.name).toBe(PROPS[i]!.name);
+      expect(item.url).toBe(`${ORIGIN}/property/${slugify(PROPS[i]!.name)}`);
+    });
+  });
+
+  it('scopes the about.address to the city in Nevada', () => {
+    const payload = buildCityJsonLd(CITY, PROPS, ORIGIN);
+    const about = payload.about as Record<string, unknown>;
+    const address = about.address as Record<string, unknown>;
+    expect(address.addressLocality).toBe(CITY);
+    expect(address.addressRegion).toBe('NV');
+    expect(address.addressCountry).toBe('US');
+  });
+});

--- a/client-tenant/src/i18n/en/discover.json
+++ b/client-tenant/src/i18n/en/discover.json
@@ -114,5 +114,11 @@
   "saved.removeShort": "Remove from shortlist",
   "saved.alertOn": "Vacancy alerts on",
   "saved.alertOff": "Get vacancy alerts",
-  "saved.apply": "Apply"
+  "saved.apply": "Apply",
+  "city.heading": "Affordable housing in {{city}}",
+  "city.intro": "{{count}} affordable senior and family communities in {{city}}, Nevada. Browse live availability, rent ranges, and AMI eligibility.",
+  "city.viewOnMap": "View all {{city}} homes on the map",
+  "city.backToAll": "All Nevada communities",
+  "city.metaTitle": "Affordable Housing in {{city}}, NV — {{count}} Communities",
+  "city.metaDescription": "Find affordable senior and family apartments in {{city}}, Nevada. Browse {{count}} communities with live availability, rent ranges, and AMI eligibility."
 }

--- a/client-tenant/src/i18n/es/discover.json
+++ b/client-tenant/src/i18n/es/discover.json
@@ -114,5 +114,11 @@
   "saved.removeShort": "Quitar de la lista",
   "saved.alertOn": "Alertas de disponibilidad activadas",
   "saved.alertOff": "Recibir alertas de disponibilidad",
-  "saved.apply": "Solicitar"
+  "saved.apply": "Solicitar",
+  "city.heading": "Vivienda asequible en {{city}}",
+  "city.intro": "{{count}} comunidades asequibles para personas mayores y familias en {{city}}, Nevada. Explora la disponibilidad en vivo, los rangos de renta y la elegibilidad por AMI.",
+  "city.viewOnMap": "Ver todas las viviendas de {{city}} en el mapa",
+  "city.backToAll": "Todas las comunidades de Nevada",
+  "city.metaTitle": "Vivienda asequible en {{city}}, NV — {{count}} comunidades",
+  "city.metaDescription": "Encuentra apartamentos asequibles para personas mayores y familias en {{city}}, Nevada. Explora {{count}} comunidades con disponibilidad en vivo, rangos de renta y elegibilidad por AMI."
 }

--- a/client-tenant/src/pages/discover/CityLanding.tsx
+++ b/client-tenant/src/pages/discover/CityLanding.tsx
@@ -1,0 +1,270 @@
+/**
+ * City-named landing page — `/discover/city/:city`.
+ *
+ * The discover wedge's SEO play: one crawlable page per Nevada city that has
+ * GPMG inventory, keyed off {@link GPMG_CITIES} (derived from the fixtures, so
+ * it can never list a city with zero properties). Each page carries a real
+ * `<h1>`, an intro copy block, a property card grid linking to the existing
+ * `/property/{slug}` detail pages, and city-scoped `ItemList` JSON-LD via
+ * {@link CityJsonLd}. Unknown slugs bounce to `/discover`.
+ *
+ * Cards here are intentionally lighter than `PropertyList`'s `PropertyTile`
+ * (no per-card mini-map / live-availability fetch) — this page is a search
+ * landing surface, not the interactive browser. The "view on the map" CTA
+ * hands off to `/discover?city={canonical}` for the full filtered experience.
+ *
+ * SPA SEO caveat: there's no SSR/react-helmet on this app, so `document.title`
+ * + the meta description are set via `useEffect`. Google's JS renderer + the
+ * sitemap + JSON-LD carry crawl coverage (see the wedge plan); a prerender
+ * step is deferred until coverage proves insufficient.
+ */
+
+import { useEffect, useMemo } from 'react';
+import { Link, Navigate, useParams } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { ArrowLeft } from 'lucide-react';
+import {
+  findCityBySlug,
+  propertiesInCity,
+  slugify,
+  rentEstimate,
+  type GPMGProperty,
+} from '@/api/gpmg-fixtures';
+import { CityJsonLd } from '@/components/CityJsonLd';
+import { Card } from '@/components/primitives';
+import { SaveButton } from '@/components/SaveButton';
+import { placeholderFor } from '@/utils/unitPlaceholder';
+import { HF } from '@/styles/tokens';
+
+/** Canonical origin for JSON-LD item URLs — prefer the live origin in-browser. */
+function canonicalOrigin(): string {
+  if (typeof window !== 'undefined' && window.location?.origin) {
+    return window.location.origin;
+  }
+  return (
+    (import.meta.env.VITE_PUBLIC_SITE_URL as string | undefined) ??
+    'https://frank-pilot-tenant.vercel.app'
+  );
+}
+
+export function CityLanding() {
+  const { city: citySlugParam = '' } = useParams<{ city: string }>();
+  const { t } = useTranslation('discover');
+
+  // Resolve once per slug — fixture scans shouldn't re-run on i18n suspense.
+  const cityEntry = useMemo(() => findCityBySlug(citySlugParam), [citySlugParam]);
+  const properties = useMemo<GPMGProperty[]>(
+    () => (cityEntry ? propertiesInCity(cityEntry.name) : []),
+    [cityEntry],
+  );
+
+  // Per-page <title> + meta description (no SSR — see file header). Restore the
+  // previous title on unmount so SPA navigation away doesn't leak the city name.
+  useEffect(() => {
+    if (!cityEntry || typeof document === 'undefined') return;
+    const prevTitle = document.title;
+    document.title = t('city.metaTitle', {
+      city: cityEntry.name,
+      count: cityEntry.count,
+    });
+
+    const meta = document.querySelector<HTMLMetaElement>('meta[name="description"]');
+    const prevDesc = meta?.getAttribute('content') ?? null;
+    const created = !meta;
+    const el = meta ?? document.createElement('meta');
+    if (created) {
+      el.setAttribute('name', 'description');
+      document.head.appendChild(el);
+    }
+    el.setAttribute(
+      'content',
+      t('city.metaDescription', { city: cityEntry.name, count: cityEntry.count }),
+    );
+
+    return () => {
+      document.title = prevTitle;
+      if (created) {
+        el.remove();
+      } else if (prevDesc !== null) {
+        el.setAttribute('content', prevDesc);
+      }
+    };
+  }, [cityEntry, t]);
+
+  // Unknown city slug → the main discover page (no dead-end 404 for crawlers).
+  if (!cityEntry) {
+    return <Navigate to="/discover" replace />;
+  }
+
+  return (
+    <div
+      style={{ background: HF.cream, minHeight: '100vh', fontFamily: HF.body, color: HF.ink }}
+    >
+      <CityJsonLd
+        city={cityEntry.name}
+        properties={properties}
+        origin={canonicalOrigin()}
+      />
+      <div className="mx-auto max-w-5xl p-4 sm:p-6">
+        <Link
+          to="/discover"
+          data-testid="city-back-to-all"
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 6,
+            fontSize: 13,
+            fontWeight: 600,
+            color: HF.ink3,
+            textDecoration: 'none',
+            marginBottom: 12,
+          }}
+        >
+          <ArrowLeft width={16} height={16} aria-hidden="true" />
+          {t('city.backToAll')}
+        </Link>
+
+        <header className="mb-4">
+          <h1
+            data-testid="city-heading"
+            style={{
+              fontFamily: HF.display,
+              fontWeight: 800,
+              fontSize: 26,
+              color: HF.ink,
+              letterSpacing: '-0.01em',
+              margin: 0,
+            }}
+          >
+            {t('city.heading', { city: cityEntry.name })}
+          </h1>
+          <p style={{ marginTop: 6, fontSize: 14, color: HF.ink3, maxWidth: 560 }}>
+            {t('city.intro', { city: cityEntry.name, count: cityEntry.count })}
+          </p>
+          <Link
+            to={`/discover?city=${encodeURIComponent(cityEntry.name)}`}
+            data-testid="city-view-on-map"
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 6,
+              marginTop: 12,
+              padding: '8px 16px',
+              borderRadius: HF.r.pill,
+              background: HF.accent,
+              color: HF.paper,
+              fontSize: 13,
+              fontWeight: 700,
+              textDecoration: 'none',
+            }}
+          >
+            {t('city.viewOnMap', { city: cityEntry.name })}
+          </Link>
+        </header>
+
+        <ul
+          className="grid grid-cols-1 gap-4 sm:grid-cols-2"
+          data-testid="city-property-grid"
+        >
+          {properties.map((p) => (
+            <CityPropertyCard key={p.name} prop={p} />
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Lean property card for the city grid — name, address, type, from-$ estimate,
+ * ♥ save, and a tap-through to the detail page. No mini-map / availability
+ * fetch (that's `PropertyList`'s job); this surface optimises for fast paint.
+ */
+function CityPropertyCard({ prop }: { prop: GPMGProperty }) {
+  const slug = slugify(prop.name);
+  return (
+    <li>
+      <Link
+        to={`/property/${slug}`}
+        aria-label={prop.name}
+        data-testid={`city-tile-${slug}`}
+        style={{ display: 'block', textDecoration: 'none', color: 'inherit', borderRadius: HF.r.md }}
+      >
+        <Card variant="mobile" padding={0} elevation="sm" style={{ overflow: 'hidden' }}>
+          <div className="relative">
+            <div
+              className="aspect-[16/9] w-full"
+              style={{
+                background: HF.sageLo,
+                backgroundImage: `url(${placeholderFor(slug, prop.name)})`,
+                backgroundSize: 'cover',
+                backgroundPosition: 'center',
+              }}
+              aria-hidden="true"
+            />
+            <div style={{ position: 'absolute', top: 8, right: 8 }}>
+              <SaveButton slug={slug} size={36} />
+            </div>
+          </div>
+          <div style={{ padding: 16 }}>
+            <h2
+              style={{
+                fontFamily: HF.display,
+                fontWeight: 700,
+                fontSize: 16,
+                color: HF.ink,
+                margin: 0,
+                lineHeight: 1.25,
+              }}
+            >
+              {prop.name}
+            </h2>
+            <p style={{ margin: '4px 0 0', fontSize: 12, color: HF.ink3 }}>
+              {prop.addr} · {prop.city}, NV {prop.zip}
+            </p>
+            <div
+              className="flex items-center justify-between"
+              style={{
+                marginTop: 12,
+                paddingTop: 12,
+                borderTop: `1px solid ${HF.border}`,
+                gap: 8,
+              }}
+            >
+              <span
+                style={{
+                  fontFamily: HF.display,
+                  fontWeight: 700,
+                  fontSize: 14,
+                  color: HF.ink,
+                }}
+              >
+                From ${rentEstimate(prop)}/mo
+              </span>
+              <div className="flex items-center" style={{ gap: 8 }}>
+                <span
+                  style={{
+                    background: HF.accentLo,
+                    color: HF.accentInk,
+                    border: '1px solid #F3D7CB',
+                    borderRadius: HF.r.pill,
+                    padding: '2px 10px',
+                    fontSize: 11,
+                    fontWeight: 700,
+                    textTransform: 'capitalize',
+                    fontFamily: HF.body,
+                  }}
+                >
+                  {prop.type}
+                </span>
+                <span style={{ fontSize: 13, color: HF.accent, fontWeight: 600 }}>
+                  View →
+                </span>
+              </div>
+            </div>
+          </div>
+        </Card>
+      </Link>
+    </li>
+  );
+}


### PR DESCRIPTION
## What

The discover-wedge **Play 1** from the NV-housing market-recon: one crawlable landing page per Nevada city with GPMG inventory, at `/discover/city/:city`. Targets the city-search intent the recon found the incumbent under-serving.

3 pages today (keyed off `GPMG_CITIES`, derived from fixtures so it can never list an empty city):
- `/discover/city/las-vegas` (13 communities)
- `/discover/city/north-las-vegas` (4)
- `/discover/city/henderson` (1)

## How

- **`gpmg-fixtures.ts`** — `GPMG_CITIES` + `citySlug` / `findCityBySlug` / `propertiesInCity` helpers, all derived from the 17 fixtures.
- **`CityLanding.tsx`** — `<h1>` + intro copy + a lean property card grid linking to the existing `/property/{slug}` detail pages, a "view on map" CTA → `/discover?city={canonical}`, and per-page `document.title`/meta description via `useEffect` (restored on unmount). Unknown slug → redirect to `/discover` (no crawler dead-end).
- **`CityJsonLd.tsx`** — schema.org `CollectionPage` + `ItemList` structured data, mirroring `PropertyJsonLd`'s effect-based injection (no react-helmet on the dep tree).
- **`generate-sitemap.mjs`** — 3 city URLs at priority `0.7` weekly; sitemap regenerated (23 URLs).
- **i18n** — `city.*` strings in en + es (`check:i18n` parity clean).

### SEO caveat (DECISION)
SPA has no SSR/react-helmet, so per-route `<title>`/meta render only after JS. We rely on Google's JS renderer + the sitemap + JSON-LD (cheapest, matches the existing `/property` approach). A prerender step is deferred until crawl coverage proves insufficient.

## Verify
- `tsc --noEmit` clean
- `vite build` clean
- `check:i18n` EN-ES parity clean
- `vitest`: city helpers (8) + CityJsonLd (4) + sitemap city coverage — 20 green
- sitemap lists all 3 `/discover/city/{slug}` URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)