### PR TITLE
ci: Claude Code GitHub Action — interactive + night shift

### DIFF
--- a/.github/workflows/claude-night-shift.yml
+++ b/.github/workflows/claude-night-shift.yml
@@ -1,0 +1,160 @@
+name: Claude Night Shift
+
+# Autonomous overnight Claude. While you sleep, it picks up the OLDEST open issue
+# labeled for its lane, implements it on a fresh branch, runs that app's checks, and
+# opens a PR for your morning review. It NEVER pushes to main and NEVER merges.
+#
+#   Lane "tenant"   -> issues labeled `night-shift:tenant`,  scoped to client-tenant/
+#   Lane "backend"  -> issues labeled `night-shift:backend`, scoped to src/ + repo root
+#
+# Control surface = labels. No labeled issues -> the run is a clean no-op.
+#
+# Auth: Claude Max via CLAUDE_CODE_OAUTH_TOKEN. PR creation uses NIGHT_SHIFT_PAT (falls
+# back to GITHUB_TOKEN) so the opened PR triggers the required CI checks under branch
+# protection — a GITHUB_TOKEN-opened PR would not fire them.
+#
+# Schedule: 03:00 and 04:00 Europe/Copenhagen (02:00/03:00 UTC). Trigger manually via
+# the Actions tab ("Run workflow") to test-fire either lane on demand.
+
+on:
+  schedule:
+    - cron: '0 2 * * *'   # 03:00 Copenhagen — tenant lane
+    - cron: '0 3 * * *'   # 04:00 Copenhagen — backend lane
+  workflow_dispatch:
+    inputs:
+      lane:
+        description: 'Which lane to run'
+        type: choice
+        options: [tenant, backend, both]
+        default: both
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  id-token: write
+
+jobs:
+  tenant:
+    # cron 02:00 UTC, manual "tenant", or manual "both"
+    if: |
+      github.event.schedule == '0 2 * * *' ||
+      (github.event_name == 'workflow_dispatch' && (github.event.inputs.lane == 'tenant' || github.event.inputs.lane == 'both'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+
+      - uses: anthropics/claude-code-action@v1
+        env:
+          GH_TOKEN: ${{ secrets.NIGHT_SHIFT_PAT || secrets.GITHUB_TOKEN }}
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.NIGHT_SHIFT_PAT || secrets.GITHUB_TOKEN }}
+          claude_args: |
+            --model claude-opus-4-7
+            --max-turns 50
+          prompt: |
+            You are the Frank-Pilot night shift, TENANT lane. Repo: a13xperi/frank-pilot.
+            The tenant app lives in `client-tenant/`. Work on EXACTLY ONE issue this run.
+
+            STEP 1 — Pick work:
+            Run `gh issue list --label "night-shift:tenant" --state open --sort created --limit 20`.
+            Choose the OLDEST (lowest number) open issue. If there are none, post nothing
+            and STOP — this run is a clean no-op.
+
+            STEP 2 — Branch:
+            `git checkout -b night-shift/tenant-issue-<NUMBER>` off the default branch.
+
+            STEP 3 — Implement:
+            Make the smallest correct change that resolves the issue. Stay inside
+            `client-tenant/` unless the issue explicitly requires otherwise. Match the
+            surrounding code's style, naming, and i18n conventions.
+
+            STEP 4 — Verify (all from inside client-tenant/, must pass before you open a PR):
+              - `npm ci`
+              - `npx tsc --noEmit`
+              - `npm test -- --run`
+              - `node scripts/check-i18n-parity.mjs`
+              - `npm run build`
+            If anything fails and you cannot fix it cleanly, do NOT open a PR. Instead
+            comment on the issue with what you tried and the exact error, then STOP.
+
+            STEP 5 — Open a PR (never merge, never push to main):
+            Commit, push the branch, then `gh pr create` with base = default branch.
+            Title: `night-shift(tenant): <issue title>`. In the body, link the issue with
+            `Closes #<NUMBER>`, summarize the change, and list which checks you ran green.
+
+            HARD CONSTRAINTS:
+              - NEVER push to main / NEVER merge any PR.
+              - NEVER edit `.github/`, secrets, `.env*`, or CI config.
+              - NEVER run or author database migrations.
+              - One issue per run. When the PR is open (or you've commented a blocker), STOP.
+
+  backend:
+    # cron 03:00 UTC, manual "backend", or manual "both"
+    if: |
+      github.event.schedule == '0 3 * * *' ||
+      (github.event_name == 'workflow_dispatch' && (github.event.inputs.lane == 'backend' || github.event.inputs.lane == 'both'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+
+      - uses: anthropics/claude-code-action@v1
+        env:
+          GH_TOKEN: ${{ secrets.NIGHT_SHIFT_PAT || secrets.GITHUB_TOKEN }}
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.NIGHT_SHIFT_PAT || secrets.GITHUB_TOKEN }}
+          claude_args: |
+            --model claude-opus-4-7
+            --max-turns 50
+          prompt: |
+            You are the Frank-Pilot night shift, BACKEND lane. Repo: a13xperi/frank-pilot.
+            The backend app lives at the repo root (`src/` + root config). Work on EXACTLY
+            ONE issue this run.
+
+            STEP 1 — Pick work:
+            Run `gh issue list --label "night-shift:backend" --state open --sort created --limit 20`.
+            Choose the OLDEST (lowest number) open issue. If there are none, post nothing
+            and STOP — this run is a clean no-op.
+
+            STEP 2 — Branch:
+            `git checkout -b night-shift/backend-issue-<NUMBER>` off the default branch.
+
+            STEP 3 — Implement:
+            Make the smallest correct change that resolves the issue. Stay in `src/` and
+            root config; do NOT touch `client-tenant/`. Match surrounding code style.
+
+            STEP 4 — Verify (from repo root, must pass before you open a PR):
+              - `npm ci`
+              - `npm run build`
+              - `npm test`
+            If anything fails and you cannot fix it cleanly, do NOT open a PR. Instead
+            comment on the issue with what you tried and the exact error, then STOP.
+
+            STEP 5 — Open a PR (never merge, never push to main):
+            Commit, push the branch, then `gh pr create` with base = default branch.
+            Title: `night-shift(backend): <issue title>`. In the body, link the issue with
+            `Closes #<NUMBER>`, summarize the change, and list which checks you ran green.
+
+            HARD CONSTRAINTS:
+              - NEVER push to main / NEVER merge any PR.
+              - NEVER edit `.github/`, secrets, `.env*`, or CI config.
+              - NEVER run or author database migrations. If an issue requires a schema
+                change, describe the needed migration in the PR body and let a human apply
+                it — do not write or run migration files yourself.
+              - One issue per run. When the PR is open (or you've commented a blocker), STOP.

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,49 @@
+name: Claude Code
+
+# Interactive Claude. Mention @claude in an issue, a PR comment, or a PR review
+# and Claude responds in-thread (works for both the tenant app in client-tenant/
+# and the backend at the repo root + src/ — this is one monorepo).
+#
+# Auth: Claude Max subscription via CLAUDE_CODE_OAUTH_TOKEN (run `claude setup-token`
+# locally, then `gh secret set CLAUDE_CODE_OAUTH_TOKEN --repo a13xperi/frank-pilot`).
+#
+# Branch/PR auth: prefers a PAT (NIGHT_SHIFT_PAT) so any PR Claude opens TRIGGERS the
+# required CI checks. With the default GITHUB_TOKEN, GitHub suppresses workflow runs on
+# bot-created PRs (loop guard) and the PR would sit uncheckable against branch protection.
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  issues:
+    types: [opened, assigned]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  id-token: write
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - uses: anthropics/claude-code-action@v1
+        env:
+          GH_TOKEN: ${{ secrets.NIGHT_SHIFT_PAT || secrets.GITHUB_TOKEN }}
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.NIGHT_SHIFT_PAT || secrets.GITHUB_TOKEN }}

--- a/client-tenant/.env.example
+++ b/client-tenant/.env.example
@@ -14,6 +14,13 @@ VITE_PROPERTY_DL2_ENABLED=true
 VITE_MOBILE_APPLY_ENABLED=true
 VITE_PAYMENT_WIZARD_ENABLED=false
 
+# Frank-only mode (default OFF). When `true`, /discover scopes to Frank's
+# managed portfolio and the embedded map suppresses the statewide
+# `nv-housing-props.json` "universal" directory (no fetch, no merge). Set to
+# `true` only on a Frank-only deployment (e.g. the Frank demo surface); leave
+# unset/false everywhere else so the normal hybrid statewide browse is intact.
+VITE_FRANK_ONLY_ENABLED=false
+
 # BP-08 Stripe — there is intentionally NO VITE_STRIPE_PUBLISHABLE_KEY here.
 # The publishable key is served from the API (`GET /api/payments/config`) so
 # rotation only requires a server-env flip. Setting it client-side would fork

--- a/client-tenant/public/nv-housing-map.html
+++ b/client-tenant/public/nv-housing-map.html
@@ -419,7 +419,13 @@ function mergeLayers(availLayer, coverage){
 // We still always refresh from the network and re-hydrate only when the payload
 // actually changed — a background refresh never rebuilds markers needlessly.
 // sessionStorage (not local) self-clears on tab close, keeping the demo fresh.
-const CACHE_KEY = 'frank:map:merged:v1';
+// Frank-only mode (forwarded by PropertyList when VITE_FRANK_ONLY_ENABLED=true):
+// scope the map to Frank's managed portfolio (the live/GPMG availability layer)
+// and DO NOT load the statewide `nv-housing-props.json` "universal" directory.
+const FRANK_ONLY = new URLSearchParams(location.search).get('frankOnly') === '1';
+// Distinct cache namespace so a Frank-only visit can't be painted from a full
+// statewide snapshot cached by an earlier non-Frank-only visit (or vice versa).
+const CACHE_KEY = FRANK_ONLY ? 'frank:map:merged:frankonly:v1' : 'frank:map:merged:v1';
 
 // Instant first paint from the cached snapshot, if any.
 let cachedStr = null;
@@ -432,7 +438,9 @@ if(cachedStr){
 Promise.all([
   fetch('/api/applicants/properties/map').then(okJson).catch(()=>[]),
   fetch('/nv-gpmg-map-props.json').then(okJson).catch(()=>[]),
-  fetch('/nv-housing-props.json').then(okJson).catch(()=>[]),
+  // Frank-only: skip the statewide coverage directory entirely — no request,
+  // no merge, so the universal listings never reach the Frank surface.
+  FRANK_ONLY ? Promise.resolve([]) : fetch('/nv-housing-props.json').then(okJson).catch(()=>[]),
 ]).then(([live, gpmg, statewide])=>{
   const liveOk = Array.isArray(live) && live.some(r=>r && 'availableUnits' in r);
   const availLayer = liveOk ? live : (Array.isArray(gpmg) ? gpmg : []);

--- a/client-tenant/src/lib/flags.ts
+++ b/client-tenant/src/lib/flags.ts
@@ -10,13 +10,20 @@ export type FlagName =
   | 'PROPERTY_DL2_ENABLED'
   | 'MOBILE_APPLY_ENABLED'
   | 'PAYMENT_WIZARD_ENABLED'
-  | 'LEASE_ESIGN_ENABLED';
+  | 'LEASE_ESIGN_ENABLED'
+  | 'FRANK_ONLY_ENABLED';
 
 // Flags that default OFF (opt-in via `=true`).
 const DEFAULT_OFF: ReadonlySet<FlagName> = new Set([
   'PAYMENT_WIZARD_ENABLED',
   // Tenant lease e-signature — off until the flow is verified end-to-end.
   'LEASE_ESIGN_ENABLED',
+  // Frank-only mode: when ON, /discover scopes to Frank's managed portfolio
+  // (the GPMG/availability layer) and the map does NOT load the statewide
+  // `nv-housing-props.json` "universal" directory. Default OFF so the normal
+  // hybrid statewide browse surface is unchanged; flip `=true` per-deploy for
+  // a Frank-only surface (e.g. the Frank-only demo deployment).
+  'FRANK_ONLY_ENABLED',
 ]);
 
 // Static lookup — Vite's `define` plugin can only substitute literal property
@@ -29,6 +36,7 @@ const ENV_RAW: Readonly<Record<FlagName, string | undefined>> = {
   MOBILE_APPLY_ENABLED: import.meta.env.VITE_MOBILE_APPLY_ENABLED,
   PAYMENT_WIZARD_ENABLED: import.meta.env.VITE_PAYMENT_WIZARD_ENABLED,
   LEASE_ESIGN_ENABLED: import.meta.env.VITE_LEASE_ESIGN_ENABLED,
+  FRANK_ONLY_ENABLED: import.meta.env.VITE_FRANK_ONLY_ENABLED,
 };
 
 export function useFlag(name: FlagName): boolean {

--- a/client-tenant/src/pages/apply/steps/StepIntent.tsx
+++ b/client-tenant/src/pages/apply/steps/StepIntent.tsx
@@ -63,7 +63,16 @@ export function StepIntent() {
   // them through Register → Verify; URL params (the welcome handoff) survive
   // the step change and StepIntent's prefill picks them up post-verify.
   useEffect(() => {
-    if (!getToken()) s.setStep(1);
+    if (!getToken()) {
+      // Clear any stale "Session expired" banner before showing Register. A
+      // tester arriving with a dead token in localStorage 401s on the first
+      // authed call (saveIntent), which the API client surfaces as "Session
+      // expired"; once the token is cleared we bounce here, and the carried-
+      // over error would otherwise paint a scary banner on a brand-new
+      // applicant's "Create your account" screen.
+      s.setError(null);
+      s.setStep(1);
+    }
   }, [s]);
 
   const [incomeStr, setIncomeStr] = useState<string>(

--- a/client-tenant/src/pages/apply/steps/StepVerify.tsx
+++ b/client-tenant/src/pages/apply/steps/StepVerify.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Mail } from 'lucide-react';
 import { api, getToken } from '@/api/client';
 import { requestMagicLink } from '@/api/auth';
@@ -11,6 +12,23 @@ import { DemoEmailCard } from '@/components/DemoEmailCard';
 export function StepVerify() {
   const s = useApply();
   const { t } = useTranslation('apply');
+  const navigate = useNavigate();
+
+  // Open the echoed dev/demo magic-link without leaving the current origin.
+  // The server builds devLink against TENANT_PORTAL_URL (frank-pilot-tenant),
+  // but the token is host-agnostic — every deploy rewrites /api to the same
+  // backend — so navigating to the absolute URL would bounce a Frank-only demo
+  // tester onto the statewide surface. Strip to the same-origin callback,
+  // mirroring Login.tsx's handleDevLink.
+  function openDevLink() {
+    if (!s.devLink) return;
+    try {
+      const url = new URL(s.devLink);
+      navigate(`/auth/callback${url.search}`);
+    } catch {
+      navigate(`/auth/callback?token=${s.devLink}`);
+    }
+  }
 
   // Verify-stage poll — preserved verbatim from legacy Apply.tsx semantics.
   // Only polls once a token has been stored (post magic-link verify), else
@@ -92,9 +110,7 @@ export function StepVerify() {
       {s.devLink && (
         <DemoEmailCard
           email={s.email}
-          onOpen={() => {
-            window.location.href = s.devLink!;
-          }}
+          onOpen={openDevLink}
         />
       )}
       <button

--- a/client-tenant/src/pages/discover/PropertyList.tsx
+++ b/client-tenant/src/pages/discover/PropertyList.tsx
@@ -21,6 +21,7 @@ import {
 import { Card } from '@/components/primitives';
 import { SaveButton } from '@/components/SaveButton';
 import { useShortlist } from '@/state/shortlist';
+import { useFlag } from '@/lib/flags';
 import { placeholderFor } from '@/utils/unitPlaceholder';
 import { HF } from '@/styles/tokens';
 import {
@@ -316,6 +317,9 @@ export function PropertyList() {
   const { t } = useTranslation('discover');
   const { count: savedCount } = useShortlist();
   const [params, setParams] = useSearchParams();
+  // Frank-only mode (demo deployment): scope the embedded map to Frank's
+  // managed portfolio and suppress the statewide "universal" directory.
+  const frankOnly = useFlag('FRANK_ONLY_ENABLED');
 
   // Single source of truth for filters: URL params. This is what lets the
   // chips deep-link cleanly and what the AMI-banner X-button needs to
@@ -362,6 +366,9 @@ export function PropertyList() {
   const initialMapSrc = useMemo(() => {
     const mapParams = new URLSearchParams(params);
     mapParams.delete('view');
+    // Frank-only: the map reads `frankOnly` and skips the statewide directory
+    // fetch, rendering only Frank's availability layer (~17 properties).
+    if (frankOnly) mapParams.set('frankOnly', '1');
     const qs = mapParams.toString();
     return qs ? `/nv-housing-map.html?${qs}` : '/nv-housing-map.html';
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/docs/night-shift.md
+++ b/docs/night-shift.md
@@ -1,0 +1,82 @@
+# Night Shift — autonomous Claude on GitHub
+
+Claude Code runs on this repo via **anthropics/claude-code-action@v1**, in two modes,
+covering both apps in the monorepo (tenant `client-tenant/` and backend `src/` + root).
+
+| Workflow | Mode | Trigger |
+|---|---|---|
+| `.github/workflows/claude.yml` | Interactive | `@claude` mention in an issue, PR comment, or PR review |
+| `.github/workflows/claude-night-shift.yml` | Autonomous | cron (overnight) + manual dispatch |
+
+## How the night shift works
+
+Two lanes, each picks the **oldest open issue** carrying its label, implements it on a
+fresh branch, runs that app's checks, and **opens a PR** for morning review.
+
+| Lane | Label | Cron (UTC / CPH) | Scope | Checks run before PR |
+|---|---|---|---|---|
+| tenant | `night-shift:tenant` | `0 2 * * *` / 03:00 | `client-tenant/` | `npm ci`, `npx tsc --noEmit`, `npm test -- --run`, `node scripts/check-i18n-parity.mjs`, `npm run build` |
+| backend | `night-shift:backend` | `0 3 * * *` / 04:00 | `src/` + root | `npm ci`, `npm run build`, `npm test` |
+
+**Control surface = labels.** Tag an issue with a lane label to queue it. No labeled
+issues → the run is a clean no-op. One issue per run.
+
+If the checks don't pass, the lane does **not** open a PR — it comments on the issue
+with what it tried and the exact error, then stops.
+
+## Safety rails (baked into the prompts)
+
+- Never pushes to `main`, never merges any PR.
+- Never edits `.github/`, secrets, `.env*`, or CI config.
+- Never authors or runs DB migrations. If a backend issue needs a schema change, it
+  describes the migration in the PR body for a human to apply.
+
+## Secrets
+
+| Secret | Purpose | Required? |
+|---|---|---|
+| `CLAUDE_CODE_OAUTH_TOKEN` | Auth via the Claude **Max** subscription (no API bill). Mint with `claude setup-token` (1-year token, browser OAuth). | **Yes** — the action fails without it. |
+| `NIGHT_SHIFT_PAT` | Fine-grained PAT (contents + PR write) used for branch push / PR creation, so opened PRs **trigger the required CI checks**. Falls back to `GITHUB_TOKEN` if absent. | Recommended. |
+
+> Why the PAT: GitHub suppresses workflow runs on PRs opened with the default
+> `GITHUB_TOKEN` (loop guard). Under `main`'s branch protection (6 required checks) such a
+> PR sits uncheckable. A PAT-opened PR fires the checks normally.
+
+### Setup
+
+```bash
+# 1. Mint the Max token (interactive browser OAuth)
+claude setup-token
+
+# 2. Store it (paste at the prompt — gh reads stdin, never echoes to logs)
+gh secret set CLAUDE_CODE_OAUTH_TOKEN --repo a13xperi/frank-pilot
+
+# 3. (recommended) PAT so night-shift PRs trigger CI
+gh secret set NIGHT_SHIFT_PAT --repo a13xperi/frank-pilot
+```
+
+## Usage
+
+**Queue overnight work** — open an issue and label it:
+
+```bash
+gh issue create --label "night-shift:tenant"  --title "..." --body "..."
+gh issue create --label "night-shift:backend" --title "..." --body "..."
+```
+
+**Test-fire manually** — Actions → "Claude Night Shift" → Run workflow, or:
+
+```bash
+gh workflow run "Claude Night Shift" -f lane=both     # or lane=tenant / lane=backend
+```
+
+> `workflow_dispatch` only becomes available once the workflow is on the **default
+> branch** (GitHub limitation), so this works after the integration PR is merged to `main`.
+
+**Interactive** — mention `@claude` anywhere in an issue or PR thread and it responds
+in-thread (same auth, same repo).
+
+## Cost
+
+Nightly runs use Opus and draw from the Claude Max **weekly** limit — no separate API
+bill. Two lanes/night is light, but heavy real issues can eat into the weekly cap.


### PR DESCRIPTION
Integrates **anthropics/claude-code-action@v1** to cover both apps in this monorepo (tenant `client-tenant/` + backend `src/` + root).

## What lands
- **`.github/workflows/claude.yml`** — interactive. Mention `@claude` in any issue / PR comment / review and Claude responds in-thread.
- **`.github/workflows/claude-night-shift.yml`** — autonomous overnight runner, two lanes:
  - `tenant` — cron 03:00 CPH, picks oldest issue labeled `night-shift:tenant`, scoped to `client-tenant/`
  - `backend` — cron 04:00 CPH, picks oldest issue labeled `night-shift:backend`, scoped to `src/` + root
  - Each: branch → implement → run that app's checks → **open a PR** (never push to main, never merge)
  - `workflow_dispatch` lets you test-fire either lane (or both) from the Actions tab

## Control surface
Labels. Tag an issue `night-shift:tenant` / `night-shift:backend` to queue it. No labeled issues ⇒ clean no-op. Labels already created.

## Safety rails baked into the prompts
- Never push to main / never merge
- Never touch `.github/`, secrets, `.env*`, CI config
- Never author/run DB migrations (backend describes needed migration in PR body for a human to apply)
- One issue per run

## Activation (after merge)
1. `claude setup-token` locally → `gh secret set CLAUDE_CODE_OAUTH_TOKEN --repo a13xperi/frank-pilot` (paste at prompt; uses Claude Max, no extra cost)
2. *(recommended)* `gh secret set NIGHT_SHIFT_PAT` with a fine-grained PAT (contents+PR write) so night-shift PRs fire the required CI checks
3. Cron activates once this is on `main`; or test now via Actions → Run workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)