### PR TITLE
feat(voice-intake): ElevenLabs Conv. AI post-call webhook + PM review (foundation, flag-gated off)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,18 @@ TWILIO_ACCOUNT_SID=changeme
 TWILIO_AUTH_TOKEN=changeme
 TWILIO_PHONE_NUMBER=+1changeme
 
+# Voice intake — ElevenLabs Conv. AI (Frank-onboarder agent).
+# `VOICE_INTAKE_ENABLED=true` flips on the post-call webhook receiver AND
+# the PM-console review routes; off by default so a misconfigured deploy
+# can't surface unstamped review surface area. `ELEVENLABS_WEBHOOK_SECRET`
+# is the shared secret set on the ElevenLabs agent's webhook config —
+# `wsec_changeme` is a sentinel the receiver refuses (fail-closed on
+# misconfig). `ELEVENLABS_API_KEY` is used by the PM-console audio proxy
+# (Phase 3) and never sent to the browser.
+VOICE_INTAKE_ENABLED=false
+ELEVENLABS_WEBHOOK_SECRET=wsec_changeme
+ELEVENLABS_API_KEY=
+
 # Resend (Email Notifications — magic links + application status)
 # Leave RESEND_API_KEY unset to disable email delivery (sends become no-ops
 # that log a WARN). RESEND_FROM defaults to Resend's verified sandbox sender

--- a/src/__tests__/voice-intake-service.test.ts
+++ b/src/__tests__/voice-intake-service.test.ts
@@ -1,0 +1,415 @@
+/**
+ * Unit tests for src/modules/voice-intake/service.ts.
+ *
+ * `persistConversation` is the upsert path the webhook calls — exercised here
+ * directly so the shape of what lands in `voice_intake_calls` is locked in
+ * (consent defaults, language slicing, callback flag parsing).
+ *
+ * `promoteIntakeToApplication` and `rejectIntake` are the PM-console review
+ * actions — they're the moments the intake becomes a real `applications` row
+ * (with a HUD-stamped audit anchor) or is closed out. Both are state
+ * transitions worth pinning, and the SMS handoff is fire-and-forget so we
+ * mock `sendMagicLinkSms` to assert the call vs the no-phone skip path.
+ *
+ * Database is fully mocked — these are unit tests on the SQL we issue and
+ * the side-effects we emit, not integration tests against Postgres.
+ */
+
+const mockQuery = jest.fn();
+jest.mock("../config/database", () => ({
+  query: (...args: unknown[]) => mockQuery(...args),
+}));
+
+jest.mock("../utils/logger", () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+const mockStampTape = jest.fn().mockResolvedValue(null);
+jest.mock("../modules/tape", () => {
+  const real = jest.requireActual("../modules/tape");
+  return { ...real, stampTape: mockStampTape };
+});
+
+const mockSendMagicLinkSms = jest.fn();
+jest.mock("../modules/auth/magic-link-service", () => ({
+  sendMagicLinkSms: mockSendMagicLinkSms,
+}));
+
+import {
+  persistConversation,
+  promoteIntakeToApplication,
+  rejectIntake,
+  type PostCallPayload,
+} from "../modules/voice-intake/service";
+
+const flush = () => new Promise((resolve) => setImmediate(resolve));
+
+const CALL_ROW_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+const APP_ROW_ID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+const ACTOR_ID = "cccccccc-cccc-cccc-cccc-cccccccccccc";
+const PROPERTY_ID = "dddddddd-dddd-dddd-dddd-dddddddddddd";
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+// ── persistConversation ────────────────────────────────────────────────────
+
+describe("persistConversation", () => {
+  it("upserts a complete payload — language, callSuccessful, consent and callback flags all surfaced", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: CALL_ROW_ID }] });
+
+    const payload: PostCallPayload = {
+      conversation_id: "conv_persist_001",
+      agent_id: "agent_frank_v1",
+      metadata: {
+        start_time_unix_secs: 1_700_000_000,
+        call_duration_secs: 120,
+        detected_language: "en",
+        main_language: "es",
+        cost: { total: 0.034 },
+      },
+      analysis: {
+        call_successful: "success",
+        evaluation_criteria_results: { name: { result: "success" } },
+        data_collection_results: {
+          name: { value: "Jane Caller" },
+          phone: { value: "(702) 555-0123" },
+          current_city: { value: "Las Vegas" },
+          consent_recording: { value: "true" },
+          callback_requested: { value: "yes" },
+        },
+      },
+      transcript_url: "https://api.elevenlabs.io/v1/convai/conversations/conv_persist_001/transcript",
+      audio_url: "https://api.elevenlabs.io/v1/convai/conversations/conv_persist_001/audio",
+    };
+
+    const result = await persistConversation(payload);
+
+    expect(result).toEqual({
+      callId: CALL_ROW_ID,
+      language: "en",
+      callSuccessful: "success",
+      consentRecording: true,
+      callbackRequested: true,
+    });
+
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+    const [sql, params] = mockQuery.mock.calls[0];
+    expect(String(sql)).toContain("INSERT INTO voice_intake_calls");
+    expect(String(sql)).toContain("ON CONFLICT (conversation_id) DO UPDATE");
+    // Positional params (see service.ts persistConversation):
+    //   1 conversation_id, 2 agent_id, 3 startedAt, 4 endedAt, 5 language,
+    //   6 callSuccessful, 7..8 jsonb, 9 transcript_url, 10 audio_url,
+    //   11 cost_breakdown, 12 consent_recording, 13 callback_requested, 14 raw_payload
+    expect(params[0]).toBe("conv_persist_001");
+    expect(params[1]).toBe("agent_frank_v1");
+    expect(params[3]).toBeInstanceOf(Date); // endedAt computed from start + duration
+    expect(params[4]).toBe("en"); // detected_language wins over main_language
+    expect(params[5]).toBe("success");
+    expect(params[8]).toBe(payload.transcript_url);
+    expect(params[9]).toBe(payload.audio_url);
+    expect(params[11]).toBe(true);
+    expect(params[12]).toBe(true);
+  });
+
+  it("defaults consent to TRUE when the caller never opted out (implied-consent path)", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: CALL_ROW_ID }] });
+
+    const payload: PostCallPayload = {
+      conversation_id: "conv_no_consent_field",
+      agent_id: "agent_frank_v1",
+      analysis: { data_collection_results: { name: { value: "Anon" } } },
+    };
+
+    const result = await persistConversation(payload);
+    expect(result.consentRecording).toBe(true);
+    expect(result.callbackRequested).toBe(false);
+  });
+
+  it("respects an explicit consent_recording='false'", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: CALL_ROW_ID }] });
+
+    const payload: PostCallPayload = {
+      conversation_id: "conv_explicit_no",
+      agent_id: "agent_frank_v1",
+      analysis: {
+        data_collection_results: {
+          consent_recording: { value: "false" },
+        },
+      },
+    };
+
+    const result = await persistConversation(payload);
+    expect(result.consentRecording).toBe(false);
+  });
+
+  it("computes startedAt from now() when metadata.start_time_unix_secs is missing", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: CALL_ROW_ID }] });
+
+    const before = Date.now();
+    await persistConversation({
+      conversation_id: "conv_no_start",
+      agent_id: "agent_frank_v1",
+    });
+    const after = Date.now();
+
+    const startedAt = mockQuery.mock.calls[0][1][2] as Date;
+    expect(startedAt).toBeInstanceOf(Date);
+    expect(startedAt.getTime()).toBeGreaterThanOrEqual(before);
+    expect(startedAt.getTime()).toBeLessThanOrEqual(after);
+
+    // endedAt stays null when we can't compute it.
+    expect(mockQuery.mock.calls[0][1][3]).toBeNull();
+  });
+
+  it("slices language and callSuccessful so DB VARCHAR limits can't be overrun", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: CALL_ROW_ID }] });
+
+    await persistConversation({
+      conversation_id: "conv_long_strings",
+      agent_id: "agent_frank_v1",
+      metadata: { main_language: "en-US-extra-very-long-tag" },
+      analysis: { call_successful: "wildly_overshot_status_string" },
+    });
+
+    const params = mockQuery.mock.calls[0][1];
+    expect((params[4] as string).length).toBeLessThanOrEqual(8);
+    expect((params[5] as string).length).toBeLessThanOrEqual(16);
+  });
+});
+
+// ── promoteIntakeToApplication ─────────────────────────────────────────────
+
+describe("promoteIntakeToApplication", () => {
+  function arrangeCallLookup(opts: {
+    data?: Record<string, unknown>;
+    applicantId?: string | null;
+    notFound?: boolean;
+  } = {}) {
+    if (opts.notFound) {
+      mockQuery.mockResolvedValueOnce({ rows: [] });
+      return;
+    }
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        {
+          data_collection_results: opts.data ?? {
+            name: { value: "Jane Caller" },
+            phone: { value: "(702) 555-0123" },
+            current_city: { value: "Las Vegas" },
+            household: { value: "3" },
+            monthly_income: { value: "$2,500" },
+          },
+          applicant_id: opts.applicantId ?? null,
+        },
+      ],
+    });
+  }
+
+  it("inserts an applications row with source='voice', back-references the call, stamps a HUD decision, and fires the SMS doc-upload handoff", async () => {
+    arrangeCallLookup();
+    // INSERT applications → returns applicationId
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: APP_ROW_ID }] });
+    // UPDATE voice_intake_calls back-reference
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    const result = await promoteIntakeToApplication({
+      callId: CALL_ROW_ID,
+      propertyId: PROPERTY_ID,
+      actorId: ACTOR_ID,
+    });
+
+    expect(result.applicationId).toBe(APP_ROW_ID);
+
+    // INSERT applications has the right shape — source/voice_call_id/submitted_by.
+    const insertCall = mockQuery.mock.calls.find((c) =>
+      String(c[0]).includes("INSERT INTO applications")
+    );
+    expect(insertCall).toBeDefined();
+    const sql = String(insertCall![0]);
+    expect(sql).toContain("source");
+    expect(sql).toContain("voice_call_id");
+    expect(sql).toContain("'voice'"); // source literal
+    const params = insertCall![1];
+    expect(params[0]).toBe(PROPERTY_ID);
+    expect(params[1]).toBe("Jane"); // firstName
+    expect(params[2]).toBe("Caller"); // lastName
+    expect(params[3]).toBe("+17025550123"); // phone normalized
+    expect(params[4]).toBe("Las Vegas");
+    expect(params[5]).toBe(3); // household
+    expect(params[6]).toBe(30000); // monthly * 12 ($2,500 × 12)
+    expect(params[7]).toBe(CALL_ROW_ID); // voice_call_id
+    expect(params[8]).toBe(ACTOR_ID); // submitted_by
+
+    // Back-reference UPDATE wires applicant_id back onto the call row.
+    const backRefCall = mockQuery.mock.calls.find((c) =>
+      String(c[0]).includes("UPDATE voice_intake_calls SET applicant_id")
+    );
+    expect(backRefCall).toBeDefined();
+    expect(backRefCall![1]).toEqual([APP_ROW_ID, CALL_ROW_ID]);
+
+    expect(mockStampTape).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "VOICE_INTAKE_DECISION",
+        actor: ACTOR_ID,
+        sessionId: CALL_ROW_ID,
+        payload: expect.objectContaining({
+          callId: CALL_ROW_ID,
+          applicationId: APP_ROW_ID,
+          decision: "approved",
+          propertyId: PROPERTY_ID,
+        }),
+      })
+    );
+
+    // SMS doc-upload handoff fired with normalized phone + apply link.
+    expect(mockSendMagicLinkSms).toHaveBeenCalledTimes(1);
+    const [phoneArg, linkArg] = mockSendMagicLinkSms.mock.calls[0];
+    expect(phoneArg).toBe("+17025550123");
+    expect(linkArg).toContain(`/apply/${APP_ROW_ID}/documents`);
+  });
+
+  it("throws with code ALREADY_PROMOTED when the call already has an applicant_id (idempotency guard)", async () => {
+    arrangeCallLookup({ applicantId: "prior-applicant-row" });
+
+    await expect(
+      promoteIntakeToApplication({
+        callId: CALL_ROW_ID,
+        propertyId: PROPERTY_ID,
+        actorId: ACTOR_ID,
+      })
+    ).rejects.toMatchObject({ code: "ALREADY_PROMOTED" });
+
+    // No INSERT happened — only the lookup query ran.
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+    expect(mockStampTape).not.toHaveBeenCalled();
+    expect(mockSendMagicLinkSms).not.toHaveBeenCalled();
+  });
+
+  it("throws a plain Error when the call row is missing", async () => {
+    arrangeCallLookup({ notFound: true });
+
+    await expect(
+      promoteIntakeToApplication({
+        callId: CALL_ROW_ID,
+        propertyId: PROPERTY_ID,
+        actorId: ACTOR_ID,
+      })
+    ).rejects.toThrow(/not found/i);
+  });
+
+  it("skips the SMS doc-upload handoff (no throw) when no phone was captured", async () => {
+    arrangeCallLookup({
+      data: { name: { value: "No Phone" } },
+    });
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: APP_ROW_ID }] });
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    const result = await promoteIntakeToApplication({
+      callId: CALL_ROW_ID,
+      propertyId: PROPERTY_ID,
+      actorId: ACTOR_ID,
+    });
+
+    expect(result.applicationId).toBe(APP_ROW_ID);
+    expect(mockSendMagicLinkSms).not.toHaveBeenCalled();
+  });
+
+  it("defaults to 'Unknown Caller' (first 'Unknown', last 'Caller') when no name was captured", async () => {
+    arrangeCallLookup({ data: {} });
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: APP_ROW_ID }] });
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    await promoteIntakeToApplication({
+      callId: CALL_ROW_ID,
+      propertyId: PROPERTY_ID,
+      actorId: ACTOR_ID,
+    });
+
+    const insertCall = mockQuery.mock.calls.find((c) =>
+      String(c[0]).includes("INSERT INTO applications")
+    )!;
+    expect(insertCall[1][1]).toBe("Unknown");
+    expect(insertCall[1][2]).toBe("Caller");
+  });
+
+  it("falls back to '—' lastName when the captured name has no space (single-token)", async () => {
+    arrangeCallLookup({
+      data: { name: { value: "Madonna" } },
+    });
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: APP_ROW_ID }] });
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    await promoteIntakeToApplication({
+      callId: CALL_ROW_ID,
+      propertyId: PROPERTY_ID,
+      actorId: ACTOR_ID,
+    });
+
+    const insertCall = mockQuery.mock.calls.find((c) =>
+      String(c[0]).includes("INSERT INTO applications")
+    )!;
+    expect(insertCall[1][1]).toBe("Madonna");
+    expect(insertCall[1][2]).toBe("—");
+  });
+
+  it("treats an international phone (E.164) as-is rather than prepending +1", async () => {
+    arrangeCallLookup({
+      data: {
+        name: { value: "Ana Inter" },
+        phone: { value: "+4520123456" },
+      },
+    });
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: APP_ROW_ID }] });
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    await promoteIntakeToApplication({
+      callId: CALL_ROW_ID,
+      propertyId: PROPERTY_ID,
+      actorId: ACTOR_ID,
+    });
+
+    const insertCall = mockQuery.mock.calls.find((c) =>
+      String(c[0]).includes("INSERT INTO applications")
+    )!;
+    expect(insertCall[1][3]).toBe("+4520123456");
+  });
+});
+
+// ── rejectIntake ───────────────────────────────────────────────────────────
+
+describe("rejectIntake", () => {
+  it("stamps VOICE_INTAKE_DECISION with decision='rejected' + reason and soft-drops the row from the callback queue", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    await rejectIntake({
+      callId: CALL_ROW_ID,
+      actorId: ACTOR_ID,
+      reason: "Not the unit they wanted — caller asked for 3BR, we only have 1BR/2BR.",
+    });
+
+    expect(mockStampTape).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "VOICE_INTAKE_DECISION",
+        actor: ACTOR_ID,
+        sessionId: CALL_ROW_ID,
+        payload: expect.objectContaining({
+          callId: CALL_ROW_ID,
+          decision: "rejected",
+          reason: expect.stringContaining("3BR"),
+        }),
+      })
+    );
+
+    // Soft-reject: callback_requested := FALSE on the voice_intake_calls row.
+    const updateCall = mockQuery.mock.calls.find((c) =>
+      String(c[0]).includes("UPDATE voice_intake_calls SET callback_requested = FALSE")
+    );
+    expect(updateCall).toBeDefined();
+    expect(updateCall![1]).toEqual([CALL_ROW_ID]);
+
+    // Tape stamp is fire-and-forget — let it settle to avoid flakiness.
+    await flush();
+  });
+});

--- a/src/__tests__/voice-intake-webhook.test.ts
+++ b/src/__tests__/voice-intake-webhook.test.ts
@@ -1,0 +1,285 @@
+/**
+ * Webhook tests for src/modules/voice-intake/webhook.ts.
+ *
+ * Signature path: we compute `HMAC-SHA256(secret, "<ts>.<rawBody>")` directly
+ * (mirrors ElevenLabs' signing scheme) and send it as `ElevenLabs-Signature:
+ * t=<ts>,v0=<hex>`. The router verifies against the same secret and either
+ * accepts or rejects.
+ *
+ * The DB layer is mocked end-to-end so the test is hermetic — we assert on
+ * the exact SQL we expect (alreadyProcessed lookup, persistConversation
+ * upsert, markProcessed insert) and on the tape stamp side-effect.
+ *
+ * Mount order: the webhook router installs its own `express.raw` body parser.
+ * The test app does NOT install `express.json()`, mirroring the production
+ * order in src/index.ts: webhook MUST sit before json().
+ */
+
+import express from "express";
+import request from "supertest";
+import crypto from "crypto";
+
+const SECRET = "wsec_test_fixture_12345";
+
+// ── Mocks (must be declared before module imports) ─────────────────────────
+
+const mockQuery = jest.fn();
+jest.mock("../config/database", () => ({
+  query: (...args: unknown[]) => mockQuery(...args),
+}));
+
+jest.mock("../utils/logger", () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+const mockStampTape = jest.fn().mockResolvedValue(null);
+jest.mock("../modules/tape", () => {
+  const real = jest.requireActual("../modules/tape");
+  return { ...real, stampTape: mockStampTape };
+});
+
+const mockSendMagicLinkSms = jest.fn();
+jest.mock("../modules/auth/magic-link-service", () => ({
+  sendMagicLinkSms: mockSendMagicLinkSms,
+}));
+
+// ── Import under test (must come after the mocks above) ───────────────────
+
+import webhookRouter, { __test } from "../modules/voice-intake/webhook";
+
+function buildApp(): express.Express {
+  const app = express();
+  app.use("/api/webhooks/elevenlabs/post-call", webhookRouter);
+  return app;
+}
+
+function signedBody(
+  payload: Record<string, unknown>,
+  opts?: { skewSecs?: number; tamper?: boolean; secret?: string }
+): { body: string; header: string; ts: number } {
+  const ts = Math.floor(Date.now() / 1000) + (opts?.skewSecs ?? 0);
+  const body = JSON.stringify(payload);
+  const secret = opts?.secret ?? SECRET;
+  const sig = crypto
+    .createHmac("sha256", secret)
+    .update(`${ts}.`)
+    .update(body, "utf8")
+    .digest("hex");
+  const finalSig = opts?.tamper ? sig.replace(/.$/, "0") : sig;
+  return { body, header: `t=${ts},v0=${finalSig}`, ts };
+}
+
+const PAYLOAD = {
+  type: "post_call_transcription",
+  event_timestamp: 1700000000,
+  data: {
+    conversation_id: "conv_TEST_123",
+    agent_id: "agent_8001ksp9ar8cf8ct2x70kacxr8qq",
+    status: "done",
+    metadata: {
+      start_time_unix_secs: 1700000000,
+      call_duration_secs: 120,
+      detected_language: "en",
+      cost: { llm_input_tokens: 1500 },
+    },
+    analysis: {
+      call_successful: "success",
+      evaluation_criteria_results: { name: { result: "success" } },
+      data_collection_results: {
+        name: { value: "Maria Garcia" },
+        phone: { value: "+17025551212" },
+        current_city: { value: "Las Vegas" },
+      },
+    },
+  },
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  process.env.VOICE_INTAKE_ENABLED = "true";
+  process.env.ELEVENLABS_WEBHOOK_SECRET = SECRET;
+});
+
+afterAll(() => {
+  delete process.env.VOICE_INTAKE_ENABLED;
+  delete process.env.ELEVENLABS_WEBHOOK_SECRET;
+});
+
+describe("voice-intake webhook", () => {
+  it("returns 503 when VOICE_INTAKE_ENABLED is off", async () => {
+    process.env.VOICE_INTAKE_ENABLED = "false";
+    const { body, header } = signedBody(PAYLOAD);
+    const res = await request(buildApp())
+      .post("/api/webhooks/elevenlabs/post-call")
+      .set("Content-Type", "application/json")
+      .set("ElevenLabs-Signature", header)
+      .send(body);
+    expect(res.status).toBe(503);
+  });
+
+  it("returns 503 when secret is sentinel", async () => {
+    process.env.ELEVENLABS_WEBHOOK_SECRET = "wsec_changeme";
+    const { body, header } = signedBody(PAYLOAD);
+    const res = await request(buildApp())
+      .post("/api/webhooks/elevenlabs/post-call")
+      .set("Content-Type", "application/json")
+      .set("ElevenLabs-Signature", header)
+      .send(body);
+    expect(res.status).toBe(503);
+  });
+
+  it("rejects tampered signature with 400", async () => {
+    const { body, header } = signedBody(PAYLOAD, { tamper: true });
+    const res = await request(buildApp())
+      .post("/api/webhooks/elevenlabs/post-call")
+      .set("Content-Type", "application/json")
+      .set("ElevenLabs-Signature", header)
+      .send(body);
+    expect(res.status).toBe(400);
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  it("rejects stale timestamp with 400 (replay window)", async () => {
+    const { body, header } = signedBody(PAYLOAD, { skewSecs: -60 * 60 });
+    const res = await request(buildApp())
+      .post("/api/webhooks/elevenlabs/post-call")
+      .set("Content-Type", "application/json")
+      .set("ElevenLabs-Signature", header)
+      .send(body);
+    expect(res.status).toBe(400);
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  it("rejects missing header with 400", async () => {
+    const res = await request(buildApp())
+      .post("/api/webhooks/elevenlabs/post-call")
+      .set("Content-Type", "application/json")
+      .send(JSON.stringify(PAYLOAD));
+    expect(res.status).toBe(400);
+  });
+
+  it("accepts a valid signed payload, persists call, stamps tape, returns 200", async () => {
+    mockQuery
+      // alreadyProcessed → no rows
+      .mockResolvedValueOnce({ rows: [] })
+      // persistConversation upsert → returns id
+      .mockResolvedValueOnce({ rows: [{ id: "11111111-1111-1111-1111-111111111111" }] })
+      // markProcessed
+      .mockResolvedValueOnce({ rows: [] });
+
+    const { body, header } = signedBody(PAYLOAD);
+    const res = await request(buildApp())
+      .post("/api/webhooks/elevenlabs/post-call")
+      .set("Content-Type", "application/json")
+      .set("ElevenLabs-Signature", header)
+      .send(body);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ received: true });
+
+    // L2 dedupe checked first.
+    const firstSql = mockQuery.mock.calls[0][0] as string;
+    expect(firstSql).toContain("FROM elevenlabs_processed_events");
+
+    // Upsert into voice_intake_calls fired with the conversation_id payload.
+    const upsertCall = mockQuery.mock.calls.find((c) =>
+      String(c[0]).includes("INSERT INTO voice_intake_calls")
+    );
+    expect(upsertCall).toBeDefined();
+    expect(upsertCall![1]).toEqual(
+      expect.arrayContaining(["conv_TEST_123", PAYLOAD.data.agent_id])
+    );
+
+    // markProcessed fired.
+    const markCall = mockQuery.mock.calls.find((c) =>
+      String(c[0]).includes("INSERT INTO elevenlabs_processed_events")
+    );
+    expect(markCall).toBeDefined();
+
+    // Compliance stamp fired with the right kind + conversation id.
+    expect(mockStampTape).toHaveBeenCalledTimes(1);
+    expect(mockStampTape.mock.calls[0][0]).toMatchObject({
+      kind: "VOICE_INTAKE_COMPLETED",
+      sessionId: "conv_TEST_123",
+    });
+  });
+
+  it("short-circuits a duplicate event with 200 and skips dispatch", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ exists: 1 }] }); // alreadyProcessed → hit
+
+    const { body, header } = signedBody(PAYLOAD);
+    const res = await request(buildApp())
+      .post("/api/webhooks/elevenlabs/post-call")
+      .set("Content-Type", "application/json")
+      .set("ElevenLabs-Signature", header)
+      .send(body);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ received: true, duplicate: true });
+    // Only the dedupe SELECT ran — no upsert, no markProcessed.
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+    expect(mockStampTape).not.toHaveBeenCalled();
+  });
+
+  it("parks failures in DLQ and still 200s ElevenLabs", async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [] }) // alreadyProcessed
+      .mockRejectedValueOnce(new Error("simulated upsert failure")) // persistConversation throws
+      // DLQ probe: not yet parked
+      .mockResolvedValueOnce({ rows: [] })
+      // DLQ row count under cap
+      .mockResolvedValueOnce({ rows: [{ count: 0 }] })
+      // DLQ insert
+      .mockResolvedValueOnce({ rows: [] });
+
+    const { body, header } = signedBody(PAYLOAD);
+    const res = await request(buildApp())
+      .post("/api/webhooks/elevenlabs/post-call")
+      .set("Content-Type", "application/json")
+      .set("ElevenLabs-Signature", header)
+      .send(body);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ received: true });
+
+    const dlqInsert = mockQuery.mock.calls.find((c) =>
+      String(c[0]).includes("INSERT INTO elevenlabs_webhook_dlq")
+    );
+    expect(dlqInsert).toBeDefined();
+    expect(dlqInsert![1][3]).toBe("simulated upsert failure");
+
+    // markProcessed must NOT fire on a dispatch failure — otherwise the next
+    // delivery would short-circuit and we'd silently drop the event.
+    const markCall = mockQuery.mock.calls.find((c) =>
+      String(c[0]).includes("INSERT INTO elevenlabs_processed_events")
+    );
+    expect(markCall).toBeUndefined();
+  });
+});
+
+describe("voice-intake signature helpers", () => {
+  it("parses a well-formed header", () => {
+    const out = __test.parseSignatureHeader("t=12345,v0=abc");
+    expect(out).toEqual({ timestamp: 12345, signatures: ["abc"] });
+  });
+
+  it("accepts multiple v0 signatures (rotation window)", () => {
+    const out = __test.parseSignatureHeader("t=12345,v0=aaa,v0=bbb");
+    expect(out?.signatures).toEqual(["aaa", "bbb"]);
+  });
+
+  it("rejects a header with no timestamp", () => {
+    expect(__test.parseSignatureHeader("v0=abc")).toBeNull();
+  });
+
+  it("rejects a header with no signature", () => {
+    expect(__test.parseSignatureHeader("t=12345")).toBeNull();
+  });
+
+  it("computes a stable HMAC for fixed inputs", () => {
+    const sig = __test.computeSignature("secret", 1, Buffer.from("hello"));
+    expect(sig).toBe(
+      crypto.createHmac("sha256", "secret").update("1.").update("hello").digest("hex")
+    );
+  });
+});

--- a/src/db/migrations/2026-05-27-voice-intake.sql
+++ b/src/db/migrations/2026-05-27-voice-intake.sql
@@ -1,0 +1,118 @@
+-- Voice intake (Phase 1 foundation)
+--
+-- Persists ElevenLabs Conv. AI post-call webhooks so a phone-only applicant
+-- becomes a real `applications` row, with the same compliance-tape ledger
+-- the web funnel uses. Schema mirrors the BP-08 payment webhook tables
+-- (stripe_processed_events / stripe_webhook_dlq) so the proven idempotency
+-- + DLQ pattern carries over verbatim — see src/modules/payment/webhook.ts.
+--
+-- Tables added:
+--   voice_intake_calls        — one row per Conv. AI conversation
+--   voice_intake_costs        — daily rollup of per-call cost telemetry
+--   elevenlabs_processed_events  — webhook event_id dedupe (3-layer idem L2)
+--   elevenlabs_webhook_dlq    — parked payloads when dispatch throws
+--
+-- Columns added to applications:
+--   source                    — entry path (web|voice|sms|operator)
+--   voice_call_id             — links back to voice_intake_calls.conversation_id
+--   consent_outbound_ai_calls — TCPA PEWC flag (gates Phase 2 outbound)
+
+BEGIN;
+
+-- 1) Enum: application_source
+-- CREATE TYPE has no IF NOT EXISTS; wrap so re-runs are no-ops.
+DO $$ BEGIN
+  CREATE TYPE application_source AS ENUM ('web', 'voice', 'sms', 'operator');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+-- 2) applications columns
+ALTER TABLE applications
+  ADD COLUMN IF NOT EXISTS source application_source NOT NULL DEFAULT 'web';
+ALTER TABLE applications
+  ADD COLUMN IF NOT EXISTS voice_call_id TEXT;
+ALTER TABLE applications
+  ADD COLUMN IF NOT EXISTS consent_outbound_ai_calls BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- 3) voice_intake_calls
+-- One row per ElevenLabs Conv. AI conversation. conversation_id is the
+-- natural key (ElevenLabs-issued, globally unique per-conversation), so we
+-- enforce it UNIQUE — the webhook handler uses it for L3 idempotency on the
+-- applicant-create transition, beyond the L2 event_id dedupe below.
+CREATE TABLE IF NOT EXISTS voice_intake_calls (
+  id                          UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  conversation_id             TEXT NOT NULL UNIQUE,
+  agent_id                    TEXT NOT NULL,
+  started_at                  TIMESTAMPTZ NOT NULL,
+  ended_at                    TIMESTAMPTZ,
+  language                    VARCHAR(8),         -- BCP-47 (en / es)
+  call_successful             VARCHAR(16),        -- success | failure | unknown
+  evaluation_criteria_results JSONB NOT NULL DEFAULT '{}'::jsonb,
+  data_collection_results     JSONB NOT NULL DEFAULT '{}'::jsonb,
+  transcript_url              TEXT,
+  audio_url                   TEXT,
+  cost_breakdown              JSONB NOT NULL DEFAULT '{}'::jsonb,
+  consent_recording           BOOLEAN NOT NULL DEFAULT TRUE,
+  callback_requested          BOOLEAN NOT NULL DEFAULT FALSE,
+  applicant_id                UUID REFERENCES applications(id) ON DELETE SET NULL,
+  raw_payload                 JSONB,              -- full webhook body, debug + replay
+  created_at                  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at                  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_voice_intake_calls_applicant
+  ON voice_intake_calls(applicant_id, started_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_voice_intake_calls_started
+  ON voice_intake_calls(started_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_voice_intake_calls_callback_pending
+  ON voice_intake_calls(started_at DESC)
+  WHERE callback_requested = TRUE;
+
+-- 4) voice_intake_costs (daily rollup)
+-- Aggregated by date so the dashboard / Slack-budget alert is one cheap SELECT.
+-- Per-call cost lives in voice_intake_calls.cost_breakdown for drill-down.
+CREATE TABLE IF NOT EXISTS voice_intake_costs (
+  date                DATE PRIMARY KEY,
+  call_count          INTEGER NOT NULL DEFAULT 0,
+  tts_chars           BIGINT  NOT NULL DEFAULT 0,
+  asr_seconds         BIGINT  NOT NULL DEFAULT 0,
+  llm_input_tokens    BIGINT  NOT NULL DEFAULT 0,
+  llm_output_tokens   BIGINT  NOT NULL DEFAULT 0,
+  convai_minutes      NUMERIC(12,2) NOT NULL DEFAULT 0,
+  cost_usd            NUMERIC(10,4) NOT NULL DEFAULT 0,
+  updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- 5) elevenlabs_processed_events (L2 idempotency — exact analog of stripe_processed_events)
+CREATE TABLE IF NOT EXISTS elevenlabs_processed_events (
+  event_id        TEXT PRIMARY KEY,
+  event_type      TEXT NOT NULL,
+  conversation_id TEXT,
+  processed_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_elevenlabs_processed_conv
+  ON elevenlabs_processed_events(conversation_id);
+
+-- 6) elevenlabs_webhook_dlq (exact analog of stripe_webhook_dlq)
+-- Soft-capped at 10k active rows in webhook.ts; this is a pressure-relief
+-- valve, not a hard limit. Always 200 to ElevenLabs (retries here are
+-- pointless — failures go here, not back to the wire).
+CREATE TABLE IF NOT EXISTS elevenlabs_webhook_dlq (
+  event_id        TEXT PRIMARY KEY,
+  event_type      TEXT NOT NULL,
+  raw_payload     JSONB NOT NULL,
+  error_message   TEXT NOT NULL,
+  attempt_count   INTEGER NOT NULL DEFAULT 1,
+  first_failed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  last_failed_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_elevenlabs_dlq_active
+  ON elevenlabs_webhook_dlq(last_failed_at DESC)
+  WHERE attempt_count < 5;
+
+COMMIT;

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -49,6 +49,17 @@ CREATE TYPE screening_result AS ENUM (
   'review_required'
 );
 
+-- Entry path for an application. 'web' is the historical default; 'voice'
+-- means ElevenLabs Conv. AI intake (voice_intake_calls join on
+-- applications.voice_call_id), 'sms' for SMS-funnel applicants, 'operator'
+-- for rows created by PM staff.
+CREATE TYPE application_source AS ENUM (
+  'web',
+  'voice',
+  'sms',
+  'operator'
+);
+
 CREATE TYPE payment_method AS ENUM (
   'ach',
   'credit_card',
@@ -429,6 +440,15 @@ CREATE TABLE applications (
   -- Unit claim (soft reservation while applicant completes the application)
   claimed_unit_id UUID,
   claim_expires_at TIMESTAMPTZ,
+
+  -- Voice intake (Phase 1 foundation). The source column records the entry path;
+  -- voice_call_id links back to voice_intake_calls.conversation_id when
+  -- the applicant came in over the phone. consent_outbound_ai_calls is a
+  -- TCPA PEWC gate for outbound AI calls (Phase 2 — outbound endpoint
+  -- refuses when false).
+  source application_source NOT NULL DEFAULT 'web',
+  voice_call_id TEXT,
+  consent_outbound_ai_calls BOOLEAN NOT NULL DEFAULT FALSE,
 
   -- Metadata
   created_at TIMESTAMPTZ DEFAULT NOW(),
@@ -1157,6 +1177,83 @@ CREATE TABLE IF NOT EXISTS stripe_webhook_dlq (
   last_failed_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
+-- ============================================================
+-- Voice intake — ElevenLabs Conv. AI post-call persistence
+-- See src/modules/voice-intake/webhook.ts and
+-- src/db/migrations/2026-05-27-voice-intake.sql for the rationale.
+-- Mirrors the BP-08 Stripe webhook idempotency + DLQ pattern.
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS voice_intake_calls (
+  id                          UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  conversation_id             TEXT NOT NULL UNIQUE,
+  agent_id                    TEXT NOT NULL,
+  started_at                  TIMESTAMPTZ NOT NULL,
+  ended_at                    TIMESTAMPTZ,
+  language                    VARCHAR(8),
+  call_successful             VARCHAR(16),
+  evaluation_criteria_results JSONB NOT NULL DEFAULT '{}'::jsonb,
+  data_collection_results     JSONB NOT NULL DEFAULT '{}'::jsonb,
+  transcript_url              TEXT,
+  audio_url                   TEXT,
+  cost_breakdown              JSONB NOT NULL DEFAULT '{}'::jsonb,
+  consent_recording           BOOLEAN NOT NULL DEFAULT TRUE,
+  callback_requested          BOOLEAN NOT NULL DEFAULT FALSE,
+  applicant_id                UUID REFERENCES applications(id) ON DELETE SET NULL,
+  raw_payload                 JSONB,
+  created_at                  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at                  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_voice_intake_calls_applicant
+  ON voice_intake_calls(applicant_id, started_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_voice_intake_calls_started
+  ON voice_intake_calls(started_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_voice_intake_calls_callback_pending
+  ON voice_intake_calls(started_at DESC)
+  WHERE callback_requested = TRUE;
+
+-- Daily rollup of cost telemetry. Per-call detail stays in
+-- voice_intake_calls.cost_breakdown for drill-down; this table powers the
+-- Slack budget alert and the Mission Control dashboard with a single SELECT.
+CREATE TABLE IF NOT EXISTS voice_intake_costs (
+  date              DATE PRIMARY KEY,
+  call_count        INTEGER NOT NULL DEFAULT 0,
+  tts_chars         BIGINT  NOT NULL DEFAULT 0,
+  asr_seconds       BIGINT  NOT NULL DEFAULT 0,
+  llm_input_tokens  BIGINT  NOT NULL DEFAULT 0,
+  llm_output_tokens BIGINT  NOT NULL DEFAULT 0,
+  convai_minutes    NUMERIC(12,2) NOT NULL DEFAULT 0,
+  cost_usd          NUMERIC(10,4) NOT NULL DEFAULT 0,
+  updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS elevenlabs_processed_events (
+  event_id        TEXT PRIMARY KEY,
+  event_type      TEXT NOT NULL,
+  conversation_id TEXT,
+  processed_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_elevenlabs_processed_conv
+  ON elevenlabs_processed_events(conversation_id);
+
+CREATE TABLE IF NOT EXISTS elevenlabs_webhook_dlq (
+  event_id        TEXT PRIMARY KEY,
+  event_type      TEXT NOT NULL,
+  raw_payload     JSONB NOT NULL,
+  error_message   TEXT NOT NULL,
+  attempt_count   INTEGER NOT NULL DEFAULT 1,
+  first_failed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  last_failed_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_elevenlabs_dlq_active
+  ON elevenlabs_webhook_dlq(last_failed_at DESC)
+  WHERE attempt_count < 5;
+
 -- Lease e-signature (native). One tenant signature row per application; the
 -- executed PDF + a sha256 hash give tamper-evidence, and the compliance tape
 -- (LEASE_EXECUTED stamp) is the legally-meaningful audit record. ESIGN/UETA:
@@ -1273,6 +1370,7 @@ DROP TYPE IF EXISTS modification_type CASCADE;
 DROP TYPE IF EXISTS fraud_flag_type CASCADE;
 DROP TYPE IF EXISTS audit_action CASCADE;
 DROP TYPE IF EXISTS payment_method CASCADE;
+DROP TYPE IF EXISTS application_source CASCADE;
 DROP TYPE IF EXISTS screening_result CASCADE;
 DROP TYPE IF EXISTS application_status CASCADE;
 DROP TYPE IF EXISTS user_role CASCADE;

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import approvalRoutes from "./modules/approval/routes";
 import paymentRoutes from "./modules/payment/routes";
 import paymentWebhookRouter from "./modules/payment/webhook";
 import { assertStripeProdConfig } from "./modules/payment/boot-guard";
+import { voiceIntakeWebhookRouter, voiceIntakeRoutes } from "./modules/voice-intake";
 import decisionMatrixRoutes from "./modules/decision-matrix/routes";
 import leaseRoutes from "./modules/lease/routes";
 import adverseActionRoutes from "./modules/adverse-action/routes";
@@ -88,6 +89,14 @@ app.use(cors({ origin: corsOrigins, credentials: true }));
 // parser consumes the buffer and we lose the bytes the HMAC was computed
 // over. Do not reorder.
 app.use("/api/payments/webhook", paymentWebhookRouter);
+
+// Voice intake (ElevenLabs Conv. AI) webhook — same raw-body constraint as
+// the Stripe receiver above. The router itself flag-gates on
+// VOICE_INTAKE_ENABLED so it can sit in the chain even when the feature is
+// off; mounting unconditionally keeps the request path stable across
+// environments (otherwise webhook delivery during a config flip would 404
+// and ElevenLabs would auto-disable us after 10 consecutive failures).
+app.use("/api/webhooks/elevenlabs/post-call", voiceIntakeWebhookRouter);
 
 app.use(express.json({ limit: "1mb" }));
 
@@ -246,6 +255,15 @@ app.use("/api/properties", propertyRoutes);
 
 // QAP acquisitions — Demand-Evidence Engine (asset_manager+ / acquisition:view)
 app.use("/api/acquisitions", acquisitionRoutes);
+
+// Voice intake PM console (flag-gated to avoid surfacing unstamped review
+// surface area when the feature is off in an environment).
+if (process.env.VOICE_INTAKE_ENABLED === "true") {
+  app.use("/api/pm/voice-intakes", voiceIntakeRoutes);
+  logger.info("Voice intake PM routes mounted");
+} else {
+  logger.info("Voice intake PM routes skipped — VOICE_INTAKE_ENABLED is off");
+}
 
 // Compliance reports (Fair Housing Act — audit:view / Regional Manager+)
 app.use("/api/compliance", complianceRoutes);

--- a/src/middleware/rbac.ts
+++ b/src/middleware/rbac.ts
@@ -90,6 +90,12 @@ const PERMISSIONS: Record<string, string[]> = {
   // project scoring, award). Asset managers and admins only.
   "acquisition:view": ["asset_manager", "system_admin"],
   "acquisition:manage": ["asset_manager", "system_admin"],
+
+  // Voice intake review (ElevenLabs Conv. AI post-call). View is open to
+  // leasing agents (they can triage callback queue); approve/reject gates the
+  // promotion of an intake into an `applications` row, so it's senior+ only.
+  "voice_intake:view": ["leasing_agent", "senior_manager", "regional_manager", "asset_manager", "system_admin"],
+  "voice_intake:approve": ["senior_manager", "regional_manager", "asset_manager", "system_admin"],
 };
 
 export function requireRole(...roles: string[]) {

--- a/src/modules/tape/index.ts
+++ b/src/modules/tape/index.ts
@@ -37,6 +37,14 @@ export const TAPE_STAMP_KINDS = {
   BP08_PAYMENT_REPLAY_BLOCKED: "bp08.payment_replay_blocked",
   BP08_PAYMENT_REFUND_REQUESTED: "bp08.payment_refund_requested",
   BP08_PAYMENT_REFUNDED: "bp08.payment_refunded",
+  // Voice intake — HUD fair-housing audit trail anchors. Every completed
+  // ElevenLabs Conv. AI intake stamps VOICE_INTAKE_COMPLETED; every Frank
+  // decision (skipped item, escalation, hangup, language) stamps
+  // VOICE_INTAKE_DECISION; every outbound AI call attempt stamps
+  // VOICE_INTAKE_OUTBOUND_ATTEMPTED with the consent record id (TCPA PEWC).
+  VOICE_INTAKE_COMPLETED: "voice_intake.completed",
+  VOICE_INTAKE_DECISION: "voice_intake.decision",
+  VOICE_INTAKE_OUTBOUND_ATTEMPTED: "voice_intake.outbound_attempted",
 } as const;
 
 export type TapeStampKind = keyof typeof TAPE_STAMP_KINDS;
@@ -56,6 +64,12 @@ export const TAPE_CITATIONS: Record<TapeStampKind, string> = {
   BP08_PAYMENT_REPLAY_BLOCKED: "HUD 4350.3 Ch. 4-6",
   BP08_PAYMENT_REFUND_REQUESTED: "HUD 4350.3 Ch. 4-6",
   BP08_PAYMENT_REFUNDED: "HUD 4350.3 Ch. 4-6",
+  // HUD 4350.3 Ch. 4-6 governs waiting-list application capture; FCC AI
+  // disclosure + Nevada NRS 200.620 two-party consent share the same audit
+  // anchor for the voice-channel intake.
+  VOICE_INTAKE_COMPLETED: "HUD 4350.3 Ch. 4-6 / NRS 200.620",
+  VOICE_INTAKE_DECISION: "HUD 4350.3 Ch. 4-6",
+  VOICE_INTAKE_OUTBOUND_ATTEMPTED: "TCPA 47 CFR §64.1200(a)(2)",
 };
 
 export interface TapeStampInput {

--- a/src/modules/voice-intake/index.ts
+++ b/src/modules/voice-intake/index.ts
@@ -1,0 +1,11 @@
+export { default as voiceIntakeWebhookRouter } from "./webhook";
+export { default as voiceIntakeRoutes } from "./routes";
+export {
+  persistConversation,
+  promoteIntakeToApplication,
+  rejectIntake,
+  type PostCallPayload,
+  type PersistResult,
+  type ApproveOptions,
+  type RejectOptions,
+} from "./service";

--- a/src/modules/voice-intake/routes.ts
+++ b/src/modules/voice-intake/routes.ts
@@ -1,0 +1,200 @@
+import { Router, Response } from "express";
+import { z } from "zod";
+import { authenticate, AuthRequest } from "../../middleware/auth";
+import { requirePermission } from "../../middleware/rbac";
+import { query } from "../../config/database";
+import { logger } from "../../utils/logger";
+import { param } from "../../utils/params";
+import { promoteIntakeToApplication, rejectIntake } from "./service";
+
+/**
+ * PM-console routes for voice intakes.
+ *
+ * Mount path: /api/pm/voice-intakes
+ * All routes require authentication; list/detail are open to leasing agents
+ * (so they can triage the callback queue), approve/reject is senior+ only.
+ *
+ * No raw-body concerns here — these endpoints are mounted AFTER the global
+ * express.json(); the webhook is a separate router with its own raw mount.
+ */
+
+const router = Router();
+
+const listQuerySchema = z.object({
+  status: z.enum(["all", "pending", "approved", "rejected", "callback"]).default("pending"),
+  language: z.string().optional(),
+  limit: z.coerce.number().int().min(1).max(200).default(50),
+  offset: z.coerce.number().int().min(0).default(0),
+});
+
+router.get(
+  "/",
+  authenticate,
+  requirePermission("voice_intake:view"),
+  async (req: AuthRequest, res: Response): Promise<void> => {
+    const parsed = listQuerySchema.safeParse(req.query);
+    if (!parsed.success) {
+      res.status(400).json({ error: "Invalid query", details: parsed.error.format() });
+      return;
+    }
+    const { status, language, limit, offset } = parsed.data;
+
+    const where: string[] = [];
+    const params: unknown[] = [];
+    if (status === "pending") {
+      where.push(`applicant_id IS NULL AND callback_requested = FALSE`);
+    } else if (status === "approved") {
+      where.push(`applicant_id IS NOT NULL`);
+    } else if (status === "rejected") {
+      // No explicit rejected_at yet — surface rows the PM has decisioned away
+      // (no applicant, no pending callback) via call_successful='failure'.
+      where.push(`applicant_id IS NULL AND callback_requested = FALSE AND call_successful = 'failure'`);
+    } else if (status === "callback") {
+      where.push(`callback_requested = TRUE`);
+    }
+    if (language) {
+      params.push(language);
+      where.push(`language = $${params.length}`);
+    }
+
+    const whereSql = where.length ? `WHERE ${where.join(" AND ")}` : "";
+    params.push(limit, offset);
+    const limitIdx = params.length - 1;
+    const offsetIdx = params.length;
+
+    try {
+      const rows = await query(
+        `SELECT id, conversation_id, agent_id, started_at, ended_at, language,
+                call_successful, consent_recording, callback_requested,
+                applicant_id,
+                data_collection_results->'name'->>'value' AS name,
+                data_collection_results->'phone'->>'value' AS phone,
+                data_collection_results->'current_city'->>'value' AS current_city
+           FROM voice_intake_calls
+           ${whereSql}
+           ORDER BY started_at DESC
+           LIMIT $${limitIdx} OFFSET $${offsetIdx}`,
+        params
+      );
+      const totalRes = await query(
+        `SELECT COUNT(*)::int AS total FROM voice_intake_calls ${whereSql}`,
+        params.slice(0, params.length - 2)
+      );
+      res.json({ calls: rows.rows, total: Number(totalRes.rows[0]?.total ?? 0) });
+    } catch (err) {
+      logger.error("voice-intake list failed", { error: (err as Error).message });
+      res.status(500).json({ error: "Failed to list voice intakes" });
+    }
+  }
+);
+
+router.get(
+  "/:id",
+  authenticate,
+  requirePermission("voice_intake:view"),
+  async (req: AuthRequest, res: Response): Promise<void> => {
+    try {
+      const id = param(req.params.id);
+      const result = await query(
+        `SELECT id, conversation_id, agent_id, started_at, ended_at, language,
+                call_successful, evaluation_criteria_results, data_collection_results,
+                transcript_url, audio_url, cost_breakdown,
+                consent_recording, callback_requested,
+                applicant_id, raw_payload, created_at, updated_at
+           FROM voice_intake_calls WHERE id = $1`,
+        [id]
+      );
+      const row = result.rows[0];
+      if (!row) {
+        res.status(404).json({ error: "Not found" });
+        return;
+      }
+      res.json(row);
+    } catch (err) {
+      logger.error("voice-intake detail failed", { error: (err as Error).message });
+      res.status(500).json({ error: "Failed to load voice intake" });
+    }
+  }
+);
+
+const approveSchema = z.object({
+  propertyId: z.string().uuid(),
+});
+
+router.post(
+  "/:id/approve",
+  authenticate,
+  requirePermission("voice_intake:approve"),
+  async (req: AuthRequest, res: Response): Promise<void> => {
+    const parsed = approveSchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({ error: "Invalid body", details: parsed.error.format() });
+      return;
+    }
+    try {
+      const { applicationId } = await promoteIntakeToApplication({
+        callId: param(req.params.id),
+        propertyId: parsed.data.propertyId,
+        actorId: req.user!.id,
+      });
+      res.json({ applicationId });
+    } catch (err) {
+      const e = err as Error & { code?: string };
+      if (e.code === "ALREADY_PROMOTED") {
+        res.status(409).json({ error: "Voice intake already promoted to application" });
+        return;
+      }
+      logger.error("voice-intake approve failed", { error: e.message });
+      res.status(500).json({ error: "Failed to approve voice intake" });
+    }
+  }
+);
+
+const rejectSchema = z.object({
+  reason: z.string().min(3).max(500),
+});
+
+router.post(
+  "/:id/reject",
+  authenticate,
+  requirePermission("voice_intake:approve"),
+  async (req: AuthRequest, res: Response): Promise<void> => {
+    const parsed = rejectSchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({ error: "Invalid body", details: parsed.error.format() });
+      return;
+    }
+    try {
+      await rejectIntake({
+        callId: param(req.params.id),
+        actorId: req.user!.id,
+        reason: parsed.data.reason,
+      });
+      res.json({ ok: true });
+    } catch (err) {
+      logger.error("voice-intake reject failed", { error: (err as Error).message });
+      res.status(500).json({ error: "Failed to reject voice intake" });
+    }
+  }
+);
+
+router.post(
+  "/:id/callback",
+  authenticate,
+  requirePermission("voice_intake:view"),
+  async (req: AuthRequest, res: Response): Promise<void> => {
+    try {
+      const id = param(req.params.id);
+      await query(
+        `UPDATE voice_intake_calls SET callback_requested = TRUE, updated_at = NOW() WHERE id = $1`,
+        [id]
+      );
+      res.json({ ok: true });
+    } catch (err) {
+      logger.error("voice-intake callback toggle failed", { error: (err as Error).message });
+      res.status(500).json({ error: "Failed to flag callback" });
+    }
+  }
+);
+
+export default router;

--- a/src/modules/voice-intake/service.ts
+++ b/src/modules/voice-intake/service.ts
@@ -1,0 +1,331 @@
+import { query } from "../../config/database";
+import { logger } from "../../utils/logger";
+import { stampTape } from "../tape";
+import { sendMagicLinkSms } from "../auth/magic-link-service";
+
+/**
+ * Shape of the `data` payload ElevenLabs sends on `post_call_*` webhooks.
+ * Only the fields we actually persist are typed; the rest is preserved in
+ * `raw_payload` for forensic replay.
+ *
+ * Reference: ElevenLabs Conv. AI post-call webhook v1 (see e2e harness at
+ * ~/elevenlabs-training/frank-onboarder/e2e/ for the live agent shape).
+ */
+export interface PostCallPayload {
+  conversation_id: string;
+  agent_id: string;
+  status?: string;
+  transcript?: Array<{
+    role: "agent" | "user";
+    message?: string;
+    time_in_call_secs?: number;
+  }>;
+  metadata?: {
+    start_time_unix_secs?: number;
+    call_duration_secs?: number;
+    cost?: Record<string, unknown>;
+    main_language?: string;
+    detected_language?: string;
+  };
+  analysis?: {
+    call_successful?: string;
+    evaluation_criteria_results?: Record<string, unknown>;
+    data_collection_results?: Record<string, unknown>;
+  };
+  // ElevenLabs hosts the audio + transcript behind URLs that require API-key
+  // auth — we never serve these directly to the browser, the PM console
+  // proxies through our `/audio` endpoint with RBAC. Optional because not
+  // every event type carries them.
+  transcript_url?: string;
+  audio_url?: string;
+}
+
+export interface PersistResult {
+  callId: string;
+  language: string | null;
+  callSuccessful: string | null;
+  consentRecording: boolean;
+  callbackRequested: boolean;
+}
+
+/**
+ * Extract the `value` from a data_collection_results entry. ElevenLabs
+ * shapes each entry as `{ value, rationale, json_schema, ... }`. Returns
+ * null if missing or non-string.
+ */
+function pickField(
+  results: Record<string, unknown> | undefined,
+  key: string
+): string | null {
+  if (!results) return null;
+  const entry = results[key];
+  if (!entry || typeof entry !== "object") return null;
+  const value = (entry as { value?: unknown }).value;
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+/**
+ * Best-effort consent flag — Frank's tool `record_consent_decision` writes
+ * `{value: 'true'}` (or `false`). Default TRUE if the caller never opted
+ * out (matches the implied-consent path of "stayed on the call past the
+ * disclosure"). Phase 4 will tighten this with the explicit system-tool
+ * gate.
+ */
+function readConsentFlag(results: Record<string, unknown> | undefined): boolean {
+  const raw = pickField(results, "consent_recording");
+  if (raw == null) return true;
+  return /^(true|yes|1|y)$/i.test(raw);
+}
+
+function readCallbackFlag(results: Record<string, unknown> | undefined): boolean {
+  const raw = pickField(results, "callback_requested");
+  if (raw == null) return false;
+  return /^(true|yes|1|y)$/i.test(raw);
+}
+
+/**
+ * Upsert one row in `voice_intake_calls`. UNIQUE(conversation_id) lets the
+ * same call be re-delivered as `post_call_transcription` then
+ * `post_call_audio` and converge to a single record — newer non-null fields
+ * win, older fields are preserved on the second pass.
+ */
+export async function persistConversation(payload: PostCallPayload): Promise<PersistResult> {
+  const analysis = payload.analysis ?? {};
+  const metadata = payload.metadata ?? {};
+  const dataResults = analysis.data_collection_results;
+
+  const language =
+    metadata.detected_language?.slice(0, 8) ?? metadata.main_language?.slice(0, 8) ?? null;
+  const callSuccessful = (analysis.call_successful ?? "").slice(0, 16) || null;
+
+  const startedAt = metadata.start_time_unix_secs
+    ? new Date(metadata.start_time_unix_secs * 1000)
+    : new Date();
+  const endedAt =
+    metadata.start_time_unix_secs && metadata.call_duration_secs
+      ? new Date((metadata.start_time_unix_secs + metadata.call_duration_secs) * 1000)
+      : null;
+
+  const consentRecording = readConsentFlag(dataResults);
+  const callbackRequested = readCallbackFlag(dataResults);
+
+  const result = await query(
+    `INSERT INTO voice_intake_calls (
+       conversation_id, agent_id, started_at, ended_at, language, call_successful,
+       evaluation_criteria_results, data_collection_results,
+       transcript_url, audio_url, cost_breakdown,
+       consent_recording, callback_requested, raw_payload
+     )
+     VALUES ($1, $2, $3, $4, $5, $6,
+             $7::jsonb, $8::jsonb,
+             $9, $10, $11::jsonb,
+             $12, $13, $14::jsonb)
+     ON CONFLICT (conversation_id) DO UPDATE SET
+       ended_at = COALESCE(EXCLUDED.ended_at, voice_intake_calls.ended_at),
+       language = COALESCE(EXCLUDED.language, voice_intake_calls.language),
+       call_successful = COALESCE(EXCLUDED.call_successful, voice_intake_calls.call_successful),
+       evaluation_criteria_results =
+         CASE WHEN EXCLUDED.evaluation_criteria_results = '{}'::jsonb
+              THEN voice_intake_calls.evaluation_criteria_results
+              ELSE EXCLUDED.evaluation_criteria_results END,
+       data_collection_results =
+         CASE WHEN EXCLUDED.data_collection_results = '{}'::jsonb
+              THEN voice_intake_calls.data_collection_results
+              ELSE EXCLUDED.data_collection_results END,
+       transcript_url = COALESCE(EXCLUDED.transcript_url, voice_intake_calls.transcript_url),
+       audio_url = COALESCE(EXCLUDED.audio_url, voice_intake_calls.audio_url),
+       cost_breakdown =
+         CASE WHEN EXCLUDED.cost_breakdown = '{}'::jsonb
+              THEN voice_intake_calls.cost_breakdown
+              ELSE EXCLUDED.cost_breakdown END,
+       consent_recording = EXCLUDED.consent_recording,
+       callback_requested = EXCLUDED.callback_requested,
+       raw_payload = EXCLUDED.raw_payload,
+       updated_at = NOW()
+     RETURNING id`,
+    [
+      payload.conversation_id,
+      payload.agent_id,
+      startedAt,
+      endedAt,
+      language,
+      callSuccessful,
+      JSON.stringify(analysis.evaluation_criteria_results ?? {}),
+      JSON.stringify(dataResults ?? {}),
+      payload.transcript_url ?? null,
+      payload.audio_url ?? null,
+      JSON.stringify(metadata.cost ?? {}),
+      consentRecording,
+      callbackRequested,
+      JSON.stringify(payload),
+    ]
+  );
+
+  const callId = result.rows[0]?.id as string;
+  return { callId, language, callSuccessful, consentRecording, callbackRequested };
+}
+
+/**
+ * Normalize a phone string to a loose E.164 shape (`+<digits>`).
+ *
+ * Rules:
+ *   - Leading `+` in the input is honored — caller explicitly typed a country
+ *     code, so we keep their digits as-is. Stripping then re-adding `+`
+ *     mis-prefixed 10-digit international numbers (eg `+4520123456`) with
+ *     a bogus `+1`.
+ *   - No leading `+`: strip non-digits. 10 digits → assume US (+1); anything
+ *     else → prepend `+` to the digits we have.
+ *
+ * Deliberately permissive — validation/canonicalization (eg libphonenumber)
+ * happens at the downstream approve step. The column is `VARCHAR(20)`, so
+ * the looseness is tolerated.
+ */
+function normalizePhone(raw: string | null): string | null {
+  if (!raw) return null;
+  const trimmed = raw.trim();
+  if (trimmed.startsWith("+")) {
+    const digits = trimmed.slice(1).replace(/\D/g, "");
+    return digits ? `+${digits}` : null;
+  }
+  const digits = trimmed.replace(/\D/g, "");
+  if (digits.length === 0) return null;
+  if (digits.length === 10) return `+1${digits}`;
+  return `+${digits}`;
+}
+
+export interface ApproveOptions {
+  callId: string;
+  propertyId: string;
+  actorId: string;
+}
+
+/**
+ * Promote a reviewed voice intake into an `applications` row.
+ *
+ * Called from the PM console Approve action — never from the webhook,
+ * because `applications.property_id` is NOT NULL and the caller has not
+ * picked a property yet at intake time. The Approve route supplies the
+ * property the PM selected from the property picker.
+ *
+ * Side effects (all idempotent on call_id):
+ *   - INSERT applications row with source='voice', voice_call_id set
+ *   - UPDATE voice_intake_calls.applicant_id back-reference
+ *   - STAMP VOICE_INTAKE_DECISION (HUD 4350.3 Ch. 4-6 audit anchor)
+ *   - SMS magic-link to the phone-of-record (doc-upload handoff)
+ *
+ * Throws if the call has already been promoted (idempotency guard via the
+ * back-reference); callers should treat "already promoted" as a 409.
+ */
+export async function promoteIntakeToApplication(
+  opts: ApproveOptions
+): Promise<{ applicationId: string }> {
+  const callRes = await query(
+    `SELECT data_collection_results, applicant_id
+       FROM voice_intake_calls WHERE id = $1`,
+    [opts.callId]
+  );
+  const call = callRes.rows[0];
+  if (!call) throw new Error("voice intake call not found");
+  if (call.applicant_id) {
+    throw Object.assign(new Error("already promoted"), { code: "ALREADY_PROMOTED" });
+  }
+
+  const data = (call.data_collection_results ?? {}) as Record<string, unknown>;
+  const name = pickField(data, "name") ?? "Unknown Caller";
+  const [firstName, ...rest] = name.split(/\s+/);
+  const lastName = rest.join(" ") || "—";
+  const phone = normalizePhone(pickField(data, "phone"));
+  const currentCity = pickField(data, "current_city");
+
+  // Household + income are captured but stored verbatim — we don't do any AMI
+  // math here (Frank's prompt forbids it). The PM does the eligibility math.
+  const householdRaw = pickField(data, "household");
+  const householdSize = householdRaw ? parseInt(householdRaw, 10) || null : null;
+  const incomeRaw = pickField(data, "monthly_income");
+  const monthlyIncome = incomeRaw ? Number(incomeRaw.replace(/[^0-9.]/g, "")) : null;
+  const annualIncome = monthlyIncome ? monthlyIncome * 12 : null;
+
+  const inserted = await query(
+    `INSERT INTO applications (
+       property_id, first_name, last_name, phone, current_city,
+       household_size, annual_income, status,
+       source, voice_call_id, submitted_by
+     )
+     VALUES ($1, $2, $3, $4, $5, $6, $7, 'draft', 'voice', $8, $9)
+     RETURNING id`,
+    [
+      opts.propertyId,
+      firstName ?? "Unknown",
+      lastName,
+      phone,
+      currentCity,
+      householdSize,
+      annualIncome,
+      opts.callId,
+      opts.actorId,
+    ]
+  );
+  const applicationId = inserted.rows[0].id as string;
+
+  await query(
+    `UPDATE voice_intake_calls SET applicant_id = $1, updated_at = NOW() WHERE id = $2`,
+    [applicationId, opts.callId]
+  );
+
+  void stampTape({
+    kind: "VOICE_INTAKE_DECISION",
+    actor: opts.actorId,
+    sessionId: opts.callId,
+    payload: {
+      callId: opts.callId,
+      applicationId,
+      decision: "approved",
+      propertyId: opts.propertyId,
+      phone,
+      currentCity,
+      householdSize,
+    },
+  });
+
+  // Doc-upload handoff via SMS — reuses the magic-link transport so the same
+  // 15-min TTL / Twilio path applies. Fire-and-forget per the existing
+  // magic-link-service contract; failures are logged, not surfaced.
+  if (phone) {
+    sendMagicLinkSms(phone, buildDocUploadLink(applicationId));
+  } else {
+    logger.warn("voice intake approve — no phone on record, doc-upload SMS skipped", {
+      callId: opts.callId,
+      applicationId,
+    });
+  }
+
+  return { applicationId };
+}
+
+function buildDocUploadLink(applicationId: string): string {
+  const base = process.env.TENANT_PORTAL_URL || "http://localhost:5174";
+  return `${base}/apply/${applicationId}/documents`;
+}
+
+export interface RejectOptions {
+  callId: string;
+  actorId: string;
+  reason: string;
+}
+
+export async function rejectIntake(opts: RejectOptions): Promise<void> {
+  void stampTape({
+    kind: "VOICE_INTAKE_DECISION",
+    actor: opts.actorId,
+    sessionId: opts.callId,
+    payload: { callId: opts.callId, decision: "rejected", reason: opts.reason },
+  });
+
+  // Soft-reject: keep the row for audit, mark callback_requested=false so it
+  // drops out of the queue. A future schema iteration could add an explicit
+  // `rejected_at`; for now the tape stamp is the source of truth.
+  await query(
+    `UPDATE voice_intake_calls SET callback_requested = FALSE, updated_at = NOW() WHERE id = $1`,
+    [opts.callId]
+  );
+}

--- a/src/modules/voice-intake/webhook.ts
+++ b/src/modules/voice-intake/webhook.ts
@@ -1,0 +1,331 @@
+import { Router, Request, Response } from "express";
+import express from "express";
+import crypto from "crypto";
+import { query } from "../../config/database";
+import { logger } from "../../utils/logger";
+import { stampTape } from "../tape";
+import { persistConversation, type PostCallPayload } from "./service";
+
+/**
+ * ElevenLabs Conv. AI post-call webhook receiver.
+ *
+ * SECURITY-CRITICAL: this router MUST be mounted BEFORE `express.json()` in
+ * src/index.ts. ElevenLabs computes its HMAC over the raw bytes of the
+ * request body (with a leading `<timestamp>.` prefix); any JSON parsing in
+ * the chain before us mutates the buffer and breaks signature verification.
+ * We mount `express.raw({ type: 'application/json' })` here so the rest of
+ * the app keeps its JSON-parsed `req.body` everywhere else.
+ *
+ * Three layers of idempotency stack here (mirrors the BP-08 Stripe pattern):
+ *
+ *   1. Timestamp-tolerance check on the signature header — old/replayed
+ *      payloads are rejected at the door (30-minute window).
+ *
+ *   2. `elevenlabs_processed_events` table — ElevenLabs may retry the same
+ *      delivery on timeout; the second arrival short-circuits with a 200.
+ *
+ *   3. `voice_intake_calls.conversation_id` UNIQUE — even if the same call
+ *      is delivered under two distinct event ids (eg `post_call_transcription`
+ *      then `post_call_audio`), the ON CONFLICT update keeps a single row.
+ *
+ * Error handling: any throw during dispatch parks the raw payload in
+ * `elevenlabs_webhook_dlq` and returns 200. We NEVER 5xx ElevenLabs — they'd
+ * just retry the same broken event forever and we'd hit their auto-disable
+ * threshold (10 consecutive failures over 7 days).
+ */
+
+// 30-minute tolerance for the signed `t=` timestamp. Matches Stripe's default
+// and gives ElevenLabs plenty of room for delivery retries while still
+// shutting the door on the obvious replay window.
+const SIGNATURE_TIMESTAMP_TOLERANCE_SECS = 30 * 60;
+
+// Soft cap on the still-actionable DLQ rows. ElevenLabs will never make us
+// 5xx, so a buggy handler under sustained traffic could otherwise grow this
+// table without bound. Once the un-exhausted backlog (attempt_count < 5)
+// hits the cap we stop inserting NEW rows; existing rows still get their
+// attempt_count bumped on retry (ON CONFLICT path), so we never lose track of
+// an event we've already parked. Pressure-relief valve, not a hard limit.
+const DLQ_ACTIVE_ROW_CAP = 10_000;
+
+// ElevenLabs signs only `post_call_transcription` and `post_call_audio` today.
+// `dispatch()` is the single switch where new types get wired.
+type ElevenLabsEvent = {
+  type: string;
+  // Some payloads use `event_timestamp`, others `data.metadata.start_time_unix_secs`.
+  // Both are unix seconds.
+  event_timestamp?: number;
+  data: PostCallPayload;
+};
+
+interface ParsedSignature {
+  timestamp: number;
+  signatures: string[];
+}
+
+/**
+ * Parse `ElevenLabs-Signature: t=<ts>,v0=<sig>[,v0=<sig>...]`.
+ * Multiple `v0` entries can appear during key rotation; we accept any match.
+ */
+function parseSignatureHeader(header: string): ParsedSignature | null {
+  const parts = header.split(",").map((p) => p.trim());
+  let timestamp: number | null = null;
+  const signatures: string[] = [];
+  for (const part of parts) {
+    const [k, v] = part.split("=");
+    if (!k || !v) continue;
+    if (k === "t") {
+      const n = Number(v);
+      if (Number.isFinite(n)) timestamp = n;
+    } else if (k === "v0") {
+      signatures.push(v);
+    }
+  }
+  if (timestamp == null || signatures.length === 0) return null;
+  return { timestamp, signatures };
+}
+
+function timingSafeEqualHex(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  try {
+    return crypto.timingSafeEqual(Buffer.from(a, "hex"), Buffer.from(b, "hex"));
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * HMAC-SHA256 of `<timestamp>.<raw_body>` keyed with the webhook secret.
+ * Returns hex digest.
+ */
+function computeSignature(secret: string, timestamp: number, rawBody: Buffer): string {
+  const h = crypto.createHmac("sha256", secret);
+  h.update(`${timestamp}.`);
+  h.update(rawBody);
+  return h.digest("hex");
+}
+
+interface VerifyResult {
+  ok: boolean;
+  reason?: string;
+  event?: ElevenLabsEvent;
+}
+
+function verifyAndParse(
+  rawBody: Buffer,
+  signatureHeader: string | undefined,
+  secret: string,
+  nowSecs: number
+): VerifyResult {
+  if (!signatureHeader || Array.isArray(signatureHeader)) {
+    return { ok: false, reason: "missing-signature" };
+  }
+  const parsed = parseSignatureHeader(signatureHeader);
+  if (!parsed) return { ok: false, reason: "malformed-signature" };
+
+  if (Math.abs(nowSecs - parsed.timestamp) > SIGNATURE_TIMESTAMP_TOLERANCE_SECS) {
+    return { ok: false, reason: "stale-timestamp" };
+  }
+
+  const expected = computeSignature(secret, parsed.timestamp, rawBody);
+  const match = parsed.signatures.some((sig) => timingSafeEqualHex(sig, expected));
+  if (!match) return { ok: false, reason: "bad-signature" };
+
+  let event: ElevenLabsEvent;
+  try {
+    event = JSON.parse(rawBody.toString("utf8")) as ElevenLabsEvent;
+  } catch {
+    return { ok: false, reason: "invalid-json" };
+  }
+  if (!event?.type || !event?.data?.conversation_id) {
+    return { ok: false, reason: "missing-fields" };
+  }
+  return { ok: true, event };
+}
+
+/**
+ * Synthesize a stable event_id: ElevenLabs payloads don't carry a top-level
+ * `id`, so we key off (type + conversation_id + timestamp). Same call
+ * re-delivered under the same signature timestamp dedupes; an updated call
+ * (different timestamp) is allowed through and ON CONFLICT-merges at the
+ * voice_intake_calls level.
+ */
+function buildEventId(type: string, conversationId: string, ts: number): string {
+  return `${type}:${conversationId}:${ts}`;
+}
+
+async function alreadyProcessed(eventId: string): Promise<boolean> {
+  const result = await query(
+    `SELECT 1 FROM elevenlabs_processed_events WHERE event_id = $1 LIMIT 1`,
+    [eventId]
+  );
+  return result.rows.length > 0;
+}
+
+async function markProcessed(
+  eventId: string,
+  eventType: string,
+  conversationId: string
+): Promise<void> {
+  await query(
+    `INSERT INTO elevenlabs_processed_events (event_id, event_type, conversation_id)
+     VALUES ($1, $2, $3)
+     ON CONFLICT (event_id) DO NOTHING`,
+    [eventId, eventType, conversationId]
+  );
+}
+
+async function activeDlqRowCount(): Promise<number> {
+  const result = await query(
+    `SELECT COUNT(*)::int AS count FROM elevenlabs_webhook_dlq WHERE attempt_count < 5`,
+    []
+  );
+  return Number(result.rows[0]?.count ?? 0);
+}
+
+async function recordDlq(
+  eventId: string,
+  eventType: string,
+  rawPayload: unknown,
+  err: Error
+): Promise<void> {
+  try {
+    const alreadyParked = await query(
+      `SELECT 1 FROM elevenlabs_webhook_dlq WHERE event_id = $1 LIMIT 1`,
+      [eventId]
+    );
+
+    if (alreadyParked.rows.length === 0) {
+      const activeCount = await activeDlqRowCount();
+      if (activeCount >= DLQ_ACTIVE_ROW_CAP) {
+        logger.warn("ElevenLabs webhook DLQ at capacity — skipping new row", {
+          eventId,
+          type: eventType,
+          activeCount,
+          cap: DLQ_ACTIVE_ROW_CAP,
+        });
+        return;
+      }
+    }
+
+    await query(
+      `INSERT INTO elevenlabs_webhook_dlq
+         (event_id, event_type, raw_payload, error_message)
+       VALUES ($1, $2, $3::jsonb, $4)
+       ON CONFLICT (event_id) DO UPDATE
+         SET attempt_count = elevenlabs_webhook_dlq.attempt_count + 1,
+             last_failed_at = NOW(),
+             error_message = EXCLUDED.error_message`,
+      [eventId, eventType, JSON.stringify(rawPayload), err.message]
+    );
+  } catch (dlqErr) {
+    logger.error("ElevenLabs webhook DLQ insert failed", {
+      eventId,
+      error: (dlqErr as Error).message,
+    });
+  }
+}
+
+async function dispatch(event: ElevenLabsEvent): Promise<void> {
+  switch (event.type) {
+    case "post_call_transcription":
+    case "post_call_audio": {
+      const result = await persistConversation(event.data);
+      void stampTape({
+        kind: "VOICE_INTAKE_COMPLETED",
+        actor: "elevenlabs-webhook",
+        sessionId: event.data.conversation_id,
+        payload: {
+          conversationId: event.data.conversation_id,
+          agentId: event.data.agent_id,
+          language: result.language,
+          callSuccessful: result.callSuccessful,
+          consentRecording: result.consentRecording,
+          callbackRequested: result.callbackRequested,
+          eventType: event.type,
+        },
+      });
+      return;
+    }
+    default:
+      logger.info("ElevenLabs webhook event ignored", { type: event.type });
+      return;
+  }
+}
+
+const router = Router();
+
+router.post(
+  "/",
+  express.raw({ type: "application/json", limit: "5mb" }),
+  async (req: Request, res: Response): Promise<void> => {
+    if (process.env.VOICE_INTAKE_ENABLED !== "true") {
+      res.status(503).json({ error: "Voice intake disabled" });
+      return;
+    }
+
+    const secret = process.env.ELEVENLABS_WEBHOOK_SECRET ?? "";
+    if (!secret || secret === "wsec_changeme") {
+      // Fail closed on misconfiguration: refuse to accept an unsigned payload
+      // because the secret happens to be empty.
+      res.status(503).json({ error: "Webhook secret not configured" });
+      return;
+    }
+
+    const rawBody = Buffer.isBuffer(req.body) ? req.body : Buffer.from("");
+    const sigHeader = req.headers["elevenlabs-signature"];
+    const sig = Array.isArray(sigHeader) ? sigHeader[0] : sigHeader;
+    const nowSecs = Math.floor(Date.now() / 1000);
+
+    const verified = verifyAndParse(rawBody, sig, secret, nowSecs);
+    if (!verified.ok || !verified.event) {
+      logger.warn("ElevenLabs webhook rejected", { reason: verified.reason });
+      // 400 for any verification failure — never reveal which check failed.
+      res.status(400).json({ error: "Invalid signature" });
+      return;
+    }
+
+    const event = verified.event;
+    const parsedTs = parseSignatureHeader(sig as string)!.timestamp;
+    const eventId = buildEventId(event.type, event.data.conversation_id, parsedTs);
+
+    if (await alreadyProcessed(eventId)) {
+      logger.info("ElevenLabs webhook duplicate event short-circuited", {
+        eventId,
+        type: event.type,
+      });
+      res.status(200).json({ received: true, duplicate: true });
+      return;
+    }
+
+    let dispatchError: Error | null = null;
+    try {
+      await dispatch(event);
+    } catch (err) {
+      dispatchError = err as Error;
+      logger.error("ElevenLabs webhook dispatch failed", {
+        eventId,
+        type: event.type,
+        error: dispatchError.message,
+      });
+      await recordDlq(eventId, event.type, event, dispatchError);
+    }
+
+    if (!dispatchError) {
+      await markProcessed(eventId, event.type, event.data.conversation_id);
+    }
+
+    // Always 200 — see header comment. DLQ is the recovery path, not retry.
+    res.status(200).json({ received: true });
+  }
+);
+
+export default router;
+
+// Exposed for the Vitest harness — lets the spec exercise the parser and HMAC
+// path without spinning up Express.
+export const __test = {
+  parseSignatureHeader,
+  computeSignature,
+  verifyAndParse,
+  buildEventId,
+};


### PR DESCRIPTION
## Summary

- Phase 1 of the Frank-onboarder voice channel. Persists ElevenLabs Conv. AI post-call webhooks into a fair-housing-stamped ledger so a phone-only applicant can become a real `applications` row, and exposes a PM-console surface to triage / approve / reject / mark-callback the queue.
- Whole feature is **flag-gated off** (`VOICE_INTAKE_ENABLED=false`) — landing this PR adds zero behavior in any environment until ElevenLabs creds + flag flip.
- Mirrors the proven BP-08 Stripe webhook pattern: HMAC verification → 3-layer idempotency → DLQ-on-throw → always 200.

## What's in

**Webhook** (`src/modules/voice-intake/webhook.ts`, mounted before `express.json()` so raw bytes survive HMAC verification)
- HMAC-SHA256 over `<timestamp>.<rawBody>` keyed with `ELEVENLABS_WEBHOOK_SECRET`. 30-min replay window. Multi-`v0=` tolerance for key rotation. Fail-closed on sentinel/empty secret (returns 503).
- 3-layer idempotency: (1) timestamp tolerance, (2) `elevenlabs_processed_events` event_id dedupe, (3) `voice_intake_calls.conversation_id` UNIQUE upsert.
- DLQ on dispatch failure with a 10k active-row soft cap; **always** 200s ElevenLabs so their 10-consecutive-failure auto-disable threshold can't be tripped.

**Service** (`src/modules/voice-intake/service.ts`)
- `persistConversation` upserts with consent + callback flags from `data_collection_results` (default consent=TRUE for the implied-consent / stayed-past-disclosure path).
- `promoteIntakeToApplication` is the PM Approve action: inserts an `applications` row with `source='voice'`, back-references the call, stamps `VOICE_INTAKE_DECISION`, fires the SMS doc-upload handoff via the existing magic-link transport. Idempotent on call id (already-promoted → `ALREADY_PROMOTED` → 409 at the route).
- `rejectIntake` soft-rejects with a HUD-stamped reason and drops the row from the callback queue.
- Phone normalizer honors an explicit leading `+` so international numbers (e.g. `+4520123456`) aren't mis-prefixed with `+1` (caught by the new tests).

**PM routes** (`src/modules/voice-intake/routes.ts`, mounted at `/api/pm/voice-intakes` only when the flag is on)
- `GET /` with `status: pending|approved|rejected|callback|all` + language filter + pagination. `GET /:id` for detail.
- `POST /:id/approve` (requires `propertyId`, senior+), `POST /:id/reject` (reason required), `POST /:id/callback` flag toggle.
- RBAC: `voice_intake:view` → `leasing_agent+`; `voice_intake:approve` → `senior_manager+`.

**Schema** (`src/db/schema.ts` + `src/db/migrations/2026-05-27-voice-intake.sql`)
- New enum `application_source` (`web|voice|sms|operator`).
- `applications` gets `source`, `voice_call_id`, `consent_outbound_ai_calls` (TCPA PEWC gate for Phase 2 outbound).
- New tables: `voice_intake_calls`, `voice_intake_costs` (daily rollup for the budget alert / Mission Control dashboard), `elevenlabs_processed_events`, `elevenlabs_webhook_dlq` — direct analogs of the BP-08 Stripe tables.

**Compliance tape** (`src/modules/tape/index.ts`)
- Three new stamp kinds: `VOICE_INTAKE_COMPLETED`, `VOICE_INTAKE_DECISION`, `VOICE_INTAKE_OUTBOUND_ATTEMPTED` (Phase 2). Citations reference HUD 4350.3 Ch. 4-6, NRS 200.620, TCPA 47 CFR §64.1200(a)(2).

**Config** (`.env.example`)
- `VOICE_INTAKE_ENABLED=false` (kill switch — flag also gates the PM routes).
- `ELEVENLABS_WEBHOOK_SECRET=wsec_changeme` (sentinel; webhook refuses).
- `ELEVENLABS_API_KEY=` (Phase 3 audio proxy; never sent to the browser).

## Tests

**26 passing** (13 webhook + 13 service):

- Webhook: missing/malformed/stale/bad-secret/tampered-body/missing-fields signature paths, happy persist+stamp+markProcessed, duplicate event short-circuit (no side effects), unknown event type no-op, DLQ on throw (and `markProcessed` correctly NOT fired so replay still works after fix), DLQ-at-cap skip, DLQ already-parked bump, multi-`v0=` rotation header acceptance, unit coverage on `parseSignatureHeader` + `computeSignature`.
- Service: persist with full payload + consent/callback flag defaults + language/callSuccessful slicing + missing-start-time, promote happy path + idempotency guard + missing-call + no-phone SMS skip + name fallbacks + E.164 preservation, reject stamps decision + soft-drops callback queue.

## What's NOT in (Phase ≥ 2)

- Outbound AI-initiated calls (TCPA PEWC gate exists in schema; route does not).
- Audio/transcript proxy through PM console (Phase 3 — that's what `ELEVENLABS_API_KEY` is for).
- Client-side PM console UI (separate frontend slice).
- Daily cost rollup population (table exists; the cron does not).
- Live ElevenLabs agent + secret in Railway env (deploy-time wiring).

## Test plan

- [ ] CI: full jest suite green (3 pre-existing failing suites — `compliance-tape-flag`, `housing-qa-retriever`, `housing-qa-routes` — verified to fail on main too, out of scope).
- [ ] CI: tsc clean for voice-intake files (pre-existing `housing-qa/retriever.ts` errors on `fuse.js` typing also exist on main).
- [ ] Local: `curl -X POST localhost:4000/api/webhooks/elevenlabs/post-call` without signature → 400; with the test-secret-signed fixture → 200 + row in `voice_intake_calls`.
- [ ] Local: `POST /api/pm/voice-intakes/:id/approve` from a senior-manager session promotes the row, back-references the call, fires the stamp, and (if a phone was captured) queues an SMS.
- [ ] Migration replay-safe: re-running `2026-05-27-voice-intake.sql` is a no-op (`IF NOT EXISTS` everywhere, `DO $$ BEGIN ... EXCEPTION WHEN duplicate_object` on the enum).
- [ ] Deploy: keep `VOICE_INTAKE_ENABLED=false` in Railway until the ElevenLabs agent secret is provisioned. The route mount is unconditional but the handler short-circuits to 503 — verified by the first webhook test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)