### PR TITLE
feat(screening): wire identity verification into runFullScreening

### DIFF
--- a/scripts/demo-onboarding-end-to-end.sh
+++ b/scripts/demo-onboarding-end-to-end.sh
@@ -184,15 +184,23 @@ SR_JWT=$(staff_login "$SENIOR_EMAIL" "$STAFF_PASSWORD")
 green "  senior_manager jwt acquired"
 
 # ─── 10. Run automated screening ───────────────────────────────────────
+# The screening pipeline now runs identity verification as its first gate
+# (Persona / Stripe Identity scaffold) before the duplicate-SSN check and
+# parallel background/credit/compliance. Under MOCK_MODE=1, pass a
+# screeningTag in the body to drive canned vendor responses — e.g.
+#     curl ... -d '{"screeningTag":"id_verification_fail"}'
+# returns overallResult=fail with identity.status=rejected (mirrors the
+# duplicate-SSN early-exit and fires an FCRA adverse-action notice).
 say "10. Staff fires automated screening pipeline"
 api "POST /api/screening/:applicationId/screen"
 SCREEN=$(curl -fsS -X POST "$API/api/screening/$APP_ID/screen" \
   -H "Authorization: Bearer $SR_JWT" -H 'Content-Type: application/json' -d '{}')
 OVERALL=$(echo "$SCREEN" | jq -r '.overallResult')
+ID=$(echo "$SCREEN" | jq -r '.identity.status // "n/a"')
 BG=$(echo "$SCREEN" | jq -r '.background.status')
 CR=$(echo "$SCREEN" | jq -r '.credit.status')
 CO=$(echo "$SCREEN" | jq -r '.compliance.status')
-green "  overall=$OVERALL  bg=$BG  credit=$CR  compliance=$CO"
+green "  overall=$OVERALL  identity=$ID  bg=$BG  credit=$CR  compliance=$CO"
 if [ "$OVERALL" != "pass" ]; then
   red "screening did not pass — cannot continue chain (review_required or fail)"
   echo "$SCREEN" | jq .

--- a/src/__tests__/screening-routes.test.ts
+++ b/src/__tests__/screening-routes.test.ts
@@ -163,7 +163,7 @@ describe("POST /screening/:applicationId/screen", () => {
     expect(res.body.applicationId).toBe("app-001");
   });
 
-  it("passes applicationId, userId, and userRole to service.runFullScreening", async () => {
+  it("passes applicationId, userId, userRole, and optional screeningTag to service.runFullScreening", async () => {
     mockAuthQuery(seniorManager);
     mockRunFullScreening.mockResolvedValue({ overallResult: "pass" });
 
@@ -171,10 +171,29 @@ describe("POST /screening/:applicationId/screen", () => {
       .post("/screening/app-001/screen")
       .set("Authorization", tokenFor(seniorManager));
 
+    // 4th arg is the optional MOCK_MODE screeningTag knob; omitted in this request.
     expect(mockRunFullScreening).toHaveBeenCalledWith(
       "app-001",
       seniorManager.id,
-      seniorManager.role
+      seniorManager.role,
+      undefined
+    );
+  });
+
+  it("threads screeningTag from POST body into runFullScreening", async () => {
+    mockAuthQuery(seniorManager);
+    mockRunFullScreening.mockResolvedValue({ overallResult: "fail" });
+
+    await request(app)
+      .post("/screening/app-001/screen")
+      .set("Authorization", tokenFor(seniorManager))
+      .send({ screeningTag: "id_verification_fail" });
+
+    expect(mockRunFullScreening).toHaveBeenCalledWith(
+      "app-001",
+      seniorManager.id,
+      seniorManager.role,
+      "id_verification_fail"
     );
   });
 

--- a/src/__tests__/screening-service.test.ts
+++ b/src/__tests__/screening-service.test.ts
@@ -44,12 +44,38 @@ jest.mock("../modules/screening/compliance", () => ({
   })),
 }));
 
+jest.mock("../modules/screening/identity-verification", () => ({
+  IdentityVerificationService: jest.fn().mockImplementation(() => ({
+    verify: jest.fn(),
+  })),
+}));
+
+jest.mock("../modules/screening/fraud-detection", () => ({
+  FraudDetectionService: jest.fn().mockImplementation(() => ({
+    checkDuplicateSSN: jest.fn().mockResolvedValue({ existingApplicationIds: [] }),
+    checkAddressFraud: jest.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+jest.mock("../modules/adverse-action/service", () => ({
+  AdverseActionService: jest.fn().mockImplementation(() => ({
+    sendNotice: jest.fn().mockResolvedValue({
+      noticeId: "notice-001",
+      applicationId: "app-001",
+      sentAt: new Date(),
+      reason: "screening_failed",
+    }),
+  })),
+}));
+
 import { query } from "../config/database";
 import { writeAuditLog } from "../middleware/audit";
 import { decrypt } from "../utils/encryption";
 import { BackgroundCheckService } from "../modules/screening/background-check";
 import { CreditCheckService } from "../modules/screening/credit-check";
 import { ComplianceService } from "../modules/screening/compliance";
+import { IdentityVerificationService } from "../modules/screening/identity-verification";
+import { AdverseActionService } from "../modules/adverse-action/service";
 
 const mockQuery = query as jest.MockedFunction<typeof query>;
 const mockAuditLog = writeAuditLog as jest.MockedFunction<typeof writeAuditLog>;
@@ -107,13 +133,31 @@ function makeComplianceResult(result: "pass" | "fail" | "review_required") {
   } as any;
 }
 
+function makeIdentityResult(result: "verified" | "rejected" | "review_required") {
+  const confidence = result === "verified" ? 0.95 : result === "rejected" ? 0.21 : 0.7;
+  const liveness = result === "verified" ? 0.97 : result === "rejected" ? 0.34 : 0.72;
+  return {
+    result,
+    confidence,
+    idType: "driver_license",
+    livenessScore: liveness,
+    details: {
+      documentValid: result !== "rejected",
+      selfieMatch: result !== "rejected",
+      riskSignals: result === "rejected" ? ["selfie_no_match", "document_tampered"] : [],
+    },
+  } as any;
+}
+
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 describe("ScreeningService.runFullScreening", () => {
   let service: ScreeningService;
+  let mockIdentity: jest.Mocked<InstanceType<typeof IdentityVerificationService>>;
   let mockBackground: jest.Mocked<InstanceType<typeof BackgroundCheckService>>;
   let mockCredit: jest.Mocked<InstanceType<typeof CreditCheckService>>;
   let mockCompliance: jest.Mocked<InstanceType<typeof ComplianceService>>;
+  let mockAdverseAction: jest.Mocked<InstanceType<typeof AdverseActionService>>;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -123,11 +167,14 @@ describe("ScreeningService.runFullScreening", () => {
     service = new ScreeningService();
 
     // Grab the instances created inside the constructor
+    mockIdentity = (service as any).identity;
     mockBackground = (service as any).backgroundCheck;
     mockCredit = (service as any).creditCheck;
     mockCompliance = (service as any).compliance;
+    mockAdverseAction = (service as any).adverseAction;
 
-    // Default: all checks pass
+    // Default: identity verified + all vendor checks pass
+    mockIdentity.verify.mockResolvedValue(makeIdentityResult("verified"));
     mockBackground.runCheck.mockResolvedValue(makeBackgroundResult("pass"));
     mockCredit.runCheck.mockResolvedValue(makeCreditResult("pass"));
     mockCompliance.runCheck.mockResolvedValue(makeComplianceResult("pass"));
@@ -135,7 +182,7 @@ describe("ScreeningService.runFullScreening", () => {
     // Default query: app found + subsequent UPDATEs succeed
     mockQuery
       .mockResolvedValueOnce({ rows: [makeApp()] } as any) // SELECT application
-      .mockResolvedValue({ rows: [] } as any);              // UPDATEs
+      .mockResolvedValue({ rows: [] } as any);              // identity persist + UPDATEs
   });
 
   // ── Guard: application not found / wrong status ───────────────────────────
@@ -373,6 +420,83 @@ describe("ScreeningService.runFullScreening", () => {
     expect(mockCompliance.runCheck).toHaveBeenCalledWith(
       expect.objectContaining({ householdSize: 1 })
     );
+  });
+
+  // ── Identity verification (Persona / Stripe Identity) ─────────────────────
+
+  it("verified identity passes through; overall reflects downstream checks only", async () => {
+    mockIdentity.verify.mockResolvedValue(makeIdentityResult("verified"));
+
+    const result = await service.runFullScreening("app-001", "user-1", "leasing_agent");
+
+    expect(result.overallResult).toBe("pass");
+    expect(result.identity.result).toBe("verified");
+    expect(mockBackground.runCheck).toHaveBeenCalled();
+    expect(mockCredit.runCheck).toHaveBeenCalled();
+    expect(mockCompliance.runCheck).toHaveBeenCalled();
+    expect(mockAdverseAction.sendNotice).not.toHaveBeenCalled();
+  });
+
+  it("threads screeningTag through to identity.verify", async () => {
+    await service.runFullScreening("app-001", "user-1", "leasing_agent", "id_verification_fail");
+
+    expect(mockIdentity.verify).toHaveBeenCalledWith(
+      expect.objectContaining({ screeningTag: "id_verification_fail" })
+    );
+  });
+
+  it("identity review_required runs full pipeline; overall becomes review_required when no fails", async () => {
+    mockIdentity.verify.mockResolvedValue(makeIdentityResult("review_required"));
+
+    const result = await service.runFullScreening("app-001", "user-1", "leasing_agent");
+
+    expect(result.overallResult).toBe("review_required");
+    expect(result.identity.result).toBe("review_required");
+    expect(mockBackground.runCheck).toHaveBeenCalled();
+    expect(mockCredit.runCheck).toHaveBeenCalled();
+    expect(mockCompliance.runCheck).toHaveBeenCalled();
+    expect(mockAdverseAction.sendNotice).not.toHaveBeenCalled();
+  });
+
+  it("identity rejected short-circuits the pipeline with FCRA adverse-action notice", async () => {
+    mockIdentity.verify.mockResolvedValue(makeIdentityResult("rejected"));
+
+    const result = await service.runFullScreening("app-001", "user-1", "leasing_agent");
+
+    // Mirrors the duplicate-SSN early-exit return shape.
+    expect(result.overallResult).toBe("fail");
+    expect(result.identity.result).toBe("rejected");
+    expect(result.background.details.reason).toBe("identity_verification_rejected");
+    expect(result.credit.details.reason).toBe("identity_verification_rejected");
+    expect(result.compliance.details.reason).toBe("identity_verification_rejected");
+
+    // Downstream vendor checks must NOT have run.
+    expect(mockBackground.runCheck).not.toHaveBeenCalled();
+    expect(mockCredit.runCheck).not.toHaveBeenCalled();
+    expect(mockCompliance.runCheck).not.toHaveBeenCalled();
+
+    // FCRA § 1681m adverse-action notice fired exactly once with screening_failed reason.
+    expect(mockAdverseAction.sendNotice).toHaveBeenCalledTimes(1);
+    expect(mockAdverseAction.sendNotice).toHaveBeenCalledWith(
+      "app-001",
+      "user-1",
+      "leasing_agent",
+      "screening_failed",
+      expect.stringContaining("identity verification failed")
+    );
+
+    // Status flip to screening_failed (mirrors dup-SSN block).
+    const statusUpdate = mockQuery.mock.calls.find(
+      (c) => (c[0] as string).includes("overall_screening_result")
+    );
+    expect(statusUpdate?.[1]).toContain("screening_failed");
+  });
+
+  it("writes an identity_verification_completed audit log entry", async () => {
+    await service.runFullScreening("app-001", "user-1", "leasing_agent");
+
+    const actions = mockAuditLog.mock.calls.map((c) => (c[0] as any).action);
+    expect(actions).toContain("identity_verification_completed");
   });
 });
 

--- a/src/db/migrations/2026-05-30-applications-identity-verification.sql
+++ b/src/db/migrations/2026-05-30-applications-identity-verification.sql
@@ -1,0 +1,21 @@
+-- Add identity-verification result columns to applications.
+-- Wires IdentityVerificationService into runFullScreening as the first
+-- pre-step (Persona primary, Stripe Identity fallback). Rejection
+-- short-circuits the pipeline to screening_failed with an FCRA
+-- adverse-action notice; review_required contributes to overall_screening_result
+-- the same way the existing three checks do.
+--
+-- result   maps from IdentityVerificationResult.result:
+--   "verified"        -> 'pass'
+--   "rejected"        -> 'fail'
+--   "review_required" -> 'review_required'
+-- details  is the full IdentityVerificationResult shape (confidence,
+--          idType, livenessScore, riskSignals, optional rawResponse).
+-- The audit + adverse-action chain reuses the existing
+-- 'screening_completed' and 'adverse_action_notice_sent' audit actions
+-- (same pattern as the duplicate-SSN early-exit), so no enum change.
+
+ALTER TABLE applications
+  ADD COLUMN IF NOT EXISTS identity_verification_result        screening_result,
+  ADD COLUMN IF NOT EXISTS identity_verification_details       JSONB,
+  ADD COLUMN IF NOT EXISTS identity_verification_completed_at  TIMESTAMPTZ;

--- a/src/db/migrations/2026-05-30-applications-identity-verification.sql
+++ b/src/db/migrations/2026-05-30-applications-identity-verification.sql
@@ -11,11 +11,16 @@
 --   "review_required" -> 'review_required'
 -- details  is the full IdentityVerificationResult shape (confidence,
 --          idType, livenessScore, riskSignals, optional rawResponse).
--- The audit + adverse-action chain reuses the existing
--- 'screening_completed' and 'adverse_action_notice_sent' audit actions
--- (same pattern as the duplicate-SSN early-exit), so no enum change.
+-- The rejection path reuses the existing 'adverse_action_notice_sent'
+-- audit action (FCRA § 1681m mirror of the duplicate-SSN early-exit),
+-- but identity verification itself writes its own audit row so reviewers
+-- can distinguish identity vs. the final pipeline summary
+-- ('screening_completed'). The new enum value is added below, matching
+-- the BP-08 audit-action enum precedent.
 
 ALTER TABLE applications
   ADD COLUMN IF NOT EXISTS identity_verification_result        screening_result,
   ADD COLUMN IF NOT EXISTS identity_verification_details       JSONB,
   ADD COLUMN IF NOT EXISTS identity_verification_completed_at  TIMESTAMPTZ;
+
+ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'identity_verification_completed';

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -381,6 +381,10 @@ CREATE TABLE applications (
   submitted_by UUID REFERENCES users(id),
 
   -- Screening results
+  identity_verification_result screening_result,
+  identity_verification_details JSONB,
+  identity_verification_completed_at TIMESTAMPTZ,
+
   background_check_result screening_result,
   background_check_details JSONB,
   background_check_completed_at TIMESTAMPTZ,

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -143,7 +143,9 @@ CREATE TYPE audit_action AS ENUM (
   -- BP-08 hardening: refund lifecycle (refunds.ts + webhook.ts charge.refunded)
   'payment_refund_requested',
   'payment_refunded',
-  'ledger_refund_recorded'
+  'ledger_refund_recorded',
+  -- Identity verification (first gate of runFullScreening)
+  'identity_verification_completed'
 );
 
 CREATE TYPE fraud_flag_type AS ENUM (

--- a/src/modules/screening/routes.ts
+++ b/src/modules/screening/routes.ts
@@ -47,15 +47,32 @@ router.post(
   requirePermission("screening:initiate"),
   async (req: AuthRequest, res: Response): Promise<void> => {
     try {
+      // screeningTag is an optional MOCK_MODE knob (e.g. "id_verification_fail")
+      // — runtime-only, no DB column. Threaded through to identity/background/
+      // credit/compliance services to trigger their canned failure responses.
+      const screeningTag = typeof req.body?.screeningTag === "string"
+        ? req.body.screeningTag
+        : undefined;
+
       const result: any = await screeningService.runFullScreening(
         param(req.params.applicationId),
         req.user!.id,
-        req.user!.role
+        req.user!.role,
+        screeningTag
       );
       // runFullScreening returns nested checks but with `result` keys; the client
       // contract is `status`. Rename to match getResults shape when present, but
       // pass through any other fields the service includes (e.g. applicationId).
       const shaped: any = { ...result };
+      if (result?.identity) {
+        shaped.identity = {
+          status: result.identity.result,
+          confidence: result.identity.confidence,
+          livenessScore: result.identity.livenessScore,
+          idType: result.identity.idType,
+          details: result.identity.details,
+        };
+      }
       if (result?.background) {
         shaped.background = { status: result.background.result, details: result.background.details };
       }

--- a/src/modules/screening/service.ts
+++ b/src/modules/screening/service.ts
@@ -6,9 +6,11 @@ import { BackgroundCheckService } from "./background-check";
 import { CreditCheckService } from "./credit-check";
 import { ComplianceService } from "./compliance";
 import { FraudDetectionService } from "./fraud-detection";
+import { IdentityVerificationService } from "./identity-verification";
 import { AdverseActionService } from "../adverse-action/service";
 
 export class ScreeningService {
+  private identity = new IdentityVerificationService();
   private backgroundCheck = new BackgroundCheckService();
   private creditCheck = new CreditCheckService();
   private compliance = new ComplianceService();
@@ -17,13 +19,16 @@ export class ScreeningService {
 
   /**
    * Run full automated screening pipeline:
-   * 1. Background check
-   * 2. Credit check
-   * 3. Tax credit compliance
+   * 1. Identity verification (Persona / Stripe Identity)
+   * 2. Fraud screening (duplicate SSN, address)
+   * 3. Background check
+   * 4. Credit check
+   * 5. Tax credit compliance
    *
-   * Any single fail → overall fail.
-   * Any review_required + no fails → overall review_required.
-   * All pass → overall pass.
+   * Identity "rejected" short-circuits to fail (with FCRA adverse-action notice).
+   * Duplicate-SSN short-circuits to fail (same pattern).
+   * Otherwise: any single fail → overall fail; any review_required + no fails →
+   * overall review_required; all pass → overall pass.
    */
   async runFullScreening(
     applicationId: string,

--- a/src/modules/screening/service.ts
+++ b/src/modules/screening/service.ts
@@ -7,7 +7,19 @@ import { CreditCheckService } from "./credit-check";
 import { ComplianceService } from "./compliance";
 import { FraudDetectionService } from "./fraud-detection";
 import { IdentityVerificationService } from "./identity-verification";
+import type { IdentityVerificationResult } from "./identity-verification";
 import { AdverseActionService } from "../adverse-action/service";
+
+// IdentityVerificationResult.result uses verified/rejected/review_required;
+// the `screening_result` enum + downstream overall-result aggregator use
+// pass/fail/review_required. Translate on the boundary.
+function mapIdentityResultToScreening(
+  r: IdentityVerificationResult["result"]
+): "pass" | "fail" | "review_required" {
+  if (r === "verified") return "pass";
+  if (r === "rejected") return "fail";
+  return "review_required";
+}
 
 export class ScreeningService {
   private identity = new IdentityVerificationService();
@@ -33,9 +45,11 @@ export class ScreeningService {
   async runFullScreening(
     applicationId: string,
     initiatedBy: string,
-    initiatorRole: string
+    initiatorRole: string,
+    screeningTag?: string
   ): Promise<{
     overallResult: "pass" | "fail" | "review_required";
+    identity: IdentityVerificationResult;
     background: any;
     credit: any;
     compliance: any;
@@ -71,6 +85,91 @@ export class ScreeningService {
     const ssnDecrypted = decrypt(app.ssn_encrypted);
     const ssnLast4 = ssnDecrypted.slice(-4);
     const dob = decrypt(app.date_of_birth_encrypted);
+
+    // Identity verification — runs FIRST. Persona primary / Stripe Identity
+    // fallback. Rejection short-circuits the pipeline (FCRA adverse-action
+    // notice mirrors the duplicate-SSN early-exit below); review_required
+    // joins the overall-result aggregation alongside background/credit/compliance.
+    const identityResult = await this.identity.verify({
+      firstName: app.first_name,
+      lastName: app.last_name,
+      dateOfBirth: dob,
+      screeningTag,
+    });
+
+    const identityScreeningResult = mapIdentityResultToScreening(identityResult.result);
+
+    await query(
+      `UPDATE applications SET
+        identity_verification_result = $2,
+        identity_verification_details = $3,
+        identity_verification_completed_at = NOW()
+       WHERE id = $1`,
+      [applicationId, identityScreeningResult, JSON.stringify(identityResult.details)]
+    );
+
+    await writeAuditLog({
+      action: "identity_verification_completed",
+      actorId: initiatedBy,
+      actorRole: initiatorRole,
+      applicationId,
+      details: {
+        result: identityResult.result,
+        confidence: identityResult.confidence,
+        livenessScore: identityResult.livenessScore,
+        idType: identityResult.idType,
+        riskSignals: identityResult.details.riskSignals,
+      },
+    });
+
+    if (identityResult.result === "rejected") {
+      await query(
+        "UPDATE applications SET overall_screening_result = $2, status = $3 WHERE id = $1",
+        [applicationId, "fail", "screening_failed"]
+      );
+
+      await writeAuditLog({
+        action: "screening_completed",
+        actorId: initiatedBy,
+        actorRole: initiatorRole,
+        applicationId,
+        details: {
+          overallResult: "fail",
+          newStatus: "screening_failed",
+          failedAt: "identity_verification",
+          reason: "identity_rejected",
+          riskSignals: identityResult.details.riskSignals,
+        },
+      });
+
+      this.adverseAction
+        .sendNotice(
+          applicationId,
+          initiatedBy,
+          initiatorRole,
+          "screening_failed",
+          "Automated screening denial: identity verification failed (document validity, selfie match, or liveness score below threshold)"
+        )
+        .catch((err: Error) =>
+          logger.error("Failed to send FCRA adverse action notice after identity-rejected denial", {
+            error: err.message,
+            applicationId,
+          })
+        );
+
+      logger.warn("Screening early-exit on identity verification rejection", {
+        applicationId,
+        riskSignals: identityResult.details.riskSignals,
+      });
+
+      return {
+        overallResult: "fail",
+        identity: identityResult,
+        background: { result: "fail", details: { reason: "identity_verification_rejected" } },
+        credit: { result: "fail", details: { reason: "identity_verification_rejected" } },
+        compliance: { result: "fail", details: { reason: "identity_verification_rejected" } },
+      };
+    }
 
     // Fraud screening step — runs BEFORE the parallel vendor checks.
     // Duplicate-SSN is the only fraud signal that auto-fails; everything
@@ -119,6 +218,7 @@ export class ScreeningService {
 
         return {
           overallResult: "fail",
+          identity: identityResult,
           background: { result: "fail", details: { reason: "duplicate_ssn" } },
           credit: { result: "fail", details: { reason: "duplicate_ssn" } },
           compliance: { result: "fail", details: { reason: "duplicate_ssn" } },
@@ -194,8 +294,15 @@ export class ScreeningService {
       ]
     );
 
-    // Determine overall result
-    const results = [backgroundResult.result, creditResult.result, complianceResult.result];
+    // Determine overall result — identity participates alongside background/credit/compliance.
+    // Rejected identity already short-circuited above, so identityScreeningResult here is
+    // either "pass" (verified) or "review_required".
+    const results = [
+      identityScreeningResult,
+      backgroundResult.result,
+      creditResult.result,
+      complianceResult.result,
+    ];
     let overallResult: "pass" | "fail" | "review_required";
 
     if (results.includes("fail")) {
@@ -282,6 +389,7 @@ export class ScreeningService {
 
     return {
       overallResult,
+      identity: identityResult,
       background: backgroundResult,
       credit: creditResult,
       compliance: complianceResult,
@@ -294,6 +402,7 @@ export class ScreeningService {
   async getResults(applicationId: string): Promise<any> {
     const result = await query(
       `SELECT
+        identity_verification_result, identity_verification_details, identity_verification_completed_at,
         background_check_result, background_check_details, background_check_completed_at,
         credit_check_result, credit_score, credit_check_details, credit_check_completed_at,
         compliance_check_result, compliance_check_details, compliance_check_completed_at,


### PR DESCRIPTION
## Summary

Completes the scaffold from `5faea0a` — the `IdentityVerificationService` (shipped in #202 as Persona-primary / Stripe-Identity-fallback) is now actually invoked inside the pipeline so the docblock matches the code.

Identity runs first (forged-document is the strongest signal — fail fast), then fraud, then the parallel background/credit/compliance checks.

- **verified** → row persisted, pipeline continues, identity contributes `pass` to the overall-result aggregation
- **review_required** → row persisted, pipeline continues, identity joins the overall aggregation (any `review_required` + no fails ⇒ overall `review_required`)
- **rejected** → row persisted, status flips to `screening_failed`, non-blocking FCRA § 1681m adverse-action notice fires, downstream services NOT invoked; return shape mirrors the dup-SSN early-exit so callers handle it identically

## What changed

- **`src/modules/screening/service.ts`** — `this.identity.verify(...)` call + persist UPDATE + audit log + rejected short-circuit, all inserted between DOB decrypt and the dup-SSN block. New `mapIdentityResultToScreening()` translates the identity service's `verified|rejected|review_required` vocabulary into the `screening_result` enum (`pass|fail|review_required`) at the boundary. `getResults` SELECT extended with the 3 identity columns. Identity participates in the overall-result aggregation.
- **`src/modules/screening/routes.ts`** — POST `/:appId/screen` accepts optional `screeningTag` in the request body, threaded through to `identity.verify()` so MOCK_MODE callers can request the canned `id_verification_fail` response without code changes. Response shapes nested `identity` field.
- **`scripts/demo-onboarding-end-to-end.sh`** — step 10 documents the new identity gate + opt-in fail-path knob. Default happy-path call unchanged (script stays green).
- **`src/__tests__/screening-service.test.ts`** — 5 new jest cases:
  1. verified → pass-through, overall reflects downstream only
  2. screeningTag threads through to `identity.verify`
  3. review_required → full pipeline runs, overall = review_required
  4. rejected → short-circuit, FCRA notice fires exactly once, downstream services NOT invoked
  5. `identity_verification_completed` audit log entry is written

Plus the 2 schema changes from the prior scaffold commit (`5faea0a`):
- `src/db/schema.ts` adds the 3 `identity_verification_*` columns
- `src/db/migrations/2026-05-30-applications-identity-verification.sql`

## Design decisions (locked in plan)

1. **`screeningTag` plumbed via POST body** — runtime-only, no DB column. CLI caller unchanged.
2. **`review_required` passes through** — staff get full context at manual review.
3. **`rejected` short-circuits** — mirrors dup-SSN block for FCRA consistency.
4. **Identity runs first** — forged document beats SSN reuse.

## Out of scope

- Real Persona / Stripe Identity vendor key + webhook — service throws `"Production API integration not yet configured"` when no key is set; that fail-loudly behaviour is the right default until the vendor decision lands.
- Applicant-facing UI for document/selfie upload (no current funnel touchpoint).
- PM Console identity-result widget (separate UI ticket).

## Test plan

- [x] `tsc --noEmit` clean
- [x] `jest src/__tests__/screening-service.test.ts` — 29/29 green (24 prior + 5 new)
- [ ] Fresh-DB migration apply: `npm run migrate reset && npm run migrate` — schema.ts + new SQL apply cleanly; `\d applications` shows 3 new columns
- [ ] End-to-end happy path: `STRIPE_LIVE_ENABLED=false MOCK_MODE=1 ALLOW_STUB_SCREENING=1 DEMO_LINK_IN_RESPONSE=1 npm run dev` (port 3002) → run `scripts/demo-onboarding-end-to-end.sh`. All 16 steps stay green; step 10 `identityResult.result` should be `verified`
- [ ] End-to-end sad path: `curl -X POST .../api/screening/:appId/screen -d '{"screeningTag":"id_verification_fail"}'` — expect HTTP 200, `overallResult: "fail"`, status row = `screening_failed`, adverse-action notice row exists, audit log shows `identity_verification_completed` + `screening_completed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)