### PR TITLE
feat(voice-intake): Phase B — send_app_link tool + applicant prefill endpoint

### DIFF
--- a/src/__tests__/voice-applicant-routes.test.ts
+++ b/src/__tests__/voice-applicant-routes.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Tests for src/modules/voice-intake/applicant-routes.ts — applicant-facing
+ * voice-intake prefill endpoint.
+ *
+ * Mount path under test: /api/voice/intakes/:conversationId/prefill
+ *
+ * Auth: real `authenticate` middleware runs against a generateToken-minted
+ * JWT (pattern lifted from saved-properties.test.ts). The middleware fires
+ * a SELECT for the user — we script that as the first DB call, then the
+ * route's own SELECT for the voice_intake_calls row.
+ */
+
+import express from "express";
+import request from "supertest";
+import type { QueryResult } from "pg";
+import { generateToken, AuthUser } from "../middleware/auth";
+
+jest.mock("../config/database", () => ({
+  query: jest.fn(),
+}));
+jest.mock("../utils/logger", () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+import { query } from "../config/database";
+import applicantRouter from "../modules/voice-intake/applicant-routes";
+
+const mockQuery = query as jest.MockedFunction<typeof query>;
+
+function qr<T extends Record<string, unknown>>(rows: T[]): QueryResult<T> {
+  return { rows } as unknown as QueryResult<T>;
+}
+
+function buildApp(): express.Express {
+  const app = express();
+  app.use(express.json());
+  app.use("/api/voice/intakes", applicantRouter);
+  return app;
+}
+
+const app = buildApp();
+
+const USER: AuthUser = {
+  id: "00000000-0000-0000-0000-000000000001",
+  email: "applicant@example.com",
+  role: "applicant",
+  firstName: "Ann",
+  lastName: "App",
+  propertyIds: [],
+  emailVerified: true,
+};
+
+function authRow() {
+  return {
+    id: USER.id,
+    email: USER.email,
+    role: USER.role,
+    first_name: USER.firstName,
+    last_name: USER.lastName,
+    property_ids: [],
+    is_active: true,
+    email_verified_at: new Date(),
+  };
+}
+
+const TOKEN = generateToken(USER, { emailVerified: true });
+const AUTH = `Bearer ${TOKEN}`;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("GET /api/voice/intakes/:conversationId/prefill — auth", () => {
+  it("returns 401 without a bearer token", async () => {
+    const res = await request(app).get("/api/voice/intakes/conv_TEST/prefill");
+    expect(res.status).toBe(401);
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+});
+
+describe("GET /api/voice/intakes/:conversationId/prefill — validation", () => {
+  it("returns 400 when the conversationId is too long", async () => {
+    mockQuery.mockResolvedValueOnce(qr([authRow()]));
+    const longId = "x".repeat(150);
+    const res = await request(app)
+      .get(`/api/voice/intakes/${longId}/prefill`)
+      .set("Authorization", AUTH);
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: "Invalid conversation_id" });
+  });
+});
+
+describe("GET /api/voice/intakes/:conversationId/prefill — lookup", () => {
+  it("returns 404 with neutral error when no row matches", async () => {
+    mockQuery
+      .mockResolvedValueOnce(qr([authRow()])) // authenticate user lookup
+      .mockResolvedValueOnce(qr([])); // prefill SELECT → miss
+
+    const res = await request(app)
+      .get("/api/voice/intakes/conv_NEVER/prefill")
+      .set("Authorization", AUTH);
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: "Not found" });
+  });
+
+  it("returns a normalized prefill object when row exists", async () => {
+    mockQuery
+      .mockResolvedValueOnce(qr([authRow()]))
+      .mockResolvedValueOnce(
+        qr([
+          {
+            data_collection_results: {
+              name: { value: "Alex Peri" },
+              phone: { value: "702 555 1212" },
+              current_city: { value: "Henderson" },
+              household: { value: "3" },
+              monthly_income: { value: "$2,500" },
+              consent_recording: { value: "true" },
+            },
+            language: "en",
+          },
+        ])
+      );
+
+    const res = await request(app)
+      .get("/api/voice/intakes/conv_TEST_xyz/prefill")
+      .set("Authorization", AUTH);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      conversationId: "conv_TEST_xyz",
+      language: "en",
+      prefill: {
+        firstName: "Alex",
+        lastName: "Peri",
+        phone: "+17025551212",
+        currentCity: "Henderson",
+        householdSize: 3,
+        monthlyIncome: 2500,
+        consentRecording: true,
+      },
+    });
+  });
+
+  it("nulls out missing fields instead of leaking undefined", async () => {
+    mockQuery
+      .mockResolvedValueOnce(qr([authRow()]))
+      .mockResolvedValueOnce(
+        qr([
+          {
+            data_collection_results: {
+              name: { value: "Sam" },
+            },
+            language: null,
+          },
+        ])
+      );
+
+    const res = await request(app)
+      .get("/api/voice/intakes/conv_PARTIAL/prefill")
+      .set("Authorization", AUTH);
+
+    expect(res.status).toBe(200);
+    expect(res.body.prefill).toEqual({
+      firstName: "Sam",
+      lastName: null,
+      phone: null,
+      currentCity: null,
+      householdSize: null,
+      monthlyIncome: null,
+      consentRecording: null,
+    });
+  });
+
+  it("returns 500 on database failure", async () => {
+    mockQuery
+      .mockResolvedValueOnce(qr([authRow()]))
+      .mockRejectedValueOnce(new Error("db down"));
+
+    const res = await request(app)
+      .get("/api/voice/intakes/conv_BOOM/prefill")
+      .set("Authorization", AUTH);
+
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ error: "Failed to load prefill" });
+  });
+});

--- a/src/__tests__/voice-send-app-link.test.ts
+++ b/src/__tests__/voice-send-app-link.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Tests for src/modules/voice-intake/send-app-link.ts — the Phase B in-call
+ * tool handler that mid-call texts the caller a magic-link to the wizard.
+ *
+ * Scope:
+ *   - Phone normalization happy/fail paths
+ *   - Find-or-create: existing applicant by phone vs. fresh INSERT
+ *   - Magic-link URL gets `&intake=<conversation_id>` appended
+ *   - sendMagicLinkSms is fired with the user id + final link
+ *   - createMagicLink failure surfaces as { ok: false } message, no SMS
+ *
+ * The dispatcher (tool-callbacks.ts) is already covered end-to-end in
+ * voice-tool-callbacks.test.ts; here we exercise the handler function in
+ * isolation by calling it directly. That keeps this suite fast and pinned
+ * to the business logic.
+ */
+
+const mockQuery = jest.fn();
+jest.mock("../config/database", () => ({
+  query: (...args: unknown[]) => mockQuery(...args),
+}));
+
+jest.mock("../utils/logger", () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+const mockCreateMagicLink = jest.fn();
+const mockSendMagicLinkSms = jest.fn();
+const mockLogMagicLink = jest.fn();
+jest.mock("../modules/auth/magic-link-service", () => ({
+  createMagicLink: (...args: unknown[]) => mockCreateMagicLink(...args),
+  sendMagicLinkSms: (...args: unknown[]) => mockSendMagicLinkSms(...args),
+  logMagicLink: (...args: unknown[]) => mockLogMagicLink(...args),
+}));
+
+import {
+  sendAppLinkHandler,
+  registerVoiceToolHandlers,
+  __resetRegistrationForTests,
+} from "../modules/voice-intake/send-app-link";
+import {
+  clearToolHandlersForTests,
+  getRegisteredToolNames,
+} from "../modules/voice-intake/tool-callbacks";
+
+const CTX = {
+  agentId: "agent_test",
+  conversationId: "conv_TEST_xyz",
+  toolCallId: "tc_TEST_1",
+  toolName: "send_app_link" as const,
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("sendAppLinkHandler — phone parsing", () => {
+  it("returns ok:false when phone is missing", async () => {
+    const result = await sendAppLinkHandler({}, CTX);
+    expect(result.ok).toBe(false);
+    expect(result.message).toMatch(/phone/i);
+    expect(mockQuery).not.toHaveBeenCalled();
+    expect(mockCreateMagicLink).not.toHaveBeenCalled();
+    expect(mockSendMagicLinkSms).not.toHaveBeenCalled();
+  });
+
+  it("returns ok:false when phone is empty string", async () => {
+    const result = await sendAppLinkHandler({ phone: "   " }, CTX);
+    expect(result.ok).toBe(false);
+    expect(mockCreateMagicLink).not.toHaveBeenCalled();
+  });
+
+  it("returns ok:false when phone has no digits", async () => {
+    const result = await sendAppLinkHandler({ phone: "abc-def" }, CTX);
+    expect(result.ok).toBe(false);
+    // No createMagicLink because normalizePhone returns "+" which we treat
+    // as invalid here (handler checks for falsy).
+    expect(mockCreateMagicLink).not.toHaveBeenCalled();
+  });
+});
+
+describe("sendAppLinkHandler — happy path", () => {
+  beforeEach(() => {
+    mockCreateMagicLink.mockResolvedValue({
+      link: "http://localhost:5174/auth/callback?token=ABC",
+      userId: "user-uuid-1",
+    });
+  });
+
+  it("re-uses an existing applicant by phone (no INSERT)", async () => {
+    mockQuery
+      // findOrCreateApplicant SELECT → existing user
+      .mockResolvedValueOnce({
+        rows: [{ id: "user-uuid-1", email: "existing@example.com" }],
+      });
+
+    const result = await sendAppLinkHandler(
+      { phone: "+17025551212" },
+      CTX
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.message).toMatch(/text|link/i);
+
+    // Only the SELECT fired; no INSERT.
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+    expect(mockQuery.mock.calls[0][0]).toMatch(/SELECT id, email/);
+    expect(mockQuery.mock.calls[0][1]).toEqual(["+17025551212"]);
+
+    // Magic-link created for the existing email.
+    expect(mockCreateMagicLink).toHaveBeenCalledWith("existing@example.com");
+
+    // SMS fired with the magic-link userId, and the link has the intake
+    // query appended.
+    expect(mockSendMagicLinkSms).toHaveBeenCalledTimes(1);
+    const [userIdArg, linkArg] = mockSendMagicLinkSms.mock.calls[0];
+    expect(userIdArg).toBe("user-uuid-1");
+    expect(linkArg).toBe(
+      "http://localhost:5174/auth/callback?token=ABC&intake=conv_TEST_xyz"
+    );
+
+    // logMagicLink fired with redact-friendly args.
+    expect(mockLogMagicLink).toHaveBeenCalledWith("existing@example.com", linkArg);
+  });
+
+  it("creates a new applicant when no user has this phone", async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [] }) // SELECT → miss
+      .mockResolvedValueOnce({
+        rows: [
+          { id: "user-uuid-2", email: "voice+conv_TEST_xyz@voice-handoff.invalid" },
+        ],
+      }); // INSERT → created
+
+    mockCreateMagicLink.mockResolvedValueOnce({
+      link: "http://localhost:5174/auth/callback?token=DEF",
+      userId: "user-uuid-2",
+    });
+
+    const result = await sendAppLinkHandler(
+      { phone: "+17025551212", first_name: "Alex", last_name: "Peri" },
+      CTX
+    );
+
+    expect(result.ok).toBe(true);
+
+    // INSERT carries the synthesized email + names + phone.
+    const insertCall = mockQuery.mock.calls[1];
+    expect(insertCall[0]).toMatch(/INSERT INTO users/);
+    expect(insertCall[1]).toEqual([
+      "voice+conv_TEST_xyz@voice-handoff.invalid",
+      "Alex",
+      "Peri",
+      "+17025551212",
+    ]);
+
+    expect(mockCreateMagicLink).toHaveBeenCalledWith(
+      "voice+conv_TEST_xyz@voice-handoff.invalid"
+    );
+    expect(mockSendMagicLinkSms).toHaveBeenCalledWith(
+      "user-uuid-2",
+      "http://localhost:5174/auth/callback?token=DEF&intake=conv_TEST_xyz"
+    );
+  });
+
+  it("normalizes a 10-digit US phone to +1XXXXXXXXXX", async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: "u1", email: "e@example.com" }],
+    });
+
+    await sendAppLinkHandler({ phone: "7025551212" }, CTX);
+
+    expect(mockQuery.mock.calls[0][1]).toEqual(["+17025551212"]);
+  });
+
+  it("accepts camelCase firstName/lastName too", async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ id: "u3", email: "e@example.com" }] });
+
+    await sendAppLinkHandler(
+      { phone: "+17025551212", firstName: "Sam", lastName: "Reed" },
+      CTX
+    );
+
+    const insertCall = mockQuery.mock.calls[1];
+    expect(insertCall[1][1]).toBe("Sam");
+    expect(insertCall[1][2]).toBe("Reed");
+  });
+});
+
+describe("sendAppLinkHandler — failure paths", () => {
+  it("returns ok:false and skips SMS when createMagicLink fails", async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: "user-uuid-1", email: "u@example.com" }],
+    });
+    mockCreateMagicLink.mockResolvedValueOnce(null);
+
+    const result = await sendAppLinkHandler({ phone: "+17025551212" }, CTX);
+
+    expect(result.ok).toBe(false);
+    expect(result.message).toMatch(/sorry|trouble|call back/i);
+    expect(mockSendMagicLinkSms).not.toHaveBeenCalled();
+  });
+});
+
+describe("registerVoiceToolHandlers", () => {
+  beforeEach(() => {
+    clearToolHandlersForTests();
+    __resetRegistrationForTests();
+  });
+
+  it("registers the send_app_link handler once", () => {
+    registerVoiceToolHandlers();
+    expect(getRegisteredToolNames()).toContain("send_app_link");
+  });
+
+  it("is idempotent across repeated calls", () => {
+    registerVoiceToolHandlers();
+    registerVoiceToolHandlers();
+    const names = getRegisteredToolNames();
+    expect(names.filter((n) => n === "send_app_link")).toHaveLength(1);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,8 @@ import {
   voiceToolCallbackRouter,
   voiceBrowserSessionRouter,
   voiceIntakeRoutes,
+  voiceIntakeApplicantRoutes,
+  registerVoiceToolHandlers,
 } from "./modules/voice-intake";
 import decisionMatrixRoutes from "./modules/decision-matrix/routes";
 import leaseRoutes from "./modules/lease/routes";
@@ -283,6 +285,19 @@ if (process.env.VOICE_INTAKE_ENABLED === "true") {
 } else {
   logger.info("Voice intake PM routes skipped — VOICE_INTAKE_ENABLED is off");
 }
+
+// Applicant-facing voice-intake prefill (Phase B). Mounted on the same
+// flag as the PM console — both surfaces depend on the voice_intake_calls
+// table existing and the post-call webhook having landed rows.
+if (process.env.VOICE_INTAKE_ENABLED === "true") {
+  app.use("/api/voice/intakes", voiceIntakeApplicantRoutes);
+  logger.info("Voice intake applicant routes mounted");
+}
+
+// Phase B: register in-call server-tool handlers (send_app_link, etc.).
+// Idempotent — safe even when VOICE_TOOLS_ENABLED is off; the tool-callback
+// router will still 503 until that flag flips on.
+registerVoiceToolHandlers();
 
 // Compliance reports (Fair Housing Act — audit:view / Regional Manager+)
 app.use("/api/compliance", complianceRoutes);

--- a/src/modules/voice-intake/applicant-routes.ts
+++ b/src/modules/voice-intake/applicant-routes.ts
@@ -1,0 +1,98 @@
+import { Router, Response } from "express";
+import { authenticate, AuthRequest } from "../../middleware/auth";
+import { query } from "../../config/database";
+import { logger } from "../../utils/logger";
+import { pickField, normalizePhone } from "./service";
+
+/**
+ * Applicant-facing voice-intake endpoints.
+ *
+ * Mount path: /api/voice/intakes
+ *
+ * Distinct from src/modules/voice-intake/routes.ts (the PM-console router at
+ * /api/pm/voice-intakes) — that one is staff-only behind RBAC permissions
+ * like `voice_intake:view`. This router is for the applicant who just
+ * landed via magic-link with `?intake=<conversation_id>` in the URL and
+ * needs their voice-collected data to hydrate the wizard form.
+ *
+ * Only one endpoint today: GET /:conversationId/prefill. Returns a flat
+ * normalized object the wizard can map straight onto its form state.
+ * Authentication is required (any active user role); the conversation_id
+ * is the secret, treated like an unguessable resource handle. We do not
+ * cross-reference user ↔ conversation_id today because the matching identity
+ * (phone) may not yet be on the user record at first paint, and we don't
+ * want the wizard to flash an empty form while the link is still warm.
+ *
+ * No raw-body concerns — mounted AFTER global express.json() in src/index.ts.
+ */
+
+const router = Router();
+
+router.get(
+  "/:conversationId/prefill",
+  authenticate,
+  async (req: AuthRequest, res: Response): Promise<void> => {
+    const conversationId = String(req.params.conversationId ?? "").trim();
+    if (!conversationId || conversationId.length > 120) {
+      res.status(400).json({ error: "Invalid conversation_id" });
+      return;
+    }
+
+    try {
+      const result = await query(
+        `SELECT data_collection_results, language
+           FROM voice_intake_calls
+          WHERE conversation_id = $1
+          LIMIT 1`,
+        [conversationId]
+      );
+      const row = result.rows[0];
+      if (!row) {
+        // Soft-404: do NOT leak whether a conversation_id has ever existed.
+        // The wizard treats this as "no prefill available" and renders the
+        // blank form — same UX as a normal cold-start.
+        res.status(404).json({ error: "Not found" });
+        return;
+      }
+
+      const data = (row.data_collection_results ?? {}) as Record<string, unknown>;
+      const name = pickField(data, "name");
+      const [firstName, ...rest] = (name ?? "").split(/\s+/);
+      const lastName = rest.join(" ");
+      const phone = normalizePhone(pickField(data, "phone"));
+
+      const householdRaw = pickField(data, "household") ?? pickField(data, "household_size");
+      const householdSize = householdRaw ? parseInt(householdRaw, 10) || null : null;
+
+      const incomeRaw = pickField(data, "monthly_income");
+      const monthlyIncome = incomeRaw
+        ? Number(incomeRaw.replace(/[^0-9.]/g, "")) || null
+        : null;
+
+      const currentCity = pickField(data, "current_city");
+      const consent = pickField(data, "consent_recording");
+
+      res.json({
+        conversationId,
+        language: row.language ?? null,
+        prefill: {
+          firstName: firstName || null,
+          lastName: lastName || null,
+          phone,
+          currentCity,
+          householdSize,
+          monthlyIncome,
+          consentRecording: consent === null ? null : /^(true|yes|1|y)$/i.test(consent),
+        },
+      });
+    } catch (err) {
+      logger.error("voice-intake prefill failed", {
+        error: (err as Error).message,
+        conversationId,
+      });
+      res.status(500).json({ error: "Failed to load prefill" });
+    }
+  }
+);
+
+export default router;

--- a/src/modules/voice-intake/index.ts
+++ b/src/modules/voice-intake/index.ts
@@ -2,6 +2,8 @@ export { default as voiceIntakeWebhookRouter } from "./webhook";
 export { default as voiceToolCallbackRouter } from "./tool-callbacks";
 export { default as voiceBrowserSessionRouter } from "./browser-session";
 export { default as voiceIntakeRoutes } from "./routes";
+export { default as voiceIntakeApplicantRoutes } from "./applicant-routes";
+export { registerVoiceToolHandlers } from "./send-app-link";
 export {
   persistConversation,
   promoteIntakeToApplication,

--- a/src/modules/voice-intake/send-app-link.ts
+++ b/src/modules/voice-intake/send-app-link.ts
@@ -1,0 +1,201 @@
+import { query } from "../../config/database";
+import { logger } from "../../utils/logger";
+import {
+  createMagicLink,
+  logMagicLink,
+  sendMagicLinkSms,
+} from "../auth/magic-link-service";
+import { normalizePhone } from "./service";
+import {
+  registerToolHandler,
+  type ToolCallbackContext,
+  type ToolCallbackResult,
+} from "./tool-callbacks";
+
+/**
+ * Phase B voice tool: `send_app_link`.
+ *
+ * Mid-call, Frank asks the caller "want me to text you a link to finish in
+ * the app?" Yes → ElevenLabs fires this tool with `{phone, first_name?,
+ * last_name?}` extracted from the conversation. We find-or-create an
+ * applicant user keyed on phone, issue a magic-link with the conversation_id
+ * threaded through the deep link, and SMS it. The wizard on the other side
+ * reads `?intake=<conversation_id>` and calls the prefill endpoint to
+ * hydrate the form from the data_collection captured in-call.
+ *
+ * Why find-or-create instead of bouncing off /applicants/register:
+ *   - The register handler requires `email` and z-validates it. Voice
+ *     callers rarely spell email reliably; phone is the channel we have.
+ *   - We do NOT want a constant-time-budgeted public endpoint here — this
+ *     runs INSIDE the signed-and-deduped tool-callback pipeline already, so
+ *     a single deterministic path is fine.
+ *
+ * Returns ToolCallbackResult:
+ *   - { ok: true,  message: "I just texted you the link..." }  → agent reads back
+ *   - { ok: false, message: "I couldn't catch your phone..." } → agent retries
+ *
+ * Tape stamp: the parent dispatcher already emits VOICE_TOOL_INVOKED with
+ * ok/handler outcome. We do NOT double-stamp.
+ */
+
+export async function sendAppLinkHandler(
+  parameters: Record<string, unknown>,
+  context: ToolCallbackContext
+): Promise<ToolCallbackResult> {
+  const phoneRaw = pickString(parameters, "phone");
+  const firstName = pickString(parameters, "first_name") ?? pickString(parameters, "firstName");
+  const lastName = pickString(parameters, "last_name") ?? pickString(parameters, "lastName");
+
+  const phone = normalizePhone(phoneRaw);
+  if (!phone) {
+    logger.warn("send_app_link missing phone", {
+      conversationId: context.conversationId,
+    });
+    return {
+      ok: false,
+      message:
+        "I didn't catch your phone number. Can you say it once more, slowly?",
+    };
+  }
+
+  const user = await findOrCreateApplicant({
+    phone,
+    firstName: firstName ?? null,
+    lastName: lastName ?? null,
+    conversationId: context.conversationId,
+  });
+
+  const magic = await createMagicLink(user.email);
+  if (!magic) {
+    logger.error("send_app_link createMagicLink returned null", {
+      conversationId: context.conversationId,
+      userId: user.id,
+    });
+    return {
+      ok: false,
+      message:
+        "Sorry, I'm having trouble generating that link right now. Could you call back in a minute?",
+    };
+  }
+
+  const link = appendIntakeQuery(magic.link, context.conversationId);
+  logMagicLink(user.email, link);
+  sendMagicLinkSms(magic.userId, link);
+
+  logger.info("send_app_link issued", {
+    conversationId: context.conversationId,
+    userId: magic.userId,
+    phoneMasked: maskPhone(phone),
+  });
+
+  return {
+    ok: true,
+    result: { sent: true },
+    message:
+      "Great — I just texted you a link. Tap it and the app will pick up right where we left off.",
+  };
+}
+
+function pickString(parameters: Record<string, unknown>, key: string): string | null {
+  const value = parameters[key];
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+/**
+ * Append `&intake=<conversation_id>` to a magic-link URL. createMagicLink
+ * always returns `?token=...`, so we always need `&`. Defensive: if the URL
+ * already carries the intake param, leave it.
+ */
+function appendIntakeQuery(link: string, conversationId: string): string {
+  if (link.includes("intake=")) return link;
+  const sep = link.includes("?") ? "&" : "?";
+  return `${link}${sep}intake=${encodeURIComponent(conversationId)}`;
+}
+
+/**
+ * Last-4-digits masking for log lines. Never log the full E.164.
+ */
+function maskPhone(phone: string): string {
+  if (phone.length <= 4) return "****";
+  return `***${phone.slice(-4)}`;
+}
+
+interface FindOrCreateArgs {
+  phone: string;
+  firstName: string | null;
+  lastName: string | null;
+  conversationId: string;
+}
+
+/**
+ * Find an existing applicant/tenant user by phone, or create a new applicant.
+ *
+ * No UNIQUE(phone) on the users table — we deduplicate by picking the most
+ * recently updated applicant/tenant with this phone of record. Staff rows
+ * are intentionally excluded so a leasing agent who happens to share a
+ * household phone never receives an applicant link.
+ *
+ * New users get a deterministic synthesized email
+ * `voice+<conversation_id>@voice-handoff.invalid` so the existing
+ * createMagicLink → users-by-email lookup keeps working without a schema
+ * change. The `.invalid` TLD is reserved (RFC 2606) and never delivers
+ * mail, so a typo or stale reference can never reach a real inbox.
+ */
+async function findOrCreateApplicant(
+  args: FindOrCreateArgs
+): Promise<{ id: string; email: string }> {
+  const existing = await query(
+    `SELECT id, email
+       FROM users
+      WHERE phone = $1
+        AND role IN ('applicant', 'tenant')
+        AND is_active = TRUE
+      ORDER BY last_login DESC NULLS LAST, created_at DESC
+      LIMIT 1`,
+    [args.phone]
+  );
+  if (existing.rows.length > 0) {
+    const row = existing.rows[0];
+    return { id: row.id as string, email: row.email as string };
+  }
+
+  const email = synthEmailFromConversation(args.conversationId);
+  const inserted = await query(
+    `INSERT INTO users (
+       email, first_name, last_name, phone, role, is_active, password_hash
+     )
+     VALUES ($1, $2, $3, $4, 'applicant', TRUE, '')
+     ON CONFLICT (email) DO UPDATE SET
+       phone = EXCLUDED.phone,
+       first_name = COALESCE(EXCLUDED.first_name, users.first_name),
+       last_name  = COALESCE(EXCLUDED.last_name,  users.last_name)
+     RETURNING id, email`,
+    [email, args.firstName ?? "Voice", args.lastName ?? "Caller", args.phone]
+  );
+
+  const row = inserted.rows[0];
+  return { id: row.id as string, email: row.email as string };
+}
+
+function synthEmailFromConversation(conversationId: string): string {
+  const slug = conversationId.replace(/[^a-zA-Z0-9_-]/g, "").slice(0, 80) || "anon";
+  return `voice+${slug}@voice-handoff.invalid`;
+}
+
+let registered = false;
+/**
+ * Idempotent registration helper. Boot calls this once; tests can also call
+ * it after clearToolHandlersForTests() to re-wire.
+ */
+export function registerVoiceToolHandlers(): void {
+  if (registered) return;
+  registerToolHandler("send_app_link", sendAppLinkHandler);
+  registered = true;
+}
+
+/** Test-only: reset the one-time gate so jest can re-register fresh. */
+export function __resetRegistrationForTests(): void {
+  registered = false;
+}

--- a/src/modules/voice-intake/service.ts
+++ b/src/modules/voice-intake/service.ts
@@ -53,7 +53,7 @@ export interface PersistResult {
  * shapes each entry as `{ value, rationale, json_schema, ... }`. Returns
  * null if missing or non-string.
  */
-function pickField(
+export function pickField(
   results: Record<string, unknown> | undefined,
   key: string
 ): string | null {
@@ -180,7 +180,7 @@ export async function persistConversation(payload: PostCallPayload): Promise<Per
  * happens at the downstream approve step. The column is `VARCHAR(20)`, so
  * the looseness is tolerated.
  */
-function normalizePhone(raw: string | null): string | null {
+export function normalizePhone(raw: string | null): string | null {
   if (!raw) return null;
   const trimmed = raw.trim();
   if (trimmed.startsWith("+")) {


### PR DESCRIPTION
## Summary
- Adds the `send_app_link` in-call server tool: agent collects phone mid-call, handler normalizes it, finds-or-creates an applicant row, mints a magic link, appends `&intake=<conversation_id>` to the deeplink, and texts it via the existing magic-link SMS service.
- Adds `GET /api/voice/intakes/:conversationId/prefill` (auth-required), a flat normalized view of `data_collection_results` for the wizard to hydrate its form when the caller lands via magic link.
- Wires both into the module barrel and `src/index.ts`. Mount is flag-gated on `VOICE_INTAKE_ENABLED`; `registerVoiceToolHandlers()` runs once at boot (idempotent).

## Why this is shaped this way
- **No schema migration.** `users.phone` has no UNIQUE constraint, so find-or-create picks the most-recently-active applicant/tenant by phone and otherwise inserts with a synthesized `voice+<conversationId>@voice-handoff.invalid` email (RFC 2606).
- **Fails soft.** Missing phone, no-digit phone, or `createMagicLink` returning null surface a conversational message; the dispatcher still returns 200 to ElevenLabs and tape-stamps `VOICE_TOOL_INVOKED` — does not consume the 10-failure auto-disable budget.
- **Phone normalized at every boundary.** 10-digit US → `+1XXXXXXXXXX`, both when looking up users and when re-serializing for the prefill response.
- **Prefill is soft-404.** Does not leak whether a `conversation_id` has ever existed.
- **Reuses existing primitives.** `pickField` and `normalizePhone` promoted to exports from `service.ts` so the new modules parse the same way as the post-call promote/reject path.

## Out of scope (Phase B.2, separate PR)
- Wizard frontend wiring (touches `client-tenant/src/App.tsx`, owned by a sibling session today).

## Test plan
- [x] `voice-send-app-link.test.ts` — phone parsing, find-or-create (reuse vs INSERT), camelCase aliases, `createMagicLink` failure, registration idempotency
- [x] `voice-applicant-routes.test.ts` — 401 unauth, 400 oversized id, 404 soft-leak-proof miss, 200 normalized payload, partial-data null-out, 500 on DB error
- [x] All 88 `voice-*` jest suites green (1360 tests)
- [x] `tsc --noEmit` clean
- [ ] Manual: re-enable `VOICE_TOOLS_ENABLED=true` on a preview env, configure `send_app_link` in the ElevenLabs agent, trigger mid-call, confirm SMS arrives with `&intake=...` appended
- [ ] Manual: GET `/api/voice/intakes/<real conv id>/prefill` with an applicant bearer token, confirm normalized payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)