### PR TITLE
feat(voice-intake): Phase B.2 — wizard pre-fill from "Talk to Frank" call

### DIFF
--- a/client-tenant/src/api/__tests__/voiceIntake.test.ts
+++ b/client-tenant/src/api/__tests__/voiceIntake.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+// Mock the low-level client so we assert on the request path the helper builds,
+// without touching fetch. Mirrors how the helper is the only seam over api.get.
+vi.mock('../client', () => ({
+  api: { get: vi.fn() },
+}));
+
+import { api } from '../client';
+import { fetchVoicePrefill, type VoicePrefillResponse } from '../voiceIntake';
+
+const mockGet = api.get as unknown as ReturnType<typeof vi.fn>;
+
+describe('fetchVoicePrefill', () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+  });
+
+  it('hits the applicant prefill endpoint for the conversation id', async () => {
+    const payload: VoicePrefillResponse = {
+      conversationId: 'conv_123',
+      language: 'en',
+      prefill: {
+        firstName: 'Sarah',
+        lastName: 'Lee',
+        phone: '+17025550123',
+        currentCity: 'Henderson',
+        householdSize: 3,
+        monthlyIncome: 2400,
+        consentRecording: true,
+      },
+    };
+    mockGet.mockResolvedValueOnce(payload);
+
+    const res = await fetchVoicePrefill('conv_123');
+
+    expect(mockGet).toHaveBeenCalledWith('/voice/intakes/conv_123/prefill');
+    expect(res).toEqual(payload);
+  });
+
+  it('url-encodes the conversation id so a stray handle cannot break the path', async () => {
+    mockGet.mockResolvedValueOnce({ conversationId: 'a/b?c', language: null, prefill: {} });
+
+    await fetchVoicePrefill('a/b?c');
+
+    expect(mockGet).toHaveBeenCalledWith('/voice/intakes/a%2Fb%3Fc/prefill');
+  });
+
+  it('propagates a rejection so the caller can fall back to the blank form', async () => {
+    mockGet.mockRejectedValueOnce(new Error('Not found'));
+    await expect(fetchVoicePrefill('conv_missing')).rejects.toThrow('Not found');
+  });
+});

--- a/client-tenant/src/api/voiceIntake.ts
+++ b/client-tenant/src/api/voiceIntake.ts
@@ -1,0 +1,41 @@
+import { api } from './client';
+
+/**
+ * Phase B.2 — applicant-facing voice-intake prefill.
+ *
+ * The "Talk to Frank" call writes a `voice_intake_calls` row keyed by the
+ * ElevenLabs conversation_id. The in-call `send_app_link` tool SMSes a magic
+ * link with `&intake=<conversationId>` appended. After the applicant signs in,
+ * the apply wizard calls this to hydrate the form with what Frank already
+ * collected on the call.
+ *
+ * Server contract (GET /api/voice/intakes/:conversationId/prefill, auth-
+ * required): soft-404 when there's no row — the conversation_id is treated as
+ * an unguessable handle and we never leak whether one existed. Callers treat
+ * ANY failure (404 / 401 / network) as "no prefill" and render the blank form,
+ * identical to a cold start.
+ */
+
+export interface VoicePrefill {
+  firstName: string | null;
+  lastName: string | null;
+  phone: string | null;
+  currentCity: string | null;
+  householdSize: number | null;
+  monthlyIncome: number | null;
+  consentRecording: boolean | null;
+}
+
+export interface VoicePrefillResponse {
+  conversationId: string;
+  language: string | null;
+  prefill: VoicePrefill;
+}
+
+export async function fetchVoicePrefill(
+  conversationId: string,
+): Promise<VoicePrefillResponse> {
+  return api.get<VoicePrefillResponse>(
+    `/voice/intakes/${encodeURIComponent(conversationId)}/prefill`,
+  );
+}

--- a/client-tenant/src/pages/Apply.tsx
+++ b/client-tenant/src/pages/Apply.tsx
@@ -2,6 +2,7 @@ import { lazy, Suspense, useEffect, useState } from 'react';
 import { useSearchParams, Link } from 'react-router-dom';
 import { CheckCircle } from 'lucide-react';
 import { api } from '@/api/client';
+import { fetchVoicePrefill } from '@/api/voiceIntake';
 import { ClaimedUnitHeader } from '@/components/ClaimedUnitHeader';
 import { Card } from '@/components/primitives';
 import { HF } from '@/styles/tokens';
@@ -197,6 +198,47 @@ export function Apply() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // Phase B.2 — voice-intake prefill. When the applicant arrives from a "Talk
+  // to Frank" call, the magic link carried `?intake=<conversationId>` (preserved
+  // through AuthCallback). Hydrate the wizard with what Frank collected on the
+  // call. Best-effort and fill-only-empty: never clobber a value the user typed
+  // or one the Issue #8 /auth/me + applications hydration already set. Any
+  // failure (soft-404 / 401 / network) falls back to the blank form — identical
+  // to a cold start. Mount-once, like the Wedge #5 propertyId consumer above.
+  useEffect(() => {
+    const conversationId = search.get('intake');
+    if (!conversationId) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const { prefill: p } = await fetchVoicePrefill(conversationId);
+        if (cancelled || !p) return;
+        if (p.firstName) setFirstName((prev) => prev || p.firstName!);
+        if (p.lastName) setLastName((prev) => prev || p.lastName!);
+        if (p.phone) setPhone((prev) => prev || p.phone!);
+        if (p.currentCity) setCity((prev) => prev || p.currentCity!);
+        if (p.householdSize != null) {
+          // Local field defaults to '1'; only override the untouched default so
+          // we don't stomp a value the user changed or an application supplied.
+          setHouseholdSize((prev) => (prev === '1' ? String(p.householdSize) : prev));
+          // intentHouseholdSize defaults to 1 (ApplyContext) — never null. Guard
+          // on the untouched default so we fill it but never stomp a user/app value.
+          if (wiz.intentHouseholdSize === 1) wiz.setIntentHouseholdSize(p.householdSize);
+        }
+        if (p.monthlyIncome != null) {
+          // Frank collects MONTHLY income; the wizard's details step holds gross
+          // ANNUAL. Convert once here so AMI tiering downstream sees annual.
+          setAnnualIncome((prev) => prev || String(Math.round(p.monthlyIncome! * 12)));
+        }
+      } catch {
+        /* best-effort — soft-404 / 401 / network all fall back to blank form */
+      }
+    })();
+    return () => { cancelled = true; };
+    // Consume the intake handle once on mount, mirroring Wedge #5 above.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   // Issue #8 — gate render on intent-step deep links until hydration completes.
   // Without this, landing on `?step=intent` paints the empty quiz form for a
   // tick before /auth/me + /applicants/me/applications resolve and backfill
@@ -245,8 +287,12 @@ export function Apply() {
           if (latest.intent_budget_max != null) setIntentBudgetMax(Number(latest.intent_budget_max));
           if (latest.intent_move_in_date) setIntentMoveInDate(latest.intent_move_in_date.slice(0, 10));
           if (latest.intent_household_size != null) {
-            wiz.setIntentHouseholdSize(latest.intent_household_size);
-            setHouseholdSize(String(latest.intent_household_size));
+            // Fill-only-default, mirroring the Phase B.2 voice prefill above:
+            // these two effects both write household at mount and race, so
+            // whichever resolves first wins and neither clobbers the other.
+            const hh = latest.intent_household_size;
+            if (wiz.intentHouseholdSize === 1) wiz.setIntentHouseholdSize(hh);
+            setHouseholdSize((prev) => (prev === '1' ? String(hh) : prev));
           }
         }
       } catch {

--- a/client-tenant/src/pages/AuthCallback.tsx
+++ b/client-tenant/src/pages/AuthCallback.tsx
@@ -48,6 +48,17 @@ async function fetchMeWithRetry(): Promise<MeResponse> {
   }
 }
 
+// Phase B.2 — carry the voice-intake handle through the redirect. A "Talk to
+// Frank" magic link arrives as `…/auth/callback?token=…&intake=<conversationId>`;
+// resolvePostVerifyRoute() decides the destination but knows nothing about the
+// intake handle, so we re-attach it here. Harmless on /dashboard|/application
+// (they ignore it); the apply wizard reads it to hydrate the form from the call.
+function withIntake(dest: string, intake: string | null): string {
+  if (!intake) return dest;
+  const sep = dest.includes('?') ? '&' : '?';
+  return `${dest}${sep}intake=${encodeURIComponent(intake)}`;
+}
+
 async function resolvePostVerifyRoute(): Promise<string> {
   // Retry once on transient /auth/me failure. Defaulting to the intent quiz
   // here misroutes staff (and any returning applicant) into the wrong screen.
@@ -73,6 +84,7 @@ export function AuthCallback() {
 
   useEffect(() => {
     const token = searchParams.get('token');
+    const intake = searchParams.get('intake');
     if (!token) {
       setError('No token found in link.');
       return;
@@ -89,7 +101,7 @@ export function AuthCallback() {
           return '/login';
         }
       })
-      .then(dest => navigate(dest, { replace: true }))
+      .then(dest => navigate(withIntake(dest, intake), { replace: true }))
       .catch(err => setError(err instanceof Error ? err.message : 'Invalid or expired link'));
   }, [searchParams, navigate]);
 


### PR DESCRIPTION
## What

Closes the deferred half of voice-intake (the Phase B.2 frontend pre-fill). When an applicant arrives from a **"Talk to Frank"** call, the apply wizard now hydrates with what Frank collected on the call instead of showing a cold blank form.

Flow: the in-call `send_app_link` tool SMSes a magic link with `&intake=<conversationId>` → `AuthCallback` preserves that handle through the post-verify redirect → the wizard fetches `GET /api/voice/intakes/:conversationId/prefill` (backend shipped in #208) and fills the form.

## Changes

- **`client-tenant/src/api/voiceIntake.ts`** (new) — typed `fetchVoicePrefill` helper over the applicant prefill endpoint; url-encodes the `conversation_id` so a stray handle can't break the path.
- **`AuthCallback.tsx`** — `withIntake()` re-attaches `?intake=` after `resolvePostVerifyRoute()` chooses the destination (that fn is handle-agnostic). Harmless on `/dashboard` / `/application` (they ignore it); the wizard is the only consumer.
- **`Apply.tsx`** — mount-once, best-effort prefill effect. Fills `firstName` / `lastName` / `phone` / `city` / `householdSize` and converts Frank's **monthly** income → the wizard's gross **annual**. Any failure (soft-404 / 401 / network) falls back to the blank form, identical to a cold start.

## Correctness — household race

The new voice effect and the existing Issue #8 applications-hydration effect both write `household` at mount and race. Both are now **fill-only-default (first-writer-wins)**, so neither clobbers the other or a value the user typed. `intentHouseholdSize` defaults to `1` (never `null`), so the guard is `=== 1` — the scaffold's `=== null` was dead code that let the applications fetch silently overwrite a voice prefill. Both surfaced by an adversarial review pass and fixed here.

## Scope / safety

- Frontend-only. **No schema or backend change.**
- Flag-gated off in prod: the prefill endpoint returns soft-404 until a real voice call row exists, so this is inert until voice-intake is enabled.

## Tests

- New `voiceIntake.test.ts` (path correctness, url-encoding, rejection→blank-form fallback).
- Full apply suite + `AmiCalculator` re-run: **68/68 green**, `tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)