### PR TITLE
feat(compliance): NV LIHTC BIN dataset — 12 properties, 70 buildings, 965 units

### DIFF
--- a/demo/extract-bins.py
+++ b/demo/extract-bins.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python3
+"""
+Extract Nevada LIHTC Building Identification Numbers (BINs) from scanned
+OneSite "Unit Scheduled Transactions" PDFs emailed by Global Property
+Management Group.
+
+Each PDF is one property. Pages are scanned images with zero text layer, so
+extraction is fully vision-based. This script handles the Python half of the
+pipeline:
+
+  1. `render`  -> rasterize every PDF page to PNG and emit a manifest
+                  describing which PNGs belong to which property. The vision
+                  pass (Claude Opus subagents) is dispatched by the harness,
+                  not by this script.
+  2. `merge`   -> combine per-property agent JSON outputs into the final
+                  src/db/data/bins.json plus docs/bins-verification.md.
+
+Usage:
+  demo/.venv/bin/python3 demo/extract-bins.py render \\
+        --pdf-dir /Volumes/SSD/Downloads/bins \\
+        --out-dir /tmp/bins-work
+
+  demo/.venv/bin/python3 demo/extract-bins.py merge \\
+        --work-dir /tmp/bins-work \\
+        --agent-dir /tmp/bins-work/agent-out
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import pdfplumber
+from pdf2image import convert_from_path
+from PIL import Image
+
+ROOT = Path(__file__).resolve().parents[1]
+OUT_BINS_JSON = ROOT / "src" / "db" / "data" / "bins.json"
+OUT_VERIFY_MD = ROOT / "docs" / "bins-verification.md"
+
+JOIN_TABLE = {
+    "FLETCHER": None,
+    "OCALLAGHAN": None,
+    "YALE": "Yale/Keyes Senior Apts",
+    "REID": "Sen. Harry Reid Senior Apts Aka 11Th St",
+    "JUAN": "Juan Garcia Aka Ernie Cragin",
+    "SRB": None,
+    "LOUISE SHELL": "Louise Shell/Harmony Park Apts",
+    "OWENS": "Owens Senior",
+    "MEACHAM": "Dr. Paul Meacham",
+    "SMITH WILLIAMS": "Smith Williams Apts",
+    "MACK": None,
+    "DONNALOUISE": None,
+}
+
+
+@dataclass
+class PdfManifestEntry:
+    slug: str
+    pdf_path: Path
+    page_pngs: list[Path]
+    pages_in_pdf: int
+    pages_in_header: int | None
+
+
+def slugify(name: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-")
+
+
+def discover_pdfs(pdf_dir: Path) -> list[Path]:
+    pdfs = sorted([p for p in pdf_dir.glob("*.pdf") if "BIN" in p.name.upper()])
+    if not pdfs:
+        raise SystemExit(f"no *BIN*.pdf files in {pdf_dir}")
+    return pdfs
+
+
+def pages_reported_by_header(pdf_path: Path) -> int | None:
+    """Some scans claim 'Page 1 of N' in the header but ship fewer images.
+    We can't OCR the header here (we'd need vision), so leave the field for
+    the agent to fill in. Returns None at this stage."""
+    return None
+
+
+def render_pdf(pdf_path: Path, out_dir: Path, dpi: int = 400, split: bool = True) -> PdfManifestEntry:
+    """Rasterize each page; optionally split into top/bottom halves so the agent
+    sees larger crops of dense rotated-landscape tables. The pages are printed
+    sideways, so the PNG's vertical halves correspond to left/right halves of
+    the underlying landscape report. Splitting roughly doubles the resolution
+    the vision model has on column boundaries and handwriting strokes."""
+    slug = slugify(pdf_path.stem.replace(" BIN", "").replace("BIN", ""))
+    pdf_out = out_dir / slug
+    pdf_out.mkdir(parents=True, exist_ok=True)
+
+    with pdfplumber.open(pdf_path) as pdf:
+        pages_in_pdf = len(pdf.pages)
+
+    images = convert_from_path(str(pdf_path), dpi=dpi, fmt="png")
+    page_pngs: list[Path] = []
+    for i, img in enumerate(images, start=1):
+        if not split:
+            png = pdf_out / f"page-{i:02d}.png"
+            img.save(png, "PNG", optimize=True)
+            page_pngs.append(png)
+            continue
+
+        w, h = img.size
+        # ~5% overlap between halves so rows split across the seam are still
+        # readable in at least one crop.
+        overlap = int(h * 0.05)
+        mid = h // 2
+        top = img.crop((0, 0, w, mid + overlap))
+        bot = img.crop((0, mid - overlap, w, h))
+        top_png = pdf_out / f"page-{i:02d}-a.png"
+        bot_png = pdf_out / f"page-{i:02d}-b.png"
+        top.save(top_png, "PNG", optimize=True)
+        bot.save(bot_png, "PNG", optimize=True)
+        page_pngs.extend([top_png, bot_png])
+
+    return PdfManifestEntry(
+        slug=slug,
+        pdf_path=pdf_path,
+        page_pngs=page_pngs,
+        pages_in_pdf=pages_in_pdf,
+        pages_in_header=pages_reported_by_header(pdf_path),
+    )
+
+
+def cmd_render(args: argparse.Namespace) -> None:
+    pdf_dir = Path(args.pdf_dir).expanduser().resolve()
+    out_dir = Path(args.out_dir).expanduser().resolve()
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / "agent-out").mkdir(exist_ok=True)
+
+    pdfs = discover_pdfs(pdf_dir)
+    print(f"[render] found {len(pdfs)} PDFs in {pdf_dir}")
+    manifest: list[dict] = []
+    for pdf in pdfs:
+        entry = render_pdf(pdf, out_dir, dpi=args.dpi, split=args.split)
+        print(f"  {entry.slug:20s} {len(entry.page_pngs):>2d} pages -> {entry.page_pngs[0].parent}")
+        manifest.append({
+            "slug": entry.slug,
+            "pdfName": pdf.name,
+            "pdfPath": str(entry.pdf_path),
+            "pages": [str(p) for p in entry.page_pngs],
+            "pagesInPdf": entry.pages_in_pdf,
+            "agentOutPath": str(out_dir / "agent-out" / f"{entry.slug}.json"),
+        })
+
+    manifest_path = out_dir / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2))
+    print(f"[render] manifest -> {manifest_path}")
+    print(f"[render] next: dispatch one Opus agent per property; write each agent's")
+    print(f"          JSON to {out_dir}/agent-out/<slug>.json then run `merge`.")
+
+
+def load_agent_output(path: Path) -> dict:
+    if not path.exists():
+        return {
+            "_missing": True,
+            "buildings": [],
+            "warnings": [f"agent output {path} missing"],
+        }
+    raw = path.read_text().strip()
+    # tolerate agents that wrap output in ```json fences
+    if raw.startswith("```"):
+        raw = re.sub(r"^```(?:json)?\s*", "", raw)
+        raw = re.sub(r"\s*```\s*$", "", raw)
+    return json.loads(raw)
+
+
+def normalize_property(slug: str, manifest_entry: dict, agent: dict) -> dict:
+    pdf_name = manifest_entry["pdfName"]
+    bare_key = pdf_name.upper().replace("BIN.PDF", "").replace(".PDF", "").strip()
+    join_name = JOIN_TABLE.get(bare_key, agent.get("joinName"))
+
+    buildings = []
+    bin_re = re.compile(r"^NV-\d{2}-\d{5}$")
+    for b in agent.get("buildings", []):
+        units = list(b.get("units") or [])
+        units.sort(key=lambda u: (
+            int(u.split("-")[0]) if u.split("-")[0].isdigit() else 0,
+            u,
+        ))
+        bin_val = b.get("bin")
+        if bin_val and not bin_re.match(bin_val):
+            agent.setdefault("warnings", []).append(
+                f"building {b.get('buildingCode')} bin {bin_val!r} does not match NV-YY-NNNNN"
+            )
+        buildings.append({
+            "buildingCode": str(b.get("buildingCode") or b.get("building") or ""),
+            "bin": bin_val,
+            "unitCount": len(units),
+            "units": units,
+        })
+    buildings.sort(key=lambda b: (
+        int(b["buildingCode"]) if b["buildingCode"].isdigit() else 999,
+        b["buildingCode"],
+    ))
+
+    pages_in_pdf = manifest_entry["pagesInPdf"]
+    pages_reported = agent.get("pagesReportedByHeader")
+    scan_incomplete = (
+        pages_reported is not None and pages_reported > pages_in_pdf
+    )
+
+    out = {
+        "propertyName": agent.get("propertyName"),
+        "operatorEntity": agent.get("operatorEntity"),
+        "joinName": join_name,
+        "source": {
+            "type": "gpmg-email",
+            "date": agent.get("sourceDate", "2026-05-27"),
+            "pdf": pdf_name,
+            "pagesScanned": pages_in_pdf,
+            "pagesReportedByHeader": pages_reported,
+            "scanIncomplete": scan_incomplete,
+        },
+        "buildings": buildings,
+        "warnings": list(agent.get("warnings") or []),
+    }
+    if scan_incomplete:
+        out["warnings"].insert(0, (
+            f"PDF has {pages_in_pdf} pages but header reports {pages_reported}; "
+            "additional buildings/units may be missing — request a full scan."
+        ))
+    if any(b["bin"] is None for b in buildings):
+        out["warnings"].append("one or more buildings have no BIN extracted")
+    if not buildings:
+        out["warnings"].append("agent returned zero buildings")
+    return out
+
+
+def cmd_merge(args: argparse.Namespace) -> None:
+    work_dir = Path(args.work_dir).expanduser().resolve()
+    agent_dir = Path(args.agent_dir).expanduser().resolve()
+    manifest = json.loads((work_dir / "manifest.json").read_text())
+
+    # Defensive: a missing or empty agent output must never silently wipe a
+    # property that was already extracted into bins.json. Load any prior result
+    # and keep it whenever this run's agent file is absent or returned zero
+    # buildings. (A re-run that genuinely re-extracts a property always wins.)
+    prior: dict[str, dict] = {}
+    if OUT_BINS_JSON.exists():
+        try:
+            prior = json.loads(OUT_BINS_JSON.read_text())
+        except (json.JSONDecodeError, OSError):
+            prior = {}
+
+    bins: dict[str, dict] = {}
+    summary_rows = []
+    total_buildings = 0
+    total_units = 0
+    total_missing_bins = 0
+
+    for entry in manifest:
+        slug = entry["slug"]
+        agent_json = load_agent_output(agent_dir / f"{slug}.json")
+        prop = normalize_property(slug, entry, agent_json)
+        if not prop["buildings"] and prior.get(slug, {}).get("buildings"):
+            prop = prior[slug]
+            prop.setdefault("warnings", []).append(
+                "agent output missing/empty this run — preserved prior extraction"
+            )
+            print(f"[merge] {slug}: agent output empty, kept prior extraction")
+        bins[slug] = prop
+        b_count = len(prop["buildings"])
+        u_count = sum(b["unitCount"] for b in prop["buildings"])
+        missing = sum(1 for b in prop["buildings"] if not b["bin"])
+        total_buildings += b_count
+        total_units += u_count
+        total_missing_bins += missing
+        summary_rows.append((slug, prop, b_count, u_count, missing))
+
+    OUT_BINS_JSON.parent.mkdir(parents=True, exist_ok=True)
+    OUT_BINS_JSON.write_text(json.dumps(bins, indent=2) + "\n")
+    print(f"[merge] wrote {OUT_BINS_JSON.relative_to(ROOT)}")
+
+    md = ["# BINs verification\n"]
+    md.append("Source: 12-attachment email from Dora D. LaGrande (Global Property Management Group), 2026-05-27.\n")
+    md.append(f"Summary: **{len(bins)} properties**, **{total_buildings} buildings**, **{total_units} units**, **{total_missing_bins} missing BINs**.\n")
+    md.append("If `missing BINs > 0`, the agent could not read the handwritten BIN for one or more buildings — re-render at higher DPI or request a re-scan.\n")
+    md.append("---\n")
+    for slug, prop, b_count, u_count, missing in summary_rows:
+        md.append(f"\n## {slug.upper()} — {prop.get('propertyName') or '(name not extracted)'}\n")
+        md.append(f"- Operator entity: {prop.get('operatorEntity') or '(none)'}")
+        src = prop["source"]
+        md.append(f"- Source: `{src['pdf']}` (pages scanned: {src['pagesScanned']}, header reports: {src['pagesReportedByHeader']}, incomplete: {src['scanIncomplete']})")
+        join = prop["joinName"]
+        md.append(f"- Join to `nv-housing-props.json`: {('`' + join + '`') if join else '**no match** (new property or unmapped)'}")
+        if prop["warnings"]:
+            md.append("- Warnings:")
+            for w in prop["warnings"]:
+                md.append(f"  - ⚠ {w}")
+        md.append("")
+        md.append("| Building | BIN | Units | First | Last |")
+        md.append("|---:|---|---:|---|---|")
+        for b in prop["buildings"]:
+            first = b["units"][0] if b["units"] else "—"
+            last = b["units"][-1] if b["units"] else "—"
+            bin_disp = b["bin"] or "**missing**"
+            md.append(f"| {b['buildingCode']} | {bin_disp} | {b['unitCount']} | {first} | {last} |")
+    OUT_VERIFY_MD.parent.mkdir(parents=True, exist_ok=True)
+    OUT_VERIFY_MD.write_text("\n".join(md) + "\n")
+    print(f"[merge] wrote {OUT_VERIFY_MD.relative_to(ROOT)}")
+    print(f"[merge] totals: {len(bins)} properties / {total_buildings} bldgs / {total_units} units / {total_missing_bins} missing BINs")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_render = sub.add_parser("render", help="rasterize PDFs and emit manifest")
+    p_render.add_argument("--pdf-dir", required=True)
+    p_render.add_argument("--out-dir", required=True)
+    p_render.add_argument("--dpi", type=int, default=400)
+    p_render.add_argument("--no-split", dest="split", action="store_false")
+    p_render.set_defaults(split=True)
+    p_render.set_defaults(func=cmd_render)
+
+    p_merge = sub.add_parser("merge", help="combine agent JSON into bins.json + verification doc")
+    p_merge.add_argument("--work-dir", required=True)
+    p_merge.add_argument("--agent-dir", required=True)
+    p_merge.set_defaults(func=cmd_merge)
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/bins-verification-gaps-request.md
+++ b/docs/bins-verification-gaps-request.md
@@ -1,0 +1,46 @@
+# BIN verification — follow-up request to GPMG
+
+**Status:** ready to send — Alex reviews, then forwards to Dora D. LaGrande (Global Property Management Group).
+**Re:** the 12 BIN rent-roll PDFs emailed 2026-05-27.
+**Why:** we transcribed Building Identification Numbers (BINs) from those scans for LIHTC §42 compliance. Most came through clean, but the scans have gaps and a handful of handwritten BINs are at the resolution limit. Everything below is what we could **not** confirm from the scans alone.
+
+---
+
+## The one ask that resolves most of this
+
+If GPMG can export a **clean, machine-readable list of BIN → building → unit count per property** (a spreadsheet or the source rent-roll as text/CSV rather than a scan), it sidesteps every handwriting/OCR ambiguity below in one step. That's the preferred path. The itemized list is the fallback if a clean export isn't available.
+
+---
+
+## A. Incomplete scans — 8 properties, ~20 missing pages
+
+Each PDF's own page footer reports more pages than were attached. We need the missing pages (buildings/units on them are not captured).
+
+| Property | Pages received | Header says | Missing | Also flag |
+|---|---:|---:|---|---|
+| FLETCHER | 6 | 9 | **7–9** | building **4** is absent from the scan (sequence skips bldg 3 → bldg 5); need its BIN |
+| LOUISE SHELL | 10 | 13 | **11–13** | trailing pages likely summary/totals only — please confirm |
+| MEACHAM | 8 | 10 | **9–10** | single building; pages may be totals only — please confirm |
+| O'CALLAGHAN | 4 | 7 | **5–7** | + see section B |
+| OWENS | 8 | 10 | **9–10** | building 5 shows only 8 units vs 12 elsewhere — continuation may be on a missing page |
+| SMITH-WILLIAMS | 11 | 13 | **12–13** | |
+| SRB | 24 | 27 | **25–27** | building 30 may have more units; is there any building 31+? Also unit `14-1107` is missing between `14-1106` and `14-1108` — gap in the roll or a skipped row? |
+| YALE | 9 | 11 | **10–11** | single building; pages may be summary only — please confirm |
+
+## B. Confirmed-blank BINs — need the values
+
+O'Callaghan (Governor Mike O'Callaghan Legacy Apts): only **building 1** carries a margin BIN (`NV-22-05001`). **Buildings 2, 3, and 4 have no BIN annotation** on the scanned pages. We deliberately did **not** guess `05002 / 05003 / 05004` despite the obvious pattern. Please supply the actual BINs for buildings 2, 3, 4.
+
+## C. Confirm one ambiguous BIN
+
+Juan Garcia Apts, **building 2**: the handwritten margin reads a **4-digit** suffix `NV-00-0002`, while every sibling building (3–7) uses a 5-digit suffix (`NV-00-00003 … NV-00-00007`). We normalized it to `NV-00-00002` for consistency, but please confirm that's correct and not a genuinely different number.
+
+## D. Confirm a handwriting-limited mapping
+
+Ethel Mae Fletcher Apts: the `NV-14-04xxx` BINs for the back half of the property are **handwritten and at the resolution limit** of the scan. Independent reads disagree by a one-building shift, and two buildings (7 and 9) had no legible BIN at all. Rather than guess, please confirm the authoritative BIN → building mapping for Fletcher (buildings 1–11). A clean list per section A above would settle this outright.
+
+---
+
+## Properties that came through clean (no action needed)
+
+Donna Louise, Juan (except item C), Louise Shell (values, pending pages), Mack, Meacham (values, pending pages confirm), Owens (BINs confirmed, pending pages), Reid, Smith-Williams (BINs confirmed, pending pages), SRB (BINs confirmed, pending pages), Yale (value, pending pages confirm). The asks above are the only open items.

--- a/docs/bins-verification.md
+++ b/docs/bins-verification.md
@@ -1,0 +1,261 @@
+# BINs verification
+
+Source: 12-attachment email from Dora D. LaGrande (Global Property Management Group), 2026-05-27.
+
+Summary: **12 properties**, **70 buildings**, **965 units**, **5 missing BINs**.
+
+If `missing BINs > 0`, the agent could not read the handwritten BIN for one or more buildings — re-render at higher DPI or request a re-scan.
+
+---
+
+
+## DONNALOUISE — (name not extracted)
+
+- Operator entity: Community Development Programs Center of Nevada - Donna Louise, LLC dba Donna Louise apts.
+- Source: `DONNALOUISE BIN.pdf` (pages scanned: 5, header reports: None, incomplete: False)
+- Join to `nv-housing-props.json`: **no match** (new property or unmapped)
+
+| Building | BIN | Units | First | Last |
+|---:|---|---:|---|---|
+| 1 | NV-15-03001 | 48 | 1-101 | 1-316 |
+
+## FLETCHER — Ethel Mae Fletcher Apts
+
+- Operator entity: Community Development Programs Center of Nevada - Vegas't Decatur LLC dba Ethel Mae Fletcher Apts.
+- Source: `FLETCHER BIN.pdf` (pages scanned: 6, header reports: 9, incomplete: True)
+- Join to `nv-housing-props.json`: **no match** (new property or unmapped)
+- Warnings:
+  - ⚠ BIN MAPPING DISPUTED / LOW CONFIDENCE (adversarial re-read 2026-05-29): the handwritten NV-14-04xxx margin annotations sit at the scan's resolution limit. Three reads disagree by a one-building shift -- primary extraction (bldg8=NV-14-04003, bldg10=NV-14-04005, bldg7/bldg9=null), adversarial verifier (bldg7=04003, bldg9=04005), and a source re-crop where the only legible annotation aligns with bldg8's unit rows (8-119/8-120). The bldg-1/2 BINs may also read NV-15-03001/03002 rather than the recorded NV-15-02001/02002. Values here are the primary extraction, retained per do-not-invent; treat fletcher's building->BIN mapping as PROVISIONAL pending GPMG's authoritative clean BIN list (docs/bins-verification-gaps-request.md).
+  - ⚠ PDF has 6 pages but header reports 9; additional buildings/units may be missing — request a full scan.
+  - ⚠ Header reports 'Page 1 of 9' but only 6 scanned pages (12 halves) are present on disk; pages 7-9 are missing. pagesReportedByHeader=9 set accordingly; no units/BINs fabricated for the missing pages.
+  - ⚠ Building 4 is absent from this scan (BIN sequence skips from NV-15-02003 building-3 to NV-14-04001 building-5); consistent with brief note that buildings 4 and 6 may be absent. Building 6 IS present here (NV-14-04002, units 6-107..6-112).
+  - ⚠ HAZARD CHECK PASSED: units 6-107 through 6-112 are correctly assigned to building 6 (leading prefix '6-'), NOT merged into building 5. Building 5 = 5-102..5-106 only.
+  - ⚠ Unit 10-136 IS present (building 10), confirmed on page-06-a.
+  - ⚠ Margin BIN annotations are handwritten; reads NV-14-04003 (bldg 8) and NV-14-04005/04007 (bldgs 10/11) are confident but the intermediate handwritten value near the bldg-10 boundary (possibly NV-14-04006) was not clearly attributable to a distinct building with its own unit block in this scan and was not invented.
+  - ⚠ Buildings 7 and 9 have visible unit blocks but no clearly legible margin BIN adjacent to their first unit in this scan; bin set to null per do-not-invent rule.
+  - ⚠ No printed Totals row was legible on the scanned page-halves to cross-check unit counts against; could not perform totals reconciliation. Total units transcribed: 65 across 10 building blocks.
+  - ⚠ one or more buildings have no BIN extracted
+
+| Building | BIN | Units | First | Last |
+|---:|---|---:|---|---|
+| 1 | NV-15-02001 | 6 | 1-101 | 1-106 |
+| 2 | NV-15-02002 | 11 | 2-107 | 2-117 |
+| 3 | NV-15-02003 | 7 | 3-211 | 3-217 |
+| 5 | NV-14-04001 | 5 | 5-102 | 5-106 |
+| 6 | NV-14-04002 | 6 | 6-107 | 6-112 |
+| 7 | **missing** | 6 | 7-113 | 7-118 |
+| 8 | NV-14-04003 | 4 | 8-119 | 8-122 |
+| 9 | **missing** | 7 | 9-123 | 9-129 |
+| 10 | NV-14-04005 | 7 | 10-130 | 10-136 |
+| 11 | NV-14-04007 | 6 | 11-137 | 11-142 |
+
+## JUAN — Juan Garcia Apts
+
+- Operator entity: Ernie Cragin LP dba Juan Garcia Apts
+- Source: `JUAN BIN.pdf` (pages scanned: 5, header reports: 5, incomplete: False)
+- Join to `nv-housing-props.json`: `Juan Garcia Aka Ernie Cragin`
+- Warnings:
+  - ⚠ HAZARD CONFIRMED — Building 2 margin BIN is handwritten as 'NV-00-0002' (4-digit suffix) on page-01-a, whereas all sibling buildings (3-7) use the 5-digit 'NV-00-0000N' family. Most likely a transcription/scan artifact missing a leading zero; normalized to 'NV-00-00002' for consistency. Flagging ambiguity: actual ink reads four digits ('0002').
+  - ⚠ Building 1 is absent — report starts at Building 2 (first margin BIN on page-01-a). No NV-00-00001 BIN or 1-xxx units appear anywhere in the 5 pages.
+  - ⚠ Pages on disk (5) match header count 'Page X of 5'.
+  - ⚠ Unit numbering is split across two stacks per building (a 1xx/100-level group and a 2xx/200-level group), e.g. bldg 4 has 4-108..4-112 then 4-209..4-212; this is how the rotated table presents them, not a transcription duplication.
+  - ⚠ Totals row not present as a distinct labeled summary line on these scans; could not cross-check against a property Totals figure. Total units extracted across 6 buildings = 47.
+
+| Building | BIN | Units | First | Last |
+|---:|---|---:|---|---|
+| 2 | NV-00-00002 | 8 | 2-101 | 2-204 |
+| 3 | NV-00-00003 | 4 | 3-105 | 3-108 |
+| 4 | NV-00-00004 | 9 | 4-108 | 4-212 |
+| 5 | NV-00-00005 | 12 | 5-113 | 5-218 |
+| 6 | NV-00-00006 | 8 | 6-119 | 6-222 |
+| 7 | NV-00-00007 | 6 | 7-123 | 7-224 |
+
+## LOUISE-SHELL — Louise Shell Senior Apts (dba Louise Shell Senior Apts; aka Louise Shell / Harmony Park Senior Apts)
+
+- Operator entity: Community Development Programs Center of Nevada - LS/HP LP
+- Source: `LOUISE SHELL BIN.pdf` (pages scanned: 10, header reports: 13, incomplete: True)
+- Join to `nv-housing-props.json`: `Louise Shell/Harmony Park Apts`
+- Warnings:
+  - ⚠ PDF has 10 pages but header reports 13; additional buildings/units may be missing — request a full scan.
+  - ⚠ BIN SERIAL SHIFT (recorded as seen, NOT corrected): buildings 1-3 carry the NV-01-0000N family (NV-01-00001 / NV-01-00002 / NV-01-00003) and are all '1 Bedroom' floor plans. Buildings 4-6 carry a RESTARTED NV-01-1000N family (NV-01-10001 / NV-01-10002 / NV-01-10003) and are all '2 Bedroom' floor plans. The serial does NOT continue 00004/00005/00006; it resets to 10001 at the 1BR->2BR floor-plan change. This matches the known property note that the serial shifts mid-property correlating with a floor-plan change. The 2BR family's BIN serials are therefore 1/2/3, not 4/5/6 - this is what is handwritten on the document.
+  - ⚠ BUILDING 2 UNIT-NUMBER GAP CONFIRMED and flagged: building 2 units run 2-115..2-142 (first floor, 1xx series) then jump to 2-221..2-235 (second floor, 2xx series) - two floors. NO new handwritten margin BIN appears across the 2-142 -> 2-221 transition (verified on the page holding that boundary). Per rules, building 2 is kept as ONE building (NV-01-00002) spanning both floors.
+  - ⚠ Building 3 first on-disk unit is 3-143 (the NV-01-00003 margin BIN appears at this row). Units 3-131..3-142, if they were ever assigned, are not present on disk; building 3's lower units may be incomplete, but the transcribed rows 3-143..3-156 are continuous and verified.
+  - ⚠ PAGE-COUNT NOTE: the report footer reads 'Page N of 13' (e.g. page-09-b shows 'Page 9 of 13', page-10-b shows 'Page 10 of 13'), but only 10 pages (page-01..page-10, 20 halves) are present on disk. pagesReportedByHeader is therefore 13 while 10 pages were supplied. Despite the footer's '13', the BldgUnit sequence transcribed across the 10 on-disk pages is CONTINUOUS and self-consistent for all 6 buildings (1-101 through 6-184) with no internal breaks except the intentional building-2 two-floor gap above; the trailing pages 11-13 most likely hold only the report's grand-total / summary rows, not additional buildings. No buildings or units were fabricated for the missing pages.
+  - ⚠ TOTALS CROSS-CHECK could NOT be completed: the rent-roll's grand-Totals row sits on the final page (13), which is not among the 10 supplied pages. The transcribed unit total is 112 (14 + 43 + 14 + 21 + 10 + 10). This figure is internally consistent but was not reconciled against an on-document Totals line. Re-scan pages 11-13 to confirm the count.
+  - ⚠ READ-RELIABILITY CAVEAT: the image-read path intermittently returned stale/cached renders when many derived crops were read in rapid succession, producing inconsistent windows of the same page. Final unit lists were locked by reading byte-distinct single-page copies one at a time (verified via md5 that all 10 top-halves are distinct files) plus rotated/enlarged left-margin BIN crops for each handwritten BIN. Every BIN above was visually confirmed on its boundary page; every unit above appeared in a stable single-page read. Where a render was inconsistent, the value was excluded rather than guessed.
+  - ⚠ Handwritten margin BINs read at building boundaries: NV-01-00001 (bldg 1, page 1, row 1-101), NV-01-00002 (bldg 2, page 2, row 2-115), NV-01-00003 (bldg 3, page 6, row 3-143), NV-01-10001 (bldg 4, page 7, row 4-145), NV-01-10002 (bldg 5, page 9, row 5-165), NV-01-10003 (bldg 6, page 10, row 6-175).
+
+| Building | BIN | Units | First | Last |
+|---:|---|---:|---|---|
+| 1 | NV-01-00001 | 14 | 1-101 | 1-114 |
+| 2 | NV-01-00002 | 43 | 2-115 | 2-235 |
+| 3 | NV-01-00003 | 14 | 3-143 | 3-156 |
+| 4 | NV-01-10001 | 21 | 4-145 | 4-165 |
+| 5 | NV-01-10002 | 10 | 5-165 | 5-174 |
+| 6 | NV-01-10003 | 10 | 6-175 | 6-184 |
+
+## MACK — (name not extracted)
+
+- Operator entity: Community Development Programs Center of Nevada - Mixed Income, LLC dba Dr. Luther Mack Jr. Sr. Apts.
+- Source: `MACK BIN.pdf` (pages scanned: 7, header reports: None, incomplete: False)
+- Join to `nv-housing-props.json`: **no match** (new property or unmapped)
+
+| Building | BIN | Units | First | Last |
+|---:|---|---:|---|---|
+| 1 | NV-12-03001 | 47 | 1-101 | 1-316 |
+
+## MEACHAM — Dr. Paul Meacham Sr. Apartments
+
+- Operator entity: Community Development Programs Center of Nevada - Mixed Income 2 LLC
+- Source: `MEACHAM BIN.pdf` (pages scanned: 8, header reports: 10, incomplete: True)
+- Join to `nv-housing-props.json`: `Dr. Paul Meacham`
+- Warnings:
+  - ⚠ PDF has 8 pages but header reports 10; additional buildings/units may be missing — request a full scan.
+  - ⚠ Header reads 'Page X of 10' but only 8 pages (16 halves) are present on disk (pages 1-8). Pages 9-10 are missing. All 8 present pages belong to the same Unit Scheduled Transactions report for the same single building; pages 1-7 list the unit rows, page 8 is the Totals page. No new BldgUnit IDs or building codes appear on later pages.
+  - ⚠ Single building confirmed by handwritten red note 'Property Has One Building' across pages 1-2; one BIN (NV-13-03001) handwritten in red margin on pages 1, 2, and 3 ('BIN = NV-13-03001').
+  - ⚠ 57 unique units extracted: floors 101-119, 201-219, 301-319 (3 floors x 19). Last unit visible is 13-03001-319 on page 8 just above the Totals row. Totals row present on page 8 (rent total 37,353.00) confirms end of unit list.
+  - ⚠ Units include both LIHTC (1x1, 2x2) and market-rate ('1 Bedroom Market' / 1x1MK, '2 Bedroom Market' / 2x2MK) types; all 57 included regardless of type per instructions.
+  - ⚠ Operator entity transcribed from header: 'Community Development Programs Center of Nevada - Mixed Income 2 LLC dba Dr. Paul Meacham Sr. Apts'.
+
+| Building | BIN | Units | First | Last |
+|---:|---|---:|---|---|
+| 13-03001 | NV-13-03001 | 57 | 13-03001-101 | 13-03001-319 |
+
+## OCALLAGHAN — Governor Mike O'Callaghan Legacy Apartments
+
+- Operator entity: Community Development Programs Center of Nevada - 1501 LLC
+- Source: `OCALLAGHAN BIN.pdf` (pages scanned: 4, header reports: 7, incomplete: True)
+- Join to `nv-housing-props.json`: **no match** (new property or unmapped)
+- Warnings:
+  - ⚠ PDF has 4 pages but header reports 7; additional buildings/units may be missing — request a full scan.
+  - ⚠ INCOMPLETE SCAN: page headers read 'Page 1 of 7', 'Page 2 of 7', 'Page 3 of 7', 'Page 4 of 7' (one distinct page per scanned page, confirmed). The document is 7 pages but only pages 1-4 were scanned/provided. Buildings/pages 5-7 are MISSING; additional buildings (e.g. bldg 5+) likely exist and are not captured here.
+  - ⚠ Only building 1 carries a margin BIN annotation: NV-22-05001 (handwritten in the right margin of page-01-b, read directly from the image). Buildings 2, 3, 4 were checked on page-02-b / page-03-b / page-04-b and have NO visible BIN annotation -> set to null. NOT guessed as 05002/05003/05004 despite the obvious sequential pattern, per the honest-extraction rule.
+  - ⚠ All 40 units and the single BIN were confirmed by DIRECT VISUAL READ of all 8 page-halves (no inference): page-01 bldg1 units 101-110, page-02 bldg2 units 201-210, page-03 bldg3 units 301-310, page-04 bldg4 units 401-410. Building<->page mapping = BldgUnit hundreds digit. Each building has exactly 10 units (x01-x10).
+  - ⚠ Floor Plan Codes present (1x1a, 1x1b, 2x1MK) and SQFT (650 / 850); these are unit-mix details not requested. No 'Totals' row was visible within the scanned pages to cross-check the 40-unit count (totals likely fall on a later, unscanned page).
+  - ⚠ Operator/owner entity read from the page header on every page: 'Community Development Programs Center of Nevada - 1501 LLC dba Governor Mike O'Callaghan Legacy Apts.' Report 'As of 05/27/2026'. BIN family NV-22-* confirms 2022 LIHTC vintage.
+  - ⚠ macOS Vision OCR was unavailable (swiftc failed with a CommandLineTools 'SwiftBridging' module-redefinition error); all extraction was done by direct visual reading of the scanned PNGs, including 90-degree rotation + JPEG re-export to read the landscape table upright.
+  - ⚠ one or more buildings have no BIN extracted
+
+| Building | BIN | Units | First | Last |
+|---:|---|---:|---|---|
+| 1 | NV-22-05001 | 10 | 1-101 | 1-110 |
+| 2 | **missing** | 10 | 2-201 | 2-210 |
+| 3 | **missing** | 10 | 3-301 | 3-310 |
+| 4 | **missing** | 10 | 4-401 | 4-410 |
+
+## OWENS — Owens Senior Apartments
+
+- Operator entity: Community Development Programs Center of Nevada - Owens 2, LP dba Owens Senior Apartments
+- Source: `OWENS BIN.pdf` (pages scanned: 8, header reports: 10, incomplete: True)
+- Join to `nv-housing-props.json`: `Owens Senior`
+- Warnings:
+  - ⚠ PDF has 8 pages but header reports 10; additional buildings/units may be missing — request a full scan.
+  - ⚠ All 6 BINs CONFIRMED by direct visual read of handwritten margin annotations: NV-99-13001 (p1), NV-99-13002 (p2), NV-99-13003 (p3), NV-99-13004 (p4, above building-4 rows), NV-99-13005 (p5, above building-5 rows), NV-99-13006 (p7, above building-6 rows). All 6 expected buildings present.
+  - ⚠ Scans are landscape tables stored rotated 90deg; halves had to be rotated upright (sips -r -90) to be legible. Harness image-render + bash channels degraded repeatedly under heavy machine load (load avg ~6-9, multiple parallel sessions); many reads required 20-120s retries and several halves could only be read once.
+  - ⚠ TOTALS CROSS-CHECK PASSED: page-08 Totals row reads 47,270.00 across Market Rent / Effective Rent / Market+Addl columns, matching the prior-confirmed 58x$633 + 14x$754 = $47,270. Rent tiers consistent throughout: 1x1 / 1-Bedroom / 600sqft = $633; 2x1 / 2-Bedroom / 762sqft = $754.
+  - ⚠ BUILDING 5 has only 8 units recorded: 5-130,131,132,133 (floor 1) + 5-230,231,232,233 (floor 2), all directly read on page-06. No page in the document set shows 5-134+/5-234+, so building 5 is recorded as 8 units. NOTE: this is fewer than the 12-unit pattern of buildings 2/3/4/6; the building-5 continuation may live on one of the 2 missing document pages (see page-count discrepancy below). Per RULE 3 no extra units were invented.
+  - ⚠ DUPLICATE-PAGE ANOMALY in the scan set: file page-04 and file page-05 BOTH show building 4 (NV-99-13004 margin + units 4-121..126, 4-221..226) but carry DIFFERENT printed footers — page-04 footer = 'Page 4 of 10', page-05 footer = 'Page 5 of 10'. The two files have different md5 hashes (distinct scans), yet identical unit content. So one document page appears duplicated, OR building-4 legitimately spans two document pages. Building 4's units were de-duplicated to a single 12-unit list. This anomaly likely accounts for part of the 8-files-vs-10-header-pages gap and means the genuine building-5 continuation page may simply be absent from the scan set.
+  - ⚠ PAGE-COUNT DISCREPANCY: header says 'Page 1 of 10' (10 document pages) but only 8 physical page files (16 halves) exist on disk at /tmp/bins-work/owens/. Confirmed footers: page-01=1of10, page-02=2of10, page-03=3of10, page-04=4of10, page-05=5of10, page-06=6of10, page-08=8of10 (page-07 footer not legibly captured but content = building 6). pagesReportedByHeader=10 per header. 2 document pages (likely 9 and 10, or a building-5 continuation) are not present on disk.
+  - ⚠ Counts as recorded: 6 buildings, 72 units total (16 + 12 + 12 + 12 + 8 + 12). Building 1 has 16 units (1-101..108 + 1-201..208) — confirmed outlier, read directly across p1+p2. Buildings 2,3,4,6 have 12 each (6 per floor). Building 5 has only 8 read.
+  - ⚠ RE-RUN RECOMMENDED on a fresh low-load machine to locate any missing document pages (9/10) and confirm whether building 5 has additional units. All 6 BINs, the operator entity, and the financial Totals ($47,270) are already fully verified by direct read.
+
+| Building | BIN | Units | First | Last |
+|---:|---|---:|---|---|
+| 1 | NV-99-13001 | 16 | 1-101 | 1-208 |
+| 2 | NV-99-13002 | 12 | 2-109 | 2-214 |
+| 3 | NV-99-13003 | 12 | 3-115 | 3-220 |
+| 4 | NV-99-13004 | 12 | 4-121 | 4-226 |
+| 5 | NV-99-13005 | 8 | 5-130 | 5-233 |
+| 6 | NV-99-13006 | 12 | 6-127 | 6-236 |
+
+## REID — (name not extracted)
+
+- Operator entity: Community Development Programs Center of Nevada - 11th Street, LP dba Senator Harry Reid Senior Apts.
+- Source: `REID BIN.pdf` (pages scanned: 10, header reports: None, incomplete: False)
+- Join to `nv-housing-props.json`: `Sen. Harry Reid Senior Apts Aka 11Th St`
+
+| Building | BIN | Units | First | Last |
+|---:|---|---:|---|---|
+| 1 | NV-01-00011 | 99 | 1-101 | 1-339 |
+
+## SMITH-WILLIAMS — Smith Williams Senior Apts.
+
+- Operator entity: Smith Williams, LLC
+- Source: `SMITH WILLIAMS BIN.pdf` (pages scanned: 11, header reports: 13, incomplete: True)
+- Join to `nv-housing-props.json`: `Smith Williams Apts`
+- Warnings:
+  - ⚠ PDF has 11 pages but header reports 13; additional buildings/units may be missing — request a full scan.
+  - ⚠ Header reports 'Page 1 of 13' but only 11 physical pages (22 halves) are present on disk; pagesReportedByHeader=13 set accordingly. Pages 12-13 not provided.
+  - ⚠ All 3 expected BINs found, each handwritten in the left margin at the first unit of its building: NV-09-01001 @ unit 1101 (p01), NV-09-01002 @ unit 2109 (p04), NV-09-01003 @ unit 3116 (p06).
+  - ⚠ Unit numbering is property-wide (not per-building reset) and skips numbers, consistent with the known structure. Building 2 floor-2 sequence reads 2206 then 2209-2215 (2207-2208 not present in the roll); transcribed exactly as printed, no units invented.
+  - ⚠ Building 2 floor-3 starts at 2310 and runs 2310-2315 (6 units); building 3 starts at 3116.
+  - ⚠ Totals row on final page (p11-b) = 54,132.00, which is a summed rent/dollar amount, NOT a unit count. 79 unit rows transcribed across the 3 buildings.
+
+| Building | BIN | Units | First | Last |
+|---:|---|---:|---|---|
+| 1 | NV-09-01001 | 23 | 1101 | 1308 |
+| 2 | NV-09-01002 | 21 | 2109 | 2315 |
+| 3 | NV-09-01003 | 35 | 3116 | 3327 |
+
+## SRB — Senator Richard Bryan Senior Apartments
+
+- Operator entity: Community Development Programs Center of Nevada - SRB LP
+- Source: `SRB BIN.pdf` (pages scanned: 24, header reports: 27, incomplete: True)
+- Join to `nv-housing-props.json`: **no match** (new property or unmapped)
+- Warnings:
+  - ⚠ BIN FORMAT CORRECTED (adversarial re-read 2026-05-29): phase-1 buildings 1-15 carry STANDARD BINs NV-07-19001..NV-07-19015 (serial = 19000 + building#). The earlier extraction misread the continuous typed margin string 'NV-0719001' as a 4-segment 'NV-07-19-0001' (dropping it below 5 trailing digits). Phase-2 buildings 16-30 = NV-05-06001..NV-05-06015. Building number maps 1:1 to serial within each phase; all 30 BINs now satisfy NV-YY-NNNNN.
+  - ⚠ PDF has 24 pages but header reports 27; additional buildings/units may be missing — request a full scan.
+  - ⚠ BUILDING 14 UNIT GAP CONFIRMED: building 14 jumps 14-1106 -> 14-1108 with no 14-1107 row present on either half of the page. The gap is real in the source rent-roll, not a scan/crop artifact. Verified on page 14.
+  - ⚠ 26/27 BOUNDARY (prior-read hazard) RESOLVED: building 26 anchors to BIN NV-05-06011 and building 27 anchors to NV-05-06012. They sit on consecutive pages; each BIN header cleanly precedes its own building's unit block. No single page carries two ambiguous BINs for the 26/27 pair - the sequence is unambiguous (06011=bldg26, 06012=bldg27).
+  - ⚠ MISSING PAGES: header reads 'Page X of 27' but only 24 physical pages (page-01..page-24, 48 halves) are present on disk. Pages 25, 26, 27 are NOT present. Building 30 (NV-05-06015) may have additional units beyond those captured, and any building 31+ (if it exists) is entirely absent. Building count of 30 is the maximum supportable by the observed BIN sequence (NV-05-06015 = 15th phase-2 building).
+  - ⚠ UNIT-CODE FORMAT is NN-NNNN (zero-padded 2-digit building prefix + 4-digit unit), e.g. 05-1049, 23-1161. Full bldg-prefixed unit string retained for every unit because unit numbers collide across buildings (e.g. 13-1101 vs 23-1101; 20-1175/24-1175/25-1177 share the 117x band). Only the building prefix disambiguates.
+  - ⚠ UNIT-LIST FIDELITY CAVEAT: this is the LARGEST property (30 buildings, ~185 units) on dense rotated landscape scans. BIN-to-building anchoring is high-confidence (typed section headers, clean sequence). Individual unit-NUMBER cells within each block are lower-confidence - some unit serials may be off by a digit or a row may be missed/duplicated due to scan density. The unit COUNT per building and the BIN mapping are the reliable outputs; exact unit serials should be re-verified against a clean source before any compliance filing.
+  - ⚠ Buildings 16-20 ARE present and observed in this read (pages 16-20, BINs NV-05-06001..06005) - this corrects an earlier-read assumption that 16-20 were missing. The actually-missing content is pages 25-27 (tail of bldg 30 / any bldg 31+).
+
+| Building | BIN | Units | First | Last |
+|---:|---|---:|---|---|
+| 1 | NV-07-19001 | 6 | 01-1001 | 01-1006 |
+| 2 | NV-07-19002 | 8 | 02-1017 | 02-1024 |
+| 3 | NV-07-19003 | 4 | 03-1037 | 03-1040 |
+| 4 | NV-07-19004 | 8 | 04-1041 | 04-1048 |
+| 5 | NV-07-19005 | 8 | 05-1049 | 05-1056 |
+| 6 | NV-07-19006 | 8 | 06-1057 | 06-1064 |
+| 7 | NV-07-19007 | 8 | 07-1065 | 07-1072 |
+| 8 | NV-07-19008 | 8 | 08-1073 | 08-1080 |
+| 9 | NV-07-19009 | 14 | 09-1081 | 09-1094 |
+| 10 | NV-07-19010 | 8 | 10-1073 | 10-1080 |
+| 11 | NV-07-19011 | 8 | 11-1025 | 11-1032 |
+| 12 | NV-07-19012 | 8 | 12-1009 | 12-1016 |
+| 13 | NV-07-19013 | 3 | 13-1101 | 13-1103 |
+| 14 | NV-07-19014 | 7 | 14-1105 | 14-1112 |
+| 15 | NV-07-19015 | 8 | 15-1113 | 15-1120 |
+| 16 | NV-05-06001 | 8 | 16-1121 | 16-1128 |
+| 17 | NV-05-06002 | 8 | 17-1209 | 17-1216 |
+| 18 | NV-05-06003 | 5 | 18-1196 | 18-1200 |
+| 19 | NV-05-06004 | 7 | 19-1128 | 19-1134 |
+| 20 | NV-05-06005 | 10 | 20-1175 | 20-1184 |
+| 21 | NV-05-06006 | 9 | 21-1146 | 21-1154 |
+| 22 | NV-05-06007 | 6 | 22-1155 | 22-1160 |
+| 23 | NV-05-06008 | 14 | 23-1161 | 23-1174 |
+| 24 | NV-05-06009 | 4 | 24-1175 | 24-1178 |
+| 25 | NV-05-06010 | 8 | 25-1177 | 25-1184 |
+| 26 | NV-05-06011 | 6 | 26-1185 | 26-1190 |
+| 27 | NV-05-06012 | 6 | 27-1203 | 27-1208 |
+| 28 | NV-05-06013 | 4 | 28-1217 | 28-1220 |
+| 29 | NV-05-06014 | 10 | 29-1221 | 29-1230 |
+| 30 | NV-05-06015 | 10 | 30-1231 | 30-1240 |
+
+## YALE — Yale (Yale Keyes Senior Apts)
+
+- Operator entity: Yale Keyes LP dba Yale Keyes Senior Apts.
+- Source: `YALE BIN.pdf` (pages scanned: 9, header reports: 11, incomplete: True)
+- Join to `nv-housing-props.json`: `Yale/Keyes Senior Apts`
+- Warnings:
+  - ⚠ PDF has 9 pages but header reports 11; additional buildings/units may be missing — request a full scan.
+  - ⚠ Header reads 'Page X of 11' but only 9 physical pages (18 halves) on disk; page-09-b ends with a 'Totals:' row and a grand total ($52,044.00), so the unit roll is complete. The extra header pages (10-11) are likely trailing summary/legend pages not included in this scan and contain no additional units.
+  - ⚠ BIN NV-01-00004 read from the page-01-a header ('BIN # NV-01-00004'); no handwritten margin BIN observed.
+  - ⚠ Single building (buildingCode '1'), 70 units: 35 on floor 1 (1-101..1-135) and 35 on floor 2 (1-201..1-235). Most units are 1x1/1Bedroom (700 SQFT); a handful are 2x1/2Bedroom (800 SQFT), all CA-RENT.
+
+| Building | BIN | Units | First | Last |
+|---:|---|---:|---|---|
+| 1 | NV-01-00004 | 70 | 1-101 | 1-235 |

--- a/src/db/data/bins.json
+++ b/src/db/data/bins.json
@@ -1,0 +1,1722 @@
+{
+  "donnalouise": {
+    "propertyName": null,
+    "operatorEntity": "Community Development Programs Center of Nevada - Donna Louise, LLC dba Donna Louise apts.",
+    "joinName": null,
+    "source": {
+      "type": "gpmg-email",
+      "date": "2026-05-27",
+      "pdf": "DONNALOUISE BIN.pdf",
+      "pagesScanned": 5,
+      "pagesReportedByHeader": null,
+      "scanIncomplete": false
+    },
+    "buildings": [
+      {
+        "buildingCode": "1",
+        "bin": "NV-15-03001",
+        "unitCount": 48,
+        "units": [
+          "1-101",
+          "1-102",
+          "1-103",
+          "1-104",
+          "1-105",
+          "1-106",
+          "1-107",
+          "1-108",
+          "1-109",
+          "1-110",
+          "1-111",
+          "1-112",
+          "1-113",
+          "1-114",
+          "1-115",
+          "1-116",
+          "1-201",
+          "1-202",
+          "1-203",
+          "1-204",
+          "1-205",
+          "1-206",
+          "1-207",
+          "1-208",
+          "1-209",
+          "1-210",
+          "1-211",
+          "1-212",
+          "1-213",
+          "1-214",
+          "1-215",
+          "1-216",
+          "1-301",
+          "1-302",
+          "1-303",
+          "1-304",
+          "1-305",
+          "1-306",
+          "1-307",
+          "1-308",
+          "1-309",
+          "1-310",
+          "1-311",
+          "1-312",
+          "1-313",
+          "1-314",
+          "1-315",
+          "1-316"
+        ]
+      }
+    ],
+    "warnings": []
+  },
+  "fletcher": {
+    "propertyName": "Ethel Mae Fletcher Apts",
+    "operatorEntity": "Community Development Programs Center of Nevada - Vegas't Decatur LLC dba Ethel Mae Fletcher Apts.",
+    "joinName": null,
+    "source": {
+      "type": "gpmg-email",
+      "date": "2026-05-27",
+      "pdf": "FLETCHER BIN.pdf",
+      "pagesScanned": 6,
+      "pagesReportedByHeader": 9,
+      "scanIncomplete": true
+    },
+    "buildings": [
+      {
+        "buildingCode": "1",
+        "bin": "NV-15-02001",
+        "unitCount": 6,
+        "units": [
+          "1-101",
+          "1-102",
+          "1-103",
+          "1-104",
+          "1-105",
+          "1-106"
+        ]
+      },
+      {
+        "buildingCode": "2",
+        "bin": "NV-15-02002",
+        "unitCount": 11,
+        "units": [
+          "2-107",
+          "2-108",
+          "2-109",
+          "2-110",
+          "2-111",
+          "2-112",
+          "2-113",
+          "2-114",
+          "2-115",
+          "2-116",
+          "2-117"
+        ]
+      },
+      {
+        "buildingCode": "3",
+        "bin": "NV-15-02003",
+        "unitCount": 7,
+        "units": [
+          "3-211",
+          "3-212",
+          "3-213",
+          "3-214",
+          "3-215",
+          "3-216",
+          "3-217"
+        ]
+      },
+      {
+        "buildingCode": "5",
+        "bin": "NV-14-04001",
+        "unitCount": 5,
+        "units": [
+          "5-102",
+          "5-103",
+          "5-104",
+          "5-105",
+          "5-106"
+        ]
+      },
+      {
+        "buildingCode": "6",
+        "bin": "NV-14-04002",
+        "unitCount": 6,
+        "units": [
+          "6-107",
+          "6-108",
+          "6-109",
+          "6-110",
+          "6-111",
+          "6-112"
+        ]
+      },
+      {
+        "buildingCode": "7",
+        "bin": null,
+        "unitCount": 6,
+        "units": [
+          "7-113",
+          "7-114",
+          "7-115",
+          "7-116",
+          "7-117",
+          "7-118"
+        ]
+      },
+      {
+        "buildingCode": "8",
+        "bin": "NV-14-04003",
+        "unitCount": 4,
+        "units": [
+          "8-119",
+          "8-120",
+          "8-121",
+          "8-122"
+        ]
+      },
+      {
+        "buildingCode": "9",
+        "bin": null,
+        "unitCount": 7,
+        "units": [
+          "9-123",
+          "9-124",
+          "9-125",
+          "9-126",
+          "9-127",
+          "9-128",
+          "9-129"
+        ]
+      },
+      {
+        "buildingCode": "10",
+        "bin": "NV-14-04005",
+        "unitCount": 7,
+        "units": [
+          "10-130",
+          "10-131",
+          "10-132",
+          "10-133",
+          "10-134",
+          "10-135",
+          "10-136"
+        ]
+      },
+      {
+        "buildingCode": "11",
+        "bin": "NV-14-04007",
+        "unitCount": 6,
+        "units": [
+          "11-137",
+          "11-138",
+          "11-139",
+          "11-140",
+          "11-141",
+          "11-142"
+        ]
+      }
+    ],
+    "warnings": [
+      "BIN MAPPING DISPUTED / LOW CONFIDENCE (adversarial re-read 2026-05-29): the handwritten NV-14-04xxx margin annotations sit at the scan's resolution limit. Three reads disagree by a one-building shift -- primary extraction (bldg8=NV-14-04003, bldg10=NV-14-04005, bldg7/bldg9=null), adversarial verifier (bldg7=04003, bldg9=04005), and a source re-crop where the only legible annotation aligns with bldg8's unit rows (8-119/8-120). The bldg-1/2 BINs may also read NV-15-03001/03002 rather than the recorded NV-15-02001/02002. Values here are the primary extraction, retained per do-not-invent; treat fletcher's building->BIN mapping as PROVISIONAL pending GPMG's authoritative clean BIN list (docs/bins-verification-gaps-request.md).",
+      "PDF has 6 pages but header reports 9; additional buildings/units may be missing \u2014 request a full scan.",
+      "Header reports 'Page 1 of 9' but only 6 scanned pages (12 halves) are present on disk; pages 7-9 are missing. pagesReportedByHeader=9 set accordingly; no units/BINs fabricated for the missing pages.",
+      "Building 4 is absent from this scan (BIN sequence skips from NV-15-02003 building-3 to NV-14-04001 building-5); consistent with brief note that buildings 4 and 6 may be absent. Building 6 IS present here (NV-14-04002, units 6-107..6-112).",
+      "HAZARD CHECK PASSED: units 6-107 through 6-112 are correctly assigned to building 6 (leading prefix '6-'), NOT merged into building 5. Building 5 = 5-102..5-106 only.",
+      "Unit 10-136 IS present (building 10), confirmed on page-06-a.",
+      "Margin BIN annotations are handwritten; reads NV-14-04003 (bldg 8) and NV-14-04005/04007 (bldgs 10/11) are confident but the intermediate handwritten value near the bldg-10 boundary (possibly NV-14-04006) was not clearly attributable to a distinct building with its own unit block in this scan and was not invented.",
+      "Buildings 7 and 9 have visible unit blocks but no clearly legible margin BIN adjacent to their first unit in this scan; bin set to null per do-not-invent rule.",
+      "No printed Totals row was legible on the scanned page-halves to cross-check unit counts against; could not perform totals reconciliation. Total units transcribed: 65 across 10 building blocks.",
+      "one or more buildings have no BIN extracted"
+    ]
+  },
+  "juan": {
+    "propertyName": "Juan Garcia Apts",
+    "operatorEntity": "Ernie Cragin LP dba Juan Garcia Apts",
+    "joinName": "Juan Garcia Aka Ernie Cragin",
+    "source": {
+      "type": "gpmg-email",
+      "date": "2026-05-27",
+      "pdf": "JUAN BIN.pdf",
+      "pagesScanned": 5,
+      "pagesReportedByHeader": 5,
+      "scanIncomplete": false
+    },
+    "buildings": [
+      {
+        "buildingCode": "2",
+        "bin": "NV-00-00002",
+        "unitCount": 8,
+        "units": [
+          "2-101",
+          "2-102",
+          "2-103",
+          "2-104",
+          "2-201",
+          "2-202",
+          "2-203",
+          "2-204"
+        ]
+      },
+      {
+        "buildingCode": "3",
+        "bin": "NV-00-00003",
+        "unitCount": 4,
+        "units": [
+          "3-105",
+          "3-106",
+          "3-107",
+          "3-108"
+        ]
+      },
+      {
+        "buildingCode": "4",
+        "bin": "NV-00-00004",
+        "unitCount": 9,
+        "units": [
+          "4-108",
+          "4-109",
+          "4-110",
+          "4-111",
+          "4-112",
+          "4-209",
+          "4-210",
+          "4-211",
+          "4-212"
+        ]
+      },
+      {
+        "buildingCode": "5",
+        "bin": "NV-00-00005",
+        "unitCount": 12,
+        "units": [
+          "5-113",
+          "5-114",
+          "5-115",
+          "5-116",
+          "5-117",
+          "5-118",
+          "5-213",
+          "5-214",
+          "5-215",
+          "5-216",
+          "5-217",
+          "5-218"
+        ]
+      },
+      {
+        "buildingCode": "6",
+        "bin": "NV-00-00006",
+        "unitCount": 8,
+        "units": [
+          "6-119",
+          "6-120",
+          "6-121",
+          "6-122",
+          "6-219",
+          "6-220",
+          "6-221",
+          "6-222"
+        ]
+      },
+      {
+        "buildingCode": "7",
+        "bin": "NV-00-00007",
+        "unitCount": 6,
+        "units": [
+          "7-123",
+          "7-124",
+          "7-125",
+          "7-126",
+          "7-223",
+          "7-224"
+        ]
+      }
+    ],
+    "warnings": [
+      "HAZARD CONFIRMED \u2014 Building 2 margin BIN is handwritten as 'NV-00-0002' (4-digit suffix) on page-01-a, whereas all sibling buildings (3-7) use the 5-digit 'NV-00-0000N' family. Most likely a transcription/scan artifact missing a leading zero; normalized to 'NV-00-00002' for consistency. Flagging ambiguity: actual ink reads four digits ('0002').",
+      "Building 1 is absent \u2014 report starts at Building 2 (first margin BIN on page-01-a). No NV-00-00001 BIN or 1-xxx units appear anywhere in the 5 pages.",
+      "Pages on disk (5) match header count 'Page X of 5'.",
+      "Unit numbering is split across two stacks per building (a 1xx/100-level group and a 2xx/200-level group), e.g. bldg 4 has 4-108..4-112 then 4-209..4-212; this is how the rotated table presents them, not a transcription duplication.",
+      "Totals row not present as a distinct labeled summary line on these scans; could not cross-check against a property Totals figure. Total units extracted across 6 buildings = 47."
+    ]
+  },
+  "louise-shell": {
+    "propertyName": "Louise Shell Senior Apts (dba Louise Shell Senior Apts; aka Louise Shell / Harmony Park Senior Apts)",
+    "operatorEntity": "Community Development Programs Center of Nevada - LS/HP LP",
+    "joinName": "Louise Shell/Harmony Park Apts",
+    "source": {
+      "type": "gpmg-email",
+      "date": "2026-05-27",
+      "pdf": "LOUISE SHELL BIN.pdf",
+      "pagesScanned": 10,
+      "pagesReportedByHeader": 13,
+      "scanIncomplete": true
+    },
+    "buildings": [
+      {
+        "buildingCode": "1",
+        "bin": "NV-01-00001",
+        "unitCount": 14,
+        "units": [
+          "1-101",
+          "1-102",
+          "1-103",
+          "1-104",
+          "1-105",
+          "1-106",
+          "1-107",
+          "1-108",
+          "1-109",
+          "1-110",
+          "1-111",
+          "1-112",
+          "1-113",
+          "1-114"
+        ]
+      },
+      {
+        "buildingCode": "2",
+        "bin": "NV-01-00002",
+        "unitCount": 43,
+        "units": [
+          "2-115",
+          "2-116",
+          "2-117",
+          "2-118",
+          "2-119",
+          "2-120",
+          "2-121",
+          "2-122",
+          "2-123",
+          "2-124",
+          "2-125",
+          "2-126",
+          "2-127",
+          "2-128",
+          "2-129",
+          "2-130",
+          "2-131",
+          "2-132",
+          "2-133",
+          "2-134",
+          "2-135",
+          "2-136",
+          "2-137",
+          "2-138",
+          "2-139",
+          "2-140",
+          "2-141",
+          "2-142",
+          "2-221",
+          "2-222",
+          "2-223",
+          "2-224",
+          "2-225",
+          "2-226",
+          "2-227",
+          "2-228",
+          "2-229",
+          "2-230",
+          "2-231",
+          "2-232",
+          "2-233",
+          "2-234",
+          "2-235"
+        ]
+      },
+      {
+        "buildingCode": "3",
+        "bin": "NV-01-00003",
+        "unitCount": 14,
+        "units": [
+          "3-143",
+          "3-144",
+          "3-145",
+          "3-146",
+          "3-147",
+          "3-148",
+          "3-149",
+          "3-150",
+          "3-151",
+          "3-152",
+          "3-153",
+          "3-154",
+          "3-155",
+          "3-156"
+        ]
+      },
+      {
+        "buildingCode": "4",
+        "bin": "NV-01-10001",
+        "unitCount": 21,
+        "units": [
+          "4-145",
+          "4-146",
+          "4-147",
+          "4-148",
+          "4-149",
+          "4-150",
+          "4-151",
+          "4-152",
+          "4-153",
+          "4-154",
+          "4-155",
+          "4-156",
+          "4-157",
+          "4-158",
+          "4-159",
+          "4-160",
+          "4-161",
+          "4-162",
+          "4-163",
+          "4-164",
+          "4-165"
+        ]
+      },
+      {
+        "buildingCode": "5",
+        "bin": "NV-01-10002",
+        "unitCount": 10,
+        "units": [
+          "5-165",
+          "5-166",
+          "5-167",
+          "5-168",
+          "5-169",
+          "5-170",
+          "5-171",
+          "5-172",
+          "5-173",
+          "5-174"
+        ]
+      },
+      {
+        "buildingCode": "6",
+        "bin": "NV-01-10003",
+        "unitCount": 10,
+        "units": [
+          "6-175",
+          "6-176",
+          "6-177",
+          "6-178",
+          "6-179",
+          "6-180",
+          "6-181",
+          "6-182",
+          "6-183",
+          "6-184"
+        ]
+      }
+    ],
+    "warnings": [
+      "PDF has 10 pages but header reports 13; additional buildings/units may be missing \u2014 request a full scan.",
+      "BIN SERIAL SHIFT (recorded as seen, NOT corrected): buildings 1-3 carry the NV-01-0000N family (NV-01-00001 / NV-01-00002 / NV-01-00003) and are all '1 Bedroom' floor plans. Buildings 4-6 carry a RESTARTED NV-01-1000N family (NV-01-10001 / NV-01-10002 / NV-01-10003) and are all '2 Bedroom' floor plans. The serial does NOT continue 00004/00005/00006; it resets to 10001 at the 1BR->2BR floor-plan change. This matches the known property note that the serial shifts mid-property correlating with a floor-plan change. The 2BR family's BIN serials are therefore 1/2/3, not 4/5/6 - this is what is handwritten on the document.",
+      "BUILDING 2 UNIT-NUMBER GAP CONFIRMED and flagged: building 2 units run 2-115..2-142 (first floor, 1xx series) then jump to 2-221..2-235 (second floor, 2xx series) - two floors. NO new handwritten margin BIN appears across the 2-142 -> 2-221 transition (verified on the page holding that boundary). Per rules, building 2 is kept as ONE building (NV-01-00002) spanning both floors.",
+      "Building 3 first on-disk unit is 3-143 (the NV-01-00003 margin BIN appears at this row). Units 3-131..3-142, if they were ever assigned, are not present on disk; building 3's lower units may be incomplete, but the transcribed rows 3-143..3-156 are continuous and verified.",
+      "PAGE-COUNT NOTE: the report footer reads 'Page N of 13' (e.g. page-09-b shows 'Page 9 of 13', page-10-b shows 'Page 10 of 13'), but only 10 pages (page-01..page-10, 20 halves) are present on disk. pagesReportedByHeader is therefore 13 while 10 pages were supplied. Despite the footer's '13', the BldgUnit sequence transcribed across the 10 on-disk pages is CONTINUOUS and self-consistent for all 6 buildings (1-101 through 6-184) with no internal breaks except the intentional building-2 two-floor gap above; the trailing pages 11-13 most likely hold only the report's grand-total / summary rows, not additional buildings. No buildings or units were fabricated for the missing pages.",
+      "TOTALS CROSS-CHECK could NOT be completed: the rent-roll's grand-Totals row sits on the final page (13), which is not among the 10 supplied pages. The transcribed unit total is 112 (14 + 43 + 14 + 21 + 10 + 10). This figure is internally consistent but was not reconciled against an on-document Totals line. Re-scan pages 11-13 to confirm the count.",
+      "READ-RELIABILITY CAVEAT: the image-read path intermittently returned stale/cached renders when many derived crops were read in rapid succession, producing inconsistent windows of the same page. Final unit lists were locked by reading byte-distinct single-page copies one at a time (verified via md5 that all 10 top-halves are distinct files) plus rotated/enlarged left-margin BIN crops for each handwritten BIN. Every BIN above was visually confirmed on its boundary page; every unit above appeared in a stable single-page read. Where a render was inconsistent, the value was excluded rather than guessed.",
+      "Handwritten margin BINs read at building boundaries: NV-01-00001 (bldg 1, page 1, row 1-101), NV-01-00002 (bldg 2, page 2, row 2-115), NV-01-00003 (bldg 3, page 6, row 3-143), NV-01-10001 (bldg 4, page 7, row 4-145), NV-01-10002 (bldg 5, page 9, row 5-165), NV-01-10003 (bldg 6, page 10, row 6-175)."
+    ]
+  },
+  "mack": {
+    "propertyName": null,
+    "operatorEntity": "Community Development Programs Center of Nevada - Mixed Income, LLC dba Dr. Luther Mack Jr. Sr. Apts.",
+    "joinName": null,
+    "source": {
+      "type": "gpmg-email",
+      "date": "2026-05-27",
+      "pdf": "MACK BIN.pdf",
+      "pagesScanned": 7,
+      "pagesReportedByHeader": null,
+      "scanIncomplete": false
+    },
+    "buildings": [
+      {
+        "buildingCode": "1",
+        "bin": "NV-12-03001",
+        "unitCount": 47,
+        "units": [
+          "1-101",
+          "1-102",
+          "1-103",
+          "1-104",
+          "1-105",
+          "1-106",
+          "1-107",
+          "1-108",
+          "1-109",
+          "1-110",
+          "1-111",
+          "1-112",
+          "1-113",
+          "1-114",
+          "1-115",
+          "1-116",
+          "1-201",
+          "1-202",
+          "1-203",
+          "1-204",
+          "1-205",
+          "1-206",
+          "1-207",
+          "1-208",
+          "1-209",
+          "1-210",
+          "1-211",
+          "1-212",
+          "1-213",
+          "1-214",
+          "1-215",
+          "1-301",
+          "1-302",
+          "1-303",
+          "1-304",
+          "1-305",
+          "1-306",
+          "1-307",
+          "1-308",
+          "1-309",
+          "1-310",
+          "1-311",
+          "1-312",
+          "1-313",
+          "1-314",
+          "1-315",
+          "1-316"
+        ]
+      }
+    ],
+    "warnings": []
+  },
+  "meacham": {
+    "propertyName": "Dr. Paul Meacham Sr. Apartments",
+    "operatorEntity": "Community Development Programs Center of Nevada - Mixed Income 2 LLC",
+    "joinName": "Dr. Paul Meacham",
+    "source": {
+      "type": "gpmg-email",
+      "date": "2026-05-27",
+      "pdf": "MEACHAM BIN.pdf",
+      "pagesScanned": 8,
+      "pagesReportedByHeader": 10,
+      "scanIncomplete": true
+    },
+    "buildings": [
+      {
+        "buildingCode": "13-03001",
+        "bin": "NV-13-03001",
+        "unitCount": 57,
+        "units": [
+          "13-03001-101",
+          "13-03001-102",
+          "13-03001-103",
+          "13-03001-104",
+          "13-03001-105",
+          "13-03001-106",
+          "13-03001-107",
+          "13-03001-108",
+          "13-03001-109",
+          "13-03001-110",
+          "13-03001-111",
+          "13-03001-112",
+          "13-03001-113",
+          "13-03001-114",
+          "13-03001-115",
+          "13-03001-116",
+          "13-03001-117",
+          "13-03001-118",
+          "13-03001-119",
+          "13-03001-201",
+          "13-03001-202",
+          "13-03001-203",
+          "13-03001-204",
+          "13-03001-205",
+          "13-03001-206",
+          "13-03001-207",
+          "13-03001-208",
+          "13-03001-209",
+          "13-03001-210",
+          "13-03001-211",
+          "13-03001-212",
+          "13-03001-213",
+          "13-03001-214",
+          "13-03001-215",
+          "13-03001-216",
+          "13-03001-217",
+          "13-03001-218",
+          "13-03001-219",
+          "13-03001-301",
+          "13-03001-302",
+          "13-03001-303",
+          "13-03001-304",
+          "13-03001-305",
+          "13-03001-306",
+          "13-03001-307",
+          "13-03001-308",
+          "13-03001-309",
+          "13-03001-310",
+          "13-03001-311",
+          "13-03001-312",
+          "13-03001-313",
+          "13-03001-314",
+          "13-03001-315",
+          "13-03001-316",
+          "13-03001-317",
+          "13-03001-318",
+          "13-03001-319"
+        ]
+      }
+    ],
+    "warnings": [
+      "PDF has 8 pages but header reports 10; additional buildings/units may be missing \u2014 request a full scan.",
+      "Header reads 'Page X of 10' but only 8 pages (16 halves) are present on disk (pages 1-8). Pages 9-10 are missing. All 8 present pages belong to the same Unit Scheduled Transactions report for the same single building; pages 1-7 list the unit rows, page 8 is the Totals page. No new BldgUnit IDs or building codes appear on later pages.",
+      "Single building confirmed by handwritten red note 'Property Has One Building' across pages 1-2; one BIN (NV-13-03001) handwritten in red margin on pages 1, 2, and 3 ('BIN = NV-13-03001').",
+      "57 unique units extracted: floors 101-119, 201-219, 301-319 (3 floors x 19). Last unit visible is 13-03001-319 on page 8 just above the Totals row. Totals row present on page 8 (rent total 37,353.00) confirms end of unit list.",
+      "Units include both LIHTC (1x1, 2x2) and market-rate ('1 Bedroom Market' / 1x1MK, '2 Bedroom Market' / 2x2MK) types; all 57 included regardless of type per instructions.",
+      "Operator entity transcribed from header: 'Community Development Programs Center of Nevada - Mixed Income 2 LLC dba Dr. Paul Meacham Sr. Apts'."
+    ]
+  },
+  "ocallaghan": {
+    "propertyName": "Governor Mike O'Callaghan Legacy Apartments",
+    "operatorEntity": "Community Development Programs Center of Nevada - 1501 LLC",
+    "joinName": null,
+    "source": {
+      "type": "gpmg-email",
+      "date": "2026-05-27",
+      "pdf": "OCALLAGHAN BIN.pdf",
+      "pagesScanned": 4,
+      "pagesReportedByHeader": 7,
+      "scanIncomplete": true
+    },
+    "buildings": [
+      {
+        "buildingCode": "1",
+        "bin": "NV-22-05001",
+        "unitCount": 10,
+        "units": [
+          "1-101",
+          "1-102",
+          "1-103",
+          "1-104",
+          "1-105",
+          "1-106",
+          "1-107",
+          "1-108",
+          "1-109",
+          "1-110"
+        ]
+      },
+      {
+        "buildingCode": "2",
+        "bin": null,
+        "unitCount": 10,
+        "units": [
+          "2-201",
+          "2-202",
+          "2-203",
+          "2-204",
+          "2-205",
+          "2-206",
+          "2-207",
+          "2-208",
+          "2-209",
+          "2-210"
+        ]
+      },
+      {
+        "buildingCode": "3",
+        "bin": null,
+        "unitCount": 10,
+        "units": [
+          "3-301",
+          "3-302",
+          "3-303",
+          "3-304",
+          "3-305",
+          "3-306",
+          "3-307",
+          "3-308",
+          "3-309",
+          "3-310"
+        ]
+      },
+      {
+        "buildingCode": "4",
+        "bin": null,
+        "unitCount": 10,
+        "units": [
+          "4-401",
+          "4-402",
+          "4-403",
+          "4-404",
+          "4-405",
+          "4-406",
+          "4-407",
+          "4-408",
+          "4-409",
+          "4-410"
+        ]
+      }
+    ],
+    "warnings": [
+      "PDF has 4 pages but header reports 7; additional buildings/units may be missing \u2014 request a full scan.",
+      "INCOMPLETE SCAN: page headers read 'Page 1 of 7', 'Page 2 of 7', 'Page 3 of 7', 'Page 4 of 7' (one distinct page per scanned page, confirmed). The document is 7 pages but only pages 1-4 were scanned/provided. Buildings/pages 5-7 are MISSING; additional buildings (e.g. bldg 5+) likely exist and are not captured here.",
+      "Only building 1 carries a margin BIN annotation: NV-22-05001 (handwritten in the right margin of page-01-b, read directly from the image). Buildings 2, 3, 4 were checked on page-02-b / page-03-b / page-04-b and have NO visible BIN annotation -> set to null. NOT guessed as 05002/05003/05004 despite the obvious sequential pattern, per the honest-extraction rule.",
+      "All 40 units and the single BIN were confirmed by DIRECT VISUAL READ of all 8 page-halves (no inference): page-01 bldg1 units 101-110, page-02 bldg2 units 201-210, page-03 bldg3 units 301-310, page-04 bldg4 units 401-410. Building<->page mapping = BldgUnit hundreds digit. Each building has exactly 10 units (x01-x10).",
+      "Floor Plan Codes present (1x1a, 1x1b, 2x1MK) and SQFT (650 / 850); these are unit-mix details not requested. No 'Totals' row was visible within the scanned pages to cross-check the 40-unit count (totals likely fall on a later, unscanned page).",
+      "Operator/owner entity read from the page header on every page: 'Community Development Programs Center of Nevada - 1501 LLC dba Governor Mike O'Callaghan Legacy Apts.' Report 'As of 05/27/2026'. BIN family NV-22-* confirms 2022 LIHTC vintage.",
+      "macOS Vision OCR was unavailable (swiftc failed with a CommandLineTools 'SwiftBridging' module-redefinition error); all extraction was done by direct visual reading of the scanned PNGs, including 90-degree rotation + JPEG re-export to read the landscape table upright.",
+      "one or more buildings have no BIN extracted"
+    ]
+  },
+  "owens": {
+    "propertyName": "Owens Senior Apartments",
+    "operatorEntity": "Community Development Programs Center of Nevada - Owens 2, LP dba Owens Senior Apartments",
+    "joinName": "Owens Senior",
+    "source": {
+      "type": "gpmg-email",
+      "date": "2026-05-27",
+      "pdf": "OWENS BIN.pdf",
+      "pagesScanned": 8,
+      "pagesReportedByHeader": 10,
+      "scanIncomplete": true
+    },
+    "buildings": [
+      {
+        "buildingCode": "1",
+        "bin": "NV-99-13001",
+        "unitCount": 16,
+        "units": [
+          "1-101",
+          "1-102",
+          "1-103",
+          "1-104",
+          "1-105",
+          "1-106",
+          "1-107",
+          "1-108",
+          "1-201",
+          "1-202",
+          "1-203",
+          "1-204",
+          "1-205",
+          "1-206",
+          "1-207",
+          "1-208"
+        ]
+      },
+      {
+        "buildingCode": "2",
+        "bin": "NV-99-13002",
+        "unitCount": 12,
+        "units": [
+          "2-109",
+          "2-110",
+          "2-111",
+          "2-112",
+          "2-113",
+          "2-114",
+          "2-209",
+          "2-210",
+          "2-211",
+          "2-212",
+          "2-213",
+          "2-214"
+        ]
+      },
+      {
+        "buildingCode": "3",
+        "bin": "NV-99-13003",
+        "unitCount": 12,
+        "units": [
+          "3-115",
+          "3-116",
+          "3-117",
+          "3-118",
+          "3-119",
+          "3-120",
+          "3-215",
+          "3-216",
+          "3-217",
+          "3-218",
+          "3-219",
+          "3-220"
+        ]
+      },
+      {
+        "buildingCode": "4",
+        "bin": "NV-99-13004",
+        "unitCount": 12,
+        "units": [
+          "4-121",
+          "4-122",
+          "4-123",
+          "4-124",
+          "4-125",
+          "4-126",
+          "4-221",
+          "4-222",
+          "4-223",
+          "4-224",
+          "4-225",
+          "4-226"
+        ]
+      },
+      {
+        "buildingCode": "5",
+        "bin": "NV-99-13005",
+        "unitCount": 8,
+        "units": [
+          "5-130",
+          "5-131",
+          "5-132",
+          "5-133",
+          "5-230",
+          "5-231",
+          "5-232",
+          "5-233"
+        ]
+      },
+      {
+        "buildingCode": "6",
+        "bin": "NV-99-13006",
+        "unitCount": 12,
+        "units": [
+          "6-127",
+          "6-128",
+          "6-129",
+          "6-134",
+          "6-135",
+          "6-136",
+          "6-227",
+          "6-228",
+          "6-229",
+          "6-234",
+          "6-235",
+          "6-236"
+        ]
+      }
+    ],
+    "warnings": [
+      "PDF has 8 pages but header reports 10; additional buildings/units may be missing \u2014 request a full scan.",
+      "All 6 BINs CONFIRMED by direct visual read of handwritten margin annotations: NV-99-13001 (p1), NV-99-13002 (p2), NV-99-13003 (p3), NV-99-13004 (p4, above building-4 rows), NV-99-13005 (p5, above building-5 rows), NV-99-13006 (p7, above building-6 rows). All 6 expected buildings present.",
+      "Scans are landscape tables stored rotated 90deg; halves had to be rotated upright (sips -r -90) to be legible. Harness image-render + bash channels degraded repeatedly under heavy machine load (load avg ~6-9, multiple parallel sessions); many reads required 20-120s retries and several halves could only be read once.",
+      "TOTALS CROSS-CHECK PASSED: page-08 Totals row reads 47,270.00 across Market Rent / Effective Rent / Market+Addl columns, matching the prior-confirmed 58x$633 + 14x$754 = $47,270. Rent tiers consistent throughout: 1x1 / 1-Bedroom / 600sqft = $633; 2x1 / 2-Bedroom / 762sqft = $754.",
+      "BUILDING 5 has only 8 units recorded: 5-130,131,132,133 (floor 1) + 5-230,231,232,233 (floor 2), all directly read on page-06. No page in the document set shows 5-134+/5-234+, so building 5 is recorded as 8 units. NOTE: this is fewer than the 12-unit pattern of buildings 2/3/4/6; the building-5 continuation may live on one of the 2 missing document pages (see page-count discrepancy below). Per RULE 3 no extra units were invented.",
+      "DUPLICATE-PAGE ANOMALY in the scan set: file page-04 and file page-05 BOTH show building 4 (NV-99-13004 margin + units 4-121..126, 4-221..226) but carry DIFFERENT printed footers \u2014 page-04 footer = 'Page 4 of 10', page-05 footer = 'Page 5 of 10'. The two files have different md5 hashes (distinct scans), yet identical unit content. So one document page appears duplicated, OR building-4 legitimately spans two document pages. Building 4's units were de-duplicated to a single 12-unit list. This anomaly likely accounts for part of the 8-files-vs-10-header-pages gap and means the genuine building-5 continuation page may simply be absent from the scan set.",
+      "PAGE-COUNT DISCREPANCY: header says 'Page 1 of 10' (10 document pages) but only 8 physical page files (16 halves) exist on disk at /tmp/bins-work/owens/. Confirmed footers: page-01=1of10, page-02=2of10, page-03=3of10, page-04=4of10, page-05=5of10, page-06=6of10, page-08=8of10 (page-07 footer not legibly captured but content = building 6). pagesReportedByHeader=10 per header. 2 document pages (likely 9 and 10, or a building-5 continuation) are not present on disk.",
+      "Counts as recorded: 6 buildings, 72 units total (16 + 12 + 12 + 12 + 8 + 12). Building 1 has 16 units (1-101..108 + 1-201..208) \u2014 confirmed outlier, read directly across p1+p2. Buildings 2,3,4,6 have 12 each (6 per floor). Building 5 has only 8 read.",
+      "RE-RUN RECOMMENDED on a fresh low-load machine to locate any missing document pages (9/10) and confirm whether building 5 has additional units. All 6 BINs, the operator entity, and the financial Totals ($47,270) are already fully verified by direct read."
+    ]
+  },
+  "reid": {
+    "propertyName": null,
+    "operatorEntity": "Community Development Programs Center of Nevada - 11th Street, LP dba Senator Harry Reid Senior Apts.",
+    "joinName": "Sen. Harry Reid Senior Apts Aka 11Th St",
+    "source": {
+      "type": "gpmg-email",
+      "date": "2026-05-27",
+      "pdf": "REID BIN.pdf",
+      "pagesScanned": 10,
+      "pagesReportedByHeader": null,
+      "scanIncomplete": false
+    },
+    "buildings": [
+      {
+        "buildingCode": "1",
+        "bin": "NV-01-00011",
+        "unitCount": 99,
+        "units": [
+          "1-101",
+          "1-102",
+          "1-103",
+          "1-104",
+          "1-105",
+          "1-106",
+          "1-107",
+          "1-108",
+          "1-109",
+          "1-110",
+          "1-111",
+          "1-112",
+          "1-113",
+          "1-114",
+          "1-115",
+          "1-116",
+          "1-117",
+          "1-118",
+          "1-119",
+          "1-120",
+          "1-121",
+          "1-122",
+          "1-123",
+          "1-124",
+          "1-125",
+          "1-201",
+          "1-202",
+          "1-203",
+          "1-204",
+          "1-205",
+          "1-206",
+          "1-207",
+          "1-208",
+          "1-209",
+          "1-210",
+          "1-211",
+          "1-212",
+          "1-213",
+          "1-214",
+          "1-215",
+          "1-216",
+          "1-217",
+          "1-218",
+          "1-219",
+          "1-220",
+          "1-221",
+          "1-222",
+          "1-223",
+          "1-224",
+          "1-225",
+          "1-226",
+          "1-227",
+          "1-228",
+          "1-229",
+          "1-230",
+          "1-231",
+          "1-232",
+          "1-233",
+          "1-234",
+          "1-235",
+          "1-301",
+          "1-302",
+          "1-303",
+          "1-304",
+          "1-305",
+          "1-306",
+          "1-307",
+          "1-308",
+          "1-309",
+          "1-310",
+          "1-311",
+          "1-312",
+          "1-313",
+          "1-314",
+          "1-315",
+          "1-316",
+          "1-317",
+          "1-318",
+          "1-319",
+          "1-320",
+          "1-321",
+          "1-322",
+          "1-323",
+          "1-324",
+          "1-325",
+          "1-326",
+          "1-327",
+          "1-328",
+          "1-329",
+          "1-330",
+          "1-331",
+          "1-332",
+          "1-333",
+          "1-334",
+          "1-335",
+          "1-336",
+          "1-337",
+          "1-338",
+          "1-339"
+        ]
+      }
+    ],
+    "warnings": []
+  },
+  "smith-williams": {
+    "propertyName": "Smith Williams Senior Apts.",
+    "operatorEntity": "Smith Williams, LLC",
+    "joinName": "Smith Williams Apts",
+    "source": {
+      "type": "gpmg-email",
+      "date": "2026-05-27",
+      "pdf": "SMITH WILLIAMS BIN.pdf",
+      "pagesScanned": 11,
+      "pagesReportedByHeader": 13,
+      "scanIncomplete": true
+    },
+    "buildings": [
+      {
+        "buildingCode": "1",
+        "bin": "NV-09-01001",
+        "unitCount": 23,
+        "units": [
+          "1101",
+          "1102",
+          "1103",
+          "1104",
+          "1105",
+          "1106",
+          "1107",
+          "1201",
+          "1202",
+          "1203",
+          "1204",
+          "1205",
+          "1206",
+          "1207",
+          "1208",
+          "1301",
+          "1302",
+          "1303",
+          "1304",
+          "1305",
+          "1306",
+          "1307",
+          "1308"
+        ]
+      },
+      {
+        "buildingCode": "2",
+        "bin": "NV-09-01002",
+        "unitCount": 21,
+        "units": [
+          "2109",
+          "2110",
+          "2111",
+          "2112",
+          "2113",
+          "2114",
+          "2115",
+          "2206",
+          "2209",
+          "2210",
+          "2211",
+          "2212",
+          "2213",
+          "2214",
+          "2215",
+          "2310",
+          "2311",
+          "2312",
+          "2313",
+          "2314",
+          "2315"
+        ]
+      },
+      {
+        "buildingCode": "3",
+        "bin": "NV-09-01003",
+        "unitCount": 35,
+        "units": [
+          "3116",
+          "3117",
+          "3118",
+          "3119",
+          "3120",
+          "3121",
+          "3122",
+          "3123",
+          "3124",
+          "3125",
+          "3126",
+          "3127",
+          "3216",
+          "3217",
+          "3218",
+          "3219",
+          "3220",
+          "3221",
+          "3222",
+          "3223",
+          "3224",
+          "3225",
+          "3226",
+          "3227",
+          "3317",
+          "3318",
+          "3319",
+          "3320",
+          "3321",
+          "3322",
+          "3323",
+          "3324",
+          "3325",
+          "3326",
+          "3327"
+        ]
+      }
+    ],
+    "warnings": [
+      "PDF has 11 pages but header reports 13; additional buildings/units may be missing \u2014 request a full scan.",
+      "Header reports 'Page 1 of 13' but only 11 physical pages (22 halves) are present on disk; pagesReportedByHeader=13 set accordingly. Pages 12-13 not provided.",
+      "All 3 expected BINs found, each handwritten in the left margin at the first unit of its building: NV-09-01001 @ unit 1101 (p01), NV-09-01002 @ unit 2109 (p04), NV-09-01003 @ unit 3116 (p06).",
+      "Unit numbering is property-wide (not per-building reset) and skips numbers, consistent with the known structure. Building 2 floor-2 sequence reads 2206 then 2209-2215 (2207-2208 not present in the roll); transcribed exactly as printed, no units invented.",
+      "Building 2 floor-3 starts at 2310 and runs 2310-2315 (6 units); building 3 starts at 3116.",
+      "Totals row on final page (p11-b) = 54,132.00, which is a summed rent/dollar amount, NOT a unit count. 79 unit rows transcribed across the 3 buildings."
+    ]
+  },
+  "srb": {
+    "propertyName": "Senator Richard Bryan Senior Apartments",
+    "operatorEntity": "Community Development Programs Center of Nevada - SRB LP",
+    "joinName": null,
+    "source": {
+      "type": "gpmg-email",
+      "date": "2026-05-27",
+      "pdf": "SRB BIN.pdf",
+      "pagesScanned": 24,
+      "pagesReportedByHeader": 27,
+      "scanIncomplete": true
+    },
+    "buildings": [
+      {
+        "buildingCode": "1",
+        "bin": "NV-07-19001",
+        "unitCount": 6,
+        "units": [
+          "01-1001",
+          "01-1002",
+          "01-1003",
+          "01-1004",
+          "01-1005",
+          "01-1006"
+        ]
+      },
+      {
+        "buildingCode": "2",
+        "bin": "NV-07-19002",
+        "unitCount": 8,
+        "units": [
+          "02-1017",
+          "02-1018",
+          "02-1019",
+          "02-1020",
+          "02-1021",
+          "02-1022",
+          "02-1023",
+          "02-1024"
+        ]
+      },
+      {
+        "buildingCode": "3",
+        "bin": "NV-07-19003",
+        "unitCount": 4,
+        "units": [
+          "03-1037",
+          "03-1038",
+          "03-1039",
+          "03-1040"
+        ]
+      },
+      {
+        "buildingCode": "4",
+        "bin": "NV-07-19004",
+        "unitCount": 8,
+        "units": [
+          "04-1041",
+          "04-1042",
+          "04-1043",
+          "04-1044",
+          "04-1045",
+          "04-1046",
+          "04-1047",
+          "04-1048"
+        ]
+      },
+      {
+        "buildingCode": "5",
+        "bin": "NV-07-19005",
+        "unitCount": 8,
+        "units": [
+          "05-1049",
+          "05-1050",
+          "05-1051",
+          "05-1052",
+          "05-1053",
+          "05-1054",
+          "05-1055",
+          "05-1056"
+        ]
+      },
+      {
+        "buildingCode": "6",
+        "bin": "NV-07-19006",
+        "unitCount": 8,
+        "units": [
+          "06-1057",
+          "06-1058",
+          "06-1059",
+          "06-1060",
+          "06-1061",
+          "06-1062",
+          "06-1063",
+          "06-1064"
+        ]
+      },
+      {
+        "buildingCode": "7",
+        "bin": "NV-07-19007",
+        "unitCount": 8,
+        "units": [
+          "07-1065",
+          "07-1066",
+          "07-1067",
+          "07-1068",
+          "07-1069",
+          "07-1070",
+          "07-1071",
+          "07-1072"
+        ]
+      },
+      {
+        "buildingCode": "8",
+        "bin": "NV-07-19008",
+        "unitCount": 8,
+        "units": [
+          "08-1073",
+          "08-1074",
+          "08-1075",
+          "08-1076",
+          "08-1077",
+          "08-1078",
+          "08-1079",
+          "08-1080"
+        ]
+      },
+      {
+        "buildingCode": "9",
+        "bin": "NV-07-19009",
+        "unitCount": 14,
+        "units": [
+          "09-1081",
+          "09-1082",
+          "09-1083",
+          "09-1084",
+          "09-1085",
+          "09-1086",
+          "09-1087",
+          "09-1088",
+          "09-1089",
+          "09-1090",
+          "09-1091",
+          "09-1092",
+          "09-1093",
+          "09-1094"
+        ]
+      },
+      {
+        "buildingCode": "10",
+        "bin": "NV-07-19010",
+        "unitCount": 8,
+        "units": [
+          "10-1073",
+          "10-1074",
+          "10-1075",
+          "10-1076",
+          "10-1077",
+          "10-1078",
+          "10-1079",
+          "10-1080"
+        ]
+      },
+      {
+        "buildingCode": "11",
+        "bin": "NV-07-19011",
+        "unitCount": 8,
+        "units": [
+          "11-1025",
+          "11-1026",
+          "11-1027",
+          "11-1028",
+          "11-1029",
+          "11-1030",
+          "11-1031",
+          "11-1032"
+        ]
+      },
+      {
+        "buildingCode": "12",
+        "bin": "NV-07-19012",
+        "unitCount": 8,
+        "units": [
+          "12-1009",
+          "12-1010",
+          "12-1011",
+          "12-1012",
+          "12-1013",
+          "12-1014",
+          "12-1015",
+          "12-1016"
+        ]
+      },
+      {
+        "buildingCode": "13",
+        "bin": "NV-07-19013",
+        "unitCount": 3,
+        "units": [
+          "13-1101",
+          "13-1102",
+          "13-1103"
+        ]
+      },
+      {
+        "buildingCode": "14",
+        "bin": "NV-07-19014",
+        "unitCount": 7,
+        "units": [
+          "14-1105",
+          "14-1106",
+          "14-1108",
+          "14-1109",
+          "14-1110",
+          "14-1111",
+          "14-1112"
+        ]
+      },
+      {
+        "buildingCode": "15",
+        "bin": "NV-07-19015",
+        "unitCount": 8,
+        "units": [
+          "15-1113",
+          "15-1114",
+          "15-1115",
+          "15-1116",
+          "15-1117",
+          "15-1118",
+          "15-1119",
+          "15-1120"
+        ]
+      },
+      {
+        "buildingCode": "16",
+        "bin": "NV-05-06001",
+        "unitCount": 8,
+        "units": [
+          "16-1121",
+          "16-1122",
+          "16-1123",
+          "16-1124",
+          "16-1125",
+          "16-1126",
+          "16-1127",
+          "16-1128"
+        ]
+      },
+      {
+        "buildingCode": "17",
+        "bin": "NV-05-06002",
+        "unitCount": 8,
+        "units": [
+          "17-1209",
+          "17-1210",
+          "17-1211",
+          "17-1212",
+          "17-1213",
+          "17-1214",
+          "17-1215",
+          "17-1216"
+        ]
+      },
+      {
+        "buildingCode": "18",
+        "bin": "NV-05-06003",
+        "unitCount": 5,
+        "units": [
+          "18-1196",
+          "18-1197",
+          "18-1198",
+          "18-1199",
+          "18-1200"
+        ]
+      },
+      {
+        "buildingCode": "19",
+        "bin": "NV-05-06004",
+        "unitCount": 7,
+        "units": [
+          "19-1128",
+          "19-1129",
+          "19-1130",
+          "19-1131",
+          "19-1132",
+          "19-1133",
+          "19-1134"
+        ]
+      },
+      {
+        "buildingCode": "20",
+        "bin": "NV-05-06005",
+        "unitCount": 10,
+        "units": [
+          "20-1175",
+          "20-1176",
+          "20-1177",
+          "20-1178",
+          "20-1179",
+          "20-1180",
+          "20-1181",
+          "20-1182",
+          "20-1183",
+          "20-1184"
+        ]
+      },
+      {
+        "buildingCode": "21",
+        "bin": "NV-05-06006",
+        "unitCount": 9,
+        "units": [
+          "21-1146",
+          "21-1147",
+          "21-1148",
+          "21-1149",
+          "21-1150",
+          "21-1151",
+          "21-1152",
+          "21-1153",
+          "21-1154"
+        ]
+      },
+      {
+        "buildingCode": "22",
+        "bin": "NV-05-06007",
+        "unitCount": 6,
+        "units": [
+          "22-1155",
+          "22-1156",
+          "22-1157",
+          "22-1158",
+          "22-1159",
+          "22-1160"
+        ]
+      },
+      {
+        "buildingCode": "23",
+        "bin": "NV-05-06008",
+        "unitCount": 14,
+        "units": [
+          "23-1161",
+          "23-1162",
+          "23-1163",
+          "23-1164",
+          "23-1165",
+          "23-1166",
+          "23-1167",
+          "23-1168",
+          "23-1169",
+          "23-1170",
+          "23-1171",
+          "23-1172",
+          "23-1173",
+          "23-1174"
+        ]
+      },
+      {
+        "buildingCode": "24",
+        "bin": "NV-05-06009",
+        "unitCount": 4,
+        "units": [
+          "24-1175",
+          "24-1176",
+          "24-1177",
+          "24-1178"
+        ]
+      },
+      {
+        "buildingCode": "25",
+        "bin": "NV-05-06010",
+        "unitCount": 8,
+        "units": [
+          "25-1177",
+          "25-1178",
+          "25-1179",
+          "25-1180",
+          "25-1181",
+          "25-1182",
+          "25-1183",
+          "25-1184"
+        ]
+      },
+      {
+        "buildingCode": "26",
+        "bin": "NV-05-06011",
+        "unitCount": 6,
+        "units": [
+          "26-1185",
+          "26-1186",
+          "26-1187",
+          "26-1188",
+          "26-1189",
+          "26-1190"
+        ]
+      },
+      {
+        "buildingCode": "27",
+        "bin": "NV-05-06012",
+        "unitCount": 6,
+        "units": [
+          "27-1203",
+          "27-1204",
+          "27-1205",
+          "27-1206",
+          "27-1207",
+          "27-1208"
+        ]
+      },
+      {
+        "buildingCode": "28",
+        "bin": "NV-05-06013",
+        "unitCount": 4,
+        "units": [
+          "28-1217",
+          "28-1218",
+          "28-1219",
+          "28-1220"
+        ]
+      },
+      {
+        "buildingCode": "29",
+        "bin": "NV-05-06014",
+        "unitCount": 10,
+        "units": [
+          "29-1221",
+          "29-1222",
+          "29-1223",
+          "29-1224",
+          "29-1225",
+          "29-1226",
+          "29-1227",
+          "29-1228",
+          "29-1229",
+          "29-1230"
+        ]
+      },
+      {
+        "buildingCode": "30",
+        "bin": "NV-05-06015",
+        "unitCount": 10,
+        "units": [
+          "30-1231",
+          "30-1232",
+          "30-1233",
+          "30-1234",
+          "30-1235",
+          "30-1236",
+          "30-1237",
+          "30-1238",
+          "30-1239",
+          "30-1240"
+        ]
+      }
+    ],
+    "warnings": [
+      "BIN FORMAT CORRECTED (adversarial re-read 2026-05-29): phase-1 buildings 1-15 carry STANDARD BINs NV-07-19001..NV-07-19015 (serial = 19000 + building#). The earlier extraction misread the continuous typed margin string 'NV-0719001' as a 4-segment 'NV-07-19-0001' (dropping it below 5 trailing digits). Phase-2 buildings 16-30 = NV-05-06001..NV-05-06015. Building number maps 1:1 to serial within each phase; all 30 BINs now satisfy NV-YY-NNNNN.",
+      "PDF has 24 pages but header reports 27; additional buildings/units may be missing \u2014 request a full scan.",
+      "BUILDING 14 UNIT GAP CONFIRMED: building 14 jumps 14-1106 -> 14-1108 with no 14-1107 row present on either half of the page. The gap is real in the source rent-roll, not a scan/crop artifact. Verified on page 14.",
+      "26/27 BOUNDARY (prior-read hazard) RESOLVED: building 26 anchors to BIN NV-05-06011 and building 27 anchors to NV-05-06012. They sit on consecutive pages; each BIN header cleanly precedes its own building's unit block. No single page carries two ambiguous BINs for the 26/27 pair - the sequence is unambiguous (06011=bldg26, 06012=bldg27).",
+      "MISSING PAGES: header reads 'Page X of 27' but only 24 physical pages (page-01..page-24, 48 halves) are present on disk. Pages 25, 26, 27 are NOT present. Building 30 (NV-05-06015) may have additional units beyond those captured, and any building 31+ (if it exists) is entirely absent. Building count of 30 is the maximum supportable by the observed BIN sequence (NV-05-06015 = 15th phase-2 building).",
+      "UNIT-CODE FORMAT is NN-NNNN (zero-padded 2-digit building prefix + 4-digit unit), e.g. 05-1049, 23-1161. Full bldg-prefixed unit string retained for every unit because unit numbers collide across buildings (e.g. 13-1101 vs 23-1101; 20-1175/24-1175/25-1177 share the 117x band). Only the building prefix disambiguates.",
+      "UNIT-LIST FIDELITY CAVEAT: this is the LARGEST property (30 buildings, ~185 units) on dense rotated landscape scans. BIN-to-building anchoring is high-confidence (typed section headers, clean sequence). Individual unit-NUMBER cells within each block are lower-confidence - some unit serials may be off by a digit or a row may be missed/duplicated due to scan density. The unit COUNT per building and the BIN mapping are the reliable outputs; exact unit serials should be re-verified against a clean source before any compliance filing.",
+      "Buildings 16-20 ARE present and observed in this read (pages 16-20, BINs NV-05-06001..06005) - this corrects an earlier-read assumption that 16-20 were missing. The actually-missing content is pages 25-27 (tail of bldg 30 / any bldg 31+)."
+    ]
+  },
+  "yale": {
+    "propertyName": "Yale (Yale Keyes Senior Apts)",
+    "operatorEntity": "Yale Keyes LP dba Yale Keyes Senior Apts.",
+    "joinName": "Yale/Keyes Senior Apts",
+    "source": {
+      "type": "gpmg-email",
+      "date": "2026-05-27",
+      "pdf": "YALE BIN.pdf",
+      "pagesScanned": 9,
+      "pagesReportedByHeader": 11,
+      "scanIncomplete": true
+    },
+    "buildings": [
+      {
+        "buildingCode": "1",
+        "bin": "NV-01-00004",
+        "unitCount": 70,
+        "units": [
+          "1-101",
+          "1-102",
+          "1-103",
+          "1-104",
+          "1-105",
+          "1-106",
+          "1-107",
+          "1-108",
+          "1-109",
+          "1-110",
+          "1-111",
+          "1-112",
+          "1-113",
+          "1-114",
+          "1-115",
+          "1-116",
+          "1-117",
+          "1-118",
+          "1-119",
+          "1-120",
+          "1-121",
+          "1-122",
+          "1-123",
+          "1-124",
+          "1-125",
+          "1-126",
+          "1-127",
+          "1-128",
+          "1-129",
+          "1-130",
+          "1-131",
+          "1-132",
+          "1-133",
+          "1-134",
+          "1-135",
+          "1-201",
+          "1-202",
+          "1-203",
+          "1-204",
+          "1-205",
+          "1-206",
+          "1-207",
+          "1-208",
+          "1-209",
+          "1-210",
+          "1-211",
+          "1-212",
+          "1-213",
+          "1-214",
+          "1-215",
+          "1-216",
+          "1-217",
+          "1-218",
+          "1-219",
+          "1-220",
+          "1-221",
+          "1-222",
+          "1-223",
+          "1-224",
+          "1-225",
+          "1-226",
+          "1-227",
+          "1-228",
+          "1-229",
+          "1-230",
+          "1-231",
+          "1-232",
+          "1-233",
+          "1-234",
+          "1-235"
+        ]
+      }
+    ],
+    "warnings": [
+      "PDF has 9 pages but header reports 11; additional buildings/units may be missing \u2014 request a full scan.",
+      "Header reads 'Page X of 11' but only 9 physical pages (18 halves) on disk; page-09-b ends with a 'Totals:' row and a grand total ($52,044.00), so the unit roll is complete. The extra header pages (10-11) are likely trailing summary/legend pages not included in this scan and contain no additional units.",
+      "BIN NV-01-00004 read from the page-01-a header ('BIN # NV-01-00004'); no handwritten margin BIN observed.",
+      "Single building (buildingCode '1'), 70 units: 35 on floor 1 (1-101..1-135) and 35 on floor 2 (1-201..1-235). Most units are 1x1/1Bedroom (700 SQFT); a handful are 2x1/2Bedroom (800 SQFT), all CA-RENT."
+    ]
+  }
+}


### PR DESCRIPTION
## What

Lands the Building Identification Number (BIN, `NV-YY-NNNNN`) dataset extracted from the 12 rent-roll PDFs Dora LaGrande (Global Property Management Group) emailed **2026-05-27**. **Reference data only** — no schema or code integration this pass.

| File | Purpose |
|---|---|
| `src/db/data/bins.json` | Lookup keyed by property slug → buildings → units |
| `docs/bins-verification.md` | Per-property tables + extraction warnings |
| `demo/extract-bins.py` | PDF → 400 DPI page-halves → margin-BIN read pipeline |

## Numbers

- **12 properties, 70 buildings, 965 units, 5 unread BINs.**
- The 5 nulls are genuinely blank/illegible in source (fletcher bldg 7 & 9; ocallaghan bldg 2, 3, 4) — **not** fabricated, routed to a GPMG re-request (`docs/bins-verification-gaps-request.md`, separate).
- **8 of 12 scans are incomplete** (~20 pages missing); **7/12** join to `nv-housing-props.json`.

## Confidence

Only the **4 highest-risk** properties were adversarially re-read against the source PNGs. The other 8 are first-pass extraction — stated here so downstream doesn't over-trust them.

Corrections folded in from the re-read:
- **SRB** — phase-1 buildings 1–15 normalized to standard `NV-07-19001..015`. The earlier read split the continuous typed margin string `NV-0719001` into a bogus 4-segment `NV-07-19-0001`. **All 65 non-null BINs now satisfy `NV-YY-NNNNN`** (SRB was the only violator; 18 stale format warnings dropped).
- **FLETCHER** — the handwritten `NV-14-04xxx` mapping is at the scan's resolution limit; three reads disagree by a one-building shift. Primary extraction **retained per do-not-invent**, flagged **PROVISIONAL** pending a clean GPMG list. Totals unchanged (70/965/5).
- **JUAN / OCALLAGHAN** — extraction confirmed; the `NV-00-0002` 4-digit ambiguity and the 3 blank O'Callaghan BINs are routed to the re-request.

## Safety / CI

- `grep -r bins.json src/ client-tenant/` → **zero importers**. Pure data + docs; no runtime or build path touches it, so the 6 required checks pass trivially.
- Deterministic consistency check passes: `unitCount == len(units)`, no duplicate BINs/units within a property, every non-null BIN regex-valid.

## Out of scope (deferred)

`buildings` table + `units.building_id` FK + making §42 NAU/AUR per-building (it's property-scoped today). Audit-sensitive; waits until the dataset is complete (post-Dora) so we don't wire incomplete data into compliance-critical paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)