### PR TITLE
feat(screening): auto-trigger screening on submit + status-transition chokepoint (flag-gated off)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -144,6 +144,14 @@ VITE_TURNSTILE_SITE_KEY=1x00000000000000000000AA
 # NDJSON line-count == compliance_tape row-count for the same session_id.
 COMPLIANCE_TAPE_V2_ENABLED=false
 
+# Auto-screening on the applicant funnel. When true, submitting an application
+# (POST /api/applications/:id/submit) advances it submitted → screening through
+# the state-machine chokepoint and kicks runFullScreening fire-and-forget, so an
+# app no longer waits for staff to manually POST /api/screening/:id/screen.
+# Default off ⇒ byte-for-byte current behavior (manual /screen only). A failed
+# pipeline leaves the app in `screening` (non-approvable), never a silent pass.
+SCREENING_ON_SUBMIT_ENABLED=false
+
 # Supabase Storage (optional — enables /api/qa/bundles, the operator QA viewer).
 # When unset, the QA viewer returns an empty list with a hint banner instead
 # of failing. Service role key is server-only — never expose to the client.

--- a/src/__tests__/application-service.test.ts
+++ b/src/__tests__/application-service.test.ts
@@ -22,6 +22,7 @@ import { ApplicationService } from "../modules/application/service";
 import { query, transaction } from "../config/database";
 import { encrypt, hashSSN, maskSSN } from "../utils/encryption";
 import { writeAuditLog } from "../middleware/audit";
+import { transitionApplicationStatus } from "../modules/screening/state-machine";
 
 /** Wrap rows in a minimal QueryResult shape without casting to `any`. */
 function qr<T extends Record<string, unknown>>(rows: T[]): QueryResult<T> {
@@ -66,12 +67,28 @@ jest.mock("../modules/screening/fraud-detection", () => ({
   })),
 }));
 
+// Auto-screening-on-submit collaborators (SCREENING_ON_SUBMIT_ENABLED path).
+// state-machine mocked inline (no out-of-scope ref → no TDZ); ScreeningService
+// reads mockRunFullScreening lazily inside the per-construction impl closure.
+const mockRunFullScreening = jest.fn();
+jest.mock("../modules/screening/state-machine", () => ({
+  transitionApplicationStatus: jest.fn(),
+}));
+jest.mock("../modules/screening/service", () => ({
+  ScreeningService: jest.fn().mockImplementation(() => ({
+    runFullScreening: mockRunFullScreening,
+  })),
+}));
+
 const mockQuery = query as jest.MockedFunction<typeof query>;
 const mockTransaction = transaction as jest.MockedFunction<typeof transaction>;
 const mockEncrypt = encrypt as jest.MockedFunction<typeof encrypt>;
 const mockHashSSN = hashSSN as jest.MockedFunction<typeof hashSSN>;
 const mockMaskSSN = maskSSN as jest.MockedFunction<typeof maskSSN>;
 const mockWriteAuditLog = writeAuditLog as jest.MockedFunction<typeof writeAuditLog>;
+const mockTransition = transitionApplicationStatus as jest.MockedFunction<
+  typeof transitionApplicationStatus
+>;
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
@@ -308,6 +325,78 @@ describe("ApplicationService.submit()", () => {
     const result = await service.submit("app-001", "user-001", "leasing_agent");
 
     expect(result).toEqual(submittedRow);
+  });
+});
+
+// ── submit() — auto-screening on submit (SCREENING_ON_SUBMIT_ENABLED) ────────
+
+describe("ApplicationService.submit() — auto-screening on submit", () => {
+  const ORIGINAL_FLAG = process.env.SCREENING_ON_SUBMIT_ENABLED;
+  const flush = () => new Promise((r) => setImmediate(r));
+
+  beforeEach(() => {
+    mockQuery.mockReset();
+    mockWriteAuditLog.mockReset();
+    mockTransition.mockReset();
+    mockRunFullScreening.mockReset();
+    mockRunFullScreening.mockResolvedValue(undefined);
+    mockTransition.mockResolvedValue({ changed: true, status: "screening" } as any);
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_FLAG === undefined) delete process.env.SCREENING_ON_SUBMIT_ENABLED;
+    else process.env.SCREENING_ON_SUBMIT_ENABLED = ORIGINAL_FLAG;
+  });
+
+  it("flag off ⇒ no chokepoint transition, no screening kickoff (byte-for-byte legacy)", async () => {
+    delete process.env.SCREENING_ON_SUBMIT_ENABLED;
+    mockQuery.mockResolvedValue(qr([{ id: "app-001", status: "submitted", submitted_at: new Date() }]));
+
+    const service = makeService();
+    const result = await service.submit("app-001", "user-001", "leasing_agent");
+    await flush();
+
+    expect(result.status).toBe("submitted");
+    expect(mockTransition).not.toHaveBeenCalled();
+    expect(mockRunFullScreening).not.toHaveBeenCalled();
+  });
+
+  it("flag on ⇒ advances submitted→screening through the chokepoint and kicks runFullScreening", async () => {
+    process.env.SCREENING_ON_SUBMIT_ENABLED = "true";
+    mockQuery.mockResolvedValue(qr([{ id: "app-001", status: "submitted", submitted_at: new Date() }]));
+
+    const service = makeService();
+    const result = await service.submit("app-001", "user-001", "leasing_agent");
+
+    // submit() still returns the submitted row synchronously.
+    expect(result.status).toBe("submitted");
+    expect(mockTransition).toHaveBeenCalledWith(
+      expect.objectContaining({
+        applicationId: "app-001",
+        from: "submitted",
+        to: "screening",
+        trigger: "screening_started",
+      })
+    );
+
+    // Fire-and-forget kickoff: flush microtasks so the void promise resolves.
+    await flush();
+    expect(mockRunFullScreening).toHaveBeenCalledWith("app-001", "user-001", "leasing_agent");
+  });
+
+  it("flag on + pipeline throws ⇒ submit() still resolves; app left in screening (non-approvable)", async () => {
+    process.env.SCREENING_ON_SUBMIT_ENABLED = "true";
+    mockQuery.mockResolvedValue(qr([{ id: "app-001", status: "submitted", submitted_at: new Date() }]));
+    mockRunFullScreening.mockRejectedValue(new Error("vendor down"));
+
+    const service = makeService();
+    // Must NOT reject — a screening failure never surfaces to the applicant.
+    const result = await service.submit("app-001", "user-001", "leasing_agent");
+    await flush();
+
+    expect(result.status).toBe("submitted");
+    expect(mockTransition).toHaveBeenCalledTimes(1);
+    expect(mockRunFullScreening).toHaveBeenCalled();
   });
 });
 

--- a/src/__tests__/screening-service.test.ts
+++ b/src/__tests__/screening-service.test.ts
@@ -68,6 +68,10 @@ jest.mock("../modules/adverse-action/service", () => ({
   })),
 }));
 
+jest.mock("../modules/screening/state-machine", () => ({
+  transitionApplicationStatus: jest.fn(),
+}));
+
 import { query } from "../config/database";
 import { writeAuditLog } from "../middleware/audit";
 import { decrypt } from "../utils/encryption";
@@ -76,10 +80,14 @@ import { CreditCheckService } from "../modules/screening/credit-check";
 import { ComplianceService } from "../modules/screening/compliance";
 import { IdentityVerificationService } from "../modules/screening/identity-verification";
 import { AdverseActionService } from "../modules/adverse-action/service";
+import { transitionApplicationStatus } from "../modules/screening/state-machine";
 
 const mockQuery = query as jest.MockedFunction<typeof query>;
 const mockAuditLog = writeAuditLog as jest.MockedFunction<typeof writeAuditLog>;
 const mockDecrypt = decrypt as jest.MockedFunction<typeof decrypt>;
+const mockTransition = transitionApplicationStatus as jest.MockedFunction<
+  typeof transitionApplicationStatus
+>;
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -163,6 +171,7 @@ describe("ScreeningService.runFullScreening", () => {
     jest.clearAllMocks();
     mockAuditLog.mockResolvedValue(undefined);
     mockDecrypt.mockImplementation((v: string) => `decrypted:${v}`);
+    mockTransition.mockResolvedValue({ changed: true, status: "screening_passed" } as any);
 
     service = new ScreeningService();
 
@@ -187,13 +196,13 @@ describe("ScreeningService.runFullScreening", () => {
 
   // ── Guard: application not found / wrong status ───────────────────────────
 
-  it("throws when application is not found or not in submitted status", async () => {
+  it("throws when application is not found or not in submitted/screening status", async () => {
     mockQuery.mockReset();
     mockQuery.mockResolvedValueOnce({ rows: [] } as any);
 
     await expect(
       service.runFullScreening("app-missing", "user-1", "leasing_agent")
-    ).rejects.toThrow(/not found or not in submitted status/i);
+    ).rejects.toThrow(/not found or not in submitted\/screening status/i);
   });
 
   // ── All-pass scenario ─────────────────────────────────────────────────────
@@ -204,13 +213,12 @@ describe("ScreeningService.runFullScreening", () => {
     expect(result.overallResult).toBe("pass");
   });
 
-  it("sets status to screening_passed when overallResult is pass", async () => {
+  it("transitions to screening_passed (all_checks_passed) when overallResult is pass", async () => {
     await service.runFullScreening("app-001", "user-1", "leasing_agent");
 
-    const statusUpdate = mockQuery.mock.calls.find(
-      (c) => (c[0] as string).includes("overall_screening_result")
+    expect(mockTransition).toHaveBeenCalledWith(
+      expect.objectContaining({ to: "screening_passed", trigger: "all_checks_passed" })
     );
-    expect(statusUpdate?.[1]).toContain("screening_passed");
   });
 
   // ── Fail propagation ──────────────────────────────────────────────────────
@@ -239,15 +247,23 @@ describe("ScreeningService.runFullScreening", () => {
     expect(result.overallResult).toBe("fail");
   });
 
-  it("sets status to screening_failed when overallResult is fail", async () => {
+  it("transitions to screening_failed (any_check_failed) when overallResult is fail", async () => {
     mockBackground.runCheck.mockResolvedValue(makeBackgroundResult("fail"));
 
     await service.runFullScreening("app-001", "user-1", "leasing_agent");
 
-    const statusUpdate = mockQuery.mock.calls.find(
-      (c) => (c[0] as string).includes("overall_screening_result")
+    expect(mockTransition).toHaveBeenCalledWith(
+      expect.objectContaining({ to: "screening_failed", trigger: "any_check_failed" })
     );
-    expect(statusUpdate?.[1]).toContain("screening_failed");
+  });
+
+  it("does NOT send the FCRA notice when the final transition loses the CAS (changed:false)", async () => {
+    mockBackground.runCheck.mockResolvedValue(makeBackgroundResult("fail"));
+    mockTransition.mockResolvedValue({ changed: false, status: "screening_failed" } as any);
+
+    await service.runFullScreening("app-001", "user-1", "leasing_agent");
+
+    expect(mockAdverseAction.sendNotice).not.toHaveBeenCalled();
   });
 
   // ── Review-required escalation ────────────────────────────────────────────
@@ -282,15 +298,14 @@ describe("ScreeningService.runFullScreening", () => {
 
   // ── review_required still sets screening_passed (routes to human review) ─
 
-  it("sets status to screening_passed even when review_required (human Tier 1 will see it)", async () => {
+  it("transitions to screening_passed (review_required_passthrough) even when review_required (human Tier 1 will see it)", async () => {
     mockBackground.runCheck.mockResolvedValue(makeBackgroundResult("review_required"));
 
     await service.runFullScreening("app-001", "user-1", "leasing_agent");
 
-    const statusUpdate = mockQuery.mock.calls.find(
-      (c) => (c[0] as string).includes("overall_screening_result")
+    expect(mockTransition).toHaveBeenCalledWith(
+      expect.objectContaining({ to: "screening_passed", trigger: "review_required_passthrough" })
     );
-    expect(statusUpdate?.[1]).toContain("screening_passed");
   });
 
   // ── PCI-DSS: SSN decryption and last-4 extraction ─────────────────────────
@@ -485,11 +500,10 @@ describe("ScreeningService.runFullScreening", () => {
       expect.stringContaining("identity verification failed")
     );
 
-    // Status flip to screening_failed (mirrors dup-SSN block).
-    const statusUpdate = mockQuery.mock.calls.find(
-      (c) => (c[0] as string).includes("overall_screening_result")
+    // Status flip to screening_failed via the chokepoint (mirrors dup-SSN block).
+    expect(mockTransition).toHaveBeenCalledWith(
+      expect.objectContaining({ to: "screening_failed", trigger: "identity_rejected" })
     );
-    expect(statusUpdate?.[1]).toContain("screening_failed");
   });
 
   it("writes an identity_verification_completed audit log entry", async () => {

--- a/src/__tests__/state-machine.test.ts
+++ b/src/__tests__/state-machine.test.ts
@@ -10,16 +10,27 @@
 import {
   TRANSITIONS,
   TERMINAL_STATES,
+  APP_STATUS_TRANSITIONS,
   canTransition,
   isTerminal,
   validTriggers,
   transition,
+  transitionApplicationStatus,
 } from "../modules/screening/state-machine";
+import { query } from "../config/database";
+import { stampV2ScreeningStateTransition } from "../modules/tape/v2-stamp";
 
 jest.mock("../middleware/audit", () => ({ writeAuditLog: jest.fn() }));
 jest.mock("../utils/logger", () => ({
   logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
 }));
+jest.mock("../config/database", () => ({ query: jest.fn() }));
+jest.mock("../modules/tape/v2-stamp", () => ({ stampV2ScreeningStateTransition: jest.fn() }));
+
+const mockQuery = query as jest.MockedFunction<typeof query>;
+const mockStamp = stampV2ScreeningStateTransition as jest.MockedFunction<
+  typeof stampV2ScreeningStateTransition
+>;
 
 describe("screening state machine — table", () => {
   it("flags terminal states correctly", () => {
@@ -146,5 +157,121 @@ describe("transition()", () => {
         trigger: "fraud_flag_raised",
       })
     ).rejects.toThrow(/Invalid trigger/);
+  });
+});
+
+// ── application_status chokepoint (transitionApplicationStatus) ──────────────
+
+describe("transitionApplicationStatus (application_status chokepoint)", () => {
+  const audit = require("../middleware/audit") as { writeAuditLog: jest.Mock };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("APP_STATUS_TRANSITIONS fans out only from submitted/screening into the screening terminals", () => {
+    const froms = new Set(APP_STATUS_TRANSITIONS.map((t) => t.from));
+    expect(froms).toEqual(new Set(["submitted", "screening"]));
+    expect(
+      APP_STATUS_TRANSITIONS.every((t) =>
+        ["screening", "screening_passed", "screening_failed"].includes(t.to)
+      )
+    ).toBe(true);
+  });
+
+  it("on a winning CAS: writes status+history, audit row, tape stamp, returns changed:true", async () => {
+    mockQuery.mockResolvedValue({ rows: [{ id: "app-1" }] } as any);
+
+    const res = await transitionApplicationStatus({
+      applicationId: "app-1",
+      from: "screening",
+      to: "screening_passed",
+      trigger: "all_checks_passed",
+      actorId: "user-1",
+      actorRole: "leasing_agent",
+      evidence: { overallResult: "pass" },
+    });
+
+    expect(res).toEqual({ changed: true, status: "screening_passed" });
+
+    // CAS UPDATE params: [id, to, from, trigger, actorId, actorRole, evidenceJson]
+    const [sql, params] = mockQuery.mock.calls[0];
+    expect(sql).toMatch(/WHERE id = \$1 AND status = \$3/);
+    expect(params).toEqual([
+      "app-1",
+      "screening_passed",
+      "screening",
+      "all_checks_passed",
+      "user-1",
+      "leasing_agent",
+      JSON.stringify({ overallResult: "pass" }),
+    ]);
+
+    expect(audit.writeAuditLog).toHaveBeenCalledTimes(1);
+    expect(audit.writeAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "screening_state_transition",
+        applicationId: "app-1",
+        details: expect.objectContaining({
+          fromStatus: "screening",
+          toStatus: "screening_passed",
+          trigger: "all_checks_passed",
+        }),
+      })
+    );
+    expect(mockStamp).toHaveBeenCalledTimes(1);
+  });
+
+  it("on a losing CAS (0 rows): no audit, no tape, returns changed:false", async () => {
+    mockQuery.mockResolvedValue({ rows: [] } as any);
+
+    const res = await transitionApplicationStatus({
+      applicationId: "app-1",
+      from: "screening",
+      to: "screening_failed",
+      trigger: "any_check_failed",
+    });
+
+    expect(res).toEqual({ changed: false, status: "screening_failed" });
+    expect(audit.writeAuditLog).not.toHaveBeenCalled();
+    expect(mockStamp).not.toHaveBeenCalled();
+  });
+
+  it("throws on an undefined (from,to) pair without touching the DB", async () => {
+    await expect(
+      transitionApplicationStatus({
+        applicationId: "app-1",
+        from: "submitted",
+        to: "screening_passed",
+        trigger: "all_checks_passed",
+      })
+    ).rejects.toThrow(/Invalid application_status transition/);
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  it("throws when the trigger is valid elsewhere but wrong for this (from,to)", async () => {
+    await expect(
+      transitionApplicationStatus({
+        applicationId: "app-1",
+        from: "screening",
+        to: "screening_failed",
+        trigger: "all_checks_passed",
+      })
+    ).rejects.toThrow(/Invalid application_status transition/);
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  it("every APP_STATUS_TRANSITIONS row is accepted by the validator", async () => {
+    for (const t of APP_STATUS_TRANSITIONS) {
+      mockQuery.mockResolvedValue({ rows: [{ id: "x" }] } as any);
+      await expect(
+        transitionApplicationStatus({
+          applicationId: "x",
+          from: t.from,
+          to: t.to,
+          trigger: t.trigger,
+        })
+      ).resolves.toEqual({ changed: true, status: t.to });
+    }
   });
 });

--- a/src/db/migrations/2026-05-31-screening-on-submit.sql
+++ b/src/db/migrations/2026-05-31-screening-on-submit.sql
@@ -1,0 +1,16 @@
+-- Screening on the applicant funnel (auto-trigger on submit).
+--
+-- Adds the audit_action used by the application_status chokepoint
+-- (transitionApplicationStatus) and the append-only status_history trail the
+-- chokepoint writes on every screening-driven status move. No application_status
+-- enum change — the in-flight `screening` state already exists and is handled by
+-- the cancel/verify guards and the approval queue.
+--
+-- Both statements are idempotent. ADD VALUE cannot run inside a transaction
+-- block, so apply this file directly via psql (NOT wrapped in BEGIN/COMMIT):
+--   psql "$DATABASE_URL" -f src/db/migrations/2026-05-31-screening-on-submit.sql
+
+ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'screening_state_transition';
+
+ALTER TABLE applications
+  ADD COLUMN IF NOT EXISTS status_history JSONB NOT NULL DEFAULT '[]'::jsonb;

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -145,7 +145,10 @@ CREATE TYPE audit_action AS ENUM (
   'payment_refunded',
   'ledger_refund_recorded',
   -- Identity verification (first gate of runFullScreening)
-  'identity_verification_completed'
+  'identity_verification_completed',
+  -- Screening state machine — every application_status transition driven by
+  -- the screening pipeline (transitionApplicationStatus chokepoint).
+  'screening_state_transition'
 );
 
 CREATE TYPE fraud_flag_type AS ENUM (
@@ -381,6 +384,11 @@ CREATE TABLE applications (
   status application_status DEFAULT 'draft',
   submitted_at TIMESTAMPTZ,
   submitted_by UUID REFERENCES users(id),
+
+  -- Append-only trail of screening-driven status transitions, written by the
+  -- transitionApplicationStatus chokepoint. One JSONB object per transition:
+  -- { from, to, trigger, actorId, actorRole, at, evidence }.
+  status_history JSONB NOT NULL DEFAULT '[]'::jsonb,
 
   -- Screening results
   identity_verification_result screening_result,

--- a/src/modules/application/service.ts
+++ b/src/modules/application/service.ts
@@ -4,6 +4,7 @@ import { writeAuditLog } from "../../middleware/audit";
 import { logger } from "../../utils/logger";
 import { CreateApplicationInput, UpdateApplicationInput } from "./validation";
 import { FraudDetectionService } from "../screening/fraud-detection";
+import { transitionApplicationStatus } from "../screening/state-machine";
 
 export class ApplicationService {
   private fraudDetection = new FraudDetectionService();
@@ -227,7 +228,59 @@ export class ApplicationService {
       details: { status: "submitted" },
     });
 
+    // Auto-screening on submit — dark-deployed behind SCREENING_ON_SUBMIT_ENABLED.
+    // Flag off ⇒ byte-for-byte current behavior (manual /screen only). When on,
+    // advance the app into `screening` through the chokepoint and kick the
+    // pipeline fire-and-forget. A screening failure leaves the app in
+    // `screening` (non-approvable) and never affects the submit response.
+    if (process.env.SCREENING_ON_SUBMIT_ENABLED === "true") {
+      try {
+        await transitionApplicationStatus({
+          applicationId,
+          from: "submitted",
+          to: "screening",
+          trigger: "screening_started",
+          actorId: submittedBy,
+          actorRole: submitterRole,
+          evidence: { source: "auto_on_submit" },
+        });
+        void this.runScreeningSafely(applicationId, submittedBy, submitterRole);
+      } catch (err) {
+        logger.error("Failed to kick off auto-screening on submit", {
+          error: (err as Error).message,
+          applicationId,
+        });
+      }
+    }
+
     return result.rows[0];
+  }
+
+  /**
+   * Run the full screening pipeline for an auto-submitted application without
+   * letting a failure surface to the applicant. Lazy-imports ScreeningService
+   * to avoid an application <-> screening import cycle. On any throw the app
+   * stays in `screening` (non-approvable) and the error is logged — never a
+   * silent pass, never a 500 to the applicant.
+   */
+  private async runScreeningSafely(
+    applicationId: string,
+    initiatedBy: string,
+    initiatorRole: string
+  ): Promise<void> {
+    try {
+      const { ScreeningService } = await import("../screening/service");
+      await new ScreeningService().runFullScreening(
+        applicationId,
+        initiatedBy,
+        initiatorRole
+      );
+    } catch (err) {
+      logger.error("Auto-screening pipeline failed after submit", {
+        error: (err as Error).message,
+        applicationId,
+      });
+    }
   }
 
   async getById(applicationId: string): Promise<any> {

--- a/src/modules/screening/service.ts
+++ b/src/modules/screening/service.ts
@@ -9,6 +9,7 @@ import { FraudDetectionService } from "./fraud-detection";
 import { IdentityVerificationService } from "./identity-verification";
 import type { IdentityVerificationResult } from "./identity-verification";
 import { AdverseActionService } from "../adverse-action/service";
+import { transitionApplicationStatus } from "./state-machine";
 
 // IdentityVerificationResult.result uses verified/rejected/review_required;
 // the `screening_result` enum + downstream overall-result aggregator use
@@ -54,23 +55,34 @@ export class ScreeningService {
     credit: any;
     compliance: any;
   }> {
-    // Fetch application data
+    // Fetch application data. Accept both 'submitted' (manual /screen) and
+    // 'screening' (auto-on-submit already advanced it through the chokepoint).
     const appResult = await query(
-      `SELECT * FROM applications WHERE id = $1 AND status = 'submitted'`,
+      `SELECT * FROM applications WHERE id = $1 AND status IN ('submitted', 'screening')`,
       [applicationId]
     );
 
     if (appResult.rows.length === 0) {
-      throw new Error("Application not found or not in submitted status");
+      throw new Error("Application not found or not in submitted/screening status");
     }
 
     const app = appResult.rows[0];
 
-    // Update status to screening
-    await query(
-      "UPDATE applications SET status = 'screening' WHERE id = $1",
-      [applicationId]
-    );
+    // Move submitted → screening through the chokepoint. The auto-on-submit
+    // path already performed this transition, so only fire it when the app is
+    // still 'submitted' (manual /screen entry). The screening_initiated audit
+    // below records the pipeline kickoff in both paths.
+    if (app.status === "submitted") {
+      await transitionApplicationStatus({
+        applicationId,
+        from: "submitted",
+        to: "screening",
+        trigger: "screening_started",
+        actorId: initiatedBy,
+        actorRole: initiatorRole,
+        evidence: { source: "run_full_screening" },
+      });
+    }
 
     await writeAuditLog({
       action: "screening_initiated",
@@ -124,9 +136,22 @@ export class ScreeningService {
 
     if (identityResult.result === "rejected") {
       await query(
-        "UPDATE applications SET overall_screening_result = $2, status = $3 WHERE id = $1",
-        [applicationId, "fail", "screening_failed"]
+        "UPDATE applications SET overall_screening_result = $2 WHERE id = $1",
+        [applicationId, "fail"]
       );
+
+      const { changed } = await transitionApplicationStatus({
+        applicationId,
+        from: "screening",
+        to: "screening_failed",
+        trigger: "identity_rejected",
+        actorId: initiatedBy,
+        actorRole: initiatorRole,
+        evidence: {
+          failedAt: "identity_verification",
+          riskSignals: identityResult.details.riskSignals,
+        },
+      });
 
       await writeAuditLog({
         action: "screening_completed",
@@ -142,20 +167,24 @@ export class ScreeningService {
         },
       });
 
-      this.adverseAction
-        .sendNotice(
-          applicationId,
-          initiatedBy,
-          initiatorRole,
-          "screening_failed",
-          "Automated screening denial: identity verification failed (document validity, selfie match, or liveness score below threshold)"
-        )
-        .catch((err: Error) =>
-          logger.error("Failed to send FCRA adverse action notice after identity-rejected denial", {
-            error: err.message,
+      // FCRA adverse-action notice — gated on the CAS winning, so a concurrent
+      // auto + manual run can never double-send the denial.
+      if (changed) {
+        this.adverseAction
+          .sendNotice(
             applicationId,
-          })
-        );
+            initiatedBy,
+            initiatorRole,
+            "screening_failed",
+            "Automated screening denial: identity verification failed (document validity, selfie match, or liveness score below threshold)"
+          )
+          .catch((err: Error) =>
+            logger.error("Failed to send FCRA adverse action notice after identity-rejected denial", {
+              error: err.message,
+              applicationId,
+            })
+          );
+      }
 
       logger.warn("Screening early-exit on identity verification rejection", {
         applicationId,
@@ -179,9 +208,23 @@ export class ScreeningService {
       const otherIds = dupCheck.existingApplicationIds.filter((id) => id !== applicationId);
       if (otherIds.length > 0) {
         await query(
-          "UPDATE applications SET overall_screening_result = $2, status = $3 WHERE id = $1",
-          [applicationId, "fail", "screening_failed"]
+          "UPDATE applications SET overall_screening_result = $2 WHERE id = $1",
+          [applicationId, "fail"]
         );
+
+        const { changed } = await transitionApplicationStatus({
+          applicationId,
+          from: "screening",
+          to: "screening_failed",
+          trigger: "duplicate_ssn",
+          actorId: initiatedBy,
+          actorRole: initiatorRole,
+          evidence: {
+            failedAt: "fraud_screening",
+            duplicateApplicationIds: otherIds,
+          },
+        });
+
         await writeAuditLog({
           action: "screening_completed",
           actorId: initiatedBy,
@@ -196,20 +239,24 @@ export class ScreeningService {
           },
         });
 
-        this.adverseAction
-          .sendNotice(
-            applicationId,
-            initiatedBy,
-            initiatorRole,
-            "screening_failed",
-            "Automated screening denial: duplicate SSN detected on another active application"
-          )
-          .catch((err: Error) =>
-            logger.error("Failed to send FCRA adverse action notice after duplicate-SSN denial", {
-              error: err.message,
+        // FCRA adverse-action notice — gated on the CAS winning so a concurrent
+        // auto + manual run can never double-send the denial.
+        if (changed) {
+          this.adverseAction
+            .sendNotice(
               applicationId,
-            })
-          );
+              initiatedBy,
+              initiatorRole,
+              "screening_failed",
+              "Automated screening denial: duplicate SSN detected on another active application"
+            )
+            .catch((err: Error) =>
+              logger.error("Failed to send FCRA adverse action notice after duplicate-SSN denial", {
+                error: err.message,
+                applicationId,
+              })
+            );
+        }
 
         logger.warn("Screening early-exit on duplicate SSN", {
           applicationId,
@@ -313,16 +360,42 @@ export class ScreeningService {
       overallResult = "pass";
     }
 
-    // Update application status based on screening result
-    const newStatus = overallResult === "fail" ? "screening_failed" : "screening_passed";
+    // Persist the aggregate result; the status column now moves exclusively
+    // through the chokepoint (transitionApplicationStatus).
     await query(
-      "UPDATE applications SET overall_screening_result = $2, status = $3 WHERE id = $1",
-      [applicationId, overallResult, newStatus]
+      "UPDATE applications SET overall_screening_result = $2 WHERE id = $1",
+      [applicationId, overallResult]
     );
+
+    const finalStatus =
+      overallResult === "fail" ? "screening_failed" : "screening_passed";
+    const finalTrigger =
+      overallResult === "fail"
+        ? "any_check_failed"
+        : overallResult === "review_required"
+          ? "review_required_passthrough"
+          : "all_checks_passed";
+
+    const { changed } = await transitionApplicationStatus({
+      applicationId,
+      from: "screening",
+      to: finalStatus,
+      trigger: finalTrigger,
+      actorId: initiatedBy,
+      actorRole: initiatorRole,
+      evidence: {
+        overallResult,
+        identity: identityScreeningResult,
+        background: backgroundResult.result,
+        credit: creditResult.result,
+        compliance: complianceResult.result,
+      },
+    });
 
     // FCRA § 1681m: send adverse action notice when screening result is fail.
     // Non-blocking — notice failure must not prevent the screening result from being returned.
-    if (overallResult === "fail") {
+    // Gated on the CAS winning so a concurrent auto + manual run can't double-send.
+    if (overallResult === "fail" && changed) {
       const failedChecks = [
         backgroundResult.result === "fail" ? "background check" : null,
         creditResult.result === "fail" ? "credit check" : null,
@@ -375,7 +448,7 @@ export class ScreeningService {
         actorId: initiatedBy,
         actorRole: initiatorRole,
         applicationId,
-        details: { overallResult, newStatus },
+        details: { overallResult, newStatus: finalStatus },
       }),
     ]);
 

--- a/src/modules/screening/state-machine.ts
+++ b/src/modules/screening/state-machine.ts
@@ -208,9 +208,15 @@ export async function transitionApplicationStatus(
     );
   }
 
+  // $2 (to) and $3 (from) are each used twice: once compared/assigned against
+  // the application_status enum column and once rendered as text inside the
+  // status_history JSONB. Without explicit casts on the enum sites, Postgres
+  // deduces conflicting types for the same parameter ("inconsistent types
+  // deduced for parameter $2") and the statement fails to prepare. Cast the
+  // enum sites explicitly so each parameter resolves to a single base type.
   const result = await query(
     `UPDATE applications
-        SET status = $2,
+        SET status = $2::application_status,
             status_history = status_history || jsonb_build_object(
               'from', $3::text,
               'to', $2::text,
@@ -220,7 +226,7 @@ export async function transitionApplicationStatus(
               'at', NOW(),
               'evidence', $7::jsonb
             )
-      WHERE id = $1 AND status = $3
+      WHERE id = $1 AND status = $3::application_status
       RETURNING id`,
     [
       applicationId,

--- a/src/modules/screening/state-machine.ts
+++ b/src/modules/screening/state-machine.ts
@@ -1,5 +1,7 @@
 import { writeAuditLog } from "../../middleware/audit";
 import { logger } from "../../utils/logger";
+import { query } from "../../config/database";
+import { stampV2ScreeningStateTransition } from "../tape/v2-stamp";
 
 export type ScreeningState =
   | "queued"
@@ -121,4 +123,159 @@ export async function transition(input: TransitionInput): Promise<void> {
     to,
     trigger,
   });
+}
+
+// ---------------------------------------------------------------------------
+// application_status chokepoint
+//
+// The abstract ScreeningState machine above models the screening pipeline's
+// internal lifecycle. The functions below operate on the real
+// `application_status` enum — the column the approval queue and applicant
+// funnel actually read — and are the single writer of `applications.status`
+// for the screening pipeline.
+//
+// Every transition is a compare-and-swap (WHERE id = $1 AND status = $from):
+//   - success      → writes status, appends an idempotent status_history entry,
+//                    writes a screening_state_transition audit row, emits a
+//                    (dark) compliance-tape stamp, returns { changed: true }.
+//   - 0-row CAS    → another writer already moved this app out of `from`
+//                    (e.g. concurrent auto + manual screening). No-op: writes
+//                    NOTHING and returns { changed: false }. Callers MUST gate
+//                    exactly-once side effects (FCRA notice) on changed.
+// ---------------------------------------------------------------------------
+
+/** Real application_status values touched by the screening pipeline. */
+export type AppStatus =
+  | "submitted"
+  | "screening"
+  | "screening_passed"
+  | "screening_failed";
+
+interface AppStatusTransition {
+  from: AppStatus;
+  to: AppStatus;
+  trigger: string;
+}
+
+export const APP_STATUS_TRANSITIONS: ReadonlyArray<AppStatusTransition> = [
+  { from: "submitted", to: "screening", trigger: "screening_started" },
+  { from: "screening", to: "screening_passed", trigger: "all_checks_passed" },
+  { from: "screening", to: "screening_passed", trigger: "review_required_passthrough" },
+  { from: "screening", to: "screening_failed", trigger: "any_check_failed" },
+  { from: "screening", to: "screening_failed", trigger: "identity_rejected" },
+  { from: "screening", to: "screening_failed", trigger: "duplicate_ssn" },
+];
+
+export interface AppStatusTransitionInput {
+  applicationId: string;
+  from: AppStatus;
+  to: AppStatus;
+  trigger: string;
+  actorId?: string;
+  actorRole?: string;
+  evidence?: Record<string, unknown>;
+}
+
+export interface AppStatusTransitionResult {
+  changed: boolean;
+  status: AppStatus;
+}
+
+function isValidAppStatusTransition(from: AppStatus, to: AppStatus, trigger: string): boolean {
+  return APP_STATUS_TRANSITIONS.some(
+    (t) => t.from === from && t.to === to && t.trigger === trigger
+  );
+}
+
+/**
+ * Atomically move applications.status via compare-and-swap, recording the
+ * transition in status_history + audit_log + (dark) compliance tape.
+ *
+ * Returns { changed: false } when the CAS matches 0 rows (the app already left
+ * `from`). Callers MUST gate any exactly-once side effect (FCRA adverse-action
+ * notice) on `changed === true`.
+ *
+ * @throws if (from, to, trigger) is not a defined transition.
+ */
+export async function transitionApplicationStatus(
+  input: AppStatusTransitionInput
+): Promise<AppStatusTransitionResult> {
+  const { applicationId, from, to, trigger, actorId, actorRole, evidence } = input;
+
+  if (!isValidAppStatusTransition(from, to, trigger)) {
+    throw new Error(
+      `Invalid application_status transition: ${from} -> ${to} (trigger '${trigger}')`
+    );
+  }
+
+  const result = await query(
+    `UPDATE applications
+        SET status = $2,
+            status_history = status_history || jsonb_build_object(
+              'from', $3::text,
+              'to', $2::text,
+              'trigger', $4::text,
+              'actorId', $5::text,
+              'actorRole', $6::text,
+              'at', NOW(),
+              'evidence', $7::jsonb
+            )
+      WHERE id = $1 AND status = $3
+      RETURNING id`,
+    [
+      applicationId,
+      to,
+      from,
+      trigger,
+      actorId ?? null,
+      actorRole ?? null,
+      JSON.stringify(evidence ?? {}),
+    ]
+  );
+
+  if (result.rows.length === 0) {
+    // Lost the compare-and-swap — skip audit, tape, and caller-gated side effects.
+    logger.info("application_status transition no-op (CAS miss)", {
+      applicationId,
+      from,
+      to,
+      trigger,
+    });
+    return { changed: false, status: to };
+  }
+
+  await writeAuditLog({
+    action: "screening_state_transition",
+    actorId,
+    actorRole,
+    applicationId,
+    resourceType: "application",
+    details: {
+      fromStatus: from,
+      toStatus: to,
+      trigger,
+      evidence: evidence || {},
+    },
+  });
+
+  // Dark compliance-tape stamp — no-op unless COMPLIANCE_TAPE_V2_ENABLED.
+  void stampV2ScreeningStateTransition({
+    applicationId,
+    fromStatus: from,
+    toStatus: to,
+    trigger,
+    actorId: actorId ?? null,
+    actorRole,
+    transitionedAt: new Date().toISOString(),
+    evidence,
+  });
+
+  logger.info("application_status transition", {
+    applicationId,
+    from,
+    to,
+    trigger,
+  });
+
+  return { changed: true, status: to };
 }

--- a/src/modules/tape/events/index.ts
+++ b/src/modules/tape/events/index.ts
@@ -38,3 +38,8 @@ export {
   makeLeaseExecutedPayload,
   type LeaseExecutedInput,
 } from "./lease-executed";
+
+export {
+  makeScreeningStateTransitionPayload,
+  type ScreeningStateTransitionInput,
+} from "./screening-state-transition";

--- a/src/modules/tape/events/screening-state-transition.ts
+++ b/src/modules/tape/events/screening-state-transition.ts
@@ -1,0 +1,73 @@
+/**
+ * BP-02 Compliance Tape — Event payload maker.
+ *
+ * Kind:     screening.state_transition
+ * Citation: FCRA 15 U.S.C. §1681b + HUD 4350.3 Ch. 4
+ *
+ * Records each screening-driven application_status transition
+ * (submitted → screening → screening_passed | screening_failed). Tenant
+ * screening is an FCRA "consumer report" use; the resulting eligibility
+ * determination is governed by HUD 4350.3 Ch. 4. This stamp attests the
+ * automated decision trail behind every status move.
+ */
+
+import { TAPE_CITATIONS, TapeJsonLdPayload } from "../types";
+
+const KIND = "screening.state_transition" as const;
+
+export interface ScreeningStateTransitionInput {
+  /** The application whose status changed (tape subject + scope key). */
+  applicationId: string;
+  /** Status the application moved from. */
+  fromStatus: string;
+  /** Status the application moved to. */
+  toStatus: string;
+  /** The trigger that drove the edge (e.g. "all_checks_passed"). */
+  trigger: string;
+  /** Who/what drove the transition (user id) or null for system. */
+  actorId?: string | null;
+  /** Role of the actor (user_role value), if any. */
+  actorRole?: string;
+  /** ISO-8601 timestamp supplied by the caller — no clock calls here. */
+  transitionedAt: string;
+  /** Optional idempotency / session key. */
+  sessionId?: string;
+  /** Kind-specific evidence (failed checks, risk signals, …). */
+  evidence?: Record<string, unknown>;
+}
+
+/**
+ * Pure function — no IO, no DB, no clock.
+ * Caller is responsible for supplying `transitionedAt`.
+ */
+export function makeScreeningStateTransitionPayload(
+  input: ScreeningStateTransitionInput
+): TapeJsonLdPayload {
+  const {
+    applicationId,
+    fromStatus,
+    toStatus,
+    trigger,
+    actorId,
+    actorRole,
+    transitionedAt,
+    evidence,
+  } = input;
+
+  return {
+    "@context": "https://frank-pilot.example/compliance-tape/v1",
+    "@type": "ComplianceEvent.ScreeningStateTransition",
+    actorId: actorId ?? null,
+    subjectId: applicationId,
+    ruleCitation: TAPE_CITATIONS[KIND],
+    evidence: {
+      applicationId,
+      fromStatus,
+      toStatus,
+      trigger,
+      transitionedAt,
+      ...(actorRole !== undefined ? { actorRole } : {}),
+      ...(evidence !== undefined ? { evidence } : {}),
+    },
+  };
+}

--- a/src/modules/tape/events/screening-state-transition.ts
+++ b/src/modules/tape/events/screening-state-transition.ts
@@ -58,7 +58,11 @@ export function makeScreeningStateTransitionPayload(
     "@context": "https://frank-pilot.example/compliance-tape/v1",
     "@type": "ComplianceEvent.ScreeningStateTransition",
     actorId: actorId ?? null,
-    subjectId: applicationId,
+    // subjectId drives tape scope → compliance_tape.applicant_id, which is an
+    // FK to users(id). An application id is NOT a users(id) and would violate
+    // that FK once COMPLIANCE_TAPE_V2_ENABLED is on. Scope by the actor user
+    // (users(id)-or-null); the application id is preserved in evidence below.
+    subjectId: actorId ?? null,
     ruleCitation: TAPE_CITATIONS[KIND],
     evidence: {
       applicationId,

--- a/src/modules/tape/types.ts
+++ b/src/modules/tape/types.ts
@@ -35,7 +35,9 @@ export type TapeStampKind =
   // QAP acquisitions Phase 3.2 — Next Available Unit Rule (global-scope admin events)
   | "acq.nau_triggered"
   | "acq.nau_satisfied"
-  | "acq.nau_lost";
+  | "acq.nau_lost"
+  // Screening pipeline — application_status transitions (screening on funnel)
+  | "screening.state_transition";
 
 /** A JSON-LD payload. Lane C provides one `make<Event>Payload` per kind.
  *  The `@context` URL is stubbed in v1 (see docs/bp-02-contracts.md §5). */
@@ -149,6 +151,7 @@ export const TAPE_CITATIONS: Record<TapeStampKind, string> = {
   "acq.nau_triggered": "IRC §42(g)(2)(D)(ii) (Next Available Unit Rule)",
   "acq.nau_satisfied": "IRC §42(g)(2)(D)(ii) (Next Available Unit Rule)",
   "acq.nau_lost": "IRC §42(g)(2)(D)(ii) (Next Available Unit Rule)",
+  "screening.state_transition": "FCRA 15 U.S.C. §1681b + HUD 4350.3 Ch. 4",
 };
 
 /** Feature flag controlling dual-write during cutover. When false, the new

--- a/src/modules/tape/v2-stamp.ts
+++ b/src/modules/tape/v2-stamp.ts
@@ -25,12 +25,14 @@ import {
   makeHud92006SupplementCapturedPayload,
   makePositionLetterSentPayload,
   makeLeaseExecutedPayload,
+  makeScreeningStateTransitionPayload,
   type WelcomeLetterDeliveredInput,
   type Hud9281FairHousingPostedInput,
   type WaitingListAppCapturedInput,
   type Hud92006SupplementCapturedInput,
   type PositionLetterSentInput,
   type LeaseExecutedInput,
+  type ScreeningStateTransitionInput,
 } from "./events";
 import { COMPLIANCE_TAPE_V2_FLAG, type TapeJsonLdPayload, type TapeStampKind } from "./types";
 
@@ -129,6 +131,17 @@ export async function stampV2LeaseExecuted(
   return stampV2(
     "LEASE_EXECUTED",
     makeLeaseExecutedPayload(input),
+    input.sessionId,
+  );
+}
+
+export async function stampV2ScreeningStateTransition(
+  input: ScreeningStateTransitionInput,
+): Promise<void> {
+  if (!flagEnabled()) return;
+  return stampV2(
+    "screening.state_transition",
+    makeScreeningStateTransitionPayload(input),
     input.sessionId,
   );
 }


### PR DESCRIPTION
## What

Auto-screening on the applicant funnel, dark-deployed. When `SCREENING_ON_SUBMIT_ENABLED=true`, `POST /api/applications/:id/submit` advances the app `submitted → screening` through a state-machine chokepoint and kicks `runFullScreening` fire-and-forget — so an app no longer waits for staff to manually `POST /api/screening/:id/screen`. A failed pipeline leaves the app in `screening` (non-approvable), never a silent pass.

## Behavior change (read before merge)

- **Submit path** (`application/service.ts`) is flag-gated: `SCREENING_ON_SUBMIT_ENABLED=false` ⇒ no auto-transition, no kickoff — unchanged from today.
- **Manual `/screen` path is NOT flag-gated.** It now routes every status move (`submitted → screening → screening_passed|failed`, plus dup-SSN / identity-rejected) through `transitionApplicationStatus()` instead of raw `UPDATE`s. Even with the flag off this changes observable behavior: an intermediate `screening` status, append-only `status_history` entries, and a new `screening_state_transition` audit row per move. (The earlier "byte-for-byte" claim held only for the submit path.)

## How

- **`transitionApplicationStatus()`** — single CAS writer of `applications.status` for screening. Enum sites are explicitly cast (`$n::application_status`) so a parameter reused at both an enum site and a `::text` site doesn't trip Postgres' "inconsistent types deduced for parameter $n" deduction. Emits the (dark) `screening.state_transition` compliance-tape event + an append-only `status_history` row, and returns `{ changed }` so downstream FCRA notices fire **exactly once** (idempotent on a CAS-miss).
- **`screening/service.ts`** — routes dup-SSN, identity-rejected, and final pass/fail status moves through the chokepoint instead of raw `UPDATE`s.
- **Compliance tape** — the `screening.state_transition` maker scopes `subjectId` to the actor `users(id)` (FK-safe vs `compliance_tape.applicant_id`); the application id rides in `evidence`.
- **Migration `2026-05-31-screening-on-submit.sql`**:
  - `ALTER TYPE audit_action ADD VALUE 'screening_state_transition'`
  - `ALTER TABLE applications ADD COLUMN status_history JSONB NOT NULL DEFAULT '[]'`
  - No `application_status` enum change (`screening` already exists). Both idempotent; `ADD VALUE` can't run in a txn → apply via `psql -f`.

## Tests

- `state-machine.test.ts` — CAS win / miss / invalid `(from,to)` / wrong-trigger / full transition-table round-trip
- `screening-service.test.ts` — chokepoint re-point of the 4 status assertions + idempotency (no double FCRA notice)
- `application-service.test.ts` — flag off ⇒ no transition/kickoff (legacy); flag on ⇒ `submitted→screening` + fire-and-forget; pipeline-throws ⇒ `submit()` still resolves, app left in `screening`

## Verification

- `npx tsc --noEmit` → clean
- Targeted suites: **96/96**
- **`pm-console-e2e` regression fixed**: the chokepoint CAS query previously failed to prepare in Postgres ("inconsistent types deduced for parameter $2"), 500'ing every manual `/screen` and stranding the row in the queue. Reproduced against Postgres: the old form errors with the exact CI message; the cast form prepares clean.

## Deploy notes (ordering matters)

- Ships **dark** behind `SCREENING_ON_SUBMIT_ENABLED=false` for the submit path.
- ⚠️ **Apply the migration BEFORE the code deploys — not just before the flag flip.** The manual `/screen` path writes the `screening_state_transition` audit action unconditionally; if the code lands before `audit_action` gains that value, every manual screening 500s. Sequence: `psql -f` the migration → `railway up` → (later) flip `SCREENING_ON_SUBMIT_ENABLED`.
- `package.json` / lockfile untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
