### PR TITLE
fix(tape): hud-928 fair-housing maker scopes subjectId to null, not propertyId

### DIFF
--- a/src/modules/tape/events/__tests__/hud-928-1-fair-housing.spec.ts
+++ b/src/modules/tape/events/__tests__/hud-928-1-fair-housing.spec.ts
@@ -1,0 +1,91 @@
+/**
+ * BP-02 Compliance Tape — unit test for the HUD_928_1_FAIR_HOUSING_POSTED maker.
+ *
+ * The maker is a pure function (no IO, no clock): same input → same JSON-LD.
+ *
+ * Regression guard (the load-bearing case): this event is PROPERTY-scoped, not
+ * applicant-scoped. The TapeService routes a non-null payload.subjectId into
+ * compliance_tape.applicant_id, which is an FK to users(id). A propertyId is
+ * NOT a users(id), so subjectId MUST stay null here even when a propertyId is
+ * supplied — otherwise the stamp silently FK-violates once
+ * COMPLIANCE_TAPE_V2_ENABLED is on (stampSafe swallows the error). The
+ * propertyId is preserved in evidence instead. Same contract/bug-class as the
+ * #150 recert fix and the #221 screening-state-transition fix.
+ */
+
+import { makeHud9281FairHousingPostedPayload } from "../hud-928-1-fair-housing";
+import { TAPE_CITATIONS } from "../../types";
+
+describe("makeHud9281FairHousingPostedPayload()", () => {
+  it("produces the canonical JSON-LD shape with the 24 CFR Part 110 citation", () => {
+    const payload = makeHud9281FairHousingPostedPayload({
+      propertyId: "prop-001",
+      postedAt: "2026-05-22T10:00:00.000Z",
+      medium: "web",
+      sessionId: "sess-1",
+    });
+
+    expect(payload["@type"]).toBe("ComplianceEvent.Hud9281FairHousingPosted");
+    expect(payload.actorId).toBeNull();
+    expect(payload.ruleCitation).toBe(TAPE_CITATIONS.HUD_928_1_FAIR_HOUSING_POSTED);
+    expect(payload.evidence).toEqual({
+      postedAt: "2026-05-22T10:00:00.000Z",
+      medium: "web",
+      sessionId: "sess-1",
+      propertyId: "prop-001",
+    });
+  });
+
+  // ── FK-safety regression guard ──────────────────────────────────────────
+  it("keeps subjectId null even when propertyId IS supplied (propertyId is not a users(id))", () => {
+    const payload = makeHud9281FairHousingPostedPayload({
+      propertyId: "prop-001",
+      postedAt: "2026-05-22T10:00:00.000Z",
+      medium: "office",
+    });
+
+    // The bug this guards: subjectId: propertyId ?? null routed a properties.id
+    // into the users(id) FK column. subjectId must be null (global scope).
+    expect(payload.subjectId).toBeNull();
+    expect(payload.subjectId).not.toBe("prop-001");
+    // …and the propertyId is not lost — it rides in evidence.
+    expect((payload.evidence as Record<string, unknown>).propertyId).toBe("prop-001");
+  });
+
+  it("keeps subjectId null when propertyId is omitted (global-scope chain)", () => {
+    const payload = makeHud9281FairHousingPostedPayload({
+      postedAt: "2026-05-22T10:00:00.000Z",
+      medium: "print",
+    });
+
+    expect(payload.subjectId).toBeNull();
+    const ev = payload.evidence as Record<string, unknown>;
+    expect(ev).not.toHaveProperty("propertyId");
+    expect(ev).toEqual({
+      postedAt: "2026-05-22T10:00:00.000Z",
+      medium: "print",
+    });
+  });
+
+  it("omits optional fields (sessionId, propertyId) when not supplied", () => {
+    const payload = makeHud9281FairHousingPostedPayload({
+      postedAt: "2026-05-22T10:00:00.000Z",
+      medium: "web",
+    });
+    const ev = payload.evidence as Record<string, unknown>;
+
+    expect(ev).not.toHaveProperty("sessionId");
+    expect(ev).not.toHaveProperty("propertyId");
+  });
+
+  it("is pure — identical input yields a deep-equal payload", () => {
+    const input = {
+      propertyId: "prop-001",
+      postedAt: "2026-05-22T10:00:00.000Z",
+      medium: "web" as const,
+    };
+    expect(makeHud9281FairHousingPostedPayload(input)).toEqual(
+      makeHud9281FairHousingPostedPayload(input)
+    );
+  });
+});

--- a/src/modules/tape/events/hud-928-1-fair-housing.ts
+++ b/src/modules/tape/events/hud-928-1-fair-housing.ts
@@ -32,9 +32,12 @@ export interface Hud9281FairHousingPostedInput {
  * Caller is responsible for supplying `postedAt`.
  *
  * Note: this event is property-scoped, not applicant-scoped. The service
- * routes subjectId → compliance_tape.applicant_id (UUID column), so when
- * propertyId is unknown subjectId must be null (= global-scope chain). A
- * non-UUID sentinel like "n/a" trips the column type and the stamp errors.
+ * routes a non-null subjectId → compliance_tape.applicant_id, which is an FK
+ * to users(id). A propertyId is NOT a users(id), so subjectId must ALWAYS be
+ * null here (= global-scope chain) regardless of whether propertyId is known;
+ * the propertyId is preserved in evidence below. (Passing propertyId as
+ * subjectId silently FK-violates once COMPLIANCE_TAPE_V2_ENABLED is on —
+ * stampSafe swallows the error and the stamp never writes.)
  */
 export function makeHud9281FairHousingPostedPayload(
   input: Hud9281FairHousingPostedInput
@@ -45,7 +48,10 @@ export function makeHud9281FairHousingPostedPayload(
     "@context": "https://frank-pilot.example/compliance-tape/v1",
     "@type": "ComplianceEvent.Hud9281FairHousingPosted",
     actorId: null,
-    subjectId: propertyId ?? null,
+    // Property-scoped event → no user subject. subjectId stays null (global
+    // scope); propertyId rides in evidence. See docblock above re: the
+    // users(id) FK on compliance_tape.applicant_id.
+    subjectId: null,
     ruleCitation: TAPE_CITATIONS[KIND],
     evidence: {
       postedAt,


### PR DESCRIPTION
## What

The HUD-928.1 fair-housing compliance-tape maker (`src/modules/tape/events/hud-928-1-fair-housing.ts`) set `subjectId: propertyId ?? null`. `TapeService` routes a non-null `subjectId` into `compliance_tape.applicant_id`, which is `REFERENCES users(id)`. A `properties.id` is **not** a `users(id)` → FK violation on insert.

The event is **property-scoped** (no user subject), so `subjectId` must be `null` (global-scope chain); the propertyId already rides in `evidence`.

## Why it matters

- **Silent failure:** `stampSafe` swallows tape errors so the business action never blocks — the stamp just never writes. You'd only notice via zero tape rows.
- **Dormant today:** gated behind `COMPLIANCE_TAPE_V2_ENABLED=false`. This is a latent landmine that fires the moment V2 is enabled.
- Same bug class + fix as #150 (recert `subjectId: recertId` → null) and #221 (screening-state-transition `subjectId: applicationId` → `actorId ?? null`).

## Changes

- `subjectId: propertyId ?? null` → `subjectId: null`.
- Rewrote the docblock that implied passing propertyId-when-known was OK (the exact misread that planted the bug).
- New regression test `hud-928-1-fair-housing.spec.ts` — asserts `subjectId` stays `null` **even when a propertyId is supplied**, and that propertyId survives in `evidence`. Fails against old code, passes against the fix.

## Audit

Adversarially audited **all 7** tape makers (each agent read the maker in full + traced its callers, instructed to default to "buggy" on any doubt): **0 buggy, 0 uncertain**. hud-928 was the only instance. Others: welcome-letter / waiting-list / hud-92006 / position-letter → `applicantId`; lease-executed → `signerId`; screening-state-transition → `actorId ?? null`.

## Verification

- `tsc --noEmit` clean
- `jest` (hud-928 + lease-executed + tape service + fair-housing suites) → **41/41**

🤖 Generated with [Claude Code](https://claude.com/claude-code)