### PR TITLE
feat(housing-qa): surface "8 of 19" match count on compact routes (#224)

### DIFF
--- a/src/__tests__/housing-qa-retriever.test.ts
+++ b/src/__tests__/housing-qa-retriever.test.ts
@@ -32,6 +32,9 @@ describe("housing-qa retriever — grounded context assembly", () => {
     // always-on facts block is present so the agent can ground the answer.
     expect(ctx.facts.applicationFee.amount).toBe("$35.95");
     expect(ctx.facts.applicationFee.refundable).toBe(false);
+    // truncation fields are compact-only — absent on process routes (#224).
+    expect(ctx.totalMatching).toBeUndefined();
+    expect(ctx.shown).toBeUndefined();
   });
 
   it("(2) 'senior housing in Henderson' → city+attribute filter, compact, capped at K=8", () => {
@@ -41,6 +44,13 @@ describe("housing-qa retriever — grounded context assembly", () => {
     // capped
     expect(ctx.properties.length).toBeLessThanOrEqual(8);
     expect(ctx.properties.length).toBeGreaterThan(0);
+    // #224: the TRUE total is surfaced as a structured field (19 senior records
+    // in Henderson) alongside how many reached the model (8) — so the prompt can
+    // make the model disclose "8 of 19" instead of implying the slice is all.
+    expect(ctx.totalMatching).toBe(19);
+    expect(ctx.shown).toBe(8);
+    expect(ctx.shown).toBe(ctx.properties.length);
+    expect(ctx.totalMatching!).toBeGreaterThan(ctx.shown!);
     // filtered by BOTH city (Henderson) and attribute (senior)
     for (const p of ctx.properties) {
       const cp = p as { city: string | null; type: string | null };

--- a/src/modules/housing-qa/prompt.ts
+++ b/src/modules/housing-qa/prompt.ts
@@ -77,6 +77,11 @@ injected context, you do not know it.
   step is usually enough.
 - When listing multiple properties, a short bulleted list is fine; don't dump
   every field — surface name, city, availability, type, and AMI tier.
+- **Disclose truncation.** When \`propertyMode\` is \`compact\` and \`totalMatching\`
+  is greater than \`shown\`, the list you were given is only a slice. You MUST
+  open by stating the count — e.g. *"Here are 8 of 19 matching properties"* —
+  and point the applicant to the **/discover map** to see them all. Never imply
+  the shown subset is the complete set.
 
 ---
 
@@ -90,6 +95,8 @@ The runner injects a JSON context payload below. Its shape:
   "routing": "named_property | city | attribute | process",
   "propertyMode": "full | compact | none",
   "properties": [ ... ],     // full normalized object(s), compact summaries, or []
+  "totalMatching": 19,       // compact only: TRUE match count before the display cap
+  "shown": 8,                // compact only: how many are included in properties[]
   "faqSections": [ {id,title,anchor} ],   // which FAQ sections to ground in
   "facts": { applicationFee, rule120, documentsNeeded, ... },  // always-on
   "notes": [ ... ],          // retrieval hints, incl. refusal flags — OBEY THESE
@@ -99,7 +106,9 @@ The runner injects a JSON context payload below. Its shape:
 
 - **\`properties\` with \`propertyMode: "full"\`** → one property; answer in detail,
   but only from fields present (null = unknown → refuse that field).
-- **\`propertyMode: "compact"\`** → a filtered list; summarize the matches.
+- **\`propertyMode: "compact"\`** → a filtered list; summarize the matches. If
+  \`totalMatching > shown\`, the list is truncated — disclose "N of TOTAL" and
+  point to /discover (see STYLE).
 - **\`propertyMode: "none"\`** (process/eligibility) → answer from \`faqSections\`
   and \`facts\` only; do not name specific properties.
 - **\`notes\`** → these are retrieval instructions. If a note says a property is

--- a/src/modules/housing-qa/retriever.ts
+++ b/src/modules/housing-qa/retriever.ts
@@ -428,6 +428,14 @@ export interface HousingContext {
   routing: Branch;
   propertyMode: "full" | "compact" | "none";
   properties: Array<EmittedProperty | CompactProperty>;
+  /**
+   * Compact routes only (city / attribute): the TRUE number of matching
+   * records before the K_COMPACT display cap, and how many actually reached
+   * the model. When `totalMatching > shown` the list is truncated and the
+   * prompt MUST disclose "N of TOTAL" (issue #224). Undefined for full/none.
+   */
+  totalMatching?: number;
+  shown?: number;
   faqSections: FaqMatch[];
   facts: typeof ALWAYS_ON_FACTS;
   notes: string[];
@@ -448,6 +456,8 @@ export function buildContext(
   const notes: string[] = [];
   let properties: Array<EmittedProperty | CompactProperty> = [];
   let mode: "full" | "compact" | "none" = "none";
+  let totalMatching: number | undefined;
+  let shown: number | undefined;
 
   if (branch === "named_property") {
     const rec = detail.record!;
@@ -467,6 +477,8 @@ export function buildContext(
     );
     properties = recs.slice(0, K_COMPACT).map(compact);
     mode = "compact";
+    totalMatching = recs.length;
+    shown = properties.length;
     if (recs.length > K_COMPACT) {
       notes.push(
         `${recs.length} properties in ${detail.city}; showing first ${K_COMPACT}.`
@@ -490,6 +502,8 @@ export function buildContext(
     );
     properties = recs.slice(0, K_COMPACT).map(compact);
     mode = "compact";
+    totalMatching = recs.length;
+    shown = properties.length;
     const scope = detail.city ? ` in ${detail.city}` : "";
     if (recs.length > K_COMPACT) {
       notes.push(`${recs.length} matches${scope}; showing first ${K_COMPACT}.`);
@@ -530,6 +544,8 @@ export function buildContext(
     routing: branch,
     propertyMode: mode,
     properties,
+    totalMatching,
+    shown,
     faqSections: faq,
     facts: ALWAYS_ON_FACTS,
     notes,


### PR DESCRIPTION
## What

Fixes **#224** — the chat widget would list 8 properties and imply that was everything, when 19 actually match. Now the model is told the true total and is required to say *"showing 8 of 19 — see the /discover map for all."*

## Why

Compact city/attribute routes intentionally cap context at `K_COMPACT=8` (cheap, grounded context — the cap is test-locked, kept). But the only signal of truncation was a free-text `note` the model surfaced unreliably. So users asking "senior housing in Henderson" got 8 results with no hint that 11 more exist.

## Change

- **`retriever.ts`** — `buildContext` now returns two structured fields on compact routes: `totalMatching` (true match count, pre-cap) and `shown` (how many reached the model). Undefined on `full`/`none` routes. `K_COMPACT=8` cap **unchanged** — context size is identical, this is metadata only.
- **`prompt.ts`** — STYLE section now *mandates*: when `propertyMode==="compact"` and `totalMatching > shown`, open with "Here are N of TOTAL …" and point to the /discover map. The INJECTED CONTEXT schema documents both new fields.
- **`housing-qa-retriever.test.ts`** — asserts `totalMatching===19` / `shown===8` for "senior housing in Henderson" (and `shown === properties.length`, `totalMatching > shown`); keeps the existing `≤8` cap lock; asserts both fields are `undefined` on process routes.

## Verification

- `housing-qa-retriever` suite: **7/7 pass** (incl. new assertions)
- `housing-qa-routes` suite: **12/12 pass** — the `--tools ""` security-arg locks are untouched and green
- `tsc -b`: clean

Cut fresh from `main` (secure `--tools ""` base). No new deps. No route/security changes.

Part of the post-launch productionization plan (WS2a). Sibling: #226 (WS1, #223 markdown render).