### PR TITLE
feat(housing-qa): metered SDK path — daily USD budget + token/cost observability

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -100,9 +100,19 @@ VOICE_BROWSER_IP_HASH_SECRET=changeme-rotate-to-forget-rate-limit-history
 #                          (system_admin only) flips an in-memory override.
 #   HOUSING_QA_DAILY_MAX — hard global call ceiling per UTC day (default 500).
 #                          Over cap → 503 until midnight UTC. 0 blocks all.
+#   HOUSING_QA_DAILY_BUDGET_USD — daily est. spend ceiling for the METERED SDK
+#                          path (default 10). Over budget → 503 until midnight
+#                          UTC. 0 blocks all SDK calls. Estimate-based (Haiku
+#                          rates in routes.ts), governs the SDK path only — the
+#                          CLI path is priced-blind and bounded by DAILY_MAX.
 #   HOUSING_QA_CLI_FALLBACK — "1" opts into the keyless `claude` CLI path.
+#
+# PROD: set ANTHROPIC_API_KEY to a METERED (org-billed) key so the SDK path is
+# primary, and KEEP HOUSING_QA_CLI_FALLBACK=1 so a revoked/unset key degrades to
+# the CLI instead of hard-503'ing. Live spend shows at GET /api/admin/housing-qa.
 HOUSING_QA_ENABLED=true
 HOUSING_QA_DAILY_MAX=500
+HOUSING_QA_DAILY_BUDGET_USD=10
 # HOUSING_QA_CLI_FALLBACK=1
 
 # Resend (Email Notifications — magic links + application status)

--- a/src/__tests__/housing-qa-routes.test.ts
+++ b/src/__tests__/housing-qa-routes.test.ts
@@ -52,7 +52,11 @@ function fakeChild(stdout: string, code = 0) {
   return child;
 }
 
-import { housingQaRouter, setHousingQaDisabled } from "../modules/housing-qa/routes";
+import {
+  housingQaRouter,
+  setHousingQaDisabled,
+  housingQaStatus,
+} from "../modules/housing-qa/routes";
 import { logger } from "../utils/logger";
 
 function makeApp() {
@@ -67,6 +71,7 @@ const ORIGINAL_CLI_FLAG = process.env.HOUSING_QA_CLI_FALLBACK;
 const ORIGINAL_CLI_PATH = process.env.CLAUDE_CLI_PATH;
 const ORIGINAL_ENABLED = process.env.HOUSING_QA_ENABLED;
 const ORIGINAL_DAILY_MAX = process.env.HOUSING_QA_DAILY_MAX;
+const ORIGINAL_DAILY_BUDGET = process.env.HOUSING_QA_DAILY_BUDGET_USD;
 
 beforeEach(() => {
   createMock.mockReset();
@@ -78,6 +83,7 @@ beforeEach(() => {
   // Guardrails default to ON / default cap for every test unless it opts in.
   delete process.env.HOUSING_QA_ENABLED;
   delete process.env.HOUSING_QA_DAILY_MAX;
+  delete process.env.HOUSING_QA_DAILY_BUDGET_USD;
   setHousingQaDisabled(false);
   // Pin the resolved binary so the spawn assertion is deterministic regardless
   // of whether @anthropic-ai/claude-code is installed in this environment.
@@ -95,6 +101,7 @@ afterAll(() => {
   restoreEnv("CLAUDE_CLI_PATH", ORIGINAL_CLI_PATH);
   restoreEnv("HOUSING_QA_ENABLED", ORIGINAL_ENABLED);
   restoreEnv("HOUSING_QA_DAILY_MAX", ORIGINAL_DAILY_MAX);
+  restoreEnv("HOUSING_QA_DAILY_BUDGET_USD", ORIGINAL_DAILY_BUDGET);
   setHousingQaDisabled(false);
 });
 
@@ -345,5 +352,84 @@ describe("POST /api/housing-qa — usage logging is PII-safe", () => {
     expect(meta.path).toBe("sdk");
     // The raw question text must NEVER appear in the structured log meta.
     expect(JSON.stringify(meta)).not.toContain("secret-codeword");
+  });
+});
+
+describe("POST /api/housing-qa — metered spend accounting + USD budget", () => {
+  it("captures SDK usage (cache folded into input) → status + success log", async () => {
+    const before = housingQaStatus();
+    // 3000 base + 500 + 500 cache = 4000 input; output 1000. Choosing the cache
+    // split this way keeps the est. cost a clean $0.009 while still proving the
+    // fold (the asserted input delta is 4000, not the 3000 base).
+    createMock.mockResolvedValueOnce({
+      content: [{ type: "text", text: "Grounded answer." }],
+      usage: {
+        input_tokens: 3000,
+        cache_creation_input_tokens: 500,
+        cache_read_input_tokens: 500,
+        output_tokens: 1000,
+      },
+    });
+
+    const res = await request(makeApp())
+      .post("/api/housing-qa")
+      .send({ question: "How much is the application fee?" });
+    expect(res.status).toBe(200);
+
+    // Status reflects exactly this call's tokens (counters are exact, not rounded);
+    // input delta = 4000 proves cache tokens are folded into the input total.
+    const after = housingQaStatus();
+    expect(after.dailyInputTokens - before.dailyInputTokens).toBe(4000);
+    expect(after.dailyOutputTokens - before.dailyOutputTokens).toBe(1000);
+    expect(after.dailyEstCostUsd).toBeGreaterThan(before.dailyEstCostUsd);
+    expect(after.dailyBudgetUsd).toBe(10); // default
+
+    // The success log carries token counts + an estimated cost (not PII).
+    const infoCall = (logger.info as jest.Mock).mock.calls.find(
+      (c) => c[0] === "housing-qa answered"
+    );
+    const meta = infoCall![1] as Record<string, unknown>;
+    expect(meta.inputTokens).toBe(4000);
+    expect(meta.outputTokens).toBe(1000);
+    // 4000/1e6*$1 + 1000/1e6*$5 = $0.004 + $0.005 = $0.009
+    expect(meta.estCostUsd).toBeCloseTo(0.009, 6);
+  });
+
+  it("503s the SDK path when HOUSING_QA_DAILY_BUDGET_USD=0 (cost kill-switch)", async () => {
+    process.env.HOUSING_QA_DAILY_BUDGET_USD = "0";
+    const res = await request(makeApp())
+      .post("/api/housing-qa")
+      .send({ question: "How much is the application fee?" });
+    expect(res.status).toBe(503);
+    expect(res.body.error).toMatch(/today's limit/i);
+    // Budget gate trips BEFORE the model is dispatched.
+    expect(createMock).not.toHaveBeenCalled();
+  });
+
+  it("the USD budget governs the SDK path ONLY — the priced-blind CLI still answers", async () => {
+    // Budget that would block the SDK, but no key + flag on → CLI path.
+    delete process.env.ANTHROPIC_API_KEY;
+    process.env.HOUSING_QA_CLI_FALLBACK = "1";
+    process.env.HOUSING_QA_DAILY_BUDGET_USD = "0";
+    spawnMock.mockImplementationOnce(() => fakeChild("CLI answer"));
+
+    const res = await request(makeApp())
+      .post("/api/housing-qa")
+      .send({ question: "How much is the application fee?" });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ answer: "CLI answer" });
+    expect(createMock).not.toHaveBeenCalled();
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+
+    // CLI path reports no usage → token fields log as null, never throws.
+    const infoCall = (logger.info as jest.Mock).mock.calls.find(
+      (c) => c[0] === "housing-qa answered"
+    );
+    const meta = infoCall![1] as Record<string, unknown>;
+    expect(meta.path).toBe("cli");
+    expect(meta.inputTokens).toBeNull();
+    expect(meta.outputTokens).toBeNull();
+    expect(meta.estCostUsd).toBeNull();
   });
 });

--- a/src/modules/housing-qa/routes.ts
+++ b/src/modules/housing-qa/routes.ts
@@ -28,6 +28,15 @@ const MODEL = "claude-haiku-4-5-20251001";
 const MAX_QUESTION_CHARS = 1000;
 const MAX_TOKENS = 1024;
 
+// Estimated Haiku 4.5 rates for the daily USD budget — INFORMATIONAL, not
+// billing-grade (the real invoice is Anthropic's). VERIFY against the current
+// pricing page when touched; both the cap and the logged `estCostUsd` derive
+// from these. Cache-read/-write tokens (if `usage` carries them) are folded in
+// at the input rate — a deliberate simplification; cache rates are lower, so
+// this over-estimates spend slightly, which is the safe direction for a cap.
+const USD_PER_MTOK_INPUT = 1.0; // ~$1.00 / 1M input tokens
+const USD_PER_MTOK_OUTPUT = 5.0; // ~$5.00 / 1M output tokens
+
 const questionSchema = z.object({
   question: z.string().trim().min(1).max(MAX_QUESTION_CHARS),
 });
@@ -80,30 +89,85 @@ function dailyMax(): number {
   const n = Number(raw);
   return Number.isFinite(n) && n >= 0 ? Math.floor(n) : 500;
 }
+
+// Daily USD budget — the operator-facing cost knob for the metered SDK path.
+// Read lazily like dailyMax(). `HOUSING_QA_DAILY_BUDGET_USD=0` blocks all SDK
+// calls (a coarse cost kill-switch, matching the DAILY_MAX=0 semantics);
+// unset/invalid falls back to $10/day. Governs the SDK path ONLY — the CLI
+// fallback has no `usage` to price, so it's bounded by the request counter
+// (dailyMax) alone.
+function dailyBudgetUsd(): number {
+  const raw = process.env.HOUSING_QA_DAILY_BUDGET_USD;
+  if (raw === undefined || raw === "") return 10;
+  const n = Number(raw);
+  return Number.isFinite(n) && n >= 0 ? n : 10;
+}
+
 let dailyCount = 0;
+let dailyInputTokens = 0;
+let dailyOutputTokens = 0;
 let dailyWindow = utcDayStamp();
 function utcDayStamp(): string {
   return new Date().toISOString().slice(0, 10); // YYYY-MM-DD in UTC
 }
-// Rolls the window on the first call of a new UTC day. Returns false when the
-// cap is already reached (caller 503s); otherwise counts this call → true.
-function underDailyCapAndCount(): boolean {
+// Rolls every per-day accumulator together on the first call of a new UTC day,
+// so the request counter and the spend counters can never desync.
+function rollWindow(): void {
   const today = utcDayStamp();
   if (today !== dailyWindow) {
     dailyWindow = today;
     dailyCount = 0;
+    dailyInputTokens = 0;
+    dailyOutputTokens = 0;
   }
+}
+// Estimated USD spent so far today, derived from accumulated tokens.
+function dailyEstCostUsd(): number {
+  return (
+    (dailyInputTokens / 1e6) * USD_PER_MTOK_INPUT +
+    (dailyOutputTokens / 1e6) * USD_PER_MTOK_OUTPUT
+  );
+}
+// Rolls the window then checks both ceilings: the USD budget (SDK path only —
+// the CLI path has no usage to price, so pass usagePriced=false there) and the
+// request counter. Returns false when either is already reached (caller 503s);
+// otherwise counts this call → true. The budget check is post-hoc: real token
+// usage is known only AFTER the call, so a call can overshoot the budget by at
+// most one call (~$0.01 at MAX_TOKENS=1024) — acceptable.
+function underDailyCapAndCount(usagePriced: boolean): boolean {
+  rollWindow();
+  if (usagePriced && dailyEstCostUsd() >= dailyBudgetUsd()) return false;
   if (dailyCount >= dailyMax()) return false;
   dailyCount++;
   return true;
+}
+// Records real token usage from a completed SDK call so the budget gate and the
+// status route reflect actual spend. Cache tokens (if present) are folded into
+// input. No-op for the CLI path, which reports no usage.
+function recordUsage(inputTokens: number, outputTokens: number): void {
+  rollWindow();
+  dailyInputTokens += Math.max(0, inputTokens);
+  dailyOutputTokens += Math.max(0, outputTokens);
 }
 // Observability for the admin status route + tests.
 export function housingQaStatus(): {
   enabled: boolean;
   dailyCount: number;
   dailyMax: number;
+  dailyInputTokens: number;
+  dailyOutputTokens: number;
+  dailyEstCostUsd: number;
+  dailyBudgetUsd: number;
 } {
-  return { enabled: housingQaEnabled(), dailyCount, dailyMax: dailyMax() };
+  return {
+    enabled: housingQaEnabled(),
+    dailyCount,
+    dailyMax: dailyMax(),
+    dailyInputTokens,
+    dailyOutputTokens,
+    dailyEstCostUsd: Number(dailyEstCostUsd().toFixed(4)),
+    dailyBudgetUsd: dailyBudgetUsd(),
+  };
 }
 
 // Lazily construct the SDK client so a missing key degrades to a 503 rather
@@ -250,10 +314,14 @@ export function housingQaRouter(): Router {
       return;
     }
 
-    // Daily volume ceiling — only well-formed, dispatchable requests count.
-    if (!underDailyCapAndCount()) {
+    // Daily ceilings — only well-formed, dispatchable requests count. The USD
+    // budget is enforced only when the SDK (metered) path will answer; the CLI
+    // path is priced-blind and bounded by the request counter alone.
+    if (!underDailyCapAndCount(Boolean(client))) {
       logger.warn("housing-qa request rejected — daily cap reached", {
         dailyMax: dailyMax(),
+        dailyBudgetUsd: dailyBudgetUsd(),
+        dailyEstCostUsd: Number(dailyEstCostUsd().toFixed(4)),
       });
       res.status(503).json({
         error:
@@ -267,6 +335,10 @@ export function housingQaRouter(): Router {
       const system = buildSystemPrompt(context);
 
       let answer: string;
+      // Captured from the SDK response for the budget gate + spend log; stays
+      // null on the CLI path, which reports no usage.
+      let inputTokens: number | null = null;
+      let outputTokens: number | null = null;
       if (client) {
         const completion = await client.messages.create({
           model: MODEL,
@@ -281,6 +353,15 @@ export function housingQaRouter(): Router {
           .map((block) => block.text)
           .join("")
           .trim();
+        // Fold cache tokens into input (over-estimates slightly — the safe
+        // direction for a cost cap). Feeds the daily budget + status route.
+        const u = completion.usage;
+        inputTokens =
+          (u?.input_tokens ?? 0) +
+          (u?.cache_creation_input_tokens ?? 0) +
+          (u?.cache_read_input_tokens ?? 0);
+        outputTokens = u?.output_tokens ?? 0;
+        recordUsage(inputTokens, outputTokens);
       } else {
         // CLI fallback (local, keyless) — see callViaCli. Bound concurrency so
         // many IPs can't fan out into unbounded subprocesses.
@@ -308,13 +389,26 @@ export function housingQaRouter(): Router {
 
       // PII-safe usage line for cost-spike + abuse visibility. Question LENGTH
       // only, never content (the logger PII-filters regardless). `route` is the
-      // retrieval branch; `path` is which backend answered.
+      // retrieval branch; `path` is which backend answered. Token counts + the
+      // estimated cost are present only on the metered SDK path (null on CLI);
+      // tokens are not PII.
       logger.info("housing-qa answered", {
         route: context.routing,
         path: client ? "sdk" : "cli",
         qLen: question.length,
         propertyCount: context.properties.length,
         latencyMs: Date.now() - startedAt,
+        inputTokens,
+        outputTokens,
+        estCostUsd:
+          inputTokens !== null && outputTokens !== null
+            ? Number(
+                (
+                  (inputTokens / 1e6) * USD_PER_MTOK_INPUT +
+                  (outputTokens / 1e6) * USD_PER_MTOK_OUTPUT
+                ).toFixed(4)
+              )
+            : null,
       });
 
       res.json({ answer });


### PR DESCRIPTION
## What

Makes the existing metered Anthropic-SDK path safe to turn on in prod. The SDK path **already** activates whenever `ANTHROPIC_API_KEY` is set — but it discarded `completion.usage`, and the WS3 daily cap (#229) only counted *requests*. So real spend was **invisible and uncapped in dollars**. This is not a new path; it makes the existing one observable and budget-bounded.

## Changes (all in `src/modules/housing-qa/routes.ts` + test + `.env.example`)

- **`HOUSING_QA_DAILY_BUDGET_USD`** — operator-facing daily $ ceiling for the metered SDK path (default `10`; `0` blocks all SDK calls = a cost kill-switch). Post-hoc gate against accumulated estimated spend; a call can overshoot by at most one call (~$0.01 at `MAX_TOKENS=1024`). **Governs the SDK path only** — the priced-blind CLI fallback stays bounded by `HOUSING_QA_DAILY_MAX`.
- **Real token accounting** — `completion.usage` (cache tokens folded into input, the safe over-estimate) accumulates per-UTC-day next to the request counter, reset together via a shared `rollWindow()` so they can't desync.
- **Observability** — success log gains `inputTokens`/`outputTokens`/`estCostUsd` (null on CLI; tokens are not PII). `housingQaStatus()` — surfaced at `GET /api/admin/housing-qa` — gains `dailyInputTokens`/`OutputTokens`/`EstCostUsd`/`BudgetUsd`.
- Pricing constants are **estimated** Haiku 4.5 rates (`$1`/MTok in, `$5`/MTok out), commented as informational, easy to bump.

## Cutover (ops — Alex-gated, NOT in this PR)

1. Provision a **metered** (org-billed) `ANTHROPIC_API_KEY` — not the personal Max token.
2. Set it on Railway, keep `HOUSING_QA_CLI_FALLBACK=1` (so a revoked/unset key degrades to the CLI instead of hard-503), set `HOUSING_QA_DAILY_BUDGET_USD`.
3. Verify via a test question → `GET /api/admin/housing-qa` shows non-zero tokens and `path:"sdk"` in logs.

## Tests

+3 cases: usage accounting + cache fold; `budget=0` 503s the SDK path; budget governs SDK-only while the CLI still answers. **19/19** routes tests, `tsc -b` clean.

## Sequencing

⚠️ **Stacked on #229** (`feat/housing-qa-hardening`) — based against that branch so the diff is just my one commit. After #229 merges to `main`, GitHub auto-retargets this to `main` (or rebase).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Reopened as new PR: original #234 was auto-closed when its stacked base branch `feat/housing-qa-hardening` (PR #229) merged into main and was deleted. Same head branch `feat/housing-qa-metered-prod`, now retargeted to main._