### PR TITLE
feat(screening): fail-loud hardening for dormant vendor adapters

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -113,9 +113,51 @@ HOUSING_QA_DAILY_MAX=500
 RESEND_API_KEY=
 RESEND_FROM=CDPC Nevada <onboarding@resend.dev>
 
-# Third-Party Screening
+# Third-Party Screening — vendor credentials.
+#
+# Each screening adapter is keyed independently so Phase-4 vendor wire-up is a
+# per-product swap, not a big-bang. They share ONE fail-loud invariant
+# (src/modules/screening/stub-policy.ts): a KEYLESS production deploy must
+# NEVER silently pass an applicant. With a key absent (or left as `changeme`)
+# the adapter throws STUB_GATE_ERROR unless the stub gate is explicitly open —
+# see MOCK_MODE / ALLOW_STUB_SCREENING at the bottom of this block. credit-check
+# and background-check catch that throw → `could_not_screen` HOLD; work-number
+# propagates it (it's not yet wired into runFullScreening); plaid/nsopw catch →
+# `review_required` HOLD. No path auto-approves without a real verdict.
+#
+# SCREENING_API_*  — credit + criminal-background bureau (credit-check.ts,
+#                    background-check.ts). The one pair already exercised today.
 SCREENING_API_URL=https://api.screening-provider.example.com
 SCREENING_API_KEY=changeme
+# IDENTITY_API_*   — identity / SSN-trace verification, first gate of
+#                    runFullScreening (identity-verification.ts, #205).
+IDENTITY_API_URL=https://api.identity-provider.example.com
+IDENTITY_API_KEY=changeme
+# NSOPW_API_*      — direct National Sex Offender registry proxy (nsopw-direct.ts),
+#                    belt-and-suspenders vs the bundled vendor NSOPW scrape.
+#                    DORMANT: built, not yet wired into runFullScreening.
+NSOPW_API_URL=https://api.nsopw-proxy.example.com
+NSOPW_API_KEY=changeme
+# PLAID_*          — bank-linked income verification (income-verification-plaid.ts).
+#                    Needs BOTH client_id and secret. DORMANT: not yet wired in.
+PLAID_CLIENT_ID=changeme
+PLAID_SECRET=changeme
+# WORK_NUMBER_API_* — Equifax The Work Number employment/income (work-number.ts).
+#                    DORMANT: not yet wired into runFullScreening.
+WORK_NUMBER_API_URL=https://api.theworknumber.example.com
+WORK_NUMBER_API_KEY=changeme
+#
+# Stub gate (stub-policy.ts). With no vendor key, screening only falls back to
+# deterministic stub data when ONE of these opens the gate; otherwise it throws.
+#   MOCK_MODE=1            — full demo/seed mode. Also unlocks the per-adapter
+#                           `screeningTag` mock fixtures (deny_sex_offender,
+#                           fraud_income_mismatch, …) used by the e2e demo.
+#   ALLOW_STUB_SCREENING=1 — narrower dev/demo escape hatch: stub fallback ON
+#                           without the rest of MOCK_MODE's behavior.
+# Leave BOTH unset in production. NODE_ENV=test opens the gate automatically so
+# the suite never needs real keys.
+# MOCK_MODE=1
+# ALLOW_STUB_SCREENING=1
 
 # Encryption
 ENCRYPTION_KEY=changeme-32-byte-hex-key

--- a/src/__tests__/screening-dormant-adapters.test.ts
+++ b/src/__tests__/screening-dormant-adapters.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Fail-loud contract for the three dormant screening adapters that are
+ * built-but-not-yet-wired into runFullScreening:
+ *
+ *   - WorkNumberService          (Equifax employment/income)
+ *   - PlaidIncomeService         (bank-linked income)
+ *   - NsopwDirectService         (direct sex-offender registry)
+ *
+ * The compliance invariant (stub-policy.ts): a KEYLESS production deploy must
+ * NEVER silently pass an applicant. Stub data is only allowed behind an
+ * explicit gate — MOCK_MODE=1, ALLOW_STUB_SCREENING=1, or NODE_ENV=test.
+ * Otherwise the missing key must surface as a hard error rather than a
+ * false-positive verdict.
+ *
+ * These tests lock that contract so the Phase-4 vendor wire-up (which swaps
+ * each adapter's "not yet configured" throw for a real API call) cannot
+ * regress it. They are also the regression guard for the work-number.ts
+ * silent-pass: before the stub gate it returned result:"verified"
+ * unconditionally when keyless.
+ *
+ * Two failure shapes, both fail-loud:
+ *   - WorkNumber has no internal try/catch → the gate error PROPAGATES (the
+ *     Phase-4 integrator decides aggregation when it wires WorkNumber in).
+ *   - Plaid / NSOPW catch internally → the gate error becomes a HOLD verdict
+ *     (review_required), matching credit-check.ts's catch → could_not_screen.
+ *
+ * NOTE: jest sets NODE_ENV=test, which itself opens the stub gate. So the
+ * fail-loud cases explicitly flip NODE_ENV=production and clear the escape
+ * hatches; env is saved/restored per test.
+ */
+
+import { WorkNumberService } from "../modules/screening/work-number";
+import { PlaidIncomeService } from "../modules/screening/income-verification-plaid";
+import { NsopwDirectService } from "../modules/screening/nsopw-direct";
+import { STUB_GATE_ERROR } from "../modules/screening/stub-policy";
+
+jest.mock("../utils/logger", () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+// Every env var these adapters or the stub policy read.
+const ENV_KEYS = [
+  "NODE_ENV",
+  "MOCK_MODE",
+  "ALLOW_STUB_SCREENING",
+  "WORK_NUMBER_API_KEY",
+  "WORK_NUMBER_API_URL",
+  "PLAID_CLIENT_ID",
+  "PLAID_SECRET",
+  "NSOPW_API_KEY",
+  "NSOPW_API_URL",
+];
+
+const saved: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  for (const k of ENV_KEYS) saved[k] = process.env[k];
+  // Guarantee a keyless baseline so every adapter takes the no-key branch.
+  for (const k of ENV_KEYS) if (k !== "NODE_ENV") delete process.env[k];
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k];
+  }
+  jest.restoreAllMocks();
+});
+
+/** Close the stub gate: simulate a real production deploy with no vendor key. */
+function disableStub() {
+  process.env.NODE_ENV = "production";
+  delete process.env.MOCK_MODE;
+  delete process.env.ALLOW_STUB_SCREENING;
+}
+
+/** Open the gate the dev/demo way (explicit escape hatch, still no key). */
+function allowStubViaFlag() {
+  process.env.NODE_ENV = "production";
+  delete process.env.MOCK_MODE;
+  process.env.ALLOW_STUB_SCREENING = "1";
+}
+
+function person() {
+  return { firstName: "Jane", lastName: "Doe", dateOfBirth: "1990-06-15" };
+}
+function wnInput() {
+  return { ...person(), ssn: "123-45-6789" };
+}
+
+// ── WorkNumberService — propagating fail-loud ───────────────────────────────
+
+describe("WorkNumberService.verifyEmployment() — fail-loud", () => {
+  it("returns verified via stub when the gate is open (NODE_ENV=test)", async () => {
+    // jest default NODE_ENV=test opens the gate
+    const r = await new WorkNumberService().verifyEmployment(wnInput());
+    expect(r.result).toBe("verified");
+  });
+
+  it("THROWS instead of silently passing when keyless in production (regression guard)", async () => {
+    disableStub();
+    await expect(
+      new WorkNumberService().verifyEmployment(wnInput())
+    ).rejects.toThrow(STUB_GATE_ERROR);
+  });
+
+  it("returns the stub when ALLOW_STUB_SCREENING=1 explicitly opts in", async () => {
+    allowStubViaFlag();
+    const r = await new WorkNumberService().verifyEmployment(wnInput());
+    expect(r.result).toBe("verified");
+  });
+});
+
+// ── PlaidIncomeService — catch → HOLD ───────────────────────────────────────
+
+describe("PlaidIncomeService.verifyIncome() — fail-loud", () => {
+  it("returns verified via stub when the gate is open (NODE_ENV=test)", async () => {
+    const r = await new PlaidIncomeService().verifyIncome(person());
+    expect(r.result).toBe("verified");
+  });
+
+  it("HOLDS (review_required, not verified) when keyless in production", async () => {
+    disableStub();
+    const r = await new PlaidIncomeService().verifyIncome(person());
+    expect(r.result).toBe("review_required");
+    expect(r.verified).toBe(false);
+  });
+
+  it("returns the stub when ALLOW_STUB_SCREENING=1 explicitly opts in", async () => {
+    allowStubViaFlag();
+    const r = await new PlaidIncomeService().verifyIncome(person());
+    expect(r.result).toBe("verified");
+  });
+});
+
+// ── NsopwDirectService — catch → HOLD ───────────────────────────────────────
+
+describe("NsopwDirectService.check() — fail-loud", () => {
+  it("returns no_match via stub when the gate is open (NODE_ENV=test)", async () => {
+    const r = await new NsopwDirectService().check(person());
+    expect(r.result).toBe("no_match");
+  });
+
+  it("HOLDS (review_required, no auto-clear) when keyless in production", async () => {
+    disableStub();
+    const r = await new NsopwDirectService().check(person());
+    expect(r.result).toBe("review_required");
+    expect(r.match).toBe(false);
+  });
+
+  it("returns the stub when ALLOW_STUB_SCREENING=1 explicitly opts in", async () => {
+    allowStubViaFlag();
+    const r = await new NsopwDirectService().check(person());
+    expect(r.result).toBe("no_match");
+  });
+});

--- a/src/modules/screening/work-number.ts
+++ b/src/modules/screening/work-number.ts
@@ -1,4 +1,5 @@
 import { logger } from "../../utils/logger";
+import { shouldUseScreeningStub, STUB_GATE_ERROR } from "./stub-policy";
 
 export interface WorkNumberResult {
   result: "verified" | "no_record" | "partial" | "review_required";
@@ -44,7 +45,15 @@ export class WorkNumberService {
     });
 
     if (!this.apiKey || this.apiKey === "changeme") {
-      logger.warn("Using stub Work Number verification — no API key configured");
+      // Fail-loud: a keyless production deploy must NOT silently report every
+      // applicant as employment-verified. Stub data is only allowed behind the
+      // explicit stub-policy gate (MOCK_MODE / ALLOW_STUB_SCREENING / test);
+      // otherwise throw so the missing key surfaces as a hard error instead of
+      // a false-positive "verified". (Matches credit-check.ts / nsopw-direct.ts.)
+      if (!shouldUseScreeningStub()) {
+        throw new Error(STUB_GATE_ERROR);
+      }
+      logger.warn("Using stub Work Number verification — no API key configured (stub policy allows fallback)");
       return {
         result: "verified",
         details: {


### PR DESCRIPTION
## What

Closes the lone **silent-pass** hole in the screening adapters and locks the fail-loud contract so the eventual Phase-4 vendor wire-up is a safe one-line key swap rather than a risk.

### The bug
`work-number.ts` was the only vendor adapter missing the stub-policy gate. When no API key was set it returned `result: "verified"` **unconditionally** — a keyless production deploy would have reported *every* applicant as employment-verified. Every sibling adapter (credit, background, nsopw, plaid) already gates the keyless stub behind `shouldUseScreeningStub()`.

## Changes

- **`work-number.ts`** — gate the keyless stub behind `shouldUseScreeningStub()`; throw `STUB_GATE_ERROR` unless the stub gate is open (`MOCK_MODE` / `ALLOW_STUB_SCREENING` / `NODE_ENV=test`). Mirrors `credit-check.ts` / `nsopw-direct.ts`. WorkNumber has no internal try/catch, so the throw **propagates** (it isn't wired into `runFullScreening` yet — the Phase-4 integrator owns aggregation).
- **`src/__tests__/screening-dormant-adapters.test.ts`** (new) — 9 contract tests, 3 per dormant adapter (work-number, plaid, nsopw):
  1. stub gate open → returns a deterministic stub verdict
  2. keyless + stub disabled → **fail-loud** (work-number THROWS; plaid/nsopw HOLD as `review_required`) — never a silent pass
  3. `ALLOW_STUB_SCREENING=1` → stub reopens
  These lock the contract so Phase-4's "swap the throw for a real API call" can't regress it. Case 2 for work-number is the direct regression guard.
- **`.env.example`** — document every screening vendor key (`IDENTITY_*`, `NSOPW_*`, `PLAID_*`, `WORK_NUMBER_*`) plus the `MOCK_MODE` / `ALLOW_STUB_SCREENING` stub gate, with the shared fail-loud invariant spelled out.

## Two fail-loud shapes (both safe)
| Adapter | On keyless + stub-disabled | Why |
|---|---|---|
| work-number | **throws** (propagates) | no internal catch; not yet wired into `runFullScreening` |
| plaid / nsopw | **HOLD** → `review_required` | internal catch converts throw to a non-approvable verdict |
| credit / background (existing) | **HOLD** → `could_not_screen` | same pattern, already shipped |

No adapter is wired into `runFullScreening` by this PR. **Flags stay OFF**: `SCREENING_ON_SUBMIT_ENABLED=false`, `COMPLIANCE_TAPE_V2_ENABLED=false`.

## Verification
- `npx tsc --noEmit` — clean
- `npx jest screening` — **114/114** pass (9 new)
- Rebased onto current `origin/main`; PR diff is the 3 files only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)