### PR TITLE
chore(deps): drop uuid for built-in node:crypto randomUUID (resolves #214)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,6 @@
         "resend": "^6.12.4",
         "stripe": "^17.2.0",
         "twilio": "^5.3.0",
-        "uuid": "^10.0.0",
         "winston": "^3.15.0",
         "zod": "^4.4.3"
       },
@@ -39,7 +38,6 @@
         "@types/node-cron": "^3.0.11",
         "@types/pg": "^8.11.10",
         "@types/supertest": "^7.2.0",
-        "@types/uuid": "^10.0.0",
         "concurrently": "^10.0.0",
         "fast-check": "^4.8.0",
         "jest": "^29.7.0",
@@ -1628,13 +1626,6 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
       "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
-      "license": "MIT"
-    },
-    "node_modules/@types/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/yargs": {
@@ -6906,19 +6897,6 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
-    },
-    "node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "resend": "^6.12.4",
     "stripe": "^17.2.0",
     "twilio": "^5.3.0",
-    "uuid": "^10.0.0",
     "winston": "^3.15.0",
     "zod": "^4.4.3"
   },
@@ -47,7 +46,6 @@
     "@types/node-cron": "^3.0.11",
     "@types/pg": "^8.11.10",
     "@types/supertest": "^7.2.0",
-    "@types/uuid": "^10.0.0",
     "concurrently": "^10.0.0",
     "fast-check": "^4.8.0",
     "jest": "^29.7.0",

--- a/src/modules/tape/__tests__/replay.spec.ts
+++ b/src/modules/tape/__tests__/replay.spec.ts
@@ -12,7 +12,7 @@
  * — un-skip after Phase 2 integration.
  */
 
-import { v4 as uuidv4 } from "uuid";
+import { randomUUID } from "node:crypto";
 import { GENESIS_HASH } from "../hashing";
 import type {
   TapeEntry,
@@ -55,7 +55,7 @@ class InMemoryTapeRepository implements TapeRepository {
   async insert(
     row: Omit<TapeEntry, "id" | "createdAt"> & { createdAt: string }
   ): Promise<TapeEntry> {
-    const entry: TapeEntry = { ...row, id: uuidv4() };
+    const entry: TapeEntry = { ...row, id: randomUUID() };
     const key = this.scopeKey(
       row.applicantId
         ? { type: "applicant", applicantId: row.applicantId }

--- a/src/modules/tape/__tests__/service.spec.ts
+++ b/src/modules/tape/__tests__/service.spec.ts
@@ -10,7 +10,7 @@
  * exactly. No IO, no database required.
  */
 
-import { v4 as uuidv4 } from "uuid";
+import { randomUUID } from "node:crypto";
 import { computeEntryHash, GENESIS_HASH, hashToHex } from "../hashing";
 import type {
   TapeEntry,
@@ -34,7 +34,7 @@ class InMemoryTapeRepository implements TapeRepository {
   async insert(
     row: Omit<TapeEntry, "id" | "createdAt"> & { createdAt: string }
   ): Promise<TapeEntry> {
-    const entry: TapeEntry = { ...row, id: uuidv4() };
+    const entry: TapeEntry = { ...row, id: randomUUID() };
     const key = this.scopeKey(
       row.applicantId
         ? { type: "applicant", applicantId: row.applicantId }
@@ -367,7 +367,7 @@ describe("TapeService", () => {
       );
 
       repo.injectFabricatedEntry(scope, {
-        id: uuidv4(),
+        id: randomUUID(),
         sequence: 3,
         kind: "WAITING_LIST_APP_CAPTURED",
         citation: TAPE_CITATIONS.WAITING_LIST_APP_CAPTURED,


### PR DESCRIPTION
Resolves dependabot **#214** (bump uuid 10→14) at the root rather than by bumping.

## Why not just bump
`uuid@14` is **ESM-only** — its `dist-node/index.js` uses `export {...}`. The repo's jest runs CJS via `ts-jest`, whose `transform` only matches `.tsx?` and (by default) skips `node_modules`. So `import { v4 } from "uuid"` blows up at parse time:

```
node_modules/uuid/dist-node/index.js:1
export { default as MAX } from './max.js';
SyntaxError: Unexpected token 'export'
```

That's exactly why **#214's `api (tsc + jest)` check is red**. Keeping uuid would mean adding `transformIgnorePatterns` + a `.js` transform just to satisfy a **test-only** dependency.

## What this does instead
`uuid` was imported in **exactly 2 test files** (`tape/__tests__/service.spec.ts`, `replay.spec.ts`) to mint a random v4 id for a fixture — **zero production usage** (the other "uuid" references in `src/` are Postgres `uuid` column types in SQL migrations, unrelated to the npm package).

- Swap `import { v4 as uuidv4 } from "uuid"` → `import { randomUUID } from "node:crypto"`; rename the 3 call sites `uuidv4()` → `randomUUID()`.
- Remove `uuid` (dependencies) + `@types/uuid` (devDependencies). uuid is no longer in `node_modules`, not even transitively.

`crypto.randomUUID()` is the stdlib drop-in for `v4()` (Node 14.17+), available on CI + local — no dependency, no ESM/jest interop, smaller surface.

## Verification
- `tsc` (npm run build) → clean.
- The 2 changed suites pass **12/12** in isolation (`jest --runInBand`).
- Remaining full-suite failures (`compliance-tape-flag` *"404 when flag unset"* → 401; magic-link rate-limit *wedge #13*) are the **documented parallel-worker flakes** that also hit #228/#230 — neither suite imports uuid; a CI re-run clears them.

Closes the need for #214 (will close it on merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)