### PR TITLE
chore(deps-dev): typescript 5.6 → 6.0.3 (+ tsconfig @types fix, supersedes #210)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "supertest": "^7.2.2",
         "ts-jest": "^29.4.11",
         "ts-node": "^10.9.2",
-        "typescript": "^5.6.0",
+        "typescript": "^6.0.3",
         "wait-on": "^8.0.0"
       }
     },
@@ -6799,9 +6799,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "supertest": "^7.2.2",
     "ts-jest": "^29.4.11",
     "ts-node": "^10.9.2",
-    "typescript": "^5.6.0",
+    "typescript": "^6.0.3",
     "wait-on": "^8.0.0"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,10 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
+    // TS 6.0 no longer auto-includes global-declaring @types/* packages
+    // (jest/node ambient globals). List them explicitly so describe/it/
+    // expect/process resolve. Module-imported @types resolve via imports.
+    "types": ["node", "jest"],
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
     "declaration": true,


### PR DESCRIPTION
## What
Bumps the root `typescript` devDep **5.6 → 6.0.3** and adds the one tsconfig change TS 6 requires.

## Why dependabot #210 was red
TS 6.0 dropped automatic inclusion of global-declaring `@types/*` packages. Our `tsconfig.json` has `include: ["src/**/*"]` (test files are in the `tsc` build) and no `types` array, so under 6.0 the **jest/node ambient globals** (`describe`/`it`/`expect`/`process`) stopped resolving — **6029 errors**, all `Cannot find name 'jest'` / `Cannot find namespace 'jest'`.

## Fix
```jsonc
"types": ["node", "jest"]   // in compilerOptions
```
Module-imported `@types/*` (express, pg, supertest, …) still resolve via their imports, so a full `tsc` over `src/**/*` is **0 errors**.

## Toolchain is already TS6-ready
- ts-jest peer `typescript: >=4.3 <7` ✓
- ts-node peer `typescript: >=2.7` ✓

## Verification (local, off current main)
- `npm run build` (tsc): **0 errors**
- jest tape + acquisitions suites: **41 passed** (incl. `acquisitions-aur-queue`, the first file to break under #210)

Supersedes #210 (the bare bump). Close #210 on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)