### PR TITLE
feat(screening): make the screening_review queue staff-usable + FCRA preview-then-confirm denial

### DIFF
--- a/client/src/pages/Screening.tsx
+++ b/client/src/pages/Screening.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Search, Play, AlertTriangle, CheckCircle, Clock } from 'lucide-react';
+import { Search, Play, AlertTriangle, CheckCircle, Clock, FileText, ShieldAlert, ArrowLeft } from 'lucide-react';
 import { useApiQuery } from '@/hooks/useApiQuery';
 import { useAuth } from '@/hooks/useAuth';
 import { DataTable, type Column } from '@/components/DataTable';
@@ -16,6 +16,7 @@ import {
   type FraudFlag,
   type ReviewQueueItem,
   type ReviewQueueResponse,
+  type AdverseActionDraft,
 } from '@/types';
 
 const columns: Column<Application>[] = [
@@ -50,6 +51,11 @@ export function Screening() {
   const [resolveApp, setResolveApp] = useState<ReviewQueueItem | null>(null);
   const [reviewNotes, setReviewNotes] = useState('');
   const [tab, setTab] = useState<'queue' | 'review' | 'completed'>('queue');
+  // Deny preview-then-confirm flow. The denial isn't committed until the staffer
+  // confirms the §1681m notice the server drafted — the client never sends it.
+  const [adverseDraft, setAdverseDraft] = useState<AdverseActionDraft | null>(null);
+  const [draftLoading, setDraftLoading] = useState(false);
+  const [draftError, setDraftError] = useState<string | null>(null);
 
   if (!user || !hasMinRole(user.role, 'senior_manager')) {
     return <p className="text-sm text-red-600">Access denied. Senior Manager or above required.</p>;
@@ -97,9 +103,36 @@ export function Screening() {
     if (selectedApp) viewResults(selectedApp);
   }
 
+  function closeResolveModal() {
+    setResolveApp(null);
+    setReviewNotes('');
+    setAdverseDraft(null);
+    setDraftError(null);
+  }
+
+  // Step 1 of the deny flow: do NOT commit. Ask the server to draft the §1681m
+  // adverse-action letter so the staffer can read exactly what the applicant will
+  // receive before they confirm. The notes become the reasonDetail in the notice.
+  async function previewDenial() {
+    if (!resolveApp || !reviewNotes.trim()) return;
+    setDraftLoading(true);
+    setDraftError(null);
+    try {
+      const res = await api.get<{ draft: AdverseActionDraft }>(
+        `/api/screening/${resolveApp.id}/adverse-action/draft?reasonDetail=${encodeURIComponent(reviewNotes.trim())}`
+      );
+      setAdverseDraft(res.draft);
+    } catch (err) {
+      setDraftError(err instanceof Error ? err.message : 'Failed to draft notice');
+    } finally {
+      setDraftLoading(false);
+    }
+  }
+
   // Manual override of a held (screening_review) application. A "pass" releases it
   // to screening_passed; a "fail" denies it (screening_failed) and the server
-  // fires the FCRA adverse-action notice — so a denial requires notes.
+  // fires the FCRA adverse-action notice — so a denial requires notes AND a
+  // confirmed preview (the deny path is only reachable after previewDenial()).
   async function resolveReview(decision: 'pass' | 'fail') {
     if (!resolveApp) return;
     if (decision === 'fail' && !reviewNotes.trim()) return;
@@ -109,8 +142,7 @@ export function Screening() {
         decision,
         notes: reviewNotes.trim(),
       });
-      setResolveApp(null);
-      setReviewNotes('');
+      closeResolveModal();
       refetchReview();
       refetch();
     } finally {
@@ -171,7 +203,7 @@ export function Screening() {
                 <Button
                   variant="primary"
                   size="sm"
-                  onClick={(e) => { e.stopPropagation(); setResolveApp(r); setReviewNotes(''); }}
+                  onClick={(e) => { e.stopPropagation(); setResolveApp(r); setReviewNotes(''); setAdverseDraft(null); setDraftError(null); }}
                 >
                   Resolve
                 </Button>
@@ -253,7 +285,7 @@ export function Screening() {
       {/* Review-resolve Modal — manual override of a held application */}
       <Modal
         open={!!resolveApp}
-        onClose={() => { setResolveApp(null); setReviewNotes(''); }}
+        onClose={closeResolveModal}
         title={resolveApp ? `Resolve Review: ${resolveApp.first_name} ${resolveApp.last_name}` : ''}
         wide
       >
@@ -269,44 +301,121 @@ export function Screening() {
               </p>
             </div>
 
-            <div className="grid grid-cols-2 gap-3">
-              <ResultCard label="Identity" status={resolveApp.identity_verification_result ?? ''} />
-              <ResultCard label="Background" status={resolveApp.background_check_result ?? ''} />
-              <ResultCard label="Credit" status={resolveApp.credit_check_result ?? ''} />
-              <ResultCard label="Compliance" status={resolveApp.compliance_check_result ?? ''} />
-            </div>
+            {adverseDraft ? (
+              /* ── Step 2: §1681m notice preview before confirming the denial ── */
+              <div className="space-y-4">
+                <div className="flex items-start gap-2 rounded-lg border border-red-200 bg-red-50 p-3 text-sm font-medium text-red-800">
+                  <ShieldAlert className="mt-0.5 h-4 w-4 shrink-0" />
+                  <p>This notice will be sent to the applicant on confirm.</p>
+                </div>
+                <div className="rounded-lg border border-gray-200 bg-gray-50 p-3 text-xs text-gray-700">
+                  <div className="mb-2 flex flex-wrap gap-x-4 gap-y-1 font-medium text-gray-600">
+                    <span>Applicant: {adverseDraft.applicantName}</span>
+                    <span>Property: {adverseDraft.propertyName}</span>
+                  </div>
+                  <pre className="max-h-72 overflow-y-auto whitespace-pre-wrap break-words font-sans leading-relaxed text-gray-800">
+                    {adverseDraft.noticeText}
+                  </pre>
+                </div>
+                <div className="flex justify-between gap-2">
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    disabled={actionLoading}
+                    onClick={() => { setAdverseDraft(null); setDraftError(null); }}
+                  >
+                    <ArrowLeft className="h-3 w-3" /> Back
+                  </Button>
+                  <div className="flex gap-2">
+                    <Button variant="ghost" size="sm" disabled={actionLoading} onClick={closeResolveModal}>
+                      Cancel
+                    </Button>
+                    <Button
+                      variant="danger"
+                      size="sm"
+                      loading={actionLoading}
+                      onClick={() => resolveReview('fail')}
+                    >
+                      <AlertTriangle className="h-3 w-3" /> Confirm denial &amp; send notice
+                    </Button>
+                  </div>
+                </div>
+              </div>
+            ) : (
+              /* ── Step 1: per-check detail review + decision entry ── */
+              <>
+                <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                  <CheckDetailCard
+                    label="Identity"
+                    status={resolveApp.identity_verification_result}
+                    completedAt={resolveApp.identity_verification_completed_at}
+                    summary={summarizeIdentity(resolveApp.identity_verification_details)}
+                    details={resolveApp.identity_verification_details}
+                  />
+                  <CheckDetailCard
+                    label="Background"
+                    status={resolveApp.background_check_result}
+                    completedAt={resolveApp.background_check_completed_at}
+                    summary={summarizeBackground(resolveApp.background_check_details)}
+                    details={resolveApp.background_check_details}
+                  />
+                  <CheckDetailCard
+                    label="Credit"
+                    status={resolveApp.credit_check_result}
+                    completedAt={resolveApp.credit_check_completed_at}
+                    summary={summarizeCredit(resolveApp.credit_check_details)}
+                    details={resolveApp.credit_check_details}
+                  />
+                  <CheckDetailCard
+                    label="Compliance"
+                    status={resolveApp.compliance_check_result}
+                    completedAt={resolveApp.compliance_check_completed_at}
+                    summary={summarizeCompliance(resolveApp.compliance_check_details)}
+                    details={resolveApp.compliance_check_details}
+                  />
+                </div>
 
-            <div>
-              <label className="mb-1 block text-sm font-medium text-gray-700">
-                Resolution notes <span className="font-normal text-gray-400">(required to deny)</span>
-              </label>
-              <textarea
-                value={reviewNotes}
-                disabled={actionLoading}
-                onChange={(e) => setReviewNotes(e.target.value)}
-                rows={3}
-                placeholder="Reason for the decision — recorded in the compliance audit trail…"
-                className="w-full rounded border border-gray-300 px-2 py-1 text-sm"
-              />
-            </div>
+                <HudCriminalReference />
 
-            <div className="flex justify-end gap-2">
-              <Button variant="secondary" size="sm" disabled={actionLoading} onClick={() => { setResolveApp(null); setReviewNotes(''); }}>
-                Cancel
-              </Button>
-              <Button
-                variant="danger"
-                size="sm"
-                loading={actionLoading}
-                disabled={!reviewNotes.trim()}
-                onClick={() => resolveReview('fail')}
-              >
-                <AlertTriangle className="h-3 w-3" /> Deny
-              </Button>
-              <Button variant="primary" size="sm" loading={actionLoading} onClick={() => resolveReview('pass')}>
-                <CheckCircle className="h-3 w-3" /> Approve
-              </Button>
-            </div>
+                <div>
+                  <label className="mb-1 block text-sm font-medium text-gray-700">
+                    Resolution notes <span className="font-normal text-gray-400">(required to deny)</span>
+                  </label>
+                  <textarea
+                    value={reviewNotes}
+                    disabled={actionLoading || draftLoading}
+                    onChange={(e) => setReviewNotes(e.target.value)}
+                    rows={3}
+                    placeholder="Reason for the decision — recorded in the compliance audit trail…"
+                    className="w-full rounded border border-gray-300 px-2 py-1 text-sm"
+                  />
+                </div>
+
+                {draftError && (
+                  <p className="text-sm text-red-600">
+                    Couldn't draft the notice: {draftError}. Adjust the notes and click Deny… to retry.
+                  </p>
+                )}
+
+                <div className="flex justify-end gap-2">
+                  <Button variant="secondary" size="sm" disabled={actionLoading || draftLoading} onClick={closeResolveModal}>
+                    Cancel
+                  </Button>
+                  <Button
+                    variant="danger"
+                    size="sm"
+                    loading={draftLoading}
+                    disabled={!reviewNotes.trim() || actionLoading}
+                    onClick={previewDenial}
+                  >
+                    <AlertTriangle className="h-3 w-3" /> Deny…
+                  </Button>
+                  <Button variant="primary" size="sm" loading={actionLoading} disabled={actionLoading || draftLoading} onClick={() => resolveReview('pass')}>
+                    <CheckCircle className="h-3 w-3" /> Approve
+                  </Button>
+                </div>
+              </>
+            )}
           </div>
         )}
       </Modal>
@@ -322,5 +431,231 @@ function ResultCard({ label, status, score, qualified }: { label: string; status
       {score !== undefined && <p className="mt-1 text-xs text-gray-400">Score: {score}</p>}
       {qualified !== undefined && <p className="mt-1 text-xs text-gray-400">AMI Qualified: {qualified ? 'Yes' : 'No'}</p>}
     </div>
+  );
+}
+
+// ── Detail-aware per-check card ───────────────────────────────────────────────
+// Surfaces the status badge plus a human-readable summary of the vendor *_details
+// payload. could_not_screen gets a prominent banner (the whole reason the app is
+// held). A collapsible raw view is offered as a fallback for unmapped shapes.
+function CheckDetailCard({
+  label,
+  status,
+  completedAt,
+  summary,
+  details,
+}: {
+  label: string;
+  status: string | null | undefined;
+  completedAt?: string | null;
+  summary: string[];
+  details?: Record<string, unknown> | null;
+}) {
+  const couldNotScreen = status === 'could_not_screen';
+  const errorText = couldNotScreen ? extractError(details) : null;
+  const hasRaw = details != null && Object.keys(details).length > 0;
+
+  return (
+    <div className={`rounded-lg border p-3 text-left ${couldNotScreen ? 'border-orange-300 bg-orange-50' : 'border-gray-200'}`}>
+      <div className="mb-1 flex items-center justify-between gap-2">
+        <p className="text-xs font-medium text-gray-500">{label}</p>
+        <StatusBadge status={status ?? ''} />
+      </div>
+
+      {couldNotScreen && (
+        <div className="mb-2 flex items-start gap-1.5 rounded border border-orange-200 bg-white/70 p-2 text-xs text-orange-800">
+          <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+          <div>
+            <p className="font-semibold">Vendor could not produce a verdict</p>
+            {errorText && <p className="mt-0.5 text-orange-700">{errorText}</p>}
+          </div>
+        </div>
+      )}
+
+      {summary.length > 0 ? (
+        <ul className="space-y-0.5 text-xs text-gray-700">
+          {summary.map((line, i) => (
+            <li key={i} className="leading-snug">{line}</li>
+          ))}
+        </ul>
+      ) : (
+        !couldNotScreen && <p className="text-xs text-gray-400">No detail reported.</p>
+      )}
+
+      {completedAt && (
+        <p className="mt-1.5 text-[11px] text-gray-400">Completed {new Date(completedAt).toLocaleString()}</p>
+      )}
+
+      {hasRaw && (
+        <details className="mt-2 text-xs">
+          <summary className="cursor-pointer text-gray-400 hover:text-gray-600">Raw detail</summary>
+          <pre className="mt-1 max-h-40 overflow-auto rounded bg-gray-50 p-2 text-[11px] text-gray-600">
+            {JSON.stringify(details, null, 2)}
+          </pre>
+        </details>
+      )}
+    </div>
+  );
+}
+
+// ── Defensive detail extractors ───────────────────────────────────────────────
+// Vendor payloads are untyped and shapes vary. Each helper coerces the few fields
+// it knows about and silently skips anything missing — never throws on a null or a
+// surprise shape. Returns a list of readable summary lines (possibly empty).
+
+function asRecord(v: unknown): Record<string, unknown> | null {
+  return v != null && typeof v === 'object' && !Array.isArray(v) ? (v as Record<string, unknown>) : null;
+}
+
+function str(v: unknown): string | null {
+  if (typeof v === 'string' && v.trim()) return v.trim();
+  if (typeof v === 'number' || typeof v === 'boolean') return String(v);
+  return null;
+}
+
+function num(v: unknown): number | null {
+  if (typeof v === 'number' && Number.isFinite(v)) return v;
+  if (typeof v === 'string' && v.trim() && Number.isFinite(Number(v))) return Number(v);
+  return null;
+}
+
+// Pull a human-readable error/reason out of a could_not_screen payload.
+function extractError(details?: Record<string, unknown> | null): string | null {
+  const d = asRecord(details);
+  if (!d) return null;
+  for (const k of ['error', 'errorMessage', 'message', 'reason', 'detail', 'failureReason', 'vendorMessage']) {
+    const v = str(d[k]);
+    if (v) return v;
+  }
+  return null;
+}
+
+function summarizeIdentity(details?: Record<string, unknown> | null): string[] {
+  const d = asRecord(details);
+  if (!d) return [];
+  const out: string[] = [];
+  const confidence = num(d.confidence) ?? num(d.confidenceScore);
+  if (confidence != null) out.push(`Confidence: ${confidence <= 1 ? `${Math.round(confidence * 100)}%` : confidence}`);
+  const liveness = num(d.livenessScore) ?? num(d.liveness);
+  if (liveness != null) out.push(`Liveness: ${liveness <= 1 ? `${Math.round(liveness * 100)}%` : liveness}`);
+  const idType = str(d.idType) ?? str(d.documentType) ?? str(d.docType);
+  if (idType) out.push(`ID type: ${idType}`);
+  const match = str(d.matchResult) ?? str(d.verificationResult);
+  if (match) out.push(`Match: ${match}`);
+  return out;
+}
+
+function summarizeBackground(details?: Record<string, unknown> | null): string[] {
+  const d = asRecord(details);
+  if (!d) return [];
+  const out: string[] = [];
+  const charges = Array.isArray(d.charges) ? d.charges : null;
+  if (charges) {
+    out.push(`Charges: ${charges.length}`);
+    charges.slice(0, 4).forEach((c) => {
+      const cr = asRecord(c);
+      const desc = cr ? (str(cr.description) ?? str(cr.charge) ?? str(cr.offense)) : str(c);
+      const disp = cr ? str(cr.disposition) : null;
+      if (desc) out.push(`• ${desc}${disp ? ` (${disp})` : ''}`);
+    });
+    if (charges.length > 4) out.push(`…and ${charges.length - 4} more`);
+  }
+  const flags = Array.isArray(d.flags) ? d.flags : null;
+  if (flags && flags.length) {
+    out.push(`Flags: ${flags.map((f) => str(asRecord(f)?.type) ?? str(f)).filter(Boolean).join(', ') || flags.length}`);
+  }
+  const message = str(d.message) ?? str(d.summary);
+  if (message) out.push(message);
+  return out;
+}
+
+function summarizeCredit(details?: Record<string, unknown> | null): string[] {
+  const d = asRecord(details);
+  if (!d) return [];
+  const out: string[] = [];
+  const score = num(d.score) ?? num(d.creditScore);
+  if (score != null) out.push(`Score: ${score}`);
+  const derogCount = num(d.derogatoryCount) ?? (Array.isArray(d.derogatory) ? d.derogatory.length : null);
+  if (derogCount != null) out.push(`Derogatory items: ${derogCount}`);
+  const derogSummary = str(d.derogatorySummary) ?? str(d.summary);
+  if (derogSummary) out.push(derogSummary);
+  const collections = num(d.collections);
+  if (collections != null) out.push(`Collections: ${collections}`);
+  return out;
+}
+
+function summarizeCompliance(details?: Record<string, unknown> | null): string[] {
+  const d = asRecord(details);
+  if (!d) return [];
+  const out: string[] = [];
+  const matched = d.matched ?? d.matchFound ?? d.hit;
+  if (typeof matched === 'boolean') out.push(matched ? 'List match found' : 'No list match');
+  const lists = Array.isArray(d.matchedLists) ? d.matchedLists : (Array.isArray(d.lists) ? d.lists : null);
+  if (lists && lists.length) {
+    out.push(`Matched lists: ${lists.map((l) => str(asRecord(l)?.name) ?? str(l)).filter(Boolean).join(', ') || lists.length}`);
+  }
+  const listName = str(d.matchedList) ?? str(d.listName);
+  if (listName) out.push(`List: ${listName}`);
+  const message = str(d.message) ?? str(d.summary);
+  if (message) out.push(message);
+  return out;
+}
+
+// ── HUD criminal-records decision reference ───────────────────────────────────
+// Static guardrail content for staffers making a discretionary denial. Collapsed
+// by default so it never crowds the per-check review.
+function HudCriminalReference() {
+  return (
+    <details className="rounded-lg border border-gray-200 bg-gray-50 text-sm">
+      <summary className="flex cursor-pointer items-center gap-2 px-3 py-2 font-medium text-gray-700">
+        <FileText className="h-4 w-4 text-gray-500" /> HUD criminal decision reference
+      </summary>
+      <div className="space-y-3 border-t border-gray-200 px-3 py-3 text-xs leading-relaxed text-gray-700">
+        <div>
+          <p className="font-semibold text-gray-900">Mandatory denials</p>
+          <ul className="mt-1 list-disc space-y-0.5 pl-4">
+            <li>Lifetime sex-offender registrant</li>
+            <li>Methamphetamine manufacture on assisted property</li>
+            <li>Current illegal drug use</li>
+            <li>Drug-related eviction (3-yr lookback)</li>
+          </ul>
+        </div>
+        <div>
+          <p className="font-semibold text-gray-900">Lookback windows</p>
+          <ul className="mt-1 list-disc space-y-0.5 pl-4">
+            <li>Felony violent / sexual / arson: 5–7 yrs post-release</li>
+            <li>Felony non-violent: 5 yrs</li>
+            <li>Misdemeanor violent: 3 yrs</li>
+            <li>Misdemeanor non-violent: 1–3 yrs</li>
+            <li>Drug-related non-meth: 3-yr floor (5 yrs distribution)</li>
+          </ul>
+        </div>
+        <div>
+          <p className="font-semibold text-gray-900">Individualized assessment</p>
+          <p className="mt-0.5 text-gray-500">Required for discretionary categories.</p>
+          <ul className="mt-1 list-disc space-y-0.5 pl-4">
+            <li>Nature / severity — must show demonstrable risk to safety or property; generic claims are insufficient</li>
+            <li>Time elapsed since conduct</li>
+            <li>Mitigating evidence: rehab, employment, references, tenancy record, age at offense, misidentification</li>
+          </ul>
+        </div>
+        <div className="flex items-start gap-1.5 rounded border border-red-200 bg-red-50 p-2 text-red-800">
+          <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+          <p>
+            <span className="font-semibold">Never</span> deny on arrest-only or a pending/open charge (no conviction) —
+            indefensible under FHA §100.500.
+          </p>
+        </div>
+        <div>
+          <p className="font-semibold text-gray-900">Before denial</p>
+          <ul className="mt-1 list-disc space-y-0.5 pl-4">
+            <li>Notify the applicant of the specific record</li>
+            <li>Allow mitigating evidence</li>
+            <li>Document the 3-factor assessment</li>
+            <li>Retain the file ≥3 yrs</li>
+          </ul>
+        </div>
+      </div>
+    </details>
   );
 }

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -174,10 +174,31 @@ export interface ReviewQueueItem {
   credit_check_result: string | null;
   compliance_check_result: string | null;
   status_history?: unknown;
+  // Per-check vendor detail payloads. Each *_details is a JSON object whose shape
+  // varies by vendor (may be null when the check never produced a payload). Surfaced
+  // in the resolve modal so the reviewer can see WHY each check landed where it did.
+  identity_verification_details?: Record<string, unknown> | null;
+  identity_verification_completed_at?: string | null;
+  background_check_details?: Record<string, unknown> | null;
+  background_check_completed_at?: string | null;
+  credit_check_details?: Record<string, unknown> | null;
+  credit_check_completed_at?: string | null;
+  compliance_check_details?: Record<string, unknown> | null;
+  compliance_check_completed_at?: string | null;
 }
 
 export interface ReviewQueueResponse {
   queue: ReviewQueueItem[];
+}
+
+// Server-rendered §1681m adverse-action letter preview. Returned by
+// GET /api/screening/:applicationId/adverse-action/draft — the client renders
+// noticeText for confirmation but NEVER sends the notice (server commits on resolve).
+export interface AdverseActionDraft {
+  applicationId: string;
+  applicantName: string;
+  propertyName: string;
+  noticeText: string;
 }
 
 export interface FraudFlag {

--- a/src/__tests__/adverse-action-service.test.ts
+++ b/src/__tests__/adverse-action-service.test.ts
@@ -216,6 +216,63 @@ describe("AdverseActionService.sendNotice()", () => {
   });
 });
 
+// ── generateNoticeDraft() ────────────────────────────────────────────────────
+
+describe("AdverseActionService.generateNoticeDraft()", () => {
+  let service: AdverseActionService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new AdverseActionService();
+  });
+
+  it("throws when application is not found", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] } as any);
+
+    await expect(
+      service.generateNoticeDraft(APP_ID)
+    ).rejects.toThrow(`Application not found: ${APP_ID}`);
+  });
+
+  it("renders a non-empty FCRA notice text from the same lookup as sendNotice", async () => {
+    mockAppQuery({ propertyName: "Sunrise Gardens" });
+
+    const draft = await service.generateNoticeDraft(APP_ID, "Manual review denial: criminal history");
+
+    expect(draft.applicationId).toBe(APP_ID);
+    expect(draft.applicantName).toBe("Jane Doe");
+    expect(draft.propertyName).toBe("Sunrise Gardens");
+    expect(draft.noticeText).toBeTruthy();
+    expect(draft.noticeText).toContain("Sunrise Gardens");
+    expect(draft.noticeText).toMatch(/Fair Credit Reporting Act/);
+    expect(draft.noticeText).toContain("Manual review denial: criminal history");
+  });
+
+  it("does a single SELECT lookup and NO INSERT (pure render — no commit)", async () => {
+    mockAppQuery();
+    // Deliberately do NOT queue an INSERT result. If the code attempted an
+    // INSERT it would consume an undefined mock return and the row read would
+    // throw — but more directly we assert exactly one query and that it is a SELECT.
+
+    await service.generateNoticeDraft(APP_ID);
+
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+    const onlyCall = mockQuery.mock.calls[0]!;
+    expect(onlyCall[0]).toMatch(/SELECT/i);
+    expect(onlyCall[0]).not.toMatch(/INSERT INTO adverse_action_notices/i);
+  });
+
+  it("sends NO SMS and writes NO audit log (it is a preview, not a sent notice)", async () => {
+    mockAppQuery({ phone: "+17025550100" });
+
+    await service.generateNoticeDraft(APP_ID);
+
+    await new Promise((r) => setImmediate(r));
+    expect(mockNotifyDenied).not.toHaveBeenCalled();
+    expect(mockWriteAuditLog).not.toHaveBeenCalled();
+  });
+});
+
 // ── getNotice() ────────────────────────────────────────────────────────────
 
 describe("AdverseActionService.getNotice()", () => {

--- a/src/__tests__/screening-routes.test.ts
+++ b/src/__tests__/screening-routes.test.ts
@@ -30,11 +30,13 @@ jest.mock("../utils/logger", () => ({
 
 const mockRunFullScreening = jest.fn();
 const mockGetResults = jest.fn();
+const mockGetAdverseActionDraft = jest.fn();
 
 jest.mock("../modules/screening/service", () => ({
   ScreeningService: jest.fn().mockImplementation(() => ({
     runFullScreening: mockRunFullScreening,
     getResults: mockGetResults,
+    getAdverseActionDraft: mockGetAdverseActionDraft,
   })),
 }));
 
@@ -453,5 +455,74 @@ describe("POST /screening/fraud-flags/:flagId/resolve", () => {
 
     expect(res.status).toBe(500);
     expect(res.body.error).toMatch(/failed to resolve fraud flag/i);
+  });
+});
+
+// ── GET /:applicationId/adverse-action/draft — preview FCRA denial notice ──
+//
+// Render-only preview, gated by screening:initiate (only staff who can deny may
+// preview the denial). reasonDetail is an optional query param coerced to a
+// string (array/duplicate params collapse to undefined).
+
+describe("GET /screening/:applicationId/adverse-action/draft", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  const sampleDraft = {
+    applicationId: "app-001",
+    applicantName: "Jane Doe",
+    propertyName: "Desert Oasis Apartments",
+    noticeText: "Dear Jane Doe, ... FCRA § 1681m ...",
+  };
+
+  it("returns 401 when no token provided", async () => {
+    const res = await request(app).get("/screening/app-001/adverse-action/draft");
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when leasing_agent attempts to preview a denial notice", async () => {
+    mockAuthQuery(leasingAgent);
+
+    const res = await request(app)
+      .get("/screening/app-001/adverse-action/draft")
+      .set("Authorization", tokenFor(leasingAgent));
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toMatch(/insufficient permissions/i);
+  });
+
+  it("returns 200 with the rendered draft when senior_manager previews", async () => {
+    mockAuthQuery(seniorManager);
+    mockGetAdverseActionDraft.mockResolvedValue(sampleDraft);
+
+    const res = await request(app)
+      .get("/screening/app-001/adverse-action/draft?reasonDetail=Criminal%20history")
+      .set("Authorization", tokenFor(seniorManager));
+
+    expect(res.status).toBe(200);
+    expect(res.body.draft).toEqual(sampleDraft);
+    expect(mockGetAdverseActionDraft).toHaveBeenCalledWith("app-001", "Criminal history");
+  });
+
+  it("coerces a duplicated reasonDetail query param to undefined (no array reaches the service)", async () => {
+    mockAuthQuery(seniorManager);
+    mockGetAdverseActionDraft.mockResolvedValue(sampleDraft);
+
+    await request(app)
+      .get("/screening/app-001/adverse-action/draft?reasonDetail=a&reasonDetail=b")
+      .set("Authorization", tokenFor(seniorManager));
+
+    expect(mockGetAdverseActionDraft).toHaveBeenCalledWith("app-001", undefined);
+  });
+
+  it("returns 400 when the service throws (e.g. application not found)", async () => {
+    mockAuthQuery(seniorManager);
+    mockGetAdverseActionDraft.mockRejectedValue(new Error("Application not found: app-001"));
+
+    const res = await request(app)
+      .get("/screening/app-001/adverse-action/draft")
+      .set("Authorization", tokenFor(seniorManager));
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/application not found/i);
   });
 });

--- a/src/__tests__/screening-service.test.ts
+++ b/src/__tests__/screening-service.test.ts
@@ -65,6 +65,12 @@ jest.mock("../modules/adverse-action/service", () => ({
       sentAt: new Date(),
       reason: "screening_failed",
     }),
+    generateNoticeDraft: jest.fn().mockResolvedValue({
+      applicationId: "app-001",
+      applicantName: "Jane Doe",
+      propertyName: "Desert Oasis Apartments",
+      noticeText: "DRAFT FCRA NOTICE TEXT",
+    }),
   })),
 }));
 
@@ -675,5 +681,160 @@ describe("ScreeningService.getResults", () => {
       expect.any(String),
       ["app-xyz"]
     );
+  });
+});
+
+// ── getReviewQueue ──────────────────────────────────────────────────────────────
+
+describe("ScreeningService.getReviewQueue", () => {
+  let service: ScreeningService;
+
+  beforeEach(() => {
+    service = new ScreeningService();
+    mockQuery.mockReset();
+  });
+
+  it("queries only screening_review rows, oldest-first", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] } as any);
+
+    await service.getReviewQueue();
+
+    const sql = mockQuery.mock.calls[0]![0] as string;
+    expect(sql).toMatch(/WHERE status = 'screening_review'/i);
+    expect(sql).toMatch(/ORDER BY created_at ASC/i);
+  });
+
+  it("SELECTs the per-check *_details and *_completed_at columns (the 'why')", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] } as any);
+
+    await service.getReviewQueue();
+
+    const sql = mockQuery.mock.calls[0]![0] as string;
+    // The whole point of the usable queue: each check's detail + timestamp.
+    expect(sql).toMatch(/identity_verification_details/);
+    expect(sql).toMatch(/identity_verification_completed_at/);
+    expect(sql).toMatch(/background_check_details/);
+    expect(sql).toMatch(/background_check_completed_at/);
+    expect(sql).toMatch(/credit_check_details/);
+    expect(sql).toMatch(/credit_check_completed_at/);
+    expect(sql).toMatch(/compliance_check_details/);
+    expect(sql).toMatch(/compliance_check_completed_at/);
+  });
+
+  it("returns rows carrying the new detail columns through verbatim", async () => {
+    const row = {
+      id: "app-held-1",
+      first_name: "Jane",
+      last_name: "Doe",
+      property_id: "prop-001",
+      overall_screening_result: "could_not_screen",
+      background_check_result: "could_not_screen",
+      background_check_details: { reason: "vendor_unavailable" },
+      background_check_completed_at: new Date("2026-05-30T10:00:00Z"),
+      credit_check_details: { creditScore: 700 },
+      credit_check_completed_at: new Date("2026-05-30T10:01:00Z"),
+      identity_verification_details: { documentValid: true },
+      identity_verification_completed_at: new Date("2026-05-30T10:02:00Z"),
+      compliance_check_details: { incomeWithinLimits: true },
+      compliance_check_completed_at: new Date("2026-05-30T10:03:00Z"),
+    };
+    mockQuery.mockResolvedValueOnce({ rows: [row] } as any);
+
+    const queue = await service.getReviewQueue();
+
+    expect(queue).toHaveLength(1);
+    expect(queue[0]).toHaveProperty("background_check_details", { reason: "vendor_unavailable" });
+    expect(queue[0]).toHaveProperty("background_check_completed_at");
+    expect(queue[0]).toHaveProperty("credit_check_details");
+    expect(queue[0]).toHaveProperty("identity_verification_details");
+    expect(queue[0]).toHaveProperty("compliance_check_details");
+  });
+});
+
+// ── getAdverseActionDraft (delegator) ─────────────────────────────────────────────
+
+describe("ScreeningService.getAdverseActionDraft", () => {
+  let service: ScreeningService;
+  let mockAdverseAction: jest.Mocked<InstanceType<typeof AdverseActionService>>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new ScreeningService();
+    mockAdverseAction = (service as any).adverseAction;
+  });
+
+  it("delegates to AdverseActionService.generateNoticeDraft with the same args", async () => {
+    await service.getAdverseActionDraft("app-001", "Criminal history within lookback window");
+
+    expect(mockAdverseAction.generateNoticeDraft).toHaveBeenCalledWith(
+      "app-001",
+      "Criminal history within lookback window"
+    );
+    // It must NOT commit/send: the draft path never touches sendNotice.
+    expect(mockAdverseAction.sendNotice).not.toHaveBeenCalled();
+  });
+
+  it("returns the rendered draft (non-empty noticeText) from the delegate", async () => {
+    const draft = await service.getAdverseActionDraft("app-001");
+
+    expect(draft.noticeText).toBeTruthy();
+    expect(typeof draft.noticeText).toBe("string");
+    expect(draft.applicationId).toBe("app-001");
+  });
+});
+
+// ── resolveReview (manual override of a held screening_review application) ─────────
+//
+// Locks the "preview === sent" invariant: the FCRA notice fired on a manual
+// denial must carry the RAW reviewer notes — the exact reasonDetail the staffer
+// previewed via getAdverseActionDraft(id, notes). A prefix/mutation here would
+// silently make the applicant's letter diverge from what was reviewed.
+
+describe("ScreeningService.resolveReview", () => {
+  let service: ScreeningService;
+  let mockAdverseAction: jest.Mocked<InstanceType<typeof AdverseActionService>>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new ScreeningService();
+    mockAdverseAction = (service as any).adverseAction;
+  });
+
+  it("fires the FCRA notice with the RAW notes as reasonDetail (no prefix) on a denial", async () => {
+    mockTransition.mockResolvedValue({ changed: true, status: "screening_failed" } as any);
+
+    const notes = "Identity documents could not be verified by the vendor.";
+    await service.resolveReview("app-001", "fail", notes, "user-sm-001", "senior_manager");
+
+    expect(mockTransition).toHaveBeenCalledWith(
+      expect.objectContaining({ to: "screening_failed", trigger: "manual_override_fail" })
+    );
+    expect(mockAdverseAction.sendNotice).toHaveBeenCalledTimes(1);
+    expect(mockAdverseAction.sendNotice).toHaveBeenCalledWith(
+      "app-001",
+      "user-sm-001",
+      "senior_manager",
+      "screening_failed",
+      notes // byte-identical to the previewed draft — must NOT be prefixed/mutated
+    );
+  });
+
+  it("does NOT fire an adverse-action notice on a manual pass", async () => {
+    mockTransition.mockResolvedValue({ changed: true, status: "screening_passed" } as any);
+
+    await service.resolveReview("app-001", "pass", "Vendor recovered; verdict clear.", "user-sm-001", "senior_manager");
+
+    expect(mockTransition).toHaveBeenCalledWith(
+      expect.objectContaining({ to: "screening_passed", trigger: "manual_override_pass" })
+    );
+    expect(mockAdverseAction.sendNotice).not.toHaveBeenCalled();
+  });
+
+  it("does NOT send when the CAS transition is lost (changed=false) — exactly-once guard", async () => {
+    mockTransition.mockResolvedValue({ changed: false, status: "screening_review" } as any);
+
+    await service.resolveReview("app-001", "fail", "Denied.", "user-sm-001", "senior_manager");
+
+    expect(mockAdverseAction.sendNotice).not.toHaveBeenCalled();
   });
 });

--- a/src/modules/adverse-action/service.ts
+++ b/src/modules/adverse-action/service.ts
@@ -135,6 +135,61 @@ export class AdverseActionService {
   }
 
   /**
+   * Render an FCRA § 1681m adverse-action notice WITHOUT committing or sending
+   * it. Lets staff preview the exact denial text before they resolve a held
+   * application into screening_failed (which is the single send path —
+   * sendNotice — used on resolve).
+   *
+   * Performs the SAME applicant-name + property-name lookups as sendNotice and
+   * calls the SAME buildNoticeText, so the preview is byte-identical to what
+   * sendNotice would persist for the same reasonDetail. It MUST NOT insert into
+   * adverse_action_notices and MUST NOT fire any SMS — it is a pure render.
+   *
+   * @param applicationId  The application a denial is being previewed for
+   * @param reasonDetail   Optional human-readable elaboration for the notice
+   */
+  async generateNoticeDraft(
+    applicationId: string,
+    reasonDetail?: string
+  ): Promise<{
+    applicationId: string;
+    applicantName: string;
+    propertyName: string;
+    noticeText: string;
+  }> {
+    // Identical lookup to sendNotice — applicant name + property name only.
+    const appResult = await query(
+      `SELECT a.first_name, a.last_name, a.email, a.phone,
+              p.name AS property_name
+       FROM applications a
+       JOIN properties p ON a.property_id = p.id
+       WHERE a.id = $1`,
+      [applicationId]
+    );
+
+    if (appResult.rows.length === 0) {
+      throw new Error(`Application not found: ${applicationId}`);
+    }
+
+    const app = appResult.rows[0];
+    const applicantName = `${app.first_name} ${app.last_name}`;
+
+    const noticeText = this.buildNoticeText(
+      applicantName,
+      app.property_name,
+      reasonDetail
+    );
+
+    // Pure render: no INSERT into adverse_action_notices, no SMS, no audit log.
+    return {
+      applicationId,
+      applicantName,
+      propertyName: app.property_name,
+      noticeText,
+    };
+  }
+
+  /**
    * Retrieve the most recently sent adverse action notice for an application.
    * Returns null if no notice has been sent yet.
    */

--- a/src/modules/screening/routes.ts
+++ b/src/modules/screening/routes.ts
@@ -144,6 +144,34 @@ router.post(
   }
 );
 
+// Preview the FCRA adverse-action notice a manual denial would send, WITHOUT
+// committing or sending it. Guarded by screening:initiate (only staff who can
+// deny may preview the denial). Optional reasonDetail query param mirrors the
+// detail a resolveReview('fail') would stamp on the notice.
+router.get(
+  "/:applicationId/adverse-action/draft",
+  authenticate,
+  requirePermission("screening:initiate"),
+  async (req: AuthRequest, res: Response): Promise<void> => {
+    try {
+      const reasonDetail =
+        typeof req.query.reasonDetail === "string" ? req.query.reasonDetail : undefined;
+
+      const draft = await screeningService.getAdverseActionDraft(
+        param(req.params.applicationId),
+        reasonDetail
+      );
+      res.json({ draft });
+    } catch (err: any) {
+      logger.error("Failed to generate adverse-action draft", {
+        error: err.message,
+        applicationId: param(req.params.applicationId),
+      });
+      res.status(400).json({ error: err.message });
+    }
+  }
+);
+
 // Get screening results (Senior Manager+)
 router.get(
   "/:applicationId/results",

--- a/src/modules/screening/service.ts
+++ b/src/modules/screening/service.ts
@@ -697,12 +697,35 @@ export class ScreeningService {
       `SELECT id, first_name, last_name, property_id, created_at,
               overall_screening_result, identity_verification_result,
               background_check_result, credit_check_result,
-              compliance_check_result, status_history
+              compliance_check_result, status_history,
+              identity_verification_details, identity_verification_completed_at,
+              background_check_details, background_check_completed_at,
+              credit_check_details, credit_check_completed_at,
+              compliance_check_details, compliance_check_completed_at
          FROM applications
         WHERE status = 'screening_review'
         ORDER BY created_at ASC`
     );
     return result.rows;
+  }
+
+  /**
+   * Render the FCRA § 1681m adverse-action notice a manual denial WOULD send,
+   * without committing or sending it — staff preview the denial text before
+   * they resolve a held application via resolveReview('fail'). Thin delegator to
+   * AdverseActionService.generateNoticeDraft (the same member resolveReview uses
+   * to actually sendNotice). No INSERT, no SMS — pure render.
+   */
+  async getAdverseActionDraft(
+    applicationId: string,
+    reasonDetail?: string
+  ): Promise<{
+    applicationId: string;
+    applicantName: string;
+    propertyName: string;
+    noticeText: string;
+  }> {
+    return this.adverseAction.generateNoticeDraft(applicationId, reasonDetail);
   }
 
   /**
@@ -733,6 +756,13 @@ export class ScreeningService {
 
     // FCRA § 1681m: send adverse-action notice on a manual denial. Non-blocking
     // and gated on the CAS winning so a concurrent resolution can't double-send.
+    //
+    // reasonDetail MUST be the raw notes — byte-identical to what the staffer
+    // previewed via getAdverseActionDraft(id, notes). Do NOT prefix or otherwise
+    // mutate it here: the applicant must receive the exact notice text that was
+    // reviewed and approved (preview === sent). The "manual review" framing lives
+    // in the manual_override_fail status-transition audit recorded above, not in
+    // the applicant-facing letter.
     if (decision === "fail" && changed) {
       this.adverseAction
         .sendNotice(
@@ -740,7 +770,7 @@ export class ScreeningService {
           reviewerId,
           reviewerRole,
           "screening_failed",
-          "Manual screening review denial: " + notes
+          notes
         )
         .catch((err: Error) =>
           logger.error("Failed to send FCRA adverse action notice after manual review denial", {


### PR DESCRIPTION
## What

The `screening_review` hold (shipped in #231) is only useful if staff can actually **work** it. Today the resolve modal shows four pass/fail badges and a notes box — no *why*, no compliance guardrails, and a manual denial fires a bare FCRA notice the staffer never sees. This makes the queue genuinely operable and makes a denial **preview-then-confirm**.

## Changes

**Backend**
- `getReviewQueue()` now selects the per-check `*_details` JSONB + `*_completed_at` columns — the reasons a hold exists, not just result badges. (No migration: columns already exist.)
- `AdverseActionService.generateNoticeDraft()` — **pure render** of the §1681m notice (no INSERT, no SMS, no audit write). Lets staff preview the exact letter before committing a denial.
- New `GET /screening/:applicationId/adverse-action/draft` — render-only preview, gated by `screening:initiate` (only staff who can deny may preview). `reasonDetail` query param coerced to string (array/duplicate params → `undefined`).

**Frontend** (`client/src/pages/Screening.tsx`)
- Per-check detail cards surfacing the real reason each check holds.
- Collapsible HUD decision-matrix reference panel (mandatory denials, lookback windows, individualized-assessment factors, "arrest-only → never deny").
- Deny → previews the rendered §1681m notice → confirm. Not fire-on-click.

## FCRA invariants (adversarially verified — PASS)
- `could_not_screen` **never** fires adverse action.
- `generateNoticeDraft` is pure-render — never persists or sends.
- Send is **exactly-once** via the CAS-gated `resolveReview`, never client-side.
- **Preview === sent**: `resolveReview` no longer prefixes the reason (`"Manual screening review denial: "` removed) — the applicant's letter is byte-identical to what staff previewed. (This was the blocker the adversarial review caught.)

## Tests
- `ScreeningService.resolveReview` unit suite (previously **zero** direct coverage): raw-notes `reasonDetail`, no double-send on pass, no send on CAS-loss.
- Draft-route RBAC suite: 401 / 403 / 200 + `reasonDetail` array→undefined coercion + 400 on service throw.

## Safety
- No DB migration. No prod flag touched — `SCREENING_ON_SUBMIT_ENABLED` stays `false`.
- Rebased onto current `main` (on top of #240/#239/#238); `service.ts` overlap with #240 merged clean — #240's extended-checks suite 6/6 still green.

Local gate on rebased base: backend tsc **0 errors**, client tsc clean, 96/96 on the 3 touched suites + 6/6 #240 extended-checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
