### PR TITLE
test(screening): make screening-routes auth mock hermetic to suite ordering

### DIFF
--- a/src/__tests__/screening-routes.test.ts
+++ b/src/__tests__/screening-routes.test.ts
@@ -120,11 +120,20 @@ function buildApp() {
 
 const app = buildApp();
 
+// Reset mock state before EVERY test, in any describe. jest.clearAllMocks()
+// clears call records but NOT the mockResolvedValueOnce queue; mockReset() on
+// the users-DB query mock additionally drains any auth row a prior test queued
+// but never consumed, so a leaked once-value can't misalign authenticate's user
+// lookup and flip a later test's status code. Keeps each test hermetic
+// regardless of suite execution order (the ordering flake the audit flagged).
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockQuery.mockReset();
+});
+
 // ── POST /:applicationId/screen — initiate screening ─────────────────────
 
 describe("POST /screening/:applicationId/screen", () => {
-  beforeEach(() => jest.clearAllMocks());
-
   it("returns 401 when no Authorization header is provided", async () => {
     const res = await request(app).post("/screening/app-001/screen");
     expect(res.status).toBe(401);
@@ -226,8 +235,6 @@ describe("POST /screening/:applicationId/screen", () => {
 // ── GET /:applicationId/results — get screening results ───────────────────
 
 describe("GET /screening/:applicationId/results", () => {
-  beforeEach(() => jest.clearAllMocks());
-
   it("returns 401 when no token provided", async () => {
     const res = await request(app).get("/screening/app-001/results");
     expect(res.status).toBe(401);
@@ -299,8 +306,6 @@ describe("GET /screening/:applicationId/results", () => {
 // ── GET /:applicationId/fraud-flags — get fraud flags ────────────────────
 
 describe("GET /screening/:applicationId/fraud-flags", () => {
-  beforeEach(() => jest.clearAllMocks());
-
   it("returns 401 when no token provided", async () => {
     const res = await request(app).get("/screening/app-001/fraud-flags");
     expect(res.status).toBe(401);
@@ -371,8 +376,6 @@ describe("GET /screening/:applicationId/fraud-flags", () => {
 // ── POST /fraud-flags/:flagId/resolve — resolve fraud flag ────────────────
 
 describe("POST /screening/fraud-flags/:flagId/resolve", () => {
-  beforeEach(() => jest.clearAllMocks());
-
   it("returns 401 when no token provided", async () => {
     const res = await request(app)
       .post("/screening/fraud-flags/flag-001/resolve")
@@ -465,8 +468,6 @@ describe("POST /screening/fraud-flags/:flagId/resolve", () => {
 // string (array/duplicate params collapse to undefined).
 
 describe("GET /screening/:applicationId/adverse-action/draft", () => {
-  beforeEach(() => jest.clearAllMocks());
-
   const sampleDraft = {
     applicationId: "app-001",
     applicantName: "Jane Doe",


### PR DESCRIPTION
## What

Hardens `src/__tests__/screening-routes.test.ts` against the test-isolation flake the **#241 pre-merge Opus audit** flagged.

## Root cause

Each `describe` reset mocks with `jest.clearAllMocks()`, which clears call records **but not** the `mockResolvedValueOnce` queue. A queued users-DB auth row that a test never consumed could survive into the next test and misalign `authenticate()`'s user lookup — flipping a later test's status code. The file passed 32/32 alone, but the audit noted "96/96 green was a lucky ordering" and the suite risked intermittent CI red under unlucky ordering.

## Fix

Replace the 5 repeated per-`describe` `beforeEach(() => jest.clearAllMocks())` with **one top-level guard** that also `mockReset()`s the query mock, draining any leaked once-value before every test.

- `clearAllMocks()` retained → preserves the `FraudDetectionService.checkDuplicateSSN` resolved value set in the mock factory (a blanket `resetAllMocks()` would wipe it).
- `mockReset()` scoped to `mockQuery` only → it has no factory implementation, so reset is safe and purely drains the once-queue.
- Zero behavior change to the 32 passing tests; the suite is now hermetic regardless of execution order.

## Verification

- `screening-routes.test.ts` alone → **32/32**.
- Full suite → screening-routes **PASS** in-context; **1469 passed**, only local-env noise (`compliance-tape-flag` needs no `.env`; that failure is a local `COMPLIANCE_TAPE_V2_ENABLED=true` + dotenv-refill artifact, green on CI).
- screening-routes + compliance-tape-flag with `.env` removed (CI-equivalent) → **35/35**.

Test-only change. No product code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)