### PR TITLE
feat(screening): vendor adapter seam + sandbox & dormant Plaid vendors (#2)

### DIFF
--- a/src/__tests__/screening-vendor-seam.test.ts
+++ b/src/__tests__/screening-vendor-seam.test.ts
@@ -1,0 +1,275 @@
+/**
+ * Contract for the screening vendor seam (src/modules/screening/vendors).
+ *
+ * Three things under test:
+ *   1. registry.resolveVendor() — precedence, default, unsupported-domain refusal.
+ *   2. SandboxVendor — self-gating fail-loud (the property that makes "sandbox"
+ *      a safe production DEFAULT), plus the MOCK_MODE demo fixtures.
+ *   3. PlaidVendor — dormant without creds; with creds it performs the real
+ *      sandbox handshake (mocked fetch) and maps deposits to income, and it
+ *      THROWS (never fabricates a pass) on HTTP error / empty signal.
+ *
+ * The existing screening-integrations / screening-dormant-adapters /
+ * screening-extended-checks suites already prove the SERVICES wired through this
+ * seam behave byte-identically. This suite proves the seam itself.
+ */
+
+import { resolveVendor, resolveVendorName } from "../modules/screening/vendors/registry";
+import { SandboxVendor } from "../modules/screening/vendors/sandbox-vendor";
+import { PlaidVendor } from "../modules/screening/vendors/plaid-vendor";
+import { STUB_GATE_ERROR } from "../modules/screening/stub-policy";
+
+jest.mock("../utils/logger", () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+const ENV_KEYS = [
+  "NODE_ENV",
+  "MOCK_MODE",
+  "ALLOW_STUB_SCREENING",
+  "SCREENING_VENDOR",
+  "SCREENING_VENDOR_BACKGROUND",
+  "SCREENING_VENDOR_CREDIT",
+  "SCREENING_VENDOR_INCOME",
+  "SCREENING_VENDOR_NSOPW",
+  "SCREENING_VENDOR_EMPLOYMENT",
+  "PLAID_CLIENT_ID",
+  "PLAID_SECRET",
+  "PLAID_ENV",
+];
+
+const saved: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  for (const k of ENV_KEYS) saved[k] = process.env[k];
+  for (const k of ENV_KEYS) if (k !== "NODE_ENV") delete process.env[k];
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k];
+  }
+  jest.restoreAllMocks();
+});
+
+function disableStub() {
+  process.env.NODE_ENV = "production";
+  delete process.env.MOCK_MODE;
+  delete process.env.ALLOW_STUB_SCREENING;
+}
+
+function person() {
+  return { firstName: "Jane", lastName: "Doe", dateOfBirth: "1990-06-15" };
+}
+
+// ── Registry ─────────────────────────────────────────────────────────────────
+
+describe("registry.resolveVendor()", () => {
+  const DOMAINS = ["background", "credit", "income", "nsopw", "employment"] as const;
+
+  it("defaults every domain to the sandbox vendor", () => {
+    for (const d of DOMAINS) {
+      expect(resolveVendorName(d)).toBe("sandbox");
+      expect(resolveVendor(d).name).toBe("sandbox");
+    }
+  });
+
+  it("SCREENING_VENDOR_<DOMAIN> overrides the global SCREENING_VENDOR", () => {
+    process.env.SCREENING_VENDOR = "sandbox";
+    process.env.SCREENING_VENDOR_INCOME = "plaid";
+    expect(resolveVendorName("income")).toBe("plaid");
+    expect(resolveVendor("income").name).toBe("plaid");
+    // Other domains keep the global.
+    expect(resolveVendor("background").name).toBe("sandbox");
+  });
+
+  it("refuses (throws) when the configured vendor does not support the domain", () => {
+    process.env.SCREENING_VENDOR = "plaid"; // plaid only supports income
+    expect(() => resolveVendor("background")).toThrow(/does not support the background check/i);
+    expect(() => resolveVendor("nsopw")).toThrow(/does not support the nsopw check/i);
+    // income is supported
+    expect(resolveVendor("income").name).toBe("plaid");
+  });
+
+  it("throws on an unknown vendor name", () => {
+    process.env.SCREENING_VENDOR_CREDIT = "experian-typo";
+    expect(() => resolveVendor("credit")).toThrow(/Unknown screening vendor "experian-typo"/i);
+  });
+
+  it("is case-insensitive and trims whitespace", () => {
+    process.env.SCREENING_VENDOR_INCOME = "  PLAID  ";
+    expect(resolveVendorName("income")).toBe("plaid");
+  });
+});
+
+// ── SandboxVendor: self-gating fail-loud ───────────────────────────────────────
+
+describe("SandboxVendor — self-gating (the reason 'sandbox' is a safe default)", () => {
+  it("with the gate OPEN (NODE_ENV=test) returns clean/passing data for every domain", async () => {
+    const v = new SandboxVendor();
+    expect((await v.background({ ...person(), ssnLast4: "6789", state: "NV" })).felonies).toBe(0);
+    expect((await v.credit({ ...person(), ssnLast4: "6789" })).creditScore).toBe(680);
+    const inc = await v.income(person());
+    expect(inc.verified).toBe(true);
+    expect(inc.annualIncomeCents).toBe(5400000);
+    expect((await v.nsopw({ ...person(), states: ["NV"] })).records).toHaveLength(0);
+    const emp = await v.employment({ ...person(), ssn: "123-45-6789" });
+    expect(emp.result).toBe("verified");
+    expect(emp.details.currentEmployer).toBe("STUB Employer Inc.");
+  });
+
+  it("with the gate CLOSED (keyless production) THROWS STUB_GATE_ERROR for every domain", async () => {
+    disableStub();
+    const v = new SandboxVendor();
+    await expect(v.background({ ...person(), ssnLast4: "6789", state: "NV" })).rejects.toThrow(STUB_GATE_ERROR);
+    await expect(v.credit({ ...person(), ssnLast4: "6789" })).rejects.toThrow(STUB_GATE_ERROR);
+    await expect(v.income(person())).rejects.toThrow(STUB_GATE_ERROR);
+    await expect(v.nsopw({ ...person(), states: ["NV"] })).rejects.toThrow(STUB_GATE_ERROR);
+    await expect(v.employment({ ...person(), ssn: "123-45-6789" })).rejects.toThrow(STUB_GATE_ERROR);
+  });
+
+  it("ALLOW_STUB_SCREENING=1 reopens the gate in production", async () => {
+    disableStub();
+    process.env.ALLOW_STUB_SCREENING = "1";
+    const v = new SandboxVendor();
+    expect((await v.income(person())).verified).toBe(true);
+  });
+
+  it("MOCK_MODE demo fixtures pass the gate and return the tagged synthetic data", async () => {
+    process.env.NODE_ENV = "production"; // gate otherwise closed
+    process.env.MOCK_MODE = "1";
+    const v = new SandboxVendor();
+
+    expect((await v.background({ ...person(), ssnLast4: "6789", state: "NV", screeningTag: "deny_felony" })).felonies).toBe(1);
+    expect((await v.background({ ...person(), ssnLast4: "6789", state: "NV", screeningTag: "deny_sex_offender" })).sexOffenses).toBe(true);
+    expect((await v.credit({ ...person(), ssnLast4: "6789", screeningTag: "review_low_credit" })).creditScore).toBe(520);
+    expect((await v.income({ ...person(), screeningTag: "fraud_income_mismatch" })).annualIncomeCents).toBe(3000000);
+
+    const nsopwMatch = await v.nsopw({ ...person(), states: ["NV"], screeningTag: "deny_sex_offender" });
+    expect(nsopwMatch.records).toHaveLength(1);
+    expect(nsopwMatch.records[0].riskTier).toBe("high");
+
+    // Unknown tag → clean default (mirrors the old mockResponse fallthrough).
+    expect((await v.income({ ...person(), screeningTag: "no_such_tag" })).annualIncomeCents).toBe(5400000);
+  });
+
+  it("supports() is true for every domain", () => {
+    const v = new SandboxVendor();
+    for (const d of ["background", "credit", "income", "nsopw", "employment"] as const) {
+      expect(v.supports(d)).toBe(true);
+    }
+  });
+});
+
+// ── PlaidVendor: dormant scaffold ──────────────────────────────────────────────
+
+describe("PlaidVendor — dormant without creds, live (mocked) with creds", () => {
+  it("supports only the income domain", () => {
+    const v = new PlaidVendor();
+    expect(v.supports("income")).toBe(true);
+    expect(v.supports("background")).toBe(false);
+    expect(v.supports("nsopw")).toBe(false);
+  });
+
+  it("non-income methods throw defensively", async () => {
+    const v = new PlaidVendor();
+    await expect(v.background({ ...person(), ssnLast4: "6789", state: "NV" })).rejects.toThrow(/supports only the income check/i);
+  });
+
+  it("no creds + gate closed → THROWS STUB_GATE_ERROR (stays dormant, fail-loud)", async () => {
+    disableStub();
+    await expect(new PlaidVendor().income(person())).rejects.toThrow(STUB_GATE_ERROR);
+  });
+
+  it("no creds + gate open → returns the deterministic stub (verified)", async () => {
+    // jest NODE_ENV=test keeps the gate open
+    const r = await new PlaidVendor().income(person());
+    expect(r.verified).toBe(true);
+    expect(r.annualIncomeCents).toBe(5400000);
+  });
+
+  describe("with creds (mocked fetch)", () => {
+    let fetchMock: jest.Mock;
+    const origFetch = global.fetch;
+
+    beforeEach(() => {
+      process.env.PLAID_CLIENT_ID = "test-client";
+      process.env.PLAID_SECRET = "test-secret";
+      process.env.PLAID_ENV = "sandbox";
+      fetchMock = jest.fn();
+      (global as any).fetch = fetchMock;
+    });
+
+    afterEach(() => {
+      (global as any).fetch = origFetch;
+    });
+
+    function ok(json: unknown) {
+      return { ok: true, status: 200, json: async () => json };
+    }
+
+    it("runs create → exchange → transactions and maps deposits to income", async () => {
+      fetchMock
+        .mockResolvedValueOnce(ok({ public_token: "public-sandbox-123" }))
+        .mockResolvedValueOnce(ok({ access_token: "access-sandbox-123" }))
+        .mockResolvedValueOnce(
+          ok({
+            accounts: [{ account_id: "acc-1" }],
+            transactions: [
+              { amount: -2000, name: "Payroll" }, // deposit
+              { amount: -2000, name: "Payroll" }, // deposit
+              { amount: 35.5, name: "Coffee" }, // debit, ignored
+            ],
+          })
+        );
+
+      const r = await new PlaidVendor().income(person());
+
+      // 4000 in deposits over a 3-month window → 400000 cents total / 3.
+      expect(r.monthlyAverageCents).toBe(133333);
+      expect(r.annualIncomeCents).toBe(133333 * 12);
+      expect(r.verified).toBe(true);
+      expect(r.accountsLinked).toBe(1);
+      expect(r.sources).toHaveLength(1);
+
+      // Hit the sandbox host with creds in the body.
+      const [url, opts] = fetchMock.mock.calls[0];
+      expect(url).toBe("https://sandbox.plaid.com/sandbox/public_token/create");
+      const body = JSON.parse((opts as any).body);
+      expect(body.client_id).toBe("test-client");
+      expect(body.secret).toBe("test-secret");
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+    });
+
+    it("THROWS on a Plaid HTTP error (→ service HOLDs, never a false pass)", async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        json: async () => ({ error_code: "INVALID_API_KEYS", error_message: "bad creds" }),
+      });
+      await expect(new PlaidVendor().income(person())).rejects.toThrow(/INVALID_API_KEYS/);
+    });
+
+    it("THROWS when no deposits are found rather than reporting $0 verified", async () => {
+      fetchMock
+        .mockResolvedValueOnce(ok({ public_token: "public-sandbox-123" }))
+        .mockResolvedValueOnce(ok({ access_token: "access-sandbox-123" }))
+        .mockResolvedValueOnce(ok({ accounts: [{ account_id: "acc-1" }], transactions: [{ amount: 50 }] }));
+
+      await expect(new PlaidVendor().income(person())).rejects.toThrow(/no deposit transactions/i);
+    });
+
+    it("skips the bootstrap when a caller-supplied access_token is present", async () => {
+      fetchMock.mockResolvedValueOnce(
+        ok({ accounts: [{ account_id: "acc-1" }], transactions: [{ amount: -3000 }] })
+      );
+
+      const r = await new PlaidVendor().income({ ...person(), plaidAccessToken: "access-preexisting" });
+      expect(r.verified).toBe(true);
+      // Only the transactions call — no create/exchange.
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(fetchMock.mock.calls[0][0]).toBe("https://sandbox.plaid.com/transactions/get");
+    });
+  });
+});

--- a/src/modules/screening/background-check.ts
+++ b/src/modules/screening/background-check.ts
@@ -1,5 +1,5 @@
 import { logger } from "../../utils/logger";
-import { shouldUseScreeningStub, STUB_GATE_ERROR } from "./stub-policy";
+import { resolveVendor } from "./vendors";
 
 export interface BackgroundCheckResult {
   result: "pass" | "fail" | "review_required" | "could_not_screen";
@@ -17,16 +17,12 @@ export interface BackgroundCheckResult {
  * Third-party background check integration.
  * Auto-fail: felonies, sex offenses, violence.
  * Risk-scored: minor misdemeanors.
+ *
+ * The raw vendor response comes from the screening vendor seam
+ * (resolveVendor("background")); this service owns only Frank's evaluation
+ * policy (evaluateResults) and the fail-loud catch → could_not_screen HOLD.
  */
 export class BackgroundCheckService {
-  private apiUrl: string;
-  private apiKey: string;
-
-  constructor() {
-    this.apiUrl = process.env.SCREENING_API_URL || "https://api.screening-provider.example.com";
-    this.apiKey = process.env.SCREENING_API_KEY || "";
-  }
-
   async runCheck(input: {
     firstName: string;
     lastName: string;
@@ -40,8 +36,6 @@ export class BackgroundCheckService {
     });
 
     try {
-      // In production, this calls the third-party clearance company API.
-      // Stub implementation for development/testing.
       const response = await this.callScreeningAPI(input);
       return this.evaluateResults(response);
     } catch (err) {
@@ -71,66 +65,9 @@ export class BackgroundCheckService {
     state: string;
     screeningTag?: string;
   }): Promise<any> {
-    // STUB: Replace with actual API call in production
-    // Example: const response = await fetch(`${this.apiUrl}/v1/background-check`, { ... });
-
-    if (process.env.MOCK_MODE === "1" && input.screeningTag) {
-      return this.mockResponse(input.screeningTag);
-    }
-
-    if (!this.apiKey || this.apiKey === "changeme") {
-      if (!shouldUseScreeningStub()) {
-        throw new Error(STUB_GATE_ERROR);
-      }
-      logger.warn("Using stub background check — no API key configured (stub policy allows fallback)");
-      return {
-        felonies: 0,
-        sexOffenses: false,
-        violentCrimes: false,
-        misdemeanors: [],
-        records: [],
-      };
-    }
-
-    // Production implementation would go here
-    throw new Error("Production API integration not yet configured");
-  }
-
-  private mockResponse(tag: string): any {
-    if (tag === "deny_felony") {
-      return {
-        felonies: 1,
-        sexOffenses: false,
-        violentCrimes: false,
-        misdemeanors: [],
-        records: [{ type: "felony", description: "synthetic" }],
-      };
-    }
-    if (tag === "deny_sex_offender") {
-      return {
-        felonies: 0,
-        sexOffenses: true,
-        violentCrimes: false,
-        misdemeanors: [],
-        records: [{ type: "lifetime_registry", description: "synthetic" }],
-      };
-    }
-    if (tag === "review_misdemeanors") {
-      return {
-        felonies: 0,
-        sexOffenses: false,
-        violentCrimes: false,
-        misdemeanors: [{ code: "M-1" }, { code: "M-2" }, { code: "M-3" }],
-        records: [],
-      };
-    }
-    return {
-      felonies: 0,
-      sexOffenses: false,
-      violentCrimes: false,
-      misdemeanors: [],
-      records: [],
-    };
+    // Delegate the raw pull to the configured vendor. The vendor self-gates on
+    // the stub policy: keyless production THROWS here → caught above → HOLD.
+    return resolveVendor("background").background(input);
   }
 
   private evaluateResults(response: any): BackgroundCheckResult {

--- a/src/modules/screening/credit-check.ts
+++ b/src/modules/screening/credit-check.ts
@@ -1,5 +1,5 @@
 import { logger } from "../../utils/logger";
-import { shouldUseScreeningStub, STUB_GATE_ERROR } from "./stub-policy";
+import { resolveVendor } from "./vendors";
 
 export interface CreditCheckResult {
   result: "pass" | "fail" | "review_required" | "could_not_screen";
@@ -17,16 +17,12 @@ export interface CreditCheckResult {
 /**
  * Credit check integration.
  * Threshold: 600+ preferred, decision matrix allows exceptions.
+ *
+ * The raw vendor response comes from the screening vendor seam
+ * (resolveVendor("credit")); this service owns only Frank's evaluation policy
+ * (evaluateResults) and the fail-loud catch → could_not_screen HOLD.
  */
 export class CreditCheckService {
-  private apiUrl: string;
-  private apiKey: string;
-
-  constructor() {
-    this.apiUrl = process.env.SCREENING_API_URL || "https://api.screening-provider.example.com";
-    this.apiKey = process.env.SCREENING_API_KEY || "";
-  }
-
   async runCheck(input: {
     firstName: string;
     lastName: string;
@@ -68,58 +64,9 @@ export class CreditCheckService {
     dateOfBirth: string;
     screeningTag?: string;
   }): Promise<any> {
-    // STUB: Replace with actual credit bureau API call
-    if (process.env.MOCK_MODE === "1" && input.screeningTag) {
-      return this.mockResponse(input.screeningTag);
-    }
-
-    if (!this.apiKey || this.apiKey === "changeme") {
-      if (!shouldUseScreeningStub()) {
-        throw new Error(STUB_GATE_ERROR);
-      }
-      logger.warn("Using stub credit check — no API key configured (stub policy allows fallback)");
-      return {
-        creditScore: 680,
-        paymentHistory: "good",
-        outstandingDebts: 2500,
-        collections: 0,
-        evictions: 0,
-        bankruptcies: 0,
-      };
-    }
-
-    throw new Error("Production API integration not yet configured");
-  }
-
-  private mockResponse(tag: string): any {
-    if (tag === "review_low_credit") {
-      return {
-        creditScore: 520,
-        paymentHistory: "fair",
-        outstandingDebts: 8200,
-        collections: 1,
-        evictions: 0,
-        bankruptcies: 0,
-      };
-    }
-    if (tag === "approve_clean") {
-      return {
-        creditScore: 720,
-        paymentHistory: "excellent",
-        outstandingDebts: 1200,
-        collections: 0,
-        evictions: 0,
-        bankruptcies: 0,
-      };
-    }
-    return {
-      creditScore: 680,
-      paymentHistory: "good",
-      outstandingDebts: 2500,
-      collections: 0,
-      evictions: 0,
-      bankruptcies: 0,
-    };
+    // Delegate the raw pull to the configured vendor. The vendor self-gates on
+    // the stub policy: keyless production THROWS here → caught above → HOLD.
+    return resolveVendor("credit").credit(input);
   }
 
   private evaluateResults(response: any): CreditCheckResult {

--- a/src/modules/screening/income-verification-plaid.ts
+++ b/src/modules/screening/income-verification-plaid.ts
@@ -1,5 +1,5 @@
 import { logger } from "../../utils/logger";
-import { shouldUseScreeningStub, STUB_GATE_ERROR } from "./stub-policy";
+import { resolveVendor } from "./vendors";
 
 export interface PlaidIncomeResult {
   result: "verified" | "unverified" | "review_required";
@@ -26,16 +26,13 @@ export interface PlaidIncomeResult {
  * Cross-checked against Equifax Work Number when the applicant declares a
  * W-2 employer (FraudDetectionService.checkIncomeMismatch fires on >15%
  * delta between the two sources).
+ *
+ * The raw vendor response comes from the screening vendor seam
+ * (resolveVendor("income")); this service owns only the evaluation policy and
+ * the catch → review_required HOLD (Plaid failures are a softer hold than the
+ * could_not_screen used by background/credit).
  */
 export class PlaidIncomeService {
-  private clientId: string;
-  private secret: string;
-
-  constructor() {
-    this.clientId = process.env.PLAID_CLIENT_ID || "";
-    this.secret = process.env.PLAID_SECRET || "";
-  }
-
   async verifyIncome(input: {
     firstName: string;
     lastName: string;
@@ -74,65 +71,10 @@ export class PlaidIncomeService {
     plaidAccessToken?: string;
     screeningTag?: string;
   }): Promise<any> {
-    if (process.env.MOCK_MODE === "1" && input.screeningTag) {
-      return this.mockResponse(input.screeningTag);
-    }
-
-    if (!this.clientId || !this.secret || this.secret === "changeme") {
-      if (!shouldUseScreeningStub()) {
-        throw new Error(STUB_GATE_ERROR);
-      }
-      logger.warn("Using stub Plaid Income — no client_id/secret configured (stub policy allows fallback)");
-      return {
-        verified: true,
-        annualIncomeCents: 5400000,
-        monthlyAverageCents: 450000,
-        sources: [
-          { type: "payroll", employer: "Acme Co", monthlyAverageCents: 450000 },
-        ],
-        accountsLinked: 1,
-        monthsHistory: 24,
-      };
-    }
-
-    throw new Error("Production API integration not yet configured");
-  }
-
-  private mockResponse(tag: string): any {
-    if (tag === "fraud_income_mismatch") {
-      return {
-        verified: true,
-        annualIncomeCents: 3000000,
-        monthlyAverageCents: 250000,
-        sources: [
-          { type: "payroll", employer: "Acme Co", monthlyAverageCents: 250000 },
-        ],
-        accountsLinked: 1,
-        monthsHistory: 18,
-      };
-    }
-    if (tag === "deny_income_over_ami") {
-      return {
-        verified: true,
-        annualIncomeCents: 9000000,
-        monthlyAverageCents: 750000,
-        sources: [
-          { type: "payroll", employer: "Acme Co", monthlyAverageCents: 750000 },
-        ],
-        accountsLinked: 1,
-        monthsHistory: 24,
-      };
-    }
-    return {
-      verified: true,
-      annualIncomeCents: 5400000,
-      monthlyAverageCents: 450000,
-      sources: [
-        { type: "payroll", employer: "Acme Co", monthlyAverageCents: 450000 },
-      ],
-      accountsLinked: 1,
-      monthsHistory: 24,
-    };
+    // Delegate the raw pull to the configured vendor (sandbox by default; plaid
+    // when SCREENING_VENDOR_INCOME=plaid + creds). The vendor self-gates on the
+    // stub policy: keyless production THROWS here → caught above → review_required.
+    return resolveVendor("income").income(input);
   }
 
   private evaluateResults(response: any): PlaidIncomeResult {

--- a/src/modules/screening/nsopw-direct.ts
+++ b/src/modules/screening/nsopw-direct.ts
@@ -1,5 +1,5 @@
 import { logger } from "../../utils/logger";
-import { shouldUseScreeningStub, STUB_GATE_ERROR } from "./stub-policy";
+import { resolveVendor } from "./vendors";
 
 export interface NsopwDirectResult {
   result: "no_match" | "match" | "review_required";
@@ -27,22 +27,11 @@ export interface NsopwDirectResult {
  * denial. If vendor and direct disagree, the orchestrator MUST hold for manual
  * review — never auto-pass on a partial match.
  *
- * Implementation notes:
- * - NSOPW.gov's public Web Services API requires registered access; in
- *   practice we proxy via a wrapper service (Sterling NSOPW endpoint or
- *   Inflection's NSOPW check) and treat NSOPW_API_KEY as the wrapper's key.
- * - The free direct-scrape path is fragile and rate-limited; not recommended
- *   for production. Stub fallback below mimics the wrapper response shape.
+ * The raw registry response comes from the screening vendor seam
+ * (resolveVendor("nsopw")); this service owns only the match evaluation and the
+ * catch → review_required HOLD (never auto-clears on a vendor failure).
  */
 export class NsopwDirectService {
-  private apiUrl: string;
-  private apiKey: string;
-
-  constructor() {
-    this.apiUrl = process.env.NSOPW_API_URL || "https://api.nsopw-proxy.example.com";
-    this.apiKey = process.env.NSOPW_API_KEY || "";
-  }
-
   async check(input: {
     firstName: string;
     lastName: string;
@@ -85,50 +74,10 @@ export class NsopwDirectService {
     states: string[];
     screeningTag?: string;
   }): Promise<any> {
-    if (process.env.MOCK_MODE === "1" && input.screeningTag) {
-      return this.mockResponse(input.screeningTag);
-    }
-
-    if (!this.apiKey || this.apiKey === "changeme") {
-      if (!shouldUseScreeningStub()) {
-        throw new Error(STUB_GATE_ERROR);
-      }
-      logger.warn("Using stub direct NSOPW check — no API key configured (stub policy allows fallback)");
-      return {
-        records: [],
-        searchedStates: input.states,
-        confidence: 0.99,
-        riskSignals: [],
-      };
-    }
-
-    throw new Error("Production direct NSOPW integration not yet configured");
-  }
-
-  private mockResponse(tag: string): any {
-    if (tag === "deny_sex_offender") {
-      return {
-        records: [
-          {
-            state: "NV",
-            nameMatch: true,
-            dobMatch: true,
-            addressHint: "Reno, NV (last known)",
-            riskTier: "high",
-          },
-        ],
-        searchedStates: ["NV"],
-        confidence: 0.98,
-        riskSignals: ["registry_match_name_and_dob"],
-      };
-    }
-
-    return {
-      records: [],
-      searchedStates: ["NV"],
-      confidence: 0.99,
-      riskSignals: [],
-    };
+    // Delegate the raw registry pull to the configured vendor. The vendor
+    // self-gates on the stub policy: keyless production THROWS here → caught
+    // above → review_required (a vendor outage never auto-clears the §5.856 gate).
+    return resolveVendor("nsopw").nsopw(input);
   }
 
   private evaluateResults(response: any, searchedStates: string[]): NsopwDirectResult {

--- a/src/modules/screening/vendors/index.ts
+++ b/src/modules/screening/vendors/index.ts
@@ -1,0 +1,11 @@
+/**
+ * Screening vendor seam — public barrel.
+ *
+ * Check services import { resolveVendor } from "./vendors" and delegate their
+ * raw-response step to it, while keeping their own compliance evaluation and
+ * catch/throw semantics. See ./types.ts for the seam contract.
+ */
+export * from "./types";
+export { resolveVendor, resolveVendorName, DEFAULT_SCREENING_VENDOR } from "./registry";
+export { SandboxVendor } from "./sandbox-vendor";
+export { PlaidVendor } from "./plaid-vendor";

--- a/src/modules/screening/vendors/plaid-vendor.ts
+++ b/src/modules/screening/vendors/plaid-vendor.ts
@@ -1,0 +1,197 @@
+import { logger } from "../../../utils/logger";
+import { shouldUseScreeningStub, STUB_GATE_ERROR } from "../stub-policy";
+import type {
+  ScreeningVendor,
+  ScreeningCheckDomain,
+  BackgroundVendorInput,
+  BackgroundVendorResponse,
+  CreditVendorInput,
+  CreditVendorResponse,
+  IncomeVendorInput,
+  IncomeVendorResponse,
+  NsopwVendorInput,
+  NsopwVendorResponse,
+  EmploymentVendorInput,
+  EmploymentVendorResponse,
+} from "./types";
+
+const PLAID_HOSTS: Record<string, string> = {
+  sandbox: "https://sandbox.plaid.com",
+  development: "https://development.plaid.com",
+  production: "https://production.plaid.com",
+};
+
+// Plaid's canonical sandbox test institution + auto-login user.
+const SANDBOX_INSTITUTION_ID = "ins_109508";
+
+/**
+ * Real Plaid adapter — DORMANT until PLAID_CLIENT_ID + PLAID_SECRET are set.
+ *
+ * It supports ONLY the income domain (Plaid is an income/bank-link product).
+ * The registry refuses to resolve plaid for any other domain, so a misconfig
+ * like SCREENING_VENDOR=plaid HOLDS the non-income checks fail-loud rather than
+ * silently passing them.
+ *
+ * Activation:
+ *   SCREENING_VENDOR_INCOME=plaid   (route only income through Plaid)
+ *   PLAID_CLIENT_ID=...             (from the Plaid dashboard)
+ *   PLAID_SECRET=...                (sandbox secret to start)
+ *   PLAID_ENV=sandbox               (default; sandbox|development|production)
+ *
+ * When creds are absent the adapter is inert: it defers to the same fail-loud
+ * stub gate as everything else (throw STUB_GATE_ERROR unless the gate is open),
+ * so adding the dependency cannot change behaviour until creds land.
+ *
+ * The live path performs the genuine, credentials-only Plaid sandbox handshake
+ * (create sandbox public_token → exchange for an access_token → pull
+ * transactions) and derives a deposit-based income estimate. This is a
+ * sandbox-grade heuristic: production should migrate to the Plaid Income product
+ * (/credit/payroll_income/get with the Link income flow + user_token), which
+ * requires enabling Income on the dashboard. Any HTTP / shape / empty-signal
+ * failure THROWS — the PlaidIncomeService catch turns that into a review_required
+ * HOLD. The adapter never fabricates a passing income.
+ */
+export class PlaidVendor implements ScreeningVendor {
+  readonly name = "plaid";
+
+  supports(domain: ScreeningCheckDomain): boolean {
+    return domain === "income";
+  }
+
+  async income(input: IncomeVendorInput): Promise<IncomeVendorResponse> {
+    const clientId = process.env.PLAID_CLIENT_ID || "";
+    const secret = process.env.PLAID_SECRET || "";
+    const env = (process.env.PLAID_ENV || "sandbox").toLowerCase();
+    const base = PLAID_HOSTS[env] || PLAID_HOSTS.sandbox;
+
+    if (!clientId || !secret || secret === "changeme") {
+      // No credentials → dormant. Defer to the global fail-loud gate: throw in
+      // real production, return the deterministic stub only behind the gate.
+      if (!shouldUseScreeningStub()) {
+        throw new Error(STUB_GATE_ERROR);
+      }
+      logger.warn("Plaid vendor selected but no credentials configured — returning stub (stub policy allows fallback)");
+      return {
+        verified: true,
+        annualIncomeCents: 5400000,
+        monthlyAverageCents: 450000,
+        sources: [{ type: "payroll", employer: "Acme Co", monthlyAverageCents: 450000 }],
+        accountsLinked: 1,
+        monthsHistory: 24,
+      };
+    }
+
+    logger.info("Plaid live income verification", { env });
+    const auth = { client_id: clientId, secret };
+
+    // 1) Use the caller-supplied access_token if present; otherwise bootstrap a
+    //    sandbox item (create public_token → exchange). The bootstrap path only
+    //    makes sense in sandbox/development with the canonical test institution.
+    let accessToken = input.plaidAccessToken;
+    if (!accessToken) {
+      const created = await this.post(base, "/sandbox/public_token/create", {
+        ...auth,
+        institution_id: SANDBOX_INSTITUTION_ID,
+        initial_products: ["transactions"],
+      });
+      const publicToken = (created as any).public_token;
+      if (!publicToken) {
+        throw new Error("Plaid sandbox public_token/create returned no public_token");
+      }
+      const exchanged = await this.post(base, "/item/public_token/exchange", {
+        ...auth,
+        public_token: publicToken,
+      });
+      accessToken = (exchanged as any).access_token;
+      if (!accessToken) {
+        throw new Error("Plaid public_token/exchange returned no access_token");
+      }
+    }
+
+    // 2) Pull a 90-day transaction window and derive income from deposits.
+    const end = new Date();
+    const start = new Date(end.getTime() - 90 * 24 * 60 * 60 * 1000);
+    const txns = await this.post(base, "/transactions/get", {
+      ...auth,
+      access_token: accessToken,
+      start_date: start.toISOString().slice(0, 10),
+      end_date: end.toISOString().slice(0, 10),
+      options: { count: 500, offset: 0 },
+    });
+
+    return this.deriveIncome(txns);
+  }
+
+  /**
+   * Map a Plaid /transactions/get response to an IncomeVendorResponse.
+   *
+   * Plaid sign convention: a NEGATIVE amount is money entering the account (a
+   * deposit). We treat recurring deposits as income, average them per month over
+   * the window, and annualise. If no deposits are found we THROW so the service
+   * HOLDs for manual review rather than reporting $0 verified income.
+   */
+  private deriveIncome(txns: unknown): IncomeVendorResponse {
+    const accounts = Array.isArray((txns as any)?.accounts) ? (txns as any).accounts : [];
+    const transactions = Array.isArray((txns as any)?.transactions) ? (txns as any).transactions : [];
+
+    const deposits = transactions.filter((t: any) => typeof t?.amount === "number" && t.amount < 0);
+    if (deposits.length === 0) {
+      throw new Error("Plaid returned no deposit transactions — income could not be derived");
+    }
+
+    const totalCents = deposits.reduce(
+      (sum: number, t: any) => sum + Math.round(Math.abs(t.amount) * 100),
+      0
+    );
+    // Window is 90 days ≈ 3 months; never divide by zero.
+    const monthsHistory = 3;
+    const monthlyAverageCents = Math.round(totalCents / monthsHistory);
+    const annualIncomeCents = monthlyAverageCents * 12;
+
+    return {
+      verified: monthlyAverageCents > 0,
+      annualIncomeCents,
+      monthlyAverageCents,
+      sources: [{ type: "payroll", monthlyAverageCents }],
+      accountsLinked: accounts.length || 1,
+      monthsHistory,
+    };
+  }
+
+  private async post(base: string, path: string, body: Record<string, unknown>): Promise<unknown> {
+    const res = await fetch(`${base}${path}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      let detail = "";
+      try {
+        const err = (await res.json()) as any;
+        detail = err?.error_code ? `${err.error_code}: ${err.error_message ?? ""}` : JSON.stringify(err);
+      } catch {
+        detail = `HTTP ${res.status}`;
+      }
+      throw new Error(`Plaid ${path} failed — ${detail}`);
+    }
+    return res.json();
+  }
+
+  // ── Unsupported domains — defensive throws (registry already refuses these) ──
+
+  private unsupported(domain: ScreeningCheckDomain): never {
+    throw new Error(`Plaid vendor supports only the income check, not ${domain}`);
+  }
+  async background(_input: BackgroundVendorInput): Promise<BackgroundVendorResponse> {
+    return this.unsupported("background");
+  }
+  async credit(_input: CreditVendorInput): Promise<CreditVendorResponse> {
+    return this.unsupported("credit");
+  }
+  async nsopw(_input: NsopwVendorInput): Promise<NsopwVendorResponse> {
+    return this.unsupported("nsopw");
+  }
+  async employment(_input: EmploymentVendorInput): Promise<EmploymentVendorResponse> {
+    return this.unsupported("employment");
+  }
+}

--- a/src/modules/screening/vendors/registry.ts
+++ b/src/modules/screening/vendors/registry.ts
@@ -1,0 +1,54 @@
+import { SandboxVendor } from "./sandbox-vendor";
+import { PlaidVendor } from "./plaid-vendor";
+import type { ScreeningVendor, ScreeningCheckDomain } from "./types";
+
+/**
+ * Vendor registry — resolves which ScreeningVendor backs a given check domain.
+ *
+ * Resolution precedence (most specific wins):
+ *   1. SCREENING_VENDOR_<DOMAIN>   e.g. SCREENING_VENDOR_INCOME=plaid
+ *   2. SCREENING_VENDOR            global override for all domains
+ *   3. "sandbox"                   safe default (self-gating; HOLDs in keyless prod)
+ *
+ * Resolution happens PER CALL (no memoisation) on purpose: the contract test
+ * suites flip env between cases, and a real deployment may set per-domain vendors
+ * independently. Vendor constructors are side-effect-free (they read env lazily
+ * inside their methods), so per-call construction is cheap and env-accurate.
+ *
+ * If a configured vendor does not support the requested domain, resolveVendor
+ * THROWS. That throw surfaces inside the calling service's try block (or
+ * propagates, for work-number) and becomes a fail-loud HOLD — never a pass.
+ */
+
+export const DEFAULT_SCREENING_VENDOR = "sandbox";
+
+type VendorFactory = () => ScreeningVendor;
+
+const VENDOR_FACTORIES: Record<string, VendorFactory> = {
+  sandbox: () => new SandboxVendor(),
+  plaid: () => new PlaidVendor(),
+};
+
+export function resolveVendorName(domain: ScreeningCheckDomain): string {
+  const perDomain = process.env[`SCREENING_VENDOR_${domain.toUpperCase()}`];
+  const name = (perDomain || process.env.SCREENING_VENDOR || DEFAULT_SCREENING_VENDOR).trim().toLowerCase();
+  return name || DEFAULT_SCREENING_VENDOR;
+}
+
+export function resolveVendor(domain: ScreeningCheckDomain): ScreeningVendor {
+  const name = resolveVendorName(domain);
+  const factory = VENDOR_FACTORIES[name];
+  if (!factory) {
+    throw new Error(
+      `Unknown screening vendor "${name}" configured for ${domain}. Known vendors: ${Object.keys(VENDOR_FACTORIES).join(", ")}.`
+    );
+  }
+  const vendor = factory();
+  if (!vendor.supports(domain)) {
+    throw new Error(
+      `Screening vendor "${name}" does not support the ${domain} check. ` +
+        `Configure a vendor that does (e.g. SCREENING_VENDOR_${domain.toUpperCase()}=sandbox).`
+    );
+  }
+  return vendor;
+}

--- a/src/modules/screening/vendors/sandbox-vendor.ts
+++ b/src/modules/screening/vendors/sandbox-vendor.ts
@@ -1,0 +1,245 @@
+import { logger } from "../../../utils/logger";
+import { shouldUseScreeningStub, STUB_GATE_ERROR } from "../stub-policy";
+import type {
+  ScreeningVendor,
+  ScreeningCheckDomain,
+  BackgroundVendorInput,
+  BackgroundVendorResponse,
+  CreditVendorInput,
+  CreditVendorResponse,
+  IncomeVendorInput,
+  IncomeVendorResponse,
+  NsopwVendorInput,
+  NsopwVendorResponse,
+  EmploymentVendorInput,
+  EmploymentVendorResponse,
+} from "./types";
+
+/**
+ * In-house, credential-free, fully deterministic screening vendor.
+ *
+ * This is the DEFAULT vendor (registry resolves to "sandbox" when nothing is
+ * configured) and the only vendor that can produce verdicts today with zero
+ * credentials. It is what lets SCREENING_ON_SUBMIT_ENABLED be flipped on in a
+ * dev/demo environment and produce real (clean) verdicts instead of parking
+ * every applicant in could_not_screen.
+ *
+ * COMPLIANCE — why this is safe as the production default:
+ *   The sandbox returns PASSING data. On its own that would be a catastrophic
+ *   silent-pass in a keyless prod deploy. It is safe ONLY because every method
+ *   self-gates on shouldUseScreeningStub(): when the gate is closed (real
+ *   production, no MOCK_MODE / ALLOW_STUB_SCREENING / NODE_ENV=test) the method
+ *   THROWS STUB_GATE_ERROR instead of returning clean data. The calling service
+ *   then turns that throw into its fail-loud HOLD (could_not_screen for
+ *   background/credit, review_required for income/nsopw, a propagating throw for
+ *   employment). Net effect in real prod: byte-identical to today's keyless HOLD.
+ *
+ * The fixtures below are lifted verbatim from each service's former private
+ * mockResponse()/stub literals, so MOCK_MODE demo tags and the no-key stub paths
+ * behave exactly as before. Tag handling mirrors the old order precisely:
+ *   MOCK_MODE=1 + screeningTag  → tagged fixture (unknown tag → clean default)
+ *   else                         → gate, then clean stub
+ */
+export class SandboxVendor implements ScreeningVendor {
+  readonly name = "sandbox";
+
+  supports(_domain: ScreeningCheckDomain): boolean {
+    return true;
+  }
+
+  /** Fail-loud gate: refuse to fabricate a verdict unless stub use is allowed. */
+  private requireGate(): void {
+    if (!shouldUseScreeningStub()) {
+      throw new Error(STUB_GATE_ERROR);
+    }
+  }
+
+  // ── background ──────────────────────────────────────────────────────────────
+
+  async background(input: BackgroundVendorInput): Promise<BackgroundVendorResponse> {
+    if (process.env.MOCK_MODE === "1" && input.screeningTag) {
+      return this.backgroundFixture(input.screeningTag);
+    }
+    this.requireGate();
+    logger.warn("Using sandbox background check — deterministic clean stub (stub policy allows fallback)");
+    return this.backgroundClean();
+  }
+
+  private backgroundClean(): BackgroundVendorResponse {
+    return { felonies: 0, sexOffenses: false, violentCrimes: false, misdemeanors: [], records: [] };
+  }
+
+  private backgroundFixture(tag: string): BackgroundVendorResponse {
+    if (tag === "deny_felony") {
+      return {
+        felonies: 1,
+        sexOffenses: false,
+        violentCrimes: false,
+        misdemeanors: [],
+        records: [{ type: "felony", description: "synthetic" }],
+      };
+    }
+    if (tag === "deny_sex_offender") {
+      return {
+        felonies: 0,
+        sexOffenses: true,
+        violentCrimes: false,
+        misdemeanors: [],
+        records: [{ type: "lifetime_registry", description: "synthetic" }],
+      };
+    }
+    if (tag === "review_misdemeanors") {
+      return {
+        felonies: 0,
+        sexOffenses: false,
+        violentCrimes: false,
+        misdemeanors: [{ code: "M-1" }, { code: "M-2" }, { code: "M-3" }],
+        records: [],
+      };
+    }
+    return this.backgroundClean();
+  }
+
+  // ── credit ──────────────────────────────────────────────────────────────────
+
+  async credit(input: CreditVendorInput): Promise<CreditVendorResponse> {
+    if (process.env.MOCK_MODE === "1" && input.screeningTag) {
+      return this.creditFixture(input.screeningTag);
+    }
+    this.requireGate();
+    logger.warn("Using sandbox credit check — deterministic clean stub (stub policy allows fallback)");
+    return this.creditClean();
+  }
+
+  private creditClean(): CreditVendorResponse {
+    return {
+      creditScore: 680,
+      paymentHistory: "good",
+      outstandingDebts: 2500,
+      collections: 0,
+      evictions: 0,
+      bankruptcies: 0,
+    };
+  }
+
+  private creditFixture(tag: string): CreditVendorResponse {
+    if (tag === "review_low_credit") {
+      return {
+        creditScore: 520,
+        paymentHistory: "fair",
+        outstandingDebts: 8200,
+        collections: 1,
+        evictions: 0,
+        bankruptcies: 0,
+      };
+    }
+    if (tag === "approve_clean") {
+      return {
+        creditScore: 720,
+        paymentHistory: "excellent",
+        outstandingDebts: 1200,
+        collections: 0,
+        evictions: 0,
+        bankruptcies: 0,
+      };
+    }
+    return this.creditClean();
+  }
+
+  // ── income ────────────────────────────────────────────────────────────────────
+
+  async income(input: IncomeVendorInput): Promise<IncomeVendorResponse> {
+    if (process.env.MOCK_MODE === "1" && input.screeningTag) {
+      return this.incomeFixture(input.screeningTag);
+    }
+    this.requireGate();
+    logger.warn("Using sandbox Plaid Income — deterministic clean stub (stub policy allows fallback)");
+    return this.incomeClean();
+  }
+
+  private incomeClean(): IncomeVendorResponse {
+    return {
+      verified: true,
+      annualIncomeCents: 5400000,
+      monthlyAverageCents: 450000,
+      sources: [{ type: "payroll", employer: "Acme Co", monthlyAverageCents: 450000 }],
+      accountsLinked: 1,
+      monthsHistory: 24,
+    };
+  }
+
+  private incomeFixture(tag: string): IncomeVendorResponse {
+    if (tag === "fraud_income_mismatch") {
+      return {
+        verified: true,
+        annualIncomeCents: 3000000,
+        monthlyAverageCents: 250000,
+        sources: [{ type: "payroll", employer: "Acme Co", monthlyAverageCents: 250000 }],
+        accountsLinked: 1,
+        monthsHistory: 18,
+      };
+    }
+    if (tag === "deny_income_over_ami") {
+      return {
+        verified: true,
+        annualIncomeCents: 9000000,
+        monthlyAverageCents: 750000,
+        sources: [{ type: "payroll", employer: "Acme Co", monthlyAverageCents: 750000 }],
+        accountsLinked: 1,
+        monthsHistory: 24,
+      };
+    }
+    return this.incomeClean();
+  }
+
+  // ── NSOPW ─────────────────────────────────────────────────────────────────────
+
+  async nsopw(input: NsopwVendorInput): Promise<NsopwVendorResponse> {
+    if (process.env.MOCK_MODE === "1" && input.screeningTag) {
+      return this.nsopwFixture(input.screeningTag);
+    }
+    this.requireGate();
+    logger.warn("Using sandbox direct NSOPW check — deterministic no-match stub (stub policy allows fallback)");
+    return { records: [], searchedStates: input.states, confidence: 0.99, riskSignals: [] };
+  }
+
+  private nsopwFixture(tag: string): NsopwVendorResponse {
+    if (tag === "deny_sex_offender") {
+      return {
+        records: [
+          {
+            state: "NV",
+            nameMatch: true,
+            dobMatch: true,
+            addressHint: "Reno, NV (last known)",
+            riskTier: "high",
+          },
+        ],
+        searchedStates: ["NV"],
+        confidence: 0.98,
+        riskSignals: ["registry_match_name_and_dob"],
+      };
+    }
+    return { records: [], searchedStates: ["NV"], confidence: 0.99, riskSignals: [] };
+  }
+
+  // ── employment ──────────────────────────────────────────────────────────────
+
+  async employment(_input: EmploymentVendorInput): Promise<EmploymentVendorResponse> {
+    // No demo tags for employment — work-number.ts never passed a screeningTag.
+    this.requireGate();
+    logger.warn("Using sandbox Work Number verification — deterministic stub (stub policy allows fallback)");
+    return {
+      result: "verified",
+      details: {
+        currentEmployer: "STUB Employer Inc.",
+        employmentStatus: "active",
+        hireDate: "2023-01-01",
+        terminationDate: null,
+        annualizedIncome: 45000,
+        incomeSource: "employer_reported",
+        rawResponse: { stub: true },
+      },
+    };
+  }
+}

--- a/src/modules/screening/vendors/types.ts
+++ b/src/modules/screening/vendors/types.ts
@@ -1,0 +1,165 @@
+/**
+ * Screening vendor seam — the pluggable abstraction that lets Frank swap the
+ * source of each screening signal (background, credit, income, NSOPW,
+ * employment) without touching the compliance logic in the check services.
+ *
+ * Design contract (why this seam exists):
+ * - Each check SERVICE owns Frank's compliance POLICY (evaluateResults +
+ *   pass/fail/review/could_not_screen semantics + its catch/throw behaviour).
+ * - Each VENDOR owns only "produce a raw response, or refuse." A vendor never
+ *   decides pass/fail — it returns facts (or throws) and the service judges.
+ *
+ * The fail-loud invariant (stub-policy.ts) lives BELOW this seam: a vendor that
+ * cannot legitimately produce a verdict (keyless production, no escape hatch)
+ * MUST throw STUB_GATE_ERROR rather than fabricate a passing response. The
+ * SandboxVendor self-gates on shouldUseScreeningStub() precisely so that the
+ * default vendor resolution ("sandbox") stays safe in production — a keyless
+ * prod deploy still HOLDS every applicant, byte-identical to today.
+ *
+ * The raw response shapes below are exactly what each service's evaluateResults
+ * already consumes (previously the private mockResponse/stub literals). Typing
+ * them here makes the seam contract explicit without changing any verdict math.
+ */
+
+export type ScreeningCheckDomain =
+  | "background"
+  | "credit"
+  | "income"
+  | "nsopw"
+  | "employment";
+
+// ── background ──────────────────────────────────────────────────────────────
+
+export interface BackgroundVendorInput {
+  firstName: string;
+  lastName: string;
+  ssnLast4: string;
+  dateOfBirth: string;
+  state: string;
+  screeningTag?: string;
+}
+
+export interface BackgroundVendorResponse {
+  felonies: number;
+  sexOffenses: boolean;
+  violentCrimes: boolean;
+  misdemeanors: unknown[];
+  records: unknown[];
+}
+
+// ── credit ──────────────────────────────────────────────────────────────────
+
+export interface CreditVendorInput {
+  firstName: string;
+  lastName: string;
+  ssnLast4: string;
+  dateOfBirth: string;
+  screeningTag?: string;
+}
+
+export interface CreditVendorResponse {
+  creditScore: number;
+  paymentHistory: string;
+  outstandingDebts: number;
+  collections: number;
+  evictions: number;
+  bankruptcies: number;
+}
+
+// ── income (Plaid-shaped) ─────────────────────────────────────────────────────
+
+export interface IncomeVendorInput {
+  firstName: string;
+  lastName: string;
+  dateOfBirth: string;
+  plaidAccessToken?: string;
+  screeningTag?: string;
+}
+
+export interface IncomeVendorResponse {
+  verified: boolean;
+  annualIncomeCents: number;
+  monthlyAverageCents: number;
+  sources: Array<{
+    type: "payroll" | "self_employment" | "benefits" | "other";
+    employer?: string;
+    monthlyAverageCents: number;
+  }>;
+  accountsLinked: number;
+  monthsHistory: number;
+}
+
+// ── NSOPW ─────────────────────────────────────────────────────────────────────
+
+export interface NsopwVendorInput {
+  firstName: string;
+  lastName: string;
+  dateOfBirth: string;
+  states: string[];
+  screeningTag?: string;
+}
+
+export interface NsopwVendorRecord {
+  state: string;
+  nameMatch: boolean;
+  dobMatch: boolean;
+  addressHint?: string;
+  riskTier: "high" | "medium" | "low";
+}
+
+export interface NsopwVendorResponse {
+  records: NsopwVendorRecord[];
+  searchedStates: string[];
+  confidence: number;
+  riskSignals: string[];
+}
+
+// ── employment (Work Number-shaped) ───────────────────────────────────────────
+//
+// Employment is the one domain where the vendor returns a near-final verdict
+// rather than raw facts: work-number.ts has no evaluateResults step (it has no
+// internal try/catch either — the P1 fail-loud contract requires the gate throw
+// to PROPAGATE). So the employment vendor response is structurally identical to
+// WorkNumberResult and the service returns it directly.
+
+export interface EmploymentVendorInput {
+  firstName: string;
+  lastName: string;
+  ssn: string;
+  dateOfBirth: string;
+  screeningTag?: string;
+}
+
+export interface EmploymentVendorResponse {
+  result: "verified" | "no_record" | "partial" | "review_required";
+  details: {
+    currentEmployer?: string;
+    employmentStatus?: "active" | "inactive" | "unknown";
+    hireDate?: string;
+    terminationDate?: string | null;
+    annualizedIncome?: number;
+    incomeSource?: "employer_reported" | "calculated" | "self_reported";
+    rawResponse?: Record<string, unknown>;
+  };
+}
+
+// ── the vendor interface ──────────────────────────────────────────────────────
+
+/**
+ * A screening vendor supplies raw responses for one or more check domains.
+ *
+ * A vendor that does not support a domain MUST report so via supports() — the
+ * registry refuses to resolve an unsupported (vendor, domain) pair and throws,
+ * which the calling service turns into a fail-loud HOLD. The per-domain methods
+ * of an unsupported domain may also throw defensively; they should never return
+ * a fabricated passing response.
+ */
+export interface ScreeningVendor {
+  readonly name: string;
+  supports(domain: ScreeningCheckDomain): boolean;
+  background(input: BackgroundVendorInput): Promise<BackgroundVendorResponse>;
+  credit(input: CreditVendorInput): Promise<CreditVendorResponse>;
+  income(input: IncomeVendorInput): Promise<IncomeVendorResponse>;
+  nsopw(input: NsopwVendorInput): Promise<NsopwVendorResponse>;
+  employment(input: EmploymentVendorInput): Promise<EmploymentVendorResponse>;
+}

--- a/src/modules/screening/work-number.ts
+++ b/src/modules/screening/work-number.ts
@@ -1,5 +1,5 @@
 import { logger } from "../../utils/logger";
-import { shouldUseScreeningStub, STUB_GATE_ERROR } from "./stub-policy";
+import { resolveVendor } from "./vendors";
 
 export interface WorkNumberResult {
   result: "verified" | "no_record" | "partial" | "review_required";
@@ -22,18 +22,15 @@ export interface WorkNumberResult {
  * module because Work Number is a separately credentialed Equifax product
  * with its own auth + endpoint, distinct from credit / criminal pulls.
  *
- * Stub pattern matches loft.ts / onesite.ts / background-check.ts: env-gated,
- * stub fallback when key absent, throws on production path until credentialed.
+ * P1 fail-loud contract: this service has NO internal try/catch. Employment is
+ * the one domain where the vendor returns a near-final verdict (no
+ * evaluateResults step), and a keyless-production gate error must PROPAGATE so
+ * the orchestrator's call-site wrapper contains it as could_not_screen rather
+ * than letting it look like a "verified" pass. The seam preserves that: the
+ * sandbox vendor's employment() throws STUB_GATE_ERROR when the stub gate is
+ * closed, and that throw flows straight out of verifyEmployment.
  */
 export class WorkNumberService {
-  private apiUrl: string;
-  private apiKey: string;
-
-  constructor() {
-    this.apiUrl = process.env.WORK_NUMBER_API_URL || "https://api.theworknumber.example.com";
-    this.apiKey = process.env.WORK_NUMBER_API_KEY || "";
-  }
-
   async verifyEmployment(input: {
     firstName: string;
     lastName: string;
@@ -44,30 +41,9 @@ export class WorkNumberService {
       applicant: `${input.firstName} ${input.lastName}`,
     });
 
-    if (!this.apiKey || this.apiKey === "changeme") {
-      // Fail-loud: a keyless production deploy must NOT silently report every
-      // applicant as employment-verified. Stub data is only allowed behind the
-      // explicit stub-policy gate (MOCK_MODE / ALLOW_STUB_SCREENING / test);
-      // otherwise throw so the missing key surfaces as a hard error instead of
-      // a false-positive "verified". (Matches credit-check.ts / nsopw-direct.ts.)
-      if (!shouldUseScreeningStub()) {
-        throw new Error(STUB_GATE_ERROR);
-      }
-      logger.warn("Using stub Work Number verification — no API key configured (stub policy allows fallback)");
-      return {
-        result: "verified",
-        details: {
-          currentEmployer: "STUB Employer Inc.",
-          employmentStatus: "active",
-          hireDate: "2023-01-01",
-          terminationDate: null,
-          annualizedIncome: 45000,
-          incomeSource: "employer_reported",
-          rawResponse: { stub: true },
-        },
-      };
-    }
-
-    throw new Error("Work Number production API not yet configured");
+    // Delegate to the configured vendor. No catch — a keyless-production gate
+    // error propagates by design (see class docblock). The employment vendor
+    // response is structurally a WorkNumberResult.
+    return resolveVendor("employment").employment(input);
   }
 }


### PR DESCRIPTION
## What

Increment **#2** of the screening build: a pluggable **`ScreeningVendor` seam**. The five checks (background / credit / income / nsopw / employment) now resolve their raw data source through a **per-domain registry** instead of each service hard-coding its own API URL + inline stub.

This is the piece that lets `SCREENING_ON_SUBMIT_ENABLED` be flipped on **safely**: with a vendor wired, applicants get real (sandbox) verdicts instead of every submit parking in `could_not_screen` HOLD.

## Design

- **One interface, two implementations.**
  - **`SandboxVendor`** (default) — in-house, deterministic, zero-credential. Verifiable today.
  - **`PlaidVendor`** — real Plaid-sandbox adapter, **dormant** until creds land.
- **Service owns policy, vendor owns data.** Services keep `evaluateResults` + their fail-loud `catch → HOLD`. Vendors only *produce raw data or refuse (throw)*. The private `callScreeningAPI` / `callCreditAPI` methods are **preserved** (bodies delegate to the registry) so the existing `jest.spyOn`-by-name tests keep working.
- **Resolution precedence:** `SCREENING_VENDOR_<DOMAIN>` ?? `SCREENING_VENDOR` ?? `"sandbox"`. Unknown vendor or unsupported domain **throws** (fail-loud).

## Why this is safe as a production default (the fail-loud invariant)

`SandboxVendor` returns *passing* data — which on its own would be a catastrophic silent-pass in a keyless prod deploy. It is safe **only** because every method self-gates on `shouldUseScreeningStub()`:

- gate **open** (MOCK_MODE / ALLOW_STUB_SCREENING / NODE_ENV=test) → clean/fixture data
- gate **closed** (real keyless prod) → **throws `STUB_GATE_ERROR`** → each service's existing catch turns it into its HOLD (`could_not_screen` for background/credit, `review_required` for income/nsopw, a propagating throw for employment per the P1 contract).

**Net effect in real prod: byte-identical to today's keyless HOLD behaviour.**

Sandbox fixtures are lifted **verbatim** from each service's former `mockResponse()`/stub literals, so MOCK_MODE demo tags are unchanged.

## Plaid (dormant)

Supports **income only** (registry refuses it for other domains → those HOLD rather than silently pass). Inert without `PLAID_CLIENT_ID`/`PLAID_SECRET`. With creds + `SCREENING_VENDOR_INCOME=plaid`, runs the genuine sandbox handshake (`create` → `exchange` → `transactions`) and derives deposit-based income. Any HTTP / shape / empty-signal failure **throws** → `review_required` HOLD. Never fabricates a pass.

## Scope guardrail

`background-check`'s naive felony auto-fail logic is **UNTOUCHED** — no real records reach it (sandbox returns clean), so no FHA exposure ships here. The criminal-decision engine is increment **#3**.

## Tests

- New `screening-vendor-seam.test.ts` (18): registry precedence/refusal, sandbox self-gating (open/closed/ALLOW_STUB/MOCK_MODE), Plaid scaffold (request shape, income mapping, HTTP-error + empty-signal degradation, access_token shortcut) via mocked `fetch`.
- Full repo suite: **1488 passing / 15 skipped**, `tsc --noEmit` clean. All four contract suites (dormant-adapters, extended-checks, integrations, service) green and behaviour-preserving.

## Ships DARK

No deploy, no flag flip. `SCREENING_ON_SUBMIT_ENABLED` and `SCREENING_EXTENDED_CHECKS_ENABLED` stay **OFF**. Default vendor resolution stays fail-loud in prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)