### PR TITLE
feat(screening): Stripe Identity production integration (Phase 4b) — dark behind IDENTITY_VERIFICATION_ENABLED

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -139,8 +139,11 @@ RESEND_FROM=CDPC Nevada <onboarding@resend.dev>
 #                    background-check.ts). The one pair already exercised today.
 SCREENING_API_URL=https://api.screening-provider.example.com
 SCREENING_API_KEY=changeme
-# IDENTITY_API_*   — identity / SSN-trace verification, first gate of
-#                    runFullScreening (identity-verification.ts, #205).
+# IDENTITY_API_*   — LEGACY. The Phase 4b production identity gate is Stripe
+#                    Identity (see IDENTITY_VERIFICATION_ENABLED below), which
+#                    reuses STRIPE_SECRET_KEY + STRIPE_WEBHOOK_SECRET — NOT these.
+#                    These vars only feed the legacy synchronous verify() stub
+#                    path (MOCK / keyless); left here for the dormant fixture flow.
 IDENTITY_API_URL=https://api.identity-provider.example.com
 IDENTITY_API_KEY=changeme
 # NSOPW_API_*      — direct National Sex Offender registry proxy (nsopw-direct.ts),
@@ -220,6 +223,22 @@ COMPLIANCE_TAPE_V2_ENABLED=false
 # Default off ⇒ byte-for-byte current behavior (manual /screen only). A failed
 # pipeline leaves the app in `screening` (non-approvable), never a silent pass.
 SCREENING_ON_SUBMIT_ENABLED=false
+
+# Stripe Identity verification (Phase 4b — first real vendor integration). When
+# true, submitting an application creates a Stripe Identity VerificationSession,
+# parks the app in `awaiting_identity`, and the applicant completes an ID +
+# selfie/liveness capture on Stripe's hosted flow. The verdict arrives via the
+# EXISTING /api/payments/webhook (identity.verification_session.* events) — no
+# new vendor key: reuses STRIPE_SECRET_KEY + STRIPE_WEBHOOK_SECRET above. The
+# webhook lands the verdict and advances awaiting_identity → screening (or →
+# screening_review on a could_not_screen HOLD; never an auto-pass).
+#
+# Independent of SCREENING_ON_SUBMIT_ENABLED: with this on but that off, identity
+# is captured and staff still run manual /screen (which reads the stored verdict
+# via identity.resolve()). Default off ⇒ byte-identical to the legacy path.
+# Rollback is a flag flip — no redeploy. Requires Stripe Identity enabled in the
+# Dashboard + identity.verification_session.* added to the webhook endpoint.
+IDENTITY_VERIFICATION_ENABLED=false
 
 # Supabase Storage (optional — enables /api/qa/bundles, the operator QA viewer).
 # When unset, the QA viewer returns an empty list with a hint banner instead

--- a/client-tenant/src/pages/Status.tsx
+++ b/client-tenant/src/pages/Status.tsx
@@ -56,6 +56,10 @@ function stageFor(status: string): StageState {
 
   if (status === 'submitted') return { current: 'submitted', done: new Set() };
 
+  // awaiting_identity (Phase 4b) — submitted, now completing the Stripe Identity
+  // capture; screening (docs) has not started yet. Stays in the submitted stage.
+  if (status === 'awaiting_identity') return { current: 'submitted', done: new Set() };
+
   if (status.startsWith('screening')) {
     return { current: 'docs', done: new Set(['submitted']) };
   }
@@ -90,6 +94,7 @@ function stageFor(status: string): StageState {
 const STATUS_BADGE: Record<string, { label: string; bg: string; fg: string }> = {
   draft: { label: 'Draft', bg: HF.warnLo, fg: HF.warn },
   submitted: { label: 'Submitted', bg: HF.accentLo, fg: HF.accentInk },
+  awaiting_identity: { label: 'Verify identity', bg: HF.accentLo, fg: HF.accentInk },
   screening: { label: 'Screening', bg: HF.accentLo, fg: HF.accentInk },
   screening_passed: { label: 'Screening passed', bg: HF.okLo, fg: HF.ok },
   screening_review: { label: 'Under review', bg: HF.warnLo, fg: HF.warn },
@@ -107,6 +112,7 @@ const STATUS_BADGE: Record<string, { label: string; bg: string; fg: string }> = 
 const SUBTITLE: Partial<Record<string, string>> = {
   draft: 'Finish your application to enter the queue.',
   submitted: 'We received your application. Frank is reviewing it next.',
+  awaiting_identity: 'One quick step: verify your identity to continue. Check your email or the apply tab for the secure link.',
   screening: 'Frank is verifying your documents.',
   screening_passed: 'Documents verified. The PM will review your file next.',
   screening_review: 'Your application is under review by our team — no action needed yet.',

--- a/client-tenant/src/types/index.ts
+++ b/client-tenant/src/types/index.ts
@@ -23,6 +23,7 @@ export interface ApiError {
 export type ApplicationStatus =
   | 'draft'
   | 'submitted'
+  | 'awaiting_identity'
   | 'screening'
   | 'screening_passed'
   | 'screening_failed'

--- a/client/src/components/StatusBadge.tsx
+++ b/client/src/components/StatusBadge.tsx
@@ -1,6 +1,7 @@
 const STATUS_COLORS: Record<string, string> = {
   draft: 'bg-gray-100 text-gray-600',
   submitted: 'bg-blue-100 text-blue-700',
+  awaiting_identity: 'bg-sky-100 text-sky-700',
   screening: 'bg-yellow-100 text-yellow-700',
   screening_review: 'bg-amber-100 text-amber-700',
   screening_passed: 'bg-emerald-100 text-emerald-700',

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -49,7 +49,7 @@ export function formatRole(role: UserRole | null | undefined): string {
 // ── Application types ─────────────────────────────────────────────
 
 export type ApplicationStatus =
-  | 'draft' | 'submitted' | 'screening' | 'screening_review' | 'screening_passed' | 'screening_failed'
+  | 'draft' | 'submitted' | 'awaiting_identity' | 'screening' | 'screening_review' | 'screening_passed' | 'screening_failed'
   | 'tier1_review' | 'tier1_approved' | 'tier1_denied'
   | 'tier2_review' | 'tier2_approved' | 'tier2_denied'
   | 'tier3_review' | 'tier3_approved' | 'tier3_denied'

--- a/src/__tests__/identity-verification-stripe.test.ts
+++ b/src/__tests__/identity-verification-stripe.test.ts
@@ -1,0 +1,306 @@
+/**
+ * Phase 4b — Stripe Identity adapter unit tests.
+ *
+ * Covers the pure mapping (mapStripeSessionToResult) table-driven, plus the
+ * resolve() flag gating and resolveStripeSession() read-back / HOLD semantics.
+ * No network: getStripe + the DB query are mocked.
+ */
+
+const mockQuery = jest.fn();
+const mockCreate = jest.fn();
+const mockRetrieve = jest.fn();
+
+jest.mock("../config/database", () => ({ query: (...a: unknown[]) => mockQuery(...a) }));
+jest.mock("../utils/logger", () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+jest.mock("../lib/stripe", () => ({
+  getStripe: () => ({
+    identity: {
+      verificationSessions: {
+        create: (...a: unknown[]) => mockCreate(...a),
+        retrieve: (...a: unknown[]) => mockRetrieve(...a),
+      },
+    },
+  }),
+}));
+
+import { IdentityVerificationService } from "../modules/screening/identity-verification";
+
+// Minimal VerificationSession factory — only the fields the mapper reads.
+function session(overrides: Record<string, unknown> = {}): any {
+  return {
+    id: "vs_test_123",
+    status: "verified",
+    last_error: null,
+    last_verification_report: null,
+    metadata: { applicationId: "app-1" },
+    ...overrides,
+  };
+}
+function report(doc: unknown, selfie: unknown, id = "vr_1"): any {
+  return { id, document: doc ?? null, selfie: selfie ?? null };
+}
+
+describe("IdentityVerificationService — Stripe Identity mapping", () => {
+  let svc: IdentityVerificationService;
+  beforeEach(() => {
+    jest.clearAllMocks();
+    svc = new IdentityVerificationService();
+    delete process.env.IDENTITY_VERIFICATION_ENABLED;
+    delete process.env.MOCK_MODE;
+  });
+
+  describe("mapStripeSessionToResult", () => {
+    it("verified session + clean report → verified, doc+selfie valid, idType mapped", () => {
+      const vs = session({
+        status: "verified",
+        last_verification_report: report(
+          { type: "driving_license", error: null, first_name: "Sam", last_name: "Lee" },
+          { error: null }
+        ),
+      });
+      const r = svc.mapStripeSessionToResult(vs);
+      expect(r.result).toBe("verified");
+      expect(r.details.documentValid).toBe(true);
+      expect(r.details.selfieMatch).toBe(true);
+      expect(r.idType).toBe("driver_license");
+      expect(r.confidence).toBeGreaterThanOrEqual(0.85);
+      expect(r.livenessScore).toBeGreaterThanOrEqual(0.85);
+    });
+
+    it.each([
+      ["passport", "passport"],
+      ["id_card", "state_id"],
+      ["driving_license", "driver_license"],
+      ["something_else", "unknown"],
+      [null, "unknown"],
+    ])("maps Stripe document type %s → %s", (stripeType, expected) => {
+      const vs = session({
+        status: "verified",
+        last_verification_report: report({ type: stripeType, error: null }, { error: null }),
+      });
+      expect(svc.mapStripeSessionToResult(vs).idType).toBe(expected);
+    });
+
+    it("processing → could_not_screen HOLD (never a pass)", () => {
+      const r = svc.mapStripeSessionToResult(session({ status: "processing" }));
+      expect(r.result).toBe("could_not_screen");
+    });
+
+    it("canceled → could_not_screen HOLD", () => {
+      const r = svc.mapStripeSessionToResult(session({ status: "canceled" }));
+      expect(r.result).toBe("could_not_screen");
+    });
+
+    it("requires_input + document error → rejected, surfaces categorical signal", () => {
+      const vs = session({
+        status: "requires_input",
+        last_verification_report: report(
+          { type: "driving_license", error: { code: "document_expired" } },
+          { error: null }
+        ),
+      });
+      const r = svc.mapStripeSessionToResult(vs);
+      expect(r.result).toBe("rejected");
+      expect(r.details.documentValid).toBe(false);
+      expect(r.details.riskSignals).toContain("document_document_expired");
+    });
+
+    it("requires_input + selfie error → rejected on selfie mismatch", () => {
+      const vs = session({
+        status: "requires_input",
+        last_verification_report: report(
+          { type: "passport", error: null },
+          { error: { code: "selfie_face_mismatch" } }
+        ),
+      });
+      const r = svc.mapStripeSessionToResult(vs);
+      expect(r.result).toBe("rejected");
+      expect(r.details.selfieMatch).toBe(false);
+      expect(r.details.riskSignals).toContain("selfie_selfie_face_mismatch");
+    });
+
+    it("requires_input with a clean report never grades verified (injects requires_input signal)", () => {
+      const vs = session({
+        status: "requires_input",
+        last_verification_report: report(
+          { type: "driving_license", error: null },
+          { error: null }
+        ),
+      });
+      const r = svc.mapStripeSessionToResult(vs);
+      expect(r.result).toBe("review_required");
+      expect(r.details.riskSignals).toContain("requires_input");
+    });
+
+    it("verified but name/DOB mismatch vs application → downgraded to review_required", () => {
+      const vs = session({
+        status: "verified",
+        last_verification_report: report(
+          {
+            type: "driving_license",
+            error: null,
+            first_name: "Robert",
+            last_name: "Smith",
+            dob: { year: 1990, month: 1, day: 2 },
+          },
+          { error: null }
+        ),
+      });
+      const r = svc.mapStripeSessionToResult(vs, {
+        firstName: "Bob",
+        lastName: "Smith",
+        dateOfBirth: "1990-01-02",
+      });
+      expect(r.result).toBe("review_required");
+      expect(r.details.riskSignals).toContain("name_dob_mismatch");
+    });
+
+    it("verified with matching name/DOB → stays verified (no mismatch signal)", () => {
+      const vs = session({
+        status: "verified",
+        last_verification_report: report(
+          {
+            type: "driving_license",
+            error: null,
+            first_name: "Bob",
+            last_name: "Smith",
+            dob: { year: 1990, month: 1, day: 2 },
+          },
+          { error: null }
+        ),
+      });
+      const r = svc.mapStripeSessionToResult(vs, {
+        firstName: "bob",
+        lastName: "SMITH",
+        dateOfBirth: "1990-01-02T00:00:00.000Z",
+      });
+      expect(r.result).toBe("verified");
+      expect(r.details.riskSignals).not.toContain("name_dob_mismatch");
+    });
+
+    it("rawResponse carries ONLY categorical fields — no name/DOB/document numbers", () => {
+      const vs = session({
+        status: "verified",
+        last_verification_report: report(
+          {
+            type: "driving_license",
+            error: null,
+            first_name: "Jane",
+            last_name: "Doe",
+            number: "D1234567",
+            dob: { year: 1985, month: 6, day: 15 },
+          },
+          { error: null }
+        ),
+      });
+      const raw = JSON.stringify(svc.mapStripeSessionToResult(vs).details.rawResponse);
+      expect(raw).toContain("vs_test_123");
+      expect(raw).not.toContain("Jane");
+      expect(raw).not.toContain("Doe");
+      expect(raw).not.toContain("D1234567");
+      expect(raw).not.toContain("1985");
+    });
+  });
+
+  describe("createSession", () => {
+    it("creates a document VerificationSession with selfie+liveness and idempotency key", async () => {
+      mockCreate.mockResolvedValue({
+        id: "vs_new",
+        status: "requires_input",
+        client_secret: "vs_new_secret",
+        url: "https://verify.stripe.com/vs_new",
+      });
+      const handle = await svc.createSession({ applicationId: "app-42", returnUrl: "https://app/return" });
+      expect(handle).toEqual({
+        id: "vs_new",
+        status: "requires_input",
+        clientSecret: "vs_new_secret",
+        url: "https://verify.stripe.com/vs_new",
+      });
+      const [params, opts] = mockCreate.mock.calls[0];
+      expect(params.type).toBe("document");
+      expect(params.options.document.require_matching_selfie).toBe(true);
+      expect(params.options.document.require_live_capture).toBe(true);
+      expect(params.metadata.applicationId).toBe("app-42");
+      expect(params.return_url).toBe("https://app/return");
+      expect(opts.idempotencyKey).toBe("idv:app-42");
+    });
+  });
+
+  describe("resolve gating", () => {
+    it("MOCK_MODE + screeningTag → legacy verify() fixture path (no DB read)", async () => {
+      process.env.MOCK_MODE = "1";
+      const r = await svc.resolve({
+        applicationId: "app-1",
+        firstName: "A",
+        lastName: "B",
+        dateOfBirth: "1990-01-01",
+        screeningTag: "id_verification_fail",
+      });
+      expect(r.result).toBe("rejected"); // the fail fixture
+      expect(mockQuery).not.toHaveBeenCalled();
+    });
+
+    it("flag OFF → legacy verify() path, not the Stripe read-back", async () => {
+      // keyless + no stub allowance → verify() throws internally → could_not_screen
+      const r = await svc.resolve({
+        applicationId: "app-1",
+        firstName: "A",
+        lastName: "B",
+        dateOfBirth: "1990-01-01",
+      });
+      expect(["could_not_screen", "verified", "rejected", "review_required"]).toContain(r.result);
+      expect(mockQuery).not.toHaveBeenCalled();
+    });
+
+    describe("flag ON → resolveStripeSession read-back", () => {
+      beforeEach(() => {
+        process.env.IDENTITY_VERIFICATION_ENABLED = "true";
+      });
+
+      it("no session on file → could_not_screen HOLD", async () => {
+        mockQuery.mockResolvedValue({ rows: [{ identity_session_id: null }] });
+        const r = await svc.resolve({ applicationId: "app-1", firstName: "A", lastName: "B", dateOfBirth: "x" });
+        expect(r.result).toBe("could_not_screen");
+      });
+
+      it("session created but no terminal verdict yet → could_not_screen HOLD", async () => {
+        mockQuery.mockResolvedValue({
+          rows: [{ identity_session_id: "vs_1", identity_verification_completed_at: null }],
+        });
+        const r = await svc.resolve({ applicationId: "app-1", firstName: "A", lastName: "B", dateOfBirth: "x" });
+        expect(r.result).toBe("could_not_screen");
+      });
+
+      it("terminal verdict persisted → returns the stored full result", async () => {
+        const stored = {
+          result: "verified",
+          confidence: 0.95,
+          idType: "driver_license",
+          livenessScore: 0.99,
+          details: { documentValid: true, selfieMatch: true, riskSignals: [] },
+        };
+        mockQuery.mockResolvedValue({
+          rows: [
+            {
+              identity_session_id: "vs_1",
+              identity_verification_completed_at: new Date().toISOString(),
+              identity_verification_details: stored,
+            },
+          ],
+        });
+        const r = await svc.resolve({ applicationId: "app-1", firstName: "A", lastName: "B", dateOfBirth: "x" });
+        expect(r.result).toBe("verified");
+        expect(r.idType).toBe("driver_license");
+      });
+
+      it("DB lookup throws → could_not_screen HOLD (fail-loud, never pass)", async () => {
+        mockQuery.mockRejectedValue(new Error("db down"));
+        const r = await svc.resolve({ applicationId: "app-1", firstName: "A", lastName: "B", dateOfBirth: "x" });
+        expect(r.result).toBe("could_not_screen");
+      });
+    });
+  });
+});

--- a/src/__tests__/identity-webhook.test.ts
+++ b/src/__tests__/identity-webhook.test.ts
@@ -1,0 +1,311 @@
+/**
+ * Webhook tests for the Stripe Identity verdict path in
+ * src/modules/payment/webhook.ts (Phase 4b).
+ *
+ * Mirrors payment-webhook.test.ts: real Stripe SDK for the signature
+ * round-trip, mocked DB + collaborators for the side-effects. The heavy
+ * collaborators (state-machine transition, the screening pipeline, the
+ * mapper, audit) are mocked so these tests assert the WEBHOOK's routing /
+ * persistence / HOLD behavior — not those units (which have their own suites).
+ *
+ * getStripe() returns the REAL webhooks helper (so constructEvent does a real
+ * HMAC check) but a MOCKED identity.verificationSessions.retrieve — the real
+ * retrieve would hit the network.
+ */
+
+import express from "express";
+import request from "supertest";
+import Stripe from "stripe";
+
+const FAKE_KEY = "sk_test_signing_only_does_not_call_api";
+const WEBHOOK_SECRET = "whsec_test_fixture_secret_abcdef";
+const stripe = new Stripe(FAKE_KEY, { apiVersion: "2025-02-24.acacia" as Stripe.LatestApiVersion });
+
+const mockRetrieve = jest.fn();
+const mockMapStripeSessionToResult = jest.fn();
+const mockTransition = jest.fn();
+const mockRunFullScreening = jest.fn();
+
+jest.mock("../config/database", () => ({ query: jest.fn(), transaction: jest.fn() }));
+jest.mock("../utils/logger", () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+jest.mock("../middleware/audit", () => ({ writeAuditLog: jest.fn().mockResolvedValue(undefined) }));
+jest.mock("../utils/encryption", () => ({ decrypt: (v: string) => `decrypted(${v})` }));
+jest.mock("../modules/tape", () => ({ stampTape: jest.fn().mockResolvedValue(null) }));
+jest.mock("../modules/ledger/service", () => ({
+  LedgerService: jest.fn().mockImplementation(() => ({ recordPayment: jest.fn(), recordRefund: jest.fn() })),
+}));
+jest.mock("../modules/integrations/email", () => ({
+  getEmailService: () => ({ sendPaymentReceipt: jest.fn(), sendRefundConfirmation: jest.fn() }),
+}));
+
+jest.mock("../lib/stripe", () => ({
+  getStripe: () => ({
+    webhooks: stripe.webhooks,
+    identity: { verificationSessions: { retrieve: (...a: unknown[]) => mockRetrieve(...a) } },
+  }),
+  expectedLivemode: () => (process.env.STRIPE_SECRET_KEY ?? "").startsWith("sk_live_"),
+}));
+
+jest.mock("../modules/screening/identity-verification", () => ({
+  IdentityVerificationService: jest.fn().mockImplementation(() => ({
+    mapStripeSessionToResult: (...a: unknown[]) => mockMapStripeSessionToResult(...a),
+  })),
+}));
+jest.mock("../modules/screening/state-machine", () => ({
+  transitionApplicationStatus: (...a: unknown[]) => mockTransition(...a),
+}));
+jest.mock("../modules/screening/service", () => ({
+  ScreeningService: jest.fn().mockImplementation(() => ({ runFullScreening: mockRunFullScreening })),
+}));
+
+import { query } from "../config/database";
+import webhookRouter from "../modules/payment/webhook";
+
+const mockQuery = query as jest.MockedFunction<typeof query>;
+const flush = () => new Promise((resolve) => setImmediate(resolve));
+
+function buildApp() {
+  const app = express();
+  app.use("/webhook", webhookRouter);
+  return app;
+}
+const app = buildApp();
+
+const APP_ID = "11111111-2222-3333-4444-555555555555";
+
+function identityEvent(
+  type: string,
+  opts: { id?: string; sessionId?: string; status?: string; applicationId?: string | null } = {}
+) {
+  const metadata =
+    opts.applicationId === null ? {} : { applicationId: opts.applicationId ?? APP_ID };
+  return {
+    id: opts.id ?? "evt_idv_001",
+    object: "event",
+    api_version: "2025-02-24.acacia",
+    created: Math.floor(Date.now() / 1000),
+    type,
+    livemode: false,
+    pending_webhooks: 1,
+    request: { id: null, idempotency_key: null },
+    data: {
+      object: {
+        id: opts.sessionId ?? "vs_test_001",
+        object: "identity.verification_session",
+        status: opts.status ?? "verified",
+        metadata,
+      },
+    },
+  };
+}
+
+function signedHeader(payload: string, secret: string = WEBHOOK_SECRET): string {
+  return stripe.webhooks.generateTestHeaderString({ payload, secret });
+}
+
+async function postEvent(event: object) {
+  const payload = JSON.stringify(event);
+  return request(app)
+    .post("/webhook")
+    .set("Content-Type", "application/json")
+    .set("Stripe-Signature", signedHeader(payload))
+    .send(payload);
+}
+
+const originalSecret = process.env.STRIPE_WEBHOOK_SECRET;
+const originalScreenFlag = process.env.SCREENING_ON_SUBMIT_ENABLED;
+
+beforeAll(() => {
+  process.env.STRIPE_WEBHOOK_SECRET = WEBHOOK_SECRET;
+});
+afterAll(() => {
+  process.env.STRIPE_WEBHOOK_SECRET = originalSecret;
+  process.env.SCREENING_ON_SUBMIT_ENABLED = originalScreenFlag;
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  delete process.env.SCREENING_ON_SUBMIT_ENABLED;
+
+  // SQL-routed DB mock — robust to call ordering.
+  mockQuery.mockImplementation((sql: any) => {
+    const s = String(sql);
+    if (/stripe_processed_events/i.test(s) && /SELECT/i.test(s)) {
+      return Promise.resolve({ rows: [] }) as any; // alreadyProcessed → not a dup
+    }
+    if (/FROM applications a/i.test(s) && /LEFT JOIN users/i.test(s)) {
+      return Promise.resolve({
+        rows: [
+          {
+            submitted_by: "99999999-8888-7777-6666-555555555555",
+            submitter_role: "applicant",
+            first_name: "Sam",
+            last_name: "Lee",
+            date_of_birth_encrypted: "enc",
+          },
+        ],
+      }) as any; // ctx
+    }
+    if (/UPDATE applications SET\s+identity_verification_result/i.test(s)) {
+      return Promise.resolve({ rows: [{ id: APP_ID }] }) as any; // persist (in awaiting_identity)
+    }
+    return Promise.resolve({ rows: [] }) as any; // markProcessed, overall update, session_status
+  });
+
+  mockRetrieve.mockResolvedValue({
+    id: "vs_test_001",
+    status: "verified",
+    last_verification_report: { id: "vr_1", document: { type: "driving_license", error: null }, selfie: { error: null } },
+  });
+  mockTransition.mockResolvedValue({ changed: true, status: "screening" });
+  mockRunFullScreening.mockResolvedValue({});
+});
+
+describe("POST /webhook — identity.verification_session.verified", () => {
+  it("maps the session, persists the verdict, advances → screening, returns 200", async () => {
+    mockMapStripeSessionToResult.mockReturnValue({
+      result: "verified",
+      confidence: 0.95,
+      idType: "driver_license",
+      livenessScore: 0.99,
+      details: { documentValid: true, selfieMatch: true, riskSignals: [] },
+    });
+
+    const res = await postEvent(identityEvent("identity.verification_session.verified"));
+
+    expect(res.status).toBe(200);
+    expect(mockRetrieve).toHaveBeenCalledWith("vs_test_001", { expand: ["last_verification_report"] });
+    expect(mockMapStripeSessionToResult).toHaveBeenCalled();
+    // persisted the verdict guarded to awaiting_identity
+    const persistCall = mockQuery.mock.calls.find((c) =>
+      /UPDATE applications SET\s+identity_verification_result/i.test(String(c[0]))
+    );
+    expect(persistCall).toBeDefined();
+    expect(String(persistCall![0])).toMatch(/status = 'awaiting_identity'/);
+    // advanced awaiting_identity → screening
+    expect(mockTransition).toHaveBeenCalledWith(
+      expect.objectContaining({ from: "awaiting_identity", to: "screening", trigger: "identity_session_resolved" })
+    );
+  });
+
+  it("does NOT kick the pipeline when SCREENING_ON_SUBMIT_ENABLED is off (staff manual /screen)", async () => {
+    mockMapStripeSessionToResult.mockReturnValue({
+      result: "verified", confidence: 0.95, idType: "driver_license", livenessScore: 0.99,
+      details: { documentValid: true, selfieMatch: true, riskSignals: [] },
+    });
+    await postEvent(identityEvent("identity.verification_session.verified"));
+    await flush();
+    expect(mockRunFullScreening).not.toHaveBeenCalled();
+  });
+
+  it("kicks runFullScreening when SCREENING_ON_SUBMIT_ENABLED is on", async () => {
+    process.env.SCREENING_ON_SUBMIT_ENABLED = "true";
+    mockMapStripeSessionToResult.mockReturnValue({
+      result: "verified", confidence: 0.95, idType: "driver_license", livenessScore: 0.99,
+      details: { documentValid: true, selfieMatch: true, riskSignals: [] },
+    });
+    await postEvent(identityEvent("identity.verification_session.verified"));
+    await flush();
+    expect(mockRunFullScreening).toHaveBeenCalledWith(
+      APP_ID,
+      "99999999-8888-7777-6666-555555555555",
+      "applicant"
+    );
+  });
+});
+
+describe("POST /webhook — could_not_screen HOLD", () => {
+  it("canceled/unmappable → screening_review + overall could_not_screen, never a pass", async () => {
+    mockMapStripeSessionToResult.mockReturnValue({
+      result: "could_not_screen", confidence: 0, idType: "unknown", livenessScore: 0,
+      details: { documentValid: false, selfieMatch: false, riskSignals: ["could_not_screen"] },
+    });
+
+    const res = await postEvent(identityEvent("identity.verification_session.canceled", { status: "canceled" }));
+    await flush();
+
+    expect(res.status).toBe(200);
+    expect(mockTransition).toHaveBeenCalledWith(
+      expect.objectContaining({ from: "awaiting_identity", to: "screening_review", trigger: "could_not_screen" })
+    );
+    const overallUpdate = mockQuery.mock.calls.find((c) =>
+      /overall_screening_result = 'could_not_screen'/i.test(String(c[0]))
+    );
+    expect(overallUpdate).toBeDefined();
+    expect(mockRunFullScreening).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /webhook — identity.verification_session.processing", () => {
+  it("records session status only — no retrieve, no transition", async () => {
+    const res = await postEvent(
+      identityEvent("identity.verification_session.processing", { status: "processing" })
+    );
+    expect(res.status).toBe(200);
+    expect(mockRetrieve).not.toHaveBeenCalled();
+    expect(mockMapStripeSessionToResult).not.toHaveBeenCalled();
+    expect(mockTransition).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /webhook — identity guards", () => {
+  it("missing applicationId metadata → 200 but no retrieve/transition", async () => {
+    const res = await postEvent(
+      identityEvent("identity.verification_session.verified", { applicationId: null })
+    );
+    expect(res.status).toBe(200);
+    expect(mockRetrieve).not.toHaveBeenCalled();
+    expect(mockTransition).not.toHaveBeenCalled();
+  });
+
+  it("duplicate event (already processed) → short-circuits before mapping", async () => {
+    mockQuery.mockImplementation((sql: any) => {
+      if (/stripe_processed_events/i.test(String(sql)) && /SELECT/i.test(String(sql))) {
+        return Promise.resolve({ rows: [{ event_id: "evt_idv_001" }] }) as any; // already processed
+      }
+      return Promise.resolve({ rows: [] }) as any;
+    });
+    const res = await postEvent(identityEvent("identity.verification_session.verified"));
+    expect(res.status).toBe(200);
+    expect(res.body.duplicate).toBe(true);
+    expect(mockMapStripeSessionToResult).not.toHaveBeenCalled();
+  });
+
+  it("verdict for an app no longer in awaiting_identity → no transition (CAS no-op)", async () => {
+    mockMapStripeSessionToResult.mockReturnValue({
+      result: "verified", confidence: 0.95, idType: "driver_license", livenessScore: 0.99,
+      details: { documentValid: true, selfieMatch: true, riskSignals: [] },
+    });
+    // persist UPDATE matches 0 rows (app already advanced)
+    mockQuery.mockImplementation((sql: any) => {
+      const s = String(sql);
+      if (/stripe_processed_events/i.test(s) && /SELECT/i.test(s)) return Promise.resolve({ rows: [] }) as any;
+      if (/FROM applications a/i.test(s) && /LEFT JOIN users/i.test(s)) {
+        return Promise.resolve({ rows: [{ submitted_by: null, submitter_role: null, first_name: "A", last_name: "B", date_of_birth_encrypted: null }] }) as any;
+      }
+      if (/UPDATE applications SET\s+identity_verification_result/i.test(s)) {
+        return Promise.resolve({ rows: [] }) as any; // 0 rows — not in awaiting_identity
+      }
+      return Promise.resolve({ rows: [] }) as any;
+    });
+
+    const res = await postEvent(identityEvent("identity.verification_session.verified"));
+    expect(res.status).toBe(200);
+    expect(mockTransition).not.toHaveBeenCalled();
+  });
+
+  it("livemode mismatch (live event at test deployment) → 400, no processing", async () => {
+    const savedKey = process.env.STRIPE_SECRET_KEY;
+    process.env.STRIPE_SECRET_KEY = "sk_live_xxx"; // expectedLivemode → true; event.livemode false
+    try {
+      const res = await postEvent(identityEvent("identity.verification_session.verified"));
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatch(/livemode mismatch/i);
+      expect(mockMapStripeSessionToResult).not.toHaveBeenCalled();
+    } finally {
+      process.env.STRIPE_SECRET_KEY = savedKey;
+    }
+  });
+});

--- a/src/__tests__/screening-extended-checks.test.ts
+++ b/src/__tests__/screening-extended-checks.test.ts
@@ -44,7 +44,7 @@ jest.mock("../modules/screening/compliance", () => ({
   ComplianceService: jest.fn().mockImplementation(() => ({ runCheck: jest.fn() })),
 }));
 jest.mock("../modules/screening/identity-verification", () => ({
-  IdentityVerificationService: jest.fn().mockImplementation(() => ({ verify: jest.fn() })),
+  IdentityVerificationService: jest.fn().mockImplementation(() => ({ resolve: jest.fn() })),
 }));
 // Fraud is mocked, but unlike the legacy suite we ALSO stub checkIncomeMismatch
 // (the cross-check call site). Default: no mismatch.
@@ -141,7 +141,7 @@ describe("ScreeningService — Phase 4a extended checks (SCREENING_EXTENDED_CHEC
     mockCompliance = (service as any).compliance;
     mockFraud = (service as any).fraud;
 
-    mockIdentity.verify.mockResolvedValue({
+    mockIdentity.resolve.mockResolvedValue({
       result: "verified",
       confidence: 0.95,
       idType: "driver_license",

--- a/src/__tests__/screening-service.test.ts
+++ b/src/__tests__/screening-service.test.ts
@@ -46,6 +46,9 @@ jest.mock("../modules/screening/compliance", () => ({
 
 jest.mock("../modules/screening/identity-verification", () => ({
   IdentityVerificationService: jest.fn().mockImplementation(() => ({
+    // resolve() is the screening-time entry point (Phase 4b). verify() is kept
+    // mocked too since the real class still exports it (legacy/MOCK path).
+    resolve: jest.fn(),
     verify: jest.fn(),
   })),
 }));
@@ -192,7 +195,7 @@ describe("ScreeningService.runFullScreening", () => {
     mockAdverseAction = (service as any).adverseAction;
 
     // Default: identity verified + all vendor checks pass
-    mockIdentity.verify.mockResolvedValue(makeIdentityResult("verified"));
+    mockIdentity.resolve.mockResolvedValue(makeIdentityResult("verified"));
     mockBackground.runCheck.mockResolvedValue(makeBackgroundResult("pass"));
     mockCredit.runCheck.mockResolvedValue(makeCreditResult("pass"));
     mockCompliance.runCheck.mockResolvedValue(makeComplianceResult("pass"));
@@ -565,7 +568,7 @@ describe("ScreeningService.runFullScreening", () => {
   // ── Identity verification (Persona / Stripe Identity) ─────────────────────
 
   it("verified identity passes through; overall reflects downstream checks only", async () => {
-    mockIdentity.verify.mockResolvedValue(makeIdentityResult("verified"));
+    mockIdentity.resolve.mockResolvedValue(makeIdentityResult("verified"));
 
     const result = await service.runFullScreening("app-001", "user-1", "leasing_agent");
 
@@ -577,16 +580,16 @@ describe("ScreeningService.runFullScreening", () => {
     expect(mockAdverseAction.sendNotice).not.toHaveBeenCalled();
   });
 
-  it("threads screeningTag through to identity.verify", async () => {
+  it("threads applicationId + screeningTag through to identity.resolve", async () => {
     await service.runFullScreening("app-001", "user-1", "leasing_agent", "id_verification_fail");
 
-    expect(mockIdentity.verify).toHaveBeenCalledWith(
-      expect.objectContaining({ screeningTag: "id_verification_fail" })
+    expect(mockIdentity.resolve).toHaveBeenCalledWith(
+      expect.objectContaining({ applicationId: "app-001", screeningTag: "id_verification_fail" })
     );
   });
 
   it("identity review_required runs full pipeline; overall becomes review_required when no fails", async () => {
-    mockIdentity.verify.mockResolvedValue(makeIdentityResult("review_required"));
+    mockIdentity.resolve.mockResolvedValue(makeIdentityResult("review_required"));
 
     const result = await service.runFullScreening("app-001", "user-1", "leasing_agent");
 
@@ -599,7 +602,7 @@ describe("ScreeningService.runFullScreening", () => {
   });
 
   it("identity rejected short-circuits the pipeline with FCRA adverse-action notice", async () => {
-    mockIdentity.verify.mockResolvedValue(makeIdentityResult("rejected"));
+    mockIdentity.resolve.mockResolvedValue(makeIdentityResult("rejected"));
 
     const result = await service.runFullScreening("app-001", "user-1", "leasing_agent");
 

--- a/src/__tests__/state-machine.test.ts
+++ b/src/__tests__/state-machine.test.ts
@@ -169,15 +169,18 @@ describe("transitionApplicationStatus (application_status chokepoint)", () => {
     jest.clearAllMocks();
   });
 
-  it("APP_STATUS_TRANSITIONS fans out from submitted/screening (+screening_review hold) into the screening terminals", () => {
-    // screening_review is a NEW non-terminal hold: a could-not-screen pipeline
+  it("APP_STATUS_TRANSITIONS fans out from submitted/awaiting_identity/screening (+screening_review hold) into the screening terminals", () => {
+    // screening_review is a non-terminal hold: a could-not-screen pipeline
     // lands there, and staff resolve it forward to passed/failed. It is both a
     // `to` (from screening) and a `from` (manual override out).
+    // awaiting_identity (Phase 4b) sits between submitted and screening: the app
+    // waits there for the applicant's Stripe Identity capture, then the webhook
+    // advances it into `screening` (or `screening_review` on could_not_screen).
     const froms = new Set(APP_STATUS_TRANSITIONS.map((t) => t.from));
-    expect(froms).toEqual(new Set(["submitted", "screening", "screening_review"]));
+    expect(froms).toEqual(new Set(["submitted", "awaiting_identity", "screening", "screening_review"]));
     expect(
       APP_STATUS_TRANSITIONS.every((t) =>
-        ["screening", "screening_review", "screening_passed", "screening_failed"].includes(t.to)
+        ["awaiting_identity", "screening", "screening_review", "screening_passed", "screening_failed"].includes(t.to)
       )
     ).toBe(true);
   });

--- a/src/db/migrations/2026-06-01-applications-identity-session.sql
+++ b/src/db/migrations/2026-06-01-applications-identity-session.sql
@@ -1,0 +1,30 @@
+-- 2026-06-01 applications-identity-session (Phase 4b — Stripe Identity go-live)
+--
+-- Stripe Identity is asynchronous + applicant-mediated: submit() creates a
+-- VerificationSession, the applicant uploads ID + selfie on Stripe's hosted/
+-- embedded flow, and the verdict arrives later by WEBHOOK. We therefore need:
+--
+--   1. A new application_status `awaiting_identity` — the state between
+--      `submitted` and `screening` that means "waiting on the applicant to
+--      finish their Stripe Identity capture". This keeps the screening_review
+--      HOLD queue clean: a session still in progress is NOT a problem, it's a
+--      pending capture. Screening only begins once the webhook lands a verdict
+--      and transitions awaiting_identity -> screening.
+--
+--   2. Three columns tracking the Stripe session reference. We persist ONLY a
+--      `vs_…` id + the categorical session status — never name/DOB/document
+--      numbers/images. Those high-sensitivity PII artifacts live on Stripe; the
+--      mapped categorical verdict lands in the existing identity_verification_*
+--      columns (added 2026-05-30-applications-identity-verification.sql).
+--
+-- NOTE: ALTER TYPE ... ADD VALUE cannot run inside a transaction block.
+-- Apply this file OUTSIDE a transaction, e.g.:
+--   psql "$DATABASE_URL" -f src/db/migrations/2026-06-01-applications-identity-session.sql
+-- (Do NOT wrap in BEGIN/COMMIT; do NOT run via a migration runner that opens a txn.)
+
+ALTER TYPE application_status ADD VALUE IF NOT EXISTS 'awaiting_identity';
+
+ALTER TABLE applications
+  ADD COLUMN IF NOT EXISTS identity_session_id          TEXT,
+  ADD COLUMN IF NOT EXISTS identity_session_status      TEXT,
+  ADD COLUMN IF NOT EXISTS identity_session_created_at  TIMESTAMPTZ;

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -25,6 +25,11 @@ CREATE TYPE user_role AS ENUM (
 CREATE TYPE application_status AS ENUM (
   'draft',
   'submitted',
+  -- Stripe Identity (Phase 4b): waiting on the applicant to finish their
+  -- hosted/embedded ID + selfie capture. The webhook advances this to
+  -- 'screening' once a verdict lands. Distinguishes "pending capture" from
+  -- "screening running" so the screening_review HOLD queue stays clean.
+  'awaiting_identity',
   'screening',
   'screening_passed',
   'screening_failed',
@@ -396,6 +401,14 @@ CREATE TABLE applications (
   identity_verification_result screening_result,
   identity_verification_details JSONB,
   identity_verification_completed_at TIMESTAMPTZ,
+
+  -- Stripe Identity session reference (Phase 4b). We persist ONLY the vs_
+  -- session id + categorical session status here -- never name/DOB/document
+  -- numbers/images (those live on Stripe). The mapped verdict lands in the
+  -- identity_verification_* columns above via the webhook.
+  identity_session_id TEXT,
+  identity_session_status TEXT,
+  identity_session_created_at TIMESTAMPTZ,
 
   background_check_result screening_result,
   background_check_details JSONB,

--- a/src/modules/applicants/routes.ts
+++ b/src/modules/applicants/routes.ts
@@ -323,16 +323,73 @@ router.post(
         return;
       }
 
+      // Optional return URL for the Stripe Identity hosted flow (Phase 4b). When
+      // IDENTITY_VERIFICATION_ENABLED is on, submit() returns an `identity`
+      // session ({url, clientSecret, status}) and parks the app in
+      // awaiting_identity; flag off, this is ignored.
+      const returnUrl =
+        typeof req.body?.returnUrl === "string" ? req.body.returnUrl : undefined;
+
       const result = await applicationService.submit(
         draft.rows[0].id,
         req.user.id,
-        req.user.role
+        req.user.role,
+        returnUrl
       );
 
       res.json(result);
     } catch (err: any) {
       logger.error("Applicant submit-draft failed", { error: (err as Error).message });
       res.status(500).json({ error: "Failed to submit application" });
+    }
+  }
+);
+
+// Poll the applicant's most recent Stripe Identity verification (Phase 4b).
+// Ownership-gated via user_applications (not RBAC), mirroring submit-draft. The
+// apply-wizard's StepIdentity polls this after redirecting to the hosted flow:
+// `complete` flips true once the webhook advances the app out of
+// awaiting_identity. Returns only categorical status — never PII.
+router.get(
+  "/me/applications/identity-status",
+  authenticate,
+  requireEmailVerified,
+  async (req: AuthRequest, res: Response): Promise<void> => {
+    try {
+      if (!req.user || !["applicant", "tenant"].includes(req.user.role)) {
+        res.status(403).json({ error: "Applicant role required" });
+        return;
+      }
+
+      const row = await query(
+        `SELECT a.id, a.status, a.identity_session_status, a.identity_verification_result
+           FROM user_applications ua
+           JOIN applications a ON a.id = ua.application_id
+          WHERE ua.user_id = $1
+            AND a.identity_session_id IS NOT NULL
+          ORDER BY a.identity_session_created_at DESC NULLS LAST, a.created_at DESC
+          LIMIT 1`,
+        [req.user.id]
+      );
+
+      if (row.rows.length === 0) {
+        res.status(404).json({ error: "No identity verification in progress" });
+        return;
+      }
+
+      const app = row.rows[0];
+      res.json({
+        applicationId: app.id,
+        status: app.status,
+        identitySessionStatus: app.identity_session_status,
+        identityResult: app.identity_verification_result,
+        complete: app.status !== "awaiting_identity",
+      });
+    } catch (err: any) {
+      logger.error("Applicant identity-status poll failed", {
+        error: (err as Error).message,
+      });
+      res.status(500).json({ error: "Failed to fetch identity status" });
     }
   }
 );

--- a/src/modules/application/service.ts
+++ b/src/modules/application/service.ts
@@ -205,7 +205,12 @@ export class ApplicationService {
     return result;
   }
 
-  async submit(applicationId: string, submittedBy: string, submitterRole: string): Promise<any> {
+  async submit(
+    applicationId: string,
+    submittedBy: string,
+    submitterRole: string,
+    returnUrl?: string
+  ): Promise<any> {
     const result = await query(
       `UPDATE applications
        SET status = 'submitted', submitted_at = NOW(), submitted_by = $2
@@ -227,6 +232,62 @@ export class ApplicationService {
       resourceId: applicationId,
       details: { status: "submitted" },
     });
+
+    // Phase 4b — Stripe Identity capture on submit, dark behind
+    // IDENTITY_VERIFICATION_ENABLED (independent of SCREENING_ON_SUBMIT_ENABLED).
+    // When armed: create a Stripe Identity VerificationSession and park the app
+    // in `awaiting_identity` until the applicant completes capture and the
+    // webhook lands a verdict (which then advances it into screening). The
+    // session url/clientSecret is returned so the caller can redirect/embed.
+    // This branch takes precedence over the legacy auto-screen path below —
+    // screening is kicked by the webhook once identity resolves.
+    if (process.env.IDENTITY_VERIFICATION_ENABLED === "true") {
+      try {
+        const { IdentityVerificationService } = await import(
+          "../screening/identity-verification"
+        );
+        const session = await new IdentityVerificationService().createSession({
+          applicationId,
+          returnUrl,
+        });
+        await transitionApplicationStatus({
+          applicationId,
+          from: "submitted",
+          to: "awaiting_identity",
+          trigger: "identity_verification_started",
+          actorId: submittedBy,
+          actorRole: submitterRole,
+          evidence: { source: "submit_identity_capture", sessionId: session.id },
+        });
+        await query(
+          `UPDATE applications SET
+             identity_session_id = $2,
+             identity_session_status = $3,
+             identity_session_created_at = NOW()
+           WHERE id = $1`,
+          [applicationId, session.id, session.status]
+        );
+        return {
+          ...result.rows[0],
+          status: "awaiting_identity",
+          identity: {
+            url: session.url,
+            clientSecret: session.clientSecret,
+            status: session.status,
+          },
+        };
+      } catch (err) {
+        // Session creation failed. Do NOT silently fall through to a normal
+        // submit (that would skip the identity gate entirely). Leave the app in
+        // `submitted` — staff/poll see no session — and surface loudly. This is
+        // fail-loud, not fail-open.
+        logger.error("Failed to create Stripe Identity session on submit", {
+          error: (err as Error).message,
+          applicationId,
+        });
+        return result.rows[0];
+      }
+    }
 
     // Auto-screening on submit — dark-deployed behind SCREENING_ON_SUBMIT_ENABLED.
     // Flag off ⇒ byte-for-byte current behavior (manual /screen only). When on,

--- a/src/modules/payment/webhook.ts
+++ b/src/modules/payment/webhook.ts
@@ -5,10 +5,14 @@ import { query } from "../../config/database";
 import { writeAuditLog } from "../../middleware/audit";
 import { logger } from "../../utils/logger";
 import { getStripe, expectedLivemode } from "../../lib/stripe";
+import { decrypt } from "../../utils/encryption";
 import { stampTape } from "../tape";
 import { buildIdempotencyKey, markStatus } from "./idempotency";
 import { LedgerService } from "../ledger/service";
 import { getEmailService } from "../integrations/email";
+import { IdentityVerificationService } from "../screening/identity-verification";
+import type { IdentityVerificationResult } from "../screening/identity-verification";
+import { transitionApplicationStatus } from "../screening/state-machine";
 
 /**
  * Stripe webhook receiver.
@@ -407,6 +411,196 @@ async function handleChargeRefunded(event: Stripe.Event): Promise<void> {
   })();
 }
 
+// IdentityVerificationResult.result (verified/rejected/review_required/
+// could_not_screen) → the `screening_result` enum the application row stores.
+// Duplicated (not imported) from screening/service.ts on purpose: keeps the
+// webhook's module graph from eagerly pulling in the whole screening subsystem
+// for a four-line mapper. could_not_screen passes straight through so the row
+// reflects the HOLD rather than a pass.
+function mapIdentityResultToScreeningEnum(
+  r: IdentityVerificationResult["result"]
+): "pass" | "fail" | "review_required" | "could_not_screen" {
+  if (r === "verified") return "pass";
+  if (r === "rejected") return "fail";
+  if (r === "could_not_screen") return "could_not_screen";
+  return "review_required";
+}
+
+/**
+ * Stripe Identity verdict handler (Phase 4b).
+ *
+ * Rides the EXISTING /api/payments/webhook endpoint — same signing secret,
+ * idempotency, livemode guard, and DLQ as the payment events. Lands the verdict
+ * onto the application row and unblocks the app out of `awaiting_identity`:
+ *
+ *   - `processing`              → not terminal; record session_status, wait.
+ *   - `verified` / `requires_input` → persist verdict, advance → `screening`;
+ *     when SCREENING_ON_SUBMIT_ENABLED, fire the full pipeline (which re-reads
+ *     this verdict via identity.resolve() — no re-capture). Otherwise the app
+ *     waits in `screening` for staff to run manual /screen.
+ *   - `canceled` / unmappable   → could_not_screen → HOLD in `screening_review`.
+ *     NEVER an auto-pass.
+ *
+ * The persist + both transitions are CAS-guarded on `status = 'awaiting_identity'`,
+ * so a duplicate or out-of-order delivery after the app already advanced is a
+ * no-op (belt-and-suspenders alongside `stripe_processed_events`).
+ */
+async function handleIdentityVerificationSession(event: Stripe.Event): Promise<void> {
+  const session = event.data.object as Stripe.Identity.VerificationSession;
+  const applicationId = (session.metadata ?? {}).applicationId;
+  if (!applicationId) {
+    logger.warn("Identity verification session missing applicationId metadata", {
+      sessionId: session.id,
+      type: event.type,
+    });
+    return;
+  }
+
+  // `processing` is non-terminal — Stripe is still evaluating. Record the
+  // status and wait for the verified/requires_input/canceled event to follow.
+  if (session.status === "processing") {
+    await query(
+      `UPDATE applications SET identity_session_status = $2
+        WHERE id = $1 AND status = 'awaiting_identity'`,
+      [applicationId, session.status]
+    );
+    logger.info("Identity verification session processing", {
+      sessionId: session.id,
+      applicationId,
+    });
+    return;
+  }
+
+  // Terminal verdict — retrieve with the report expanded (the event payload
+  // omits it) so we can map per-check document/selfie detail.
+  const stripe = getStripe();
+  const full = await stripe.identity.verificationSessions.retrieve(session.id, {
+    expand: ["last_verification_report"],
+  });
+
+  // Application context for the transient name/DOB cross-check — used only to
+  // derive a categorical `name_dob_mismatch` risk signal, never persisted.
+  const ctx = await query(
+    `SELECT a.submitted_by, u.role AS submitter_role,
+            a.first_name, a.last_name, a.date_of_birth_encrypted
+       FROM applications a
+       LEFT JOIN users u ON u.id = a.submitted_by
+      WHERE a.id = $1`,
+    [applicationId]
+  );
+  if (ctx.rows.length === 0) {
+    logger.warn("Identity verification session for unknown application", {
+      sessionId: session.id,
+      applicationId,
+    });
+    return;
+  }
+  const row = ctx.rows[0];
+  let expected: { firstName?: string; lastName?: string; dateOfBirth?: string };
+  try {
+    expected = {
+      firstName: row.first_name ?? undefined,
+      lastName: row.last_name ?? undefined,
+      dateOfBirth: row.date_of_birth_encrypted ? decrypt(row.date_of_birth_encrypted) : undefined,
+    };
+  } catch {
+    // DOB decrypt failed — fall back to name-only cross-check rather than throw.
+    expected = { firstName: row.first_name ?? undefined, lastName: row.last_name ?? undefined };
+  }
+
+  const result = new IdentityVerificationService().mapStripeSessionToResult(full, expected);
+  const screeningResult = mapIdentityResultToScreeningEnum(result.result);
+
+  // Persist the verdict, guarded to awaiting_identity so a late/duplicate event
+  // can't clobber a row that already advanced. identity_verification_details
+  // holds the FULL result here — identity.resolve() reads it back exactly once.
+  const persisted = await query(
+    `UPDATE applications SET
+        identity_verification_result = $2,
+        identity_verification_details = $3,
+        identity_verification_completed_at = NOW(),
+        identity_session_status = $4
+      WHERE id = $1 AND status = 'awaiting_identity'
+      RETURNING id`,
+    [applicationId, screeningResult, JSON.stringify(result), full.status]
+  );
+
+  if (persisted.rows.length === 0) {
+    logger.info("Identity verdict ignored — application not awaiting identity", {
+      sessionId: session.id,
+      applicationId,
+      eventType: event.type,
+    });
+    return;
+  }
+
+  await writeAuditLog({
+    // Reuses the existing audit_action member (no enum migration); actor lives
+    // in details since the Stripe webhook has no user actor.
+    action: "identity_verification_completed",
+    applicationId,
+    resourceType: "application",
+    details: {
+      actor: "stripe-webhook",
+      result: result.result,
+      sessionStatus: full.status,
+      idType: result.idType,
+      riskSignals: result.details.riskSignals,
+      sessionId: full.id,
+    },
+  });
+
+  // could_not_screen (canceled / unmappable) → HOLD directly in screening_review.
+  if (result.result === "could_not_screen") {
+    await transitionApplicationStatus({
+      applicationId,
+      from: "awaiting_identity",
+      to: "screening_review",
+      trigger: "could_not_screen",
+      evidence: { source: "stripe_identity_webhook", sessionStatus: full.status },
+    });
+    await query(
+      `UPDATE applications SET overall_screening_result = 'could_not_screen'
+        WHERE id = $1 AND overall_screening_result IS NULL`,
+      [applicationId]
+    );
+    return;
+  }
+
+  // Verdict in hand → advance into `screening` so the app is screenable.
+  const advanced = await transitionApplicationStatus({
+    applicationId,
+    from: "awaiting_identity",
+    to: "screening",
+    trigger: "identity_session_resolved",
+    actorId: row.submitted_by ?? undefined,
+    actorRole: row.submitter_role ?? undefined,
+    evidence: { source: "stripe_identity_webhook", result: result.result },
+  });
+  if (!advanced.changed) return;
+
+  // Only fire the full pipeline when auto-on-submit is armed AND we have a real
+  // submitter (the audit/actor columns are UUID-typed). resolve() will read the
+  // verdict we just persisted. Otherwise the app rests in `screening` for staff
+  // to run manual /screen.
+  if (process.env.SCREENING_ON_SUBMIT_ENABLED === "true" && row.submitted_by) {
+    const initiatedBy = row.submitted_by as string;
+    const initiatorRole = (row.submitter_role as string) ?? "applicant";
+    void (async () => {
+      try {
+        const { ScreeningService } = await import("../screening/service");
+        await new ScreeningService().runFullScreening(applicationId, initiatedBy, initiatorRole);
+      } catch (err) {
+        logger.error("Post-identity screening pipeline failed", {
+          applicationId,
+          sessionId: full.id,
+          error: (err as Error).message,
+        });
+      }
+    })();
+  }
+}
+
 async function dispatch(event: Stripe.Event): Promise<void> {
   switch (event.type) {
     case "payment_intent.succeeded":
@@ -417,6 +611,12 @@ async function dispatch(event: Stripe.Event): Promise<void> {
       return;
     case "charge.refunded":
       await handleChargeRefunded(event);
+      return;
+    case "identity.verification_session.verified":
+    case "identity.verification_session.requires_input":
+    case "identity.verification_session.processing":
+    case "identity.verification_session.canceled":
+      await handleIdentityVerificationSession(event);
       return;
     default:
       logger.info("Stripe webhook event ignored", { type: event.type, id: event.id });

--- a/src/modules/screening/identity-verification.ts
+++ b/src/modules/screening/identity-verification.ts
@@ -1,4 +1,7 @@
+import type Stripe from "stripe";
 import { logger } from "../../utils/logger";
+import { query } from "../../config/database";
+import { getStripe } from "../../lib/stripe";
 import { shouldUseScreeningStub, STUB_GATE_ERROR } from "./stub-policy";
 
 export interface IdentityVerificationResult {
@@ -14,10 +17,33 @@ export interface IdentityVerificationResult {
   };
 }
 
+/** Categorical session reference + status returned by createSession(). */
+export interface IdentitySessionHandle {
+  id: string;
+  status: string;
+  clientSecret: string | null;
+  url: string | null;
+}
+
 /**
- * Biometric ID + liveness verification (Persona primary, Stripe Identity fallback).
- * Runs before the parallel screening checks; a rejection here short-circuits
- * the pipeline to `failed` and fires an adverse-action notice.
+ * Biometric ID + liveness verification.
+ *
+ * Two lifecycles coexist behind `IDENTITY_VERIFICATION_ENABLED`:
+ *
+ *   - **Stripe Identity (production, flag ON)** — asynchronous + applicant-mediated.
+ *     `submit()` calls `createSession()` → the applicant uploads ID + selfie on
+ *     Stripe's hosted/embedded flow → the verdict arrives by WEBHOOK
+ *     (`identity.verification_session.*`), which persists it to the application
+ *     row. At screening time `resolve()` READS that persisted verdict (it never
+ *     initiates the call); a session still pending → `could_not_screen` HOLD.
+ *
+ *   - **Legacy synchronous (flag OFF / MOCK / stub)** — `verify()` returns a
+ *     verdict inline. This path is byte-identical to the pre-Phase-4b behaviour;
+ *     the Stripe production branch below was never reachable in flag-off configs
+ *     (it threw "Production API integration not yet configured").
+ *
+ * A rejection short-circuits the pipeline to `failed` (FCRA adverse-action
+ * notice); a could_not_screen HOLDs in `screening_review` (never an auto-pass).
  */
 export class IdentityVerificationService {
   private apiUrl: string;
@@ -27,6 +53,258 @@ export class IdentityVerificationService {
     this.apiUrl = process.env.IDENTITY_API_URL || "https://api.persona-identity.example.com";
     this.apiKey = process.env.IDENTITY_API_KEY || "";
   }
+
+  // ── Stripe Identity lifecycle (Phase 4b) ────────────────────────────────────
+
+  /**
+   * Create a Stripe Identity VerificationSession for an application. Called from
+   * submit() on the armed path; returns the hosted `url` / embedded
+   * `clientSecret` the applicant uses to complete their ID + selfie capture.
+   *
+   * Idempotent per application: a retried submit reuses the same session rather
+   * than spawning duplicates (idempotency key namespaced `idv:` so it never
+   * collides with the PaymentIntent keys).
+   */
+  async createSession(input: {
+    applicationId: string;
+    returnUrl?: string;
+  }): Promise<IdentitySessionHandle> {
+    const stripe = getStripe();
+    const session = await stripe.identity.verificationSessions.create(
+      {
+        type: "document",
+        options: {
+          document: {
+            require_matching_selfie: true,
+            require_live_capture: true,
+          },
+        },
+        // The webhook + markProcessed key off metadata.applicationId to route the
+        // verdict back to this row.
+        metadata: { applicationId: input.applicationId },
+        ...(input.returnUrl ? { return_url: input.returnUrl } : {}),
+      },
+      { idempotencyKey: `idv:${input.applicationId}` }
+    );
+
+    logger.info("Created Stripe Identity verification session", {
+      applicationId: input.applicationId,
+      sessionId: session.id,
+      status: session.status,
+    });
+
+    return {
+      id: session.id,
+      status: session.status,
+      clientSecret: session.client_secret ?? null,
+      url: session.url ?? null,
+    };
+  }
+
+  /**
+   * Screening-time identity entry point — replaces the direct `verify()` call.
+   *
+   *   - MOCK_MODE + a screeningTag → legacy fixture path (e2e/demo), unchanged.
+   *   - IDENTITY_VERIFICATION_ENABLED → read the webhook-persisted Stripe verdict.
+   *   - otherwise → legacy synchronous verify() (flag-off byte-identical).
+   */
+  async resolve(input: {
+    applicationId: string;
+    firstName: string;
+    lastName: string;
+    dateOfBirth: string;
+    screeningTag?: string;
+  }): Promise<IdentityVerificationResult> {
+    if (process.env.MOCK_MODE === "1" && input.screeningTag) {
+      return this.verify(input);
+    }
+    if (process.env.IDENTITY_VERIFICATION_ENABLED === "true") {
+      return this.resolveStripeSession(input.applicationId);
+    }
+    return this.verify(input);
+  }
+
+  /**
+   * Read the Stripe Identity verdict the webhook persisted onto the application
+   * row. Returns `could_not_screen` (a HOLD, never a pass) when:
+   *   - no session was ever created (`identity_session_id` null), or
+   *   - the session hasn't reached a terminal verdict yet
+   *     (`identity_verification_completed_at` null — applicant still capturing /
+   *     Stripe still processing), or
+   *   - the persisted detail isn't in the expected shape, or
+   *   - the lookup itself throws.
+   *
+   * The webhook stores the full IdentityVerificationResult in
+   * identity_verification_details on a terminal event. runFullScreening's status
+   * guard (`status IN ('submitted','screening')`) means resolve() runs exactly
+   * once per application, before the screening service overwrites that column
+   * with the nested `.details`.
+   */
+  private async resolveStripeSession(applicationId: string): Promise<IdentityVerificationResult> {
+    try {
+      const res = await query(
+        `SELECT identity_session_id,
+                identity_verification_completed_at,
+                identity_verification_details
+           FROM applications
+          WHERE id = $1`,
+        [applicationId]
+      );
+      const row = res.rows[0];
+
+      if (!row || !row.identity_session_id) {
+        return this.couldNotScreen("no Stripe Identity session on file");
+      }
+      if (!row.identity_verification_completed_at) {
+        return this.couldNotScreen("Stripe Identity capture still pending");
+      }
+
+      const stored = row.identity_verification_details;
+      if (stored && typeof stored === "object" && typeof (stored as any).result === "string") {
+        return stored as IdentityVerificationResult;
+      }
+      return this.couldNotScreen("Stripe Identity verdict not in expected shape");
+    } catch (err) {
+      logger.error("Failed to resolve Stripe Identity session", {
+        error: (err as Error).message,
+        applicationId,
+      });
+      return this.couldNotScreen("Stripe Identity lookup failed");
+    }
+  }
+
+  /**
+   * Map a Stripe Identity VerificationSession (with `last_verification_report`
+   * expanded) to our IdentityVerificationResult. Pure + side-effect-free — the
+   * webhook calls this then persists the result; the unit tests exercise it
+   * table-driven.
+   *
+   * `expected` (the application's name/DOB) is used ONLY transiently to flag a
+   * `name_dob_mismatch` review signal — never persisted.
+   *
+   * PII discipline: `rawResponse` carries ONLY categorical fields (ids, statuses,
+   * error codes, document type) — never name/DOB/document numbers/images, which
+   * live exclusively on Stripe.
+   */
+  mapStripeSessionToResult(
+    vs: Stripe.Identity.VerificationSession,
+    expected?: { firstName?: string; lastName?: string; dateOfBirth?: string }
+  ): IdentityVerificationResult {
+    // No usable verdict yet (or session abandoned) → HOLD, never a pass.
+    if (vs.status === "processing") {
+      return this.couldNotScreen("Stripe Identity session still processing");
+    }
+    if (vs.status === "canceled") {
+      return this.couldNotScreen("Stripe Identity session canceled");
+    }
+
+    const report =
+      vs.last_verification_report && typeof vs.last_verification_report === "object"
+        ? (vs.last_verification_report as Stripe.Identity.VerificationReport)
+        : null;
+    const doc = report?.document ?? null;
+    const selfie = report?.selfie ?? null;
+
+    // The session status is Stripe's authoritative roll-up; the report errors
+    // give us per-check detail for a `requires_input` (non-verified) session.
+    const verified = vs.status === "verified";
+    const documentValid = verified || !!(doc && !doc.error);
+    const selfieMatch = verified || !!(selfie && !selfie.error);
+
+    const riskSignals: string[] = [];
+    if (doc?.error?.code) riskSignals.push(`document_${doc.error.code}`);
+    if (selfie?.error?.code) riskSignals.push(`selfie_${selfie.error.code}`);
+    if (vs.last_error?.code) riskSignals.push(vs.last_error.code);
+    if (expected && doc && this.documentMismatch(doc, expected)) {
+      riskSignals.push("name_dob_mismatch");
+    }
+    // A requires_input session is, by definition, NOT a clean verification —
+    // Stripe is asking for more. If no per-check error surfaced a signal, inject
+    // one so evaluateResults() can never grade it `verified` (the plan mandates
+    // requires_input → rejected | review_required, never pass).
+    if (vs.status === "requires_input" && riskSignals.length === 0) {
+      riskSignals.push("requires_input");
+    }
+
+    // Stripe gives no numeric confidence/liveness score; derive deterministically
+    // so the shared evaluateResults() thresholds (<0.5 reject / <0.85 review)
+    // still apply uniformly across the synchronous and Stripe paths.
+    const response = {
+      documentValid,
+      selfieMatch,
+      confidence: documentValid ? 0.95 : 0.3,
+      livenessScore: selfieMatch ? 0.99 : 0.3,
+      idType: this.mapStripeDocType(doc?.type ?? null),
+      riskSignals,
+      rawResponse: {
+        sessionId: vs.id,
+        reportId: report?.id ?? null,
+        sessionStatus: vs.status,
+        documentStatus: doc ? (doc.error ? "errored" : "verified") : null,
+        selfieStatus: selfie ? (selfie.error ? "errored" : "verified") : null,
+        documentType: doc?.type ?? null,
+        documentError: doc?.error?.code ?? null,
+        selfieError: selfie?.error?.code ?? null,
+        lastErrorCode: vs.last_error?.code ?? null,
+      },
+    };
+
+    return this.evaluateResults(response);
+  }
+
+  /** Standard `could_not_screen` HOLD result (reason is categorical, no PII). */
+  private couldNotScreen(reason: string): IdentityVerificationResult {
+    return {
+      result: "could_not_screen",
+      confidence: 0,
+      idType: "unknown",
+      livenessScore: 0,
+      details: {
+        documentValid: false,
+        selfieMatch: false,
+        riskSignals: ["could_not_screen"],
+        rawResponse: { reason },
+      },
+    };
+  }
+
+  /**
+   * Transient name/DOB cross-check between the verified document and the
+   * application. Returns true on a clear mismatch. Compared values are never
+   * persisted — only the categorical `name_dob_mismatch` signal is.
+   */
+  private documentMismatch(
+    doc: Stripe.Identity.VerificationReport.Document,
+    expected: { firstName?: string; lastName?: string; dateOfBirth?: string }
+  ): boolean {
+    const norm = (s?: string | null) => (s ?? "").trim().toLowerCase();
+    if (expected.firstName && doc.first_name && norm(doc.first_name) !== norm(expected.firstName)) {
+      return true;
+    }
+    if (expected.lastName && doc.last_name && norm(doc.last_name) !== norm(expected.lastName)) {
+      return true;
+    }
+    if (expected.dateOfBirth && doc.dob && doc.dob.year && doc.dob.month && doc.dob.day) {
+      const iso = `${doc.dob.year}-${String(doc.dob.month).padStart(2, "0")}-${String(doc.dob.day).padStart(2, "0")}`;
+      if (expected.dateOfBirth.slice(0, 10) !== iso) return true;
+    }
+    return false;
+  }
+
+  private mapStripeDocType(type: string | null): IdentityVerificationResult["idType"] {
+    switch (type) {
+      case "driving_license":
+        return "driver_license";
+      case "passport":
+        return "passport";
+      case "id_card":
+        return "state_id";
+      default:
+        return "unknown";
+    }
+  }
+
+  // ── Legacy synchronous path (flag OFF / MOCK / stub) — unchanged ─────────────
 
   async verify(input: {
     firstName: string;

--- a/src/modules/screening/service.ts
+++ b/src/modules/screening/service.ts
@@ -116,11 +116,17 @@ export class ScreeningService {
     const ssnLast4 = ssnDecrypted.slice(-4);
     const dob = decrypt(app.date_of_birth_encrypted);
 
-    // Identity verification — runs FIRST. Persona primary / Stripe Identity
-    // fallback. Rejection short-circuits the pipeline (FCRA adverse-action
-    // notice mirrors the duplicate-SSN early-exit below); review_required
-    // joins the overall-result aggregation alongside background/credit/compliance.
-    const identityResult = await this.identity.verify({
+    // Identity verification — runs FIRST. Rejection short-circuits the pipeline
+    // (FCRA adverse-action notice mirrors the duplicate-SSN early-exit below);
+    // review_required joins the overall-result aggregation alongside
+    // background/credit/compliance.
+    //
+    // resolve() (not verify()) is the screening-time call: under
+    // IDENTITY_VERIFICATION_ENABLED it READS the Stripe Identity verdict the
+    // webhook already persisted (a still-pending capture → could_not_screen
+    // HOLD). MOCK/stub/keyless configs are byte-identical to the legacy verify().
+    const identityResult = await this.identity.resolve({
+      applicationId,
       firstName: app.first_name,
       lastName: app.last_name,
       dateOfBirth: dob,

--- a/src/modules/screening/state-machine.ts
+++ b/src/modules/screening/state-machine.ts
@@ -147,6 +147,7 @@ export async function transition(input: TransitionInput): Promise<void> {
 /** Real application_status values touched by the screening pipeline. */
 export type AppStatus =
   | "submitted"
+  | "awaiting_identity"
   | "screening"
   | "screening_passed"
   | "screening_failed"
@@ -160,6 +161,14 @@ interface AppStatusTransition {
 
 export const APP_STATUS_TRANSITIONS: ReadonlyArray<AppStatusTransition> = [
   { from: "submitted", to: "screening", trigger: "screening_started" },
+  // Stripe Identity (Phase 4b): submit() creates a VerificationSession and
+  // parks the app in awaiting_identity until the webhook lands a verdict.
+  // The webhook then advances awaiting_identity -> screening (verdict in hand,
+  // run the checks) or -> screening_review (could_not_screen HOLD:
+  // pending/processing/canceled/unmappable session — never an auto-pass).
+  { from: "submitted", to: "awaiting_identity", trigger: "identity_verification_started" },
+  { from: "awaiting_identity", to: "screening", trigger: "identity_session_resolved" },
+  { from: "awaiting_identity", to: "screening_review", trigger: "could_not_screen" },
   { from: "screening", to: "screening_passed", trigger: "all_checks_passed" },
   { from: "screening", to: "screening_passed", trigger: "review_required_passthrough" },
   { from: "screening", to: "screening_failed", trigger: "any_check_failed" },


### PR DESCRIPTION
## Phase 4b — Screening Go-Live: Stripe Identity (first real vendor)

First real vendor adapter, and the **template** for the other five (background, credit, Plaid, NSOPW, Work Number). Replaces the placeholder `throw new Error("Production API integration not yet configured")` with a real Stripe Identity flow, reconciled to the pipeline's fail-loud / **HOLD-never-pass** contract.

Ships **dark** behind a new default-OFF flag `IDENTITY_VERIFICATION_ENABLED`. Flag-off is byte-identical to today (the old production branch was never reachable in flag-off configs).

### The load-bearing decision (async reconciliation)
`identity.verify({firstName,lastName,dob})` is synchronous; Stripe Identity is **async + applicant-mediated** (create session → applicant uploads ID + selfie on Stripe's hosted page → verdict by **webhook**).

- **Chosen:** create-at-submit → hosted redirect → webhook lands the verdict → screening **reads** the stored result (`resolve()`), never initiates the call.
- **Rejected:** long-poll Stripe inside the fire-and-forget `runFullScreening` chain — a human-paced capture (minutes–hours) would hold the chain open and fights Stripe's webhook-first design.
- Reuses the existing `/api/payments/webhook` (raw-body, sig-verify, livemode guard, idempotency `stripe_processed_events`, DLQ, always-200) and `STRIPE_SECRET_KEY` / `STRIPE_WEBHOOK_SECRET` — **no new vendor key, no new route**.

### New state `awaiting_identity`
Between `submitted` and `screening` — distinguishes "waiting on the applicant" from "screening running", keeping the `screening_review` HOLD queue clean (pending capture ≠ problem).

### Changes
**Server (load-bearing):**
- `identity-verification.ts` — `createSession()` (document + matching-selfie + live-capture, idempotencyKey `idv:<appId>`), `resolve()` (MOCK/stub/keyless paths **byte-identical** to legacy `verify()`; flag-on reads the persisted verdict or returns `could_not_screen`), `mapStripeSessionToResult()` routed through the existing `evaluateResults()` so thresholds stay single-sourced. Hardening: a non-`verified` session can never grade `verified`.
- `payment/webhook.ts` — 4 `identity.verification_session.*` cases → retrieve with report expanded, map, persist guarded to `awaiting_identity`, transition `awaiting_identity → screening` (or `→ screening_review` on `could_not_screen`), kick `runFullScreening` only when `SCREENING_ON_SUBMIT_ENABLED` **and** a real submitter exists.
- `application/service.ts` — armed `submit()` creates the session + transitions `submitted → awaiting_identity`; on create throw, leaves the app in `submitted` (fail-loud, no fall-through).
- `applicants/routes.ts` — `submit-draft` returns the session `url`/`clientSecret`; new `GET /me/applications/identity-status` poll endpoint.
- `screening/service.ts`, `state-machine.ts`, `schema.ts`, migration `2026-06-01-applications-identity-session.sql` (`ADD VALUE` outside txn).

**Frontend (additive, graceful-fallback):**
- PM console + tenant `ApplicationStatus` unions + a sky `StatusBadge` token; tenant `Status.tsx` maps `awaiting_identity` to the submitted stage with a "Verify identity" badge + applicant subtitle.
- **Not included:** the apply-wizard redirect to Stripe's hosted capture. `submit-draft` fires at the payment step (before `Step2Details` collects DOB) and the `Step` union is a frozen contract behind a required e2e gate — the redirect point needs its own focused change.

### PII / FCRA
Persist **only** the `vs_` session reference + categorical statuses + error codes. Name/DOB used transiently for a `name_dob_mismatch` signal, **never persisted**; documents/selfies/images live on Stripe. (Unit test asserts `rawResponse` carries no PII.)

### Verification
- `tsc --noEmit` clean (server); `tsc -b` clean (both frontends).
- Full server suite **1500 passed / 0 failed** (15 pre-existing skips), run `STRIPE_LIVE_ENABLED=false`.
- New suites: `identity-verification-stripe.test.ts` (table-driven mapping + `resolve` gating), `identity-webhook.test.ts` (signed events, livemode guard, idempotency, the 4 new event types, HOLD routing). Updated: `screening-service`, `screening-extended-checks`, `state-machine` (`verify`→`resolve`, new fan-out).

### Go-live (after merge — NOT deployed by this PR)
1. Apply migration (outside txn for `ADD VALUE`).
2. `railway up` with `IDENTITY_VERIFICATION_ENABLED=false` (webhook cases ride in dark).
3. Stripe Dashboard → enable Identity; add `identity.verification_session.*` to the **existing** `/api/payments/webhook` endpoint.
4. Flip `IDENTITY_VERIFICATION_ENABLED=true` (identity captured, staff still manual-`/screen`); after clean live sessions, flip `SCREENING_ON_SUBMIT_ENABLED=true`. Keep `SCREENING_EXTENDED_CHECKS_ENABLED=false`.
5. **Rollback:** flag back to `false`, no redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)