### PR TITLE
feat(screening): HUD/FHA individualized-assessment criminal engine (#3, ships dark)

### DIFF
--- a/src/__tests__/hud-criminal-decision.test.ts
+++ b/src/__tests__/hud-criminal-decision.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Tests for src/modules/screening/hud-criminal-decision.ts — the HUD/FHA
+ * criminal-background decision engine.
+ *
+ * The compliance contract under test (docs/screening/hud-criminal-decision-matrix.md):
+ *   - Only the federal MANDATORY floors auto-deny: §5.856 lifetime registrant,
+ *     §960.204(a)(3) meth manufacture on assisted property, §960.204(a)(2)
+ *     current illegal drug use, §960.204(a)(1) 3-yr drug-related eviction.
+ *   - Every DISCRETIONARY record in lookback → individualized_review (a HOLD).
+ *     Never auto-deny (Castro forbids time-blind blanket bans), never auto-pass.
+ *   - Arrest-only / dismissed / acquitted / expunged → never used (clear).
+ *   - Open / pending / undated → no-data → pause for individualized review.
+ *   - Aged-out discretionary records → clear.
+ *
+ * A fixed `asOf` makes the lookback math deterministic.
+ */
+
+import {
+  evaluateCriminalHistory,
+  DEFAULT_LOOKBACK_POLICY,
+  type CriminalRecord,
+} from "../modules/screening/hud-criminal-decision";
+
+const ASOF = new Date("2026-06-01T00:00:00Z");
+const ev = (input: Parameters<typeof evaluateCriminalHistory>[0], policy?: any) =>
+  evaluateCriminalHistory(input, { asOf: ASOF, policy });
+
+describe("evaluateCriminalHistory — mandatory federal floors (auto-deny, no assessment)", () => {
+  it("lifetime sex-offender registrant → mandatory_denial (§5.856)", () => {
+    const r = ev({ records: [{ category: "felony_sexual", lifetimeRegistrant: true, disposition: "convicted" }] });
+    expect(r.decision).toBe("mandatory_denial");
+    expect(r.citations).toEqual(expect.arrayContaining([expect.stringMatching(/5\.856/)]));
+    expect(r.assessmentFactors).toBeUndefined();
+  });
+
+  it("explicit sex_offense_lifetime_registrant category → mandatory_denial even without the flag", () => {
+    const r = ev({ records: [{ category: "sex_offense_lifetime_registrant", disposition: "convicted" }] });
+    expect(r.decision).toBe("mandatory_denial");
+  });
+
+  it("meth manufacture on assisted property → mandatory_denial (§960.204(a)(3))", () => {
+    const r = ev({ records: [{ category: "meth_manufacture_assisted_property", disposition: "convicted" }] });
+    expect(r.decision).toBe("mandatory_denial");
+    expect(r.citations).toEqual(expect.arrayContaining([expect.stringMatching(/960\.204\(a\)\(3\)/)]));
+  });
+
+  it("current illegal drug use → mandatory_denial (§960.204(a)(2))", () => {
+    const r = ev({ records: [{ category: "current_illegal_drug_use", disposition: "convicted" }] });
+    expect(r.decision).toBe("mandatory_denial");
+    expect(r.citations).toEqual(expect.arrayContaining([expect.stringMatching(/960\.204\(a\)\(2\)/)]));
+  });
+
+  it("drug-related eviction inside the 3-yr window → mandatory_denial (§960.204(a)(1))", () => {
+    const r = ev({ records: [{ category: "drug_related_eviction", disposition: "convicted", dispositionDate: "2024-06-01" }] });
+    expect(r.decision).toBe("mandatory_denial");
+    expect(r.citations).toEqual(expect.arrayContaining([expect.stringMatching(/960\.204\(a\)\(1\)/)]));
+  });
+
+  it("drug-related eviction OLDER than 3 years → aged out (clear, not mandatory)", () => {
+    const r = ev({ records: [{ category: "drug_related_eviction", disposition: "convicted", dispositionDate: "2020-01-01" }] });
+    expect(r.decision).toBe("clear");
+  });
+
+  it("meth manufacture NOT on assisted property is discretionary, not the floor → individualized_review", () => {
+    const r = ev({
+      records: [{ category: "meth_manufacture_assisted_property", onAssistedProperty: false, disposition: "convicted", dispositionDate: "2024-01-01" }],
+    });
+    expect(r.decision).toBe("individualized_review");
+  });
+
+  it("a lifetime registrant flag overrides an otherwise-ignored disposition", () => {
+    const r = ev({ records: [{ category: "felony_sexual", lifetimeRegistrant: true, disposition: "dismissed" }] });
+    expect(r.decision).toBe("mandatory_denial");
+  });
+});
+
+describe("evaluateCriminalHistory — discretionary records (individualized assessment)", () => {
+  it("felony_violent inside the 7-yr lookback → individualized_review (NOT a fail)", () => {
+    const r = ev({ records: [{ category: "felony_violent", disposition: "convicted", releaseDate: "2022-06-01" }] });
+    expect(r.decision).toBe("individualized_review");
+    expect(r.assessmentFactors?.mitigatingEvidenceRequired).toBe(true);
+    expect(r.assessmentFactors?.applicableLookbackYears).toBe(7);
+    expect(r.assessmentFactors?.timeElapsedYears).toBeCloseTo(4.0, 0);
+    expect(r.assessmentFactors?.natureAndSeverity.length).toBeGreaterThan(0);
+    expect(r.assessmentFactors?.workflow).toMatch(/Castro/);
+  });
+
+  it("felony_nonviolent inside the 5-yr lookback → individualized_review", () => {
+    const r = ev({ records: [{ category: "felony_nonviolent", disposition: "convicted", dispositionDate: "2023-01-01" }] });
+    expect(r.decision).toBe("individualized_review");
+    expect(r.assessmentFactors?.applicableLookbackYears).toBe(5);
+  });
+
+  it("felony_nonviolent OUTSIDE the 5-yr lookback → aged out (clear)", () => {
+    const r = ev({ records: [{ category: "felony_nonviolent", disposition: "convicted", dispositionDate: "2018-01-01" }] });
+    expect(r.decision).toBe("clear");
+  });
+
+  it("misdemeanor_violent inside the 3-yr lookback → individualized_review", () => {
+    const r = ev({ records: [{ category: "misdemeanor_violent", disposition: "convicted", dispositionDate: "2024-06-01" }] });
+    expect(r.decision).toBe("individualized_review");
+    expect(r.assessmentFactors?.applicableLookbackYears).toBe(3);
+  });
+
+  it("open / pending charge → individualized_review (no-data pause)", () => {
+    const r = ev({ records: [{ category: "felony_nonviolent", disposition: "pending" }] });
+    expect(r.decision).toBe("individualized_review");
+    expect(r.assessmentFactors?.timeElapsedYears).toBeNull();
+    expect(r.reasons.join(" ")).toMatch(/pending|no-data/i);
+  });
+
+  it("an undated conviction defaults to in-lookback → individualized_review (never silently aged out)", () => {
+    const r = ev({ records: [{ category: "felony_violent", disposition: "convicted" }] });
+    expect(r.decision).toBe("individualized_review");
+    expect(r.assessmentFactors?.timeElapsedYears).toBeNull();
+  });
+
+  it("an 'other' (unclassified) conviction conservatively requires individualized_review", () => {
+    const r = ev({ records: [{ category: "other", disposition: "convicted", dispositionDate: "2025-01-01" }] });
+    expect(r.decision).toBe("individualized_review");
+  });
+});
+
+describe("evaluateCriminalHistory — records that must never be used", () => {
+  it.each(["arrest_only", "dismissed", "acquitted", "expunged"] as const)(
+    "%s disposition → clear (Castro §III.A: not a defensible basis)",
+    (disposition) => {
+      const r = ev({ records: [{ category: "felony_violent", disposition, dispositionDate: "2025-01-01" }] });
+      expect(r.decision).toBe("clear");
+    }
+  );
+
+  it("no records / empty input → clear", () => {
+    expect(ev({}).decision).toBe("clear");
+    expect(ev({ records: [] }).decision).toBe("clear");
+  });
+});
+
+describe("evaluateCriminalHistory — precedence & policy", () => {
+  it("a mandatory floor outranks a discretionary record in the same history", () => {
+    const r = ev({
+      records: [
+        { category: "felony_nonviolent", disposition: "convicted", dispositionDate: "2024-01-01" },
+        { category: "current_illegal_drug_use", disposition: "convicted" },
+      ],
+    });
+    expect(r.decision).toBe("mandatory_denial");
+  });
+
+  it("operator policy can TIGHTEN a lookback (still individualized_review, never auto-fail)", () => {
+    const rec: CriminalRecord = { category: "felony_nonviolent", disposition: "convicted", dispositionDate: "2023-01-01" };
+    expect(ev({ records: [rec] }).decision).toBe("individualized_review"); // default 5yr → in
+    // Tighten to 1 year → the 3-yr-old conviction ages out to clear.
+    expect(ev({ records: [rec] }, { felonyNonviolentYears: 1 }).decision).toBe("clear");
+  });
+
+  it("undatedConvictionInLookback=false ages out an undated conviction → clear", () => {
+    const r = ev({ records: [{ category: "felony_violent", disposition: "convicted" }] }, { undatedConvictionInLookback: false });
+    expect(r.decision).toBe("clear");
+  });
+
+  it("DEFAULT_LOOKBACK_POLICY reflects the matrix ceilings", () => {
+    expect(DEFAULT_LOOKBACK_POLICY.felonyViolentYears).toBe(7);
+    expect(DEFAULT_LOOKBACK_POLICY.felonyNonviolentYears).toBe(5);
+    expect(DEFAULT_LOOKBACK_POLICY.drugEvictionYears).toBe(3);
+    expect(DEFAULT_LOOKBACK_POLICY.undatedConvictionInLookback).toBe(true);
+  });
+});
+
+describe("evaluateCriminalHistory — legacy summary-flag path (current sandbox vendor)", () => {
+  it("sexOffenses:true → mandatory_denial (§5.856 registry hit)", () => {
+    const r = ev({ felonies: 0, sexOffenses: true, violentCrimes: false });
+    expect(r.decision).toBe("mandatory_denial");
+    expect(r.citations).toEqual(expect.arrayContaining([expect.stringMatching(/5\.856/)]));
+  });
+
+  it("felonies>0 → individualized_review (no time-blind ban)", () => {
+    const r = ev({ felonies: 2, sexOffenses: false, violentCrimes: false });
+    expect(r.decision).toBe("individualized_review");
+    expect(r.assessmentFactors?.mitigatingEvidenceRequired).toBe(true);
+  });
+
+  it("violentCrimes:true → individualized_review", () => {
+    const r = ev({ felonies: 0, sexOffenses: false, violentCrimes: true });
+    expect(r.decision).toBe("individualized_review");
+  });
+
+  it("explicit mandatory flags → mandatory_denial", () => {
+    expect(ev({ methManufactureOnAssistedProperty: true }).decision).toBe("mandatory_denial");
+    expect(ev({ currentIllegalDrugUse: true }).decision).toBe("mandatory_denial");
+    expect(ev({ drugRelatedEvictionWithinLookback: true }).decision).toBe("mandatory_denial");
+  });
+
+  it("clean summary (no felonies/offenses) → clear", () => {
+    const r = ev({ felonies: 0, sexOffenses: false, violentCrimes: false });
+    expect(r.decision).toBe("clear");
+  });
+
+  it("structured records are authoritative — legacy felonies count is ignored when records are present", () => {
+    // An aged-out structured felony + a noisy legacy felonies:5 → the records win → clear.
+    const r = ev({
+      records: [{ category: "felony_nonviolent", disposition: "convicted", dispositionDate: "2015-01-01" }],
+      felonies: 5,
+    });
+    expect(r.decision).toBe("clear");
+  });
+
+  it("explicit mandatory flags still apply alongside structured records", () => {
+    const r = ev({
+      records: [{ category: "felony_nonviolent", disposition: "convicted", dispositionDate: "2015-01-01" }],
+      sexOffenses: true,
+    });
+    expect(r.decision).toBe("mandatory_denial");
+  });
+});

--- a/src/__tests__/screening-integrations.test.ts
+++ b/src/__tests__/screening-integrations.test.ts
@@ -14,7 +14,13 @@
  *   - Error path: API throws → caught → returns could_not_screen (safe fallback)
  *
  * LIHTC/HUD/FCRA compliance notes:
- *   BackgroundCheckService: auto-fail on felonies, sex offenses, violent crimes
+ *   BackgroundCheckService: runs the HUD/FHA individualized-assessment engine
+ *     (hud-criminal-decision.ts). Only federal MANDATORY floors auto-fail
+ *     (§5.856 lifetime sex-offender registrant; §960.204 meth/current-drug/
+ *     drug-eviction). DISCRETIONARY records (felonies, violent crimes) do NOT
+ *     auto-fail — they become review_required tagged decision="individualized_review"
+ *     so the orchestrator HOLDs them for a Castro §III.B assessment (never a
+ *     time-blind blanket ban; never an auto-pass).
  *   CreditCheckService: auto-fail on evictions or active bankruptcy;
  *     sub-600 score → review_required (not auto-fail — decision matrix handles exceptions)
  */
@@ -69,6 +75,7 @@ describe("BackgroundCheckService.runCheck()", () => {
     const result = await service.runCheck(bgInput());
 
     expect(result.result).toBe("pass");
+    expect(result.details.decision).toBe("clear");
     expect(result.details.felonies).toBe(0);
     expect(result.details.sexOffenses).toBe(false);
     expect(result.details.violentCrimes).toBe(false);
@@ -78,7 +85,10 @@ describe("BackgroundCheckService.runCheck()", () => {
 
   // ── evaluateResults() via spy ────────────────────────────────────────────
 
-  it("returns fail when response contains felonies (auto-fail criterion)", async () => {
+  it("HOLDs felonies for individualized assessment — does NOT auto-fail (HUD/FHA)", async () => {
+    // Felonies are DISCRETIONARY: Castro §III forbids a time-blind blanket ban.
+    // The engine routes them to a review_required HOLD tagged for individualized
+    // assessment, never a "fail".
     jest.spyOn(service as any, "callScreeningAPI").mockResolvedValue({
       felonies: 2,
       sexOffenses: false,
@@ -88,12 +98,19 @@ describe("BackgroundCheckService.runCheck()", () => {
 
     const result = await service.runCheck(bgInput());
 
-    expect(result.result).toBe("fail");
+    expect(result.result).toBe("review_required");
+    expect(result.details.decision).toBe("individualized_review");
     expect(result.details.felonies).toBe(2);
-    expect(result.details.riskScore).toBe(100);
+    expect(result.details.riskScore).toBe(90);
+    expect(result.details.assessmentFactors?.mitigatingEvidenceRequired).toBe(true);
+    expect(result.details.citations).toEqual(
+      expect.arrayContaining([expect.stringMatching(/100\.500|Castro/)])
+    );
   });
 
-  it("returns fail when response contains sex offenses (auto-fail)", async () => {
+  it("auto-fails a sex-offender registry hit (§5.856 mandatory floor)", async () => {
+    // §5.856 lifetime registrant is one of the few MANDATORY federal denials —
+    // it is the exception that still auto-fails (no individualized assessment).
     jest.spyOn(service as any, "callScreeningAPI").mockResolvedValue({
       felonies: 0,
       sexOffenses: true,
@@ -104,11 +121,15 @@ describe("BackgroundCheckService.runCheck()", () => {
     const result = await service.runCheck(bgInput());
 
     expect(result.result).toBe("fail");
+    expect(result.details.decision).toBe("mandatory_denial");
     expect(result.details.sexOffenses).toBe(true);
     expect(result.details.riskScore).toBe(100);
+    expect(result.details.citations).toEqual(
+      expect.arrayContaining([expect.stringMatching(/5\.856/)])
+    );
   });
 
-  it("returns fail when response contains violent crimes (auto-fail)", async () => {
+  it("HOLDs violent crimes for individualized assessment — does NOT auto-fail", async () => {
     jest.spyOn(service as any, "callScreeningAPI").mockResolvedValue({
       felonies: 0,
       sexOffenses: false,
@@ -118,11 +139,16 @@ describe("BackgroundCheckService.runCheck()", () => {
 
     const result = await service.runCheck(bgInput());
 
-    expect(result.result).toBe("fail");
+    expect(result.result).toBe("review_required");
+    expect(result.details.decision).toBe("individualized_review");
     expect(result.details.violentCrimes).toBe(true);
+    expect(result.details.riskScore).toBe(90);
   });
 
-  it("returns review_required when misdemeanor count >= 3 (riskScore=75)", async () => {
+  it("returns review_required when misdemeanor count >= 3 (riskScore=75, soft-clear)", async () => {
+    // Misdemeanors are NOT a denial-consideration trigger in the engine
+    // (decision stays "clear"); the legacy soft-risk score still routes 3+ to a
+    // review_required passthrough (auto-pass), distinct from an IA hold.
     jest.spyOn(service as any, "callScreeningAPI").mockResolvedValue({
       felonies: 0,
       sexOffenses: false,
@@ -133,6 +159,7 @@ describe("BackgroundCheckService.runCheck()", () => {
     const result = await service.runCheck(bgInput());
 
     expect(result.result).toBe("review_required");
+    expect(result.details.decision).toBe("clear");
     expect(result.details.misdemeanors).toBe(3);
     expect(result.details.riskScore).toBe(75);
   });

--- a/src/__tests__/screening-service.test.ts
+++ b/src/__tests__/screening-service.test.ts
@@ -115,14 +115,38 @@ function makeApp(overrides: Record<string, unknown> = {}) {
   };
 }
 
-function makeBackgroundResult(result: "pass" | "fail" | "review_required" | "could_not_screen") {
+function makeBackgroundResult(
+  result: "pass" | "fail" | "review_required" | "could_not_screen",
+  extraDetails: Record<string, unknown> = {}
+) {
   return {
     result,
     details: {
       felonies: 0, sexOffenses: false, violentCrimes: false,
       misdemeanors: 0, riskScore: 10,
+      ...extraDetails,
     },
   } as any;
+}
+
+/** A background check that surfaced a discretionary criminal record requiring a
+ *  HUD/FHA individualized assessment (Castro §III.B): review_required result
+ *  carrying decision="individualized_review". */
+function makeBackgroundIA() {
+  return makeBackgroundResult("review_required", {
+    decision: "individualized_review",
+    riskScore: 90,
+    felonies: 1,
+    reasons: ["felony_nonviolent within 5-yr lookback — individualized assessment required"],
+    citations: ["Castro memo §III; 24 CFR §100.500"],
+    assessmentFactors: {
+      natureAndSeverity: ["felony_nonviolent"],
+      timeElapsedYears: 2.0,
+      applicableLookbackYears: 5,
+      mitigatingEvidenceRequired: true,
+      workflow: "Castro §III.B",
+    },
+  });
 }
 
 function makeCreditResult(
@@ -306,6 +330,94 @@ describe("ScreeningService.runFullScreening", () => {
     const result = await service.runFullScreening("app-001", "user-1", "leasing_agent");
 
     expect(result.overallResult).toBe("fail");
+  });
+
+  // ── HUD/FHA individualized assessment: discretionary criminal record HOLDS ──
+  //
+  // A discretionary criminal record in lookback is surfaced by background-check
+  // as result=review_required tagged details.decision="individualized_review".
+  // It must HOLD in screening_review (Castro §III.B), never auto-fail (no
+  // time-blind blanket ban) and never auto-pass via the review_required
+  // passthrough. The overall result stays the enum-safe "review_required" — the
+  // HOLD-ness is the STATUS, so this needs NO new screening_result enum value
+  // and NO migration.
+
+  it("routes a background individualized-assessment to screening_review, NEVER screening_passed", async () => {
+    mockBackground.runCheck.mockResolvedValue(makeBackgroundIA());
+    mockTransition.mockResolvedValue({ changed: true, status: "screening_review" } as any);
+
+    await service.runFullScreening("app-001", "user-1", "leasing_agent");
+
+    expect(mockTransition).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "screening_review",
+        trigger: "individualized_assessment_required",
+      })
+    );
+    // It must NEVER have attempted to mark the app passed (no auto-pass) ...
+    expect(mockTransition).not.toHaveBeenCalledWith(
+      expect.objectContaining({ to: "screening_passed" })
+    );
+    // ... and NEVER failed it (no time-blind blanket ban).
+    expect(mockTransition).not.toHaveBeenCalledWith(
+      expect.objectContaining({ to: "screening_failed" })
+    );
+  });
+
+  it("keeps overallResult=review_required for an individualized-assessment hold (enum-safe, no migration)", async () => {
+    mockBackground.runCheck.mockResolvedValue(makeBackgroundIA());
+    mockTransition.mockResolvedValue({ changed: true, status: "screening_review" } as any);
+
+    const result = await service.runFullScreening("app-001", "user-1", "leasing_agent");
+
+    expect(result.overallResult).toBe("review_required");
+    // The aggregate-result UPDATE writes the enum-safe "review_required" verbatim.
+    const wroteReviewRequired = mockQuery.mock.calls.some(
+      ([sql, params]) =>
+        typeof sql === "string" &&
+        /SET overall_screening_result = \$2/.test(sql) &&
+        Array.isArray(params) &&
+        params[1] === "review_required"
+    );
+    expect(wroteReviewRequired).toBe(true);
+  });
+
+  it("sends NO adverse-action notice for an individualized-assessment hold (assessment precedes any denial)", async () => {
+    mockBackground.runCheck.mockResolvedValue(makeBackgroundIA());
+    mockTransition.mockResolvedValue({ changed: true, status: "screening_review" } as any);
+
+    await service.runFullScreening("app-001", "user-1", "leasing_agent");
+
+    expect(mockAdverseAction.sendNotice).not.toHaveBeenCalled();
+  });
+
+  it("fail still outranks an individualized-assessment hold (a mandatory denial elsewhere wins)", async () => {
+    mockBackground.runCheck.mockResolvedValue(makeBackgroundIA());
+    mockCredit.runCheck.mockResolvedValue(makeCreditResult("fail"));
+
+    const result = await service.runFullScreening("app-001", "user-1", "leasing_agent");
+
+    expect(result.overallResult).toBe("fail");
+    expect(mockTransition).toHaveBeenCalledWith(
+      expect.objectContaining({ to: "screening_failed", trigger: "any_check_failed" })
+    );
+  });
+
+  it("a plain review_required (decision='clear', e.g. 3+ misdemeanors) still passes through to screening_passed", async () => {
+    // Regression guard: only an individualized_review decision HOLDs. A soft
+    // review_required (misdemeanor risk score) keeps the legacy passthrough.
+    mockBackground.runCheck.mockResolvedValue(
+      makeBackgroundResult("review_required", { decision: "clear", riskScore: 75, misdemeanors: 3 })
+    );
+
+    await service.runFullScreening("app-001", "user-1", "leasing_agent");
+
+    expect(mockTransition).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "screening_passed",
+        trigger: "review_required_passthrough",
+      })
+    );
   });
 
   // ── could_not_screen: misconfigured / failed pipeline HOLDS, never passes ──

--- a/src/modules/screening/background-check.ts
+++ b/src/modules/screening/background-check.ts
@@ -1,5 +1,10 @@
 import { logger } from "../../utils/logger";
 import { resolveVendor } from "./vendors";
+import {
+  evaluateCriminalHistory,
+  type CriminalDecision,
+  type CriminalAssessmentFactors,
+} from "./hud-criminal-decision";
 
 export interface BackgroundCheckResult {
   result: "pass" | "fail" | "review_required" | "could_not_screen";
@@ -9,14 +14,28 @@ export interface BackgroundCheckResult {
     violentCrimes: boolean;
     misdemeanors: number;
     riskScore: number;
+    /** HUD/FHA decision from the criminal-history engine (omitted on could_not_screen). */
+    decision?: CriminalDecision;
+    /** Human-readable rationale lines (surfaced in the staff review queue). */
+    reasons?: string[];
+    /** CFR / FHA citations backing the decision. */
+    citations?: string[];
+    /** Castro §III.B factors — present only when an individualized assessment is required. */
+    assessmentFactors?: CriminalAssessmentFactors;
     rawResponse?: Record<string, unknown>;
   };
 }
 
 /**
  * Third-party background check integration.
- * Auto-fail: felonies, sex offenses, violence.
- * Risk-scored: minor misdemeanors.
+ *
+ * The denial logic is the HUD/FHA individualized-assessment engine
+ * (hud-criminal-decision.ts), NOT a blanket ban:
+ *   - federal mandatory floors (§5.856 / §960.204) → "fail" (immediate FCRA notice)
+ *   - a discretionary record in lookback → "review_required" carrying
+ *     details.decision="individualized_review" → the orchestrator HOLDs it in
+ *     screening_review for a Castro §III.B assessment (never auto-fail, never auto-pass)
+ *   - everything else ("clear") → the legacy misdemeanor soft-risk score
  *
  * The raw vendor response comes from the screening vendor seam
  * (resolveVendor("background")); this service owns only Frank's evaluation
@@ -76,37 +95,57 @@ export class BackgroundCheckService {
     const violentCrimes = response.violentCrimes || false;
     const misdemeanors = (response.misdemeanors || []).length;
 
-    // Auto-fail criteria
-    if (felonies > 0 || sexOffenses || violentCrimes) {
-      return {
-        result: "fail",
-        details: {
-          felonies,
-          sexOffenses,
-          violentCrimes,
-          misdemeanors,
-          riskScore: 100,
-          rawResponse: response,
-        },
-      };
+    // Run the HUD/FHA decision engine. Structured `criminalRecords` (real vendor
+    // path) are authoritative; the legacy summary flags drive the engine when no
+    // structured records are present (current sandbox path).
+    const decision = evaluateCriminalHistory({
+      records: Array.isArray(response.criminalRecords) ? response.criminalRecords : undefined,
+      felonies,
+      sexOffenses,
+      violentCrimes,
+      methManufactureOnAssistedProperty: response.methManufactureOnAssistedProperty,
+      currentIllegalDrugUse: response.currentIllegalDrugUse,
+      drugRelatedEvictionWithinLookback: response.drugRelatedEvictionWithinLookback,
+    });
+
+    const baseDetails = {
+      felonies,
+      sexOffenses,
+      violentCrimes,
+      misdemeanors,
+      decision: decision.decision,
+      reasons: decision.reasons,
+      citations: decision.citations,
+      ...(decision.assessmentFactors ? { assessmentFactors: decision.assessmentFactors } : {}),
+      rawResponse: response,
+    };
+
+    // Mandatory federal floor (§5.856 / §960.204) → hard fail. The orchestrator
+    // fires the FCRA adverse-action notice on this immediately.
+    if (decision.decision === "mandatory_denial") {
+      return { result: "fail", details: { ...baseDetails, riskScore: 100 } };
     }
 
-    // Risk scoring for misdemeanors
+    // Discretionary record in lookback (or open/undated) → individualized
+    // assessment. We surface this as review_required, but tag it with
+    // decision="individualized_review" so the orchestrator routes it to a
+    // screening_review HOLD rather than the review_required auto-pass.
+    // NEVER auto-fail (Castro forbids time-blind bans); NEVER auto-pass.
+    if (decision.decision === "individualized_review") {
+      return { result: "review_required", details: { ...baseDetails, riskScore: 90 } };
+    }
+
+    // decision === "clear": no denial-consideration record. Preserve the legacy
+    // misdemeanor soft-risk behaviour (3+ → review_required passthrough).
     let riskScore = 0;
     if (misdemeanors === 1) riskScore = 25;
     else if (misdemeanors === 2) riskScore = 50;
     else if (misdemeanors >= 3) riskScore = 75;
 
     if (riskScore >= 75) {
-      return {
-        result: "review_required",
-        details: { felonies, sexOffenses, violentCrimes, misdemeanors, riskScore, rawResponse: response },
-      };
+      return { result: "review_required", details: { ...baseDetails, riskScore } };
     }
 
-    return {
-      result: "pass",
-      details: { felonies, sexOffenses, violentCrimes, misdemeanors, riskScore, rawResponse: response },
-    };
+    return { result: "pass", details: { ...baseDetails, riskScore } };
   }
 }

--- a/src/modules/screening/hud-criminal-decision.ts
+++ b/src/modules/screening/hud-criminal-decision.ts
@@ -1,0 +1,462 @@
+/**
+ * HUD / FHA criminal-background decision engine (LIHTC / Section 42, Nevada).
+ *
+ * This is the compliance heart of the background check. It replaces a naive
+ * blanket auto-fail ("any felony / sex offense / violent crime → deny") with the
+ * individualized-assessment framework that docs/screening/hud-criminal-decision-matrix.md
+ * derives from 24 CFR Part 5 Subpart I, §960.204, the FHA disparate-impact rule
+ * (24 CFR §100.500), and the 2016 OGC "Castro" memo §III.
+ *
+ * Three outcomes:
+ *   - "mandatory_denial"        — a federal floor requires denial, no assessment
+ *                                 needed (24 CFR §5.856 lifetime registrant;
+ *                                 §960.204(a)(2)/(a)(3) current drug use / meth
+ *                                 manufacture; §960.204(a)(1) 3-yr drug-eviction).
+ *   - "individualized_review"   — a discretionary record inside the lookback (or
+ *                                 an open/undated one). MUST route to a HOLD: never
+ *                                 auto-deny (Castro forbids time-blind blanket bans),
+ *                                 never auto-pass (the assessment must happen first).
+ *   - "clear"                   — nothing in scope for denial consideration
+ *                                 (aged-out, arrest-only, dismissed, or no record).
+ *
+ * NOTE ON THE 2025 TURNER RESCISSION: HUD rescinded PIH 2015-19, the Castro memo,
+ * and the McCain memo on 2025-11-25, but that is sub-regulatory — the Fair Housing
+ * Act and 24 CFR §100.500 are UNCHANGED, so private disparate-impact exposure
+ * persists. Per the standing compliance directive, Frank keeps the
+ * individualized-assessment workflow + Castro lookback ceilings as DEFAULTS and
+ * never ships a blanket ban. An operator may tighten lookbacks via `policy`, but
+ * the engine will never auto-fail a discretionary record.
+ *
+ * Pure & deterministic: no I/O, no env reads, no clock except the injectable
+ * `asOf` (defaults to now). Safe to unit-test exhaustively.
+ */
+
+export type CriminalDecision = "clear" | "individualized_review" | "mandatory_denial";
+
+/**
+ * Offense categories. The first four are the federal mandatory floors; the rest
+ * are discretionary and constrained only by the FHA + a published lookback.
+ */
+export type OffenseCategory =
+  // ── Mandatory federal floors ───────────────────────────────────────────────
+  | "sex_offense_lifetime_registrant" // §5.856 — current registry status, permanent
+  | "meth_manufacture_assisted_property" // §960.204(a)(3) — permanent
+  | "current_illegal_drug_use" // §960.204(a)(2) — current behavior
+  | "drug_related_eviction" // §960.204(a)(1) — 3-yr lookback from eviction
+  // ── Discretionary (individualized assessment required before denial) ────────
+  | "felony_violent"
+  | "felony_sexual" // a sexual felony that is NOT a lifetime-registry hit
+  | "felony_arson"
+  | "felony_nonviolent"
+  | "misdemeanor_violent"
+  | "misdemeanor_nonviolent"
+  | "drug_other" // non-meth, non-eviction drug offense
+  | "other";
+
+export type Disposition =
+  | "convicted"
+  | "arrest_only" // Castro §III.A — NEVER use, exclusion not defensible
+  | "dismissed"
+  | "acquitted"
+  | "expunged"
+  | "pending" // open charge → no-data → pause (individualized review)
+  | "open"
+  | "unknown";
+
+export interface CriminalRecord {
+  category: OffenseCategory;
+  disposition?: Disposition;
+  /** ISO date the offense occurred. */
+  offenseDate?: string;
+  /** ISO date of conviction / disposition. */
+  dispositionDate?: string;
+  /** ISO date released from custody — preferred anchor for post-release lookbacks. */
+  releaseDate?: string;
+  /** True when the subject is currently subject to lifetime sex-offender registration. */
+  lifetimeRegistrant?: boolean;
+  /** For meth-manufacture: occurred on the premises of federally assisted housing. */
+  onAssistedProperty?: boolean;
+  description?: string;
+}
+
+/**
+ * Lookback ceilings (years) for the discretionary categories. Defaults reflect
+ * the industry-consensus / Castro-era ceilings in the decision matrix §6.
+ * Operators may tighten these via policy, but cannot turn a discretionary record
+ * into an auto-fail — the engine only ever returns individualized_review for them.
+ */
+export interface LookbackPolicy {
+  felonyViolentYears: number;
+  felonyNonviolentYears: number;
+  misdemeanorViolentYears: number;
+  misdemeanorNonviolentYears: number;
+  drugOtherYears: number;
+  /** §960.204(a)(1) mandatory window — denial mandated for this many years post-eviction. */
+  drugEvictionYears: number;
+  /**
+   * When a discretionary conviction carries no usable date, treat it as
+   * in-lookback (→ individualized review) rather than silently aging it out.
+   * Default true — we never silent-clear an undated conviction.
+   */
+  undatedConvictionInLookback: boolean;
+}
+
+export const DEFAULT_LOOKBACK_POLICY: LookbackPolicy = {
+  felonyViolentYears: 7, // felony violent / sexual / arson — 5–7 yrs post-release
+  felonyNonviolentYears: 5,
+  misdemeanorViolentYears: 3,
+  misdemeanorNonviolentYears: 1, // 1–3 yrs or skip; conservative 1-yr IA window
+  drugOtherYears: 3, // §960.204(a)(1) federal floor by analogy
+  drugEvictionYears: 3, // §960.204(a)(1) mandatory
+  undatedConvictionInLookback: true,
+};
+
+export interface CriminalAssessmentFactors {
+  /** Categories / descriptions of the records that triggered the hold. */
+  natureAndSeverity: string[];
+  /** Smallest years-elapsed among triggering discretionary records; null if undated/open. */
+  timeElapsedYears: number | null;
+  /** Lookback ceiling applied; null when not date-driven (legacy summary / open case). */
+  applicableLookbackYears: number | null;
+  mitigatingEvidenceRequired: true;
+  /** The Castro §III.B workflow staff must complete before any denial. */
+  workflow: string;
+}
+
+/** Discretionary categories that may be provided as a legacy summary, plus
+ *  optional structured records and explicit mandatory signals. */
+export interface CriminalHistoryInput {
+  /** Structured records — authoritative when present (real vendor path). */
+  records?: CriminalRecord[];
+  // ── Legacy summary flags (the current sandbox / integration path) ───────────
+  felonies?: number;
+  /** Sex-offender registry hit (NSOPW / §5.856) — treated as a mandatory floor. */
+  sexOffenses?: boolean;
+  violentCrimes?: boolean;
+  // ── Explicit mandatory signals (always honored, structured or not) ──────────
+  methManufactureOnAssistedProperty?: boolean;
+  currentIllegalDrugUse?: boolean;
+  /** A drug-related eviction inside the §960.204(a)(1) 3-yr window. */
+  drugRelatedEvictionWithinLookback?: boolean;
+}
+
+export interface CriminalDecisionResult {
+  decision: CriminalDecision;
+  reasons: string[];
+  citations: string[];
+  /** Present only when decision === "individualized_review". */
+  assessmentFactors?: CriminalAssessmentFactors;
+}
+
+const MS_PER_YEAR = 365.25 * 24 * 60 * 60 * 1000;
+
+const CASTRO_WORKFLOW =
+  "Castro §III.B: notify the applicant and identify the record relied on → " +
+  "give an opportunity to provide mitigating evidence → document the nature & " +
+  "severity of the conduct, the time elapsed, and the mitigating evidence → " +
+  "issue a written rationale. Retain the file ≥3 years.";
+
+/** Dispositions that must never contribute to a denial. */
+const IGNORED_DISPOSITIONS: ReadonlySet<Disposition> = new Set([
+  "arrest_only",
+  "dismissed",
+  "acquitted",
+  "expunged",
+]);
+
+/** Open / pending charges — no-data, pause for resolution. */
+const PENDING_DISPOSITIONS: ReadonlySet<Disposition> = new Set(["pending", "open"]);
+
+/** Years-elapsed from the best available anchor; null when undated/unparseable. */
+function yearsElapsed(record: CriminalRecord, asOf: Date): number | null {
+  const raw = record.releaseDate || record.dispositionDate || record.offenseDate;
+  if (!raw) return null;
+  const t = Date.parse(raw);
+  if (Number.isNaN(t)) return null;
+  return (asOf.getTime() - t) / MS_PER_YEAR;
+}
+
+function lookbackForCategory(category: OffenseCategory, policy: LookbackPolicy): number | null {
+  switch (category) {
+    case "felony_violent":
+    case "felony_sexual":
+    case "felony_arson":
+      return policy.felonyViolentYears;
+    case "felony_nonviolent":
+      return policy.felonyNonviolentYears;
+    case "misdemeanor_violent":
+      return policy.misdemeanorViolentYears;
+    case "misdemeanor_nonviolent":
+      return policy.misdemeanorNonviolentYears;
+    case "drug_other":
+      return policy.drugOtherYears;
+    default:
+      return null; // mandatory / other — not lookback-driven here
+  }
+}
+
+interface Accumulator {
+  mandatory: boolean;
+  needsAssessment: boolean;
+  reasons: string[];
+  citations: Set<string>;
+  natureAndSeverity: string[];
+  /** Smallest elapsed among discretionary triggers; null until a dated one is seen. */
+  minElapsed: number | null;
+  /** Lookback ceiling of the first dated discretionary trigger. */
+  appliedLookback: number | null;
+}
+
+function addMandatory(acc: Accumulator, reason: string, citation: string): void {
+  acc.mandatory = true;
+  acc.reasons.push(reason);
+  acc.citations.add(citation);
+}
+
+function addAssessment(
+  acc: Accumulator,
+  reason: string,
+  citation: string,
+  nature: string,
+  elapsed: number | null,
+  lookback: number | null
+): void {
+  acc.needsAssessment = true;
+  acc.reasons.push(reason);
+  acc.citations.add(citation);
+  acc.natureAndSeverity.push(nature);
+  if (elapsed !== null && (acc.minElapsed === null || elapsed < acc.minElapsed)) {
+    acc.minElapsed = elapsed;
+  }
+  if (lookback !== null && acc.appliedLookback === null) {
+    acc.appliedLookback = lookback;
+  }
+}
+
+function processRecord(acc: Accumulator, record: CriminalRecord, policy: LookbackPolicy, asOf: Date): void {
+  const label = record.description || record.category;
+
+  // 1. §5.856 lifetime registrant — current status, disposition-independent.
+  if (record.lifetimeRegistrant === true || record.category === "sex_offense_lifetime_registrant") {
+    addMandatory(
+      acc,
+      `Lifetime sex-offender registrant (${label}) — mandatory denial`,
+      "24 CFR §5.856; 42 USC §13663"
+    );
+    return;
+  }
+
+  // 2. Disposition gate (Castro §III.A).
+  const disposition = record.disposition ?? "unknown";
+  if (IGNORED_DISPOSITIONS.has(disposition)) {
+    acc.reasons.push(`Ignored ${disposition} record (${label}) — not a usable basis for denial`);
+    return;
+  }
+  if (PENDING_DISPOSITIONS.has(disposition)) {
+    addAssessment(
+      acc,
+      `Open/pending charge (${label}) — treat as no-data; pause for individualized review`,
+      "Castro memo §III.A",
+      `${label} (pending)`,
+      null,
+      null
+    );
+    return;
+  }
+
+  // 3. Convicted / unknown disposition → classify.
+  switch (record.category) {
+    case "meth_manufacture_assisted_property":
+      if (record.onAssistedProperty === false) {
+        // Meth manufacture NOT on assisted property is discretionary, not the floor.
+        addAssessment(
+          acc,
+          `Meth manufacture not on assisted property (${label}) — individualized review`,
+          "Castro memo §III",
+          label,
+          yearsElapsed(record, asOf),
+          policy.felonyViolentYears
+        );
+      } else {
+        addMandatory(
+          acc,
+          `Methamphetamine manufacture on federally assisted property (${label}) — mandatory denial`,
+          "24 CFR §960.204(a)(3); §5.854(b)"
+        );
+      }
+      return;
+    case "current_illegal_drug_use":
+      addMandatory(
+        acc,
+        `Current illegal drug use (${label}) — mandatory denial per PHA reasonable cause`,
+        "24 CFR §960.204(a)(2)"
+      );
+      return;
+    case "drug_related_eviction": {
+      const elapsed = yearsElapsed(record, asOf);
+      const within =
+        elapsed === null ? policy.undatedConvictionInLookback : elapsed <= policy.drugEvictionYears;
+      if (within) {
+        addMandatory(
+          acc,
+          `Drug-related eviction within ${policy.drugEvictionYears} years (${label}) — mandatory denial (waivable on rehab/incarceration)`,
+          "24 CFR §960.204(a)(1)"
+        );
+      } else {
+        acc.reasons.push(
+          `Drug-related eviction older than ${policy.drugEvictionYears} years (${label}) — aged out of the mandatory window`
+        );
+      }
+      return;
+    }
+    default: {
+      // Discretionary categories (+ "other"): individualized assessment if in
+      // lookback, otherwise aged out. Never auto-fail.
+      const lookback = lookbackForCategory(record.category, policy);
+      const elapsed = yearsElapsed(record, asOf);
+      if (lookback === null) {
+        // "other" — unknown conviction; conservatively require assessment.
+        addAssessment(
+          acc,
+          `Unclassified conviction (${label}) — individualized review`,
+          "Castro memo §III; 24 CFR §100.500",
+          label,
+          elapsed,
+          null
+        );
+        return;
+      }
+      const within =
+        elapsed === null ? policy.undatedConvictionInLookback : elapsed <= lookback;
+      if (within) {
+        const when = elapsed === null ? "date unknown" : `${elapsed.toFixed(1)} yrs ago`;
+        addAssessment(
+          acc,
+          `${record.category} within ${lookback}-yr lookback (${label}, ${when}) — individualized assessment required before any denial`,
+          "Castro memo §III; 24 CFR §100.500",
+          label,
+          elapsed,
+          lookback
+        );
+      } else {
+        acc.reasons.push(
+          `${record.category} (${label}) outside the ${lookback}-yr lookback — aged out, not a basis for denial`
+        );
+      }
+    }
+  }
+}
+
+/**
+ * Evaluate a criminal history into a HUD/FHA-compliant decision.
+ *
+ * When `records` are provided they are authoritative; the legacy summary flags
+ * (`felonies` / `violentCrimes`) are then ignored to avoid double-counting.
+ * Explicit mandatory signals (`sexOffenses`, meth, current-drug, drug-eviction)
+ * are always honored.
+ */
+export function evaluateCriminalHistory(
+  input: CriminalHistoryInput,
+  opts?: { policy?: Partial<LookbackPolicy>; asOf?: Date }
+): CriminalDecisionResult {
+  const policy: LookbackPolicy = { ...DEFAULT_LOOKBACK_POLICY, ...(opts?.policy ?? {}) };
+  const asOf = opts?.asOf ?? new Date();
+
+  const acc: Accumulator = {
+    mandatory: false,
+    needsAssessment: false,
+    reasons: [],
+    citations: new Set<string>(),
+    natureAndSeverity: [],
+    minElapsed: null,
+    appliedLookback: null,
+  };
+
+  // ── Explicit mandatory signals (always honored) ─────────────────────────────
+  // A sex-offender registry hit (NSOPW / §5.856) is modeled in Frank as the
+  // `sexOffenses` boolean; it is the lifetime mandatory floor.
+  if (input.sexOffenses === true) {
+    addMandatory(
+      acc,
+      "Sex-offender registry match — mandatory denial",
+      "24 CFR §5.856; 42 USC §13663"
+    );
+  }
+  if (input.methManufactureOnAssistedProperty === true) {
+    addMandatory(
+      acc,
+      "Methamphetamine manufacture on federally assisted property — mandatory denial",
+      "24 CFR §960.204(a)(3); §5.854(b)"
+    );
+  }
+  if (input.currentIllegalDrugUse === true) {
+    addMandatory(
+      acc,
+      "Current illegal drug use — mandatory denial per PHA reasonable cause",
+      "24 CFR §960.204(a)(2)"
+    );
+  }
+  if (input.drugRelatedEvictionWithinLookback === true) {
+    addMandatory(
+      acc,
+      "Drug-related eviction within the 3-year window — mandatory denial (waivable on rehab/incarceration)",
+      "24 CFR §960.204(a)(1)"
+    );
+  }
+
+  const records = Array.isArray(input.records) ? input.records : [];
+  if (records.length > 0) {
+    // Structured path — authoritative.
+    for (const record of records) processRecord(acc, record, policy, asOf);
+  } else {
+    // Legacy summary path — discretionary felony/violent flags → individualized
+    // review (no dates available, so undated → in-lookback). Misdemeanor counts
+    // are NOT a denial-consideration trigger here; the caller applies its own
+    // soft risk-score logic for those.
+    if ((input.felonies ?? 0) > 0) {
+      addAssessment(
+        acc,
+        `${input.felonies} felony conviction(s) reported — individualized assessment required before any denial (no time-blind ban)`,
+        "Castro memo §III; 24 CFR §100.500",
+        "felony conviction (summary)",
+        null,
+        null
+      );
+    }
+    if (input.violentCrimes === true) {
+      addAssessment(
+        acc,
+        "Violent crime reported — individualized assessment required before any denial",
+        "Castro memo §III; 24 CFR §100.500",
+        "violent crime (summary)",
+        null,
+        null
+      );
+    }
+  }
+
+  const citations = Array.from(acc.citations);
+
+  if (acc.mandatory) {
+    return { decision: "mandatory_denial", reasons: acc.reasons, citations };
+  }
+  if (acc.needsAssessment) {
+    return {
+      decision: "individualized_review",
+      reasons: acc.reasons,
+      citations,
+      assessmentFactors: {
+        natureAndSeverity: acc.natureAndSeverity,
+        timeElapsedYears: acc.minElapsed === null ? null : Number(acc.minElapsed.toFixed(1)),
+        applicableLookbackYears: acc.appliedLookback,
+        mitigatingEvidenceRequired: true,
+        workflow: CASTRO_WORKFLOW,
+      },
+    };
+  }
+  return {
+    decision: "clear",
+    reasons: acc.reasons.length > 0 ? acc.reasons : ["No criminal record requiring denial consideration"],
+    citations,
+  };
+}

--- a/src/modules/screening/service.ts
+++ b/src/modules/screening/service.ts
@@ -550,24 +550,38 @@ export class ScreeningService {
       [applicationId, overallResult]
     );
 
-    // fail              -> screening_failed  / any_check_failed
-    // could_not_screen  -> screening_review  / could_not_screen   (NEW: a HOLD)
-    // review_required   -> screening_passed  / review_required_passthrough
-    // pass              -> screening_passed  / all_checks_passed
+    // The background check flags a discretionary criminal record that requires a
+    // HUD/FHA individualized assessment (Castro §III.B). This is surfaced as a
+    // review_required result tagged with decision="individualized_review". It
+    // must HOLD in screening_review — never auto-fail (no time-blind ban) and
+    // never auto-pass via the review_required passthrough. A genuine fail or a
+    // could_not_screen still outranks it (both already HOLD or deny).
+    const backgroundNeedsAssessment =
+      backgroundResult.details.decision === "individualized_review";
+
+    // fail                          -> screening_failed  / any_check_failed
+    // could_not_screen              -> screening_review  / could_not_screen
+    // individualized assessment     -> screening_review  / individualized_assessment_required
+    // review_required (passthrough) -> screening_passed  / review_required_passthrough
+    // pass                          -> screening_passed  / all_checks_passed
     const finalStatus =
       overallResult === "fail"
         ? "screening_failed"
         : overallResult === "could_not_screen"
           ? "screening_review"
-          : "screening_passed";
+          : backgroundNeedsAssessment
+            ? "screening_review"
+            : "screening_passed";
     const finalTrigger =
       overallResult === "fail"
         ? "any_check_failed"
         : overallResult === "could_not_screen"
           ? "could_not_screen"
-          : overallResult === "review_required"
-            ? "review_required_passthrough"
-            : "all_checks_passed";
+          : backgroundNeedsAssessment
+            ? "individualized_assessment_required"
+            : overallResult === "review_required"
+              ? "review_required_passthrough"
+              : "all_checks_passed";
 
     const { changed } = await transitionApplicationStatus({
       applicationId,
@@ -580,6 +594,7 @@ export class ScreeningService {
         overallResult,
         identity: identityScreeningResult,
         background: backgroundResult.result,
+        backgroundDecision: backgroundResult.details.decision,
         credit: creditResult.result,
         compliance: complianceResult.result,
         // Flag-off → empty spread → identical evidence object as before.
@@ -649,7 +664,7 @@ export class ScreeningService {
         actorId: initiatedBy,
         actorRole: initiatorRole,
         applicationId,
-        details: { overallResult, newStatus: finalStatus },
+        details: { overallResult, newStatus: finalStatus, backgroundDecision: backgroundResult.details.decision },
       }),
     ]);
 

--- a/src/modules/screening/state-machine.ts
+++ b/src/modules/screening/state-machine.ts
@@ -178,6 +178,12 @@ export const APP_STATUS_TRANSITIONS: ReadonlyArray<AppStatusTransition> = [
   // verdict). HOLD the application in a non-approvable status until staff
   // resolve it manually. NEVER auto-passes.
   { from: "screening", to: "screening_review", trigger: "could_not_screen" },
+  // individualized_assessment_required — the background check surfaced a
+  // discretionary criminal record inside the lookback (HUD/FHA Castro §III.B).
+  // It must NOT auto-fail (no time-blind blanket ban) and must NOT auto-pass
+  // (the assessment must happen). HOLD in screening_review for staff to run the
+  // individualized assessment before any denial.
+  { from: "screening", to: "screening_review", trigger: "individualized_assessment_required" },
   { from: "screening_review", to: "screening_passed", trigger: "manual_override_pass" },
   { from: "screening_review", to: "screening_failed", trigger: "manual_override_fail" },
 ];


### PR DESCRIPTION
**Build #3 of the screening hardening series.** Stacks on #243 (vendor seam). Ships **dark** — no flag flips, no deploy, **no migration**.

## What

Replaces `background-check.ts`'s naive blanket auto-fail —

```ts
if (felonies > 0 || sexOffenses || violentCrimes) return { result: "fail", … }
```

— with a HUD/FHA-compliant individualized-assessment engine driven by `docs/screening/hud-criminal-decision-matrix.md`. This is the gate that lets real criminal records safely reach background-check; #2 explicitly left this logic untouched as "#3's job."

## Compliance contract (the point of the PR)

Discretionary criminal records must **not** auto-fail and must **not** auto-pass. FHA disparate-impact exposure under **24 CFR §100.500** persists even after the Nov-2025 Turner rescission of PIH 2015-19 / Castro / McCain — those were sub-regulatory; the Act and the rule are unchanged. So:

| Engine outcome | `BackgroundCheckResult.result` | Orchestrator routing |
|---|---|---|
| `mandatory_denial` — §5.856 lifetime registrant, §960.204(a)(1)/(a)(2)/(a)(3) | `fail` | `screening_failed` → immediate FCRA notice |
| `individualized_review` — discretionary record in lookback, or open/undated | `review_required` (tagged `details.decision="individualized_review"`) | **HOLD** `screening_review` via new `individualized_assessment_required` trigger (Castro §III.B) |
| `clear` — aged-out / arrest-only / dismissed / acquitted / expunged / none | `pass` or legacy misdemeanor soft-risk | unchanged (incl. existing `review_required_passthrough`) |

Never auto-fail a discretionary record (no time-blind blanket ban); never auto-pass one (the assessment must happen). Operators may **tighten** lookbacks via `policy`, but cannot turn a discretionary record into an auto-fail.

## Zero-migration design

- `BackgroundCheckResult.result` stays inside the existing `screening_result` enum (`review_required`) — no new DB enum value.
- The HOLD signal rides on `details.decision === "individualized_review"` (JSONB).
- Routing uses a new **TS-only** state-machine trigger `individualized_assessment_required` (`screening → screening_review`), validated against `APP_STATUS_TRANSITIONS` — not a DB enum, so no migration.
- The #241 review queue already selects by `status=screening_review` and renders rationale/citations from the `background_check_details` JSONB → IA holds appear with their reasons + CFR citations for free.

## Engine (`src/modules/screening/hud-criminal-decision.ts`)

Pure & deterministic (no I/O, no env, injectable `asOf`). Structured `criminalRecords` are authoritative when present (real vendor path); the legacy summary flags (`felonies`/`sexOffenses`/`violentCrimes`) drive it on the current sandbox path. Honors disposition gates (arrest-only/dismissed/acquitted/expunged ignored; open/pending → pause) and Castro lookback ceilings (felony violent/sexual/arson 7yr, felony non-violent 5yr, misdemeanor violent 3yr, non-violent 1yr, drug-other 3yr; §960.204(a)(1) drug-eviction 3yr mandatory).

## FCRA

IA HOLD → `overallResult` stays `review_required` → no auto adverse-action notice (correct — the notice fires later when staff issue a `manual_override_fail` via the #241 queue). A genuine mandatory-floor `fail` still fires the notice immediately. `fail` and `could_not_screen` both outrank the IA hold in the precedence chain.

## Tests

- New `src/__tests__/hud-criminal-decision.test.ts` — exhaustive engine unit tests (mandatory floors, discretionary-in-lookback, aged-out, ignored dispositions, open/undated, policy tightening, legacy-flag path, precedence).
- `screening-integrations.test.ts` / `screening-service.test.ts` updated: felony/violent → IA HOLD (review_required + decision="individualized_review"), sex-offense → mandatory_denial fail, IA routes to `screening_review`/`individualized_assessment_required` and sends no FCRA notice, fail outranks IA, plain review_required (decision="clear") still passes through.
- **1524 pass (+36 over the 1488 #2 baseline), 15 skipped, `tsc --noEmit` clean.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)