### PR TITLE
fix(screening): default-OFF criminal engine flag + undated-eviction fail-safe

### DIFF
--- a/src/__tests__/hud-criminal-decision.test.ts
+++ b/src/__tests__/hud-criminal-decision.test.ts
@@ -61,6 +61,24 @@ describe("evaluateCriminalHistory — mandatory federal floors (auto-deny, no as
     expect(r.decision).toBe("clear");
   });
 
+  it("drug-related eviction with NO date → individualized_review, NOT mandatory (cannot prove the 3-yr window — never auto-deny blind)", () => {
+    // §960.204(a)(1) is date-gated; an undated eviction can't be proven in-window,
+    // so it must HOLD for staff to establish the date, not auto-deny on the
+    // undated-in-lookback presumption (the missing-date fail-safe).
+    const r = ev({ records: [{ category: "drug_related_eviction", disposition: "convicted" }] });
+    expect(r.decision).toBe("individualized_review");
+    expect(r.citations).toEqual(expect.arrayContaining([expect.stringMatching(/960\.204\(a\)\(1\)/)]));
+    expect(r.assessmentFactors?.timeElapsedYears).toBeNull();
+  });
+
+  it("undated drug-eviction stays individualized_review even with undatedConvictionInLookback=false (a mandatory floor never auto-clears on the policy knob)", () => {
+    const r = ev(
+      { records: [{ category: "drug_related_eviction", disposition: "convicted" }] },
+      { undatedConvictionInLookback: false }
+    );
+    expect(r.decision).toBe("individualized_review");
+  });
+
   it("meth manufacture NOT on assisted property is discretionary, not the floor → individualized_review", () => {
     const r = ev({
       records: [{ category: "meth_manufacture_assisted_property", onAssistedProperty: false, disposition: "convicted", dispositionDate: "2024-01-01" }],

--- a/src/__tests__/screening-integrations.test.ts
+++ b/src/__tests__/screening-integrations.test.ts
@@ -55,17 +55,22 @@ function creditInput() {
 
 // ── BackgroundCheckService ────────────────────────────────────────────────
 
-describe("BackgroundCheckService.runCheck()", () => {
+describe("BackgroundCheckService.runCheck() — engine ON", () => {
   let service: BackgroundCheckService;
 
   beforeEach(() => {
     delete process.env.SCREENING_API_KEY;
+    // These tests exercise the HUD/FHA individualized-assessment engine, which is
+    // gated behind CRIMINAL_DECISION_ENGINE_ENABLED (default OFF). Turn it on so
+    // the decision/citations/assessmentFactors keys are populated.
+    process.env.CRIMINAL_DECISION_ENGINE_ENABLED = "true";
     service = new BackgroundCheckService();
   });
 
   afterEach(() => {
     jest.restoreAllMocks();
     delete process.env.SCREENING_API_KEY;
+    delete process.env.CRIMINAL_DECISION_ENGINE_ENABLED;
   });
 
   // ── Stub path (no API key) ───────────────────────────────────────────────
@@ -237,6 +242,134 @@ describe("BackgroundCheckService.runCheck()", () => {
 
     expect(result.result).toBe("pass");
     expect(result.details.riskScore).toBe(0);
+  });
+});
+
+// ── BackgroundCheckService — engine OFF (default) ──────────────────────────
+// CRIMINAL_DECISION_ENGINE_ENABLED defaults OFF. With the flag off the service
+// must run the pre-engine blanket-ban path and write NONE of the engine keys
+// (decision / citations / reasons / assessmentFactors) into details — i.e. it is
+// byte-identical to the historical behaviour. This is the dark-merge guard: the
+// engine merged + deployed must change nothing until the flag is deliberately on.
+
+describe("BackgroundCheckService.runCheck() — engine OFF (legacy, byte-identical)", () => {
+  let service: BackgroundCheckService;
+
+  beforeEach(() => {
+    delete process.env.SCREENING_API_KEY;
+    delete process.env.CRIMINAL_DECISION_ENGINE_ENABLED; // explicit default-OFF
+    service = new BackgroundCheckService();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    delete process.env.SCREENING_API_KEY;
+    delete process.env.CRIMINAL_DECISION_ENGINE_ENABLED;
+  });
+
+  function expectNoEngineKeys(details: any) {
+    expect(details).not.toHaveProperty("decision");
+    expect(details).not.toHaveProperty("reasons");
+    expect(details).not.toHaveProperty("citations");
+    expect(details).not.toHaveProperty("assessmentFactors");
+  }
+
+  it("clean stub record → pass, no engine keys", async () => {
+    const result = await service.runCheck(bgInput());
+
+    expect(result.result).toBe("pass");
+    expect(result.details.riskScore).toBe(0);
+    expectNoEngineKeys(result.details);
+  });
+
+  it("felonies → blanket auto-fail (legacy), riskScore=100, no engine keys", async () => {
+    // The legacy path is exactly the time-blind ban the engine is meant to
+    // replace — flag-off it must still behave that way, byte-identical.
+    jest.spyOn(service as any, "callScreeningAPI").mockResolvedValue({
+      felonies: 2,
+      sexOffenses: false,
+      violentCrimes: false,
+      misdemeanors: [],
+    });
+
+    const result = await service.runCheck(bgInput());
+
+    expect(result.result).toBe("fail");
+    expect(result.details.felonies).toBe(2);
+    expect(result.details.riskScore).toBe(100);
+    expectNoEngineKeys(result.details);
+  });
+
+  it("sex offense → blanket auto-fail (legacy), no engine keys", async () => {
+    jest.spyOn(service as any, "callScreeningAPI").mockResolvedValue({
+      felonies: 0,
+      sexOffenses: true,
+      violentCrimes: false,
+      misdemeanors: [],
+    });
+
+    const result = await service.runCheck(bgInput());
+
+    expect(result.result).toBe("fail");
+    expect(result.details.riskScore).toBe(100);
+    expectNoEngineKeys(result.details);
+  });
+
+  it("violent crime → blanket auto-fail (legacy), no engine keys", async () => {
+    jest.spyOn(service as any, "callScreeningAPI").mockResolvedValue({
+      felonies: 0,
+      sexOffenses: false,
+      violentCrimes: true,
+      misdemeanors: [],
+    });
+
+    const result = await service.runCheck(bgInput());
+
+    expect(result.result).toBe("fail");
+    expect(result.details.riskScore).toBe(100);
+    expectNoEngineKeys(result.details);
+  });
+
+  it("3 misdemeanors → review_required (soft-risk 75), no engine keys", async () => {
+    jest.spyOn(service as any, "callScreeningAPI").mockResolvedValue({
+      felonies: 0,
+      sexOffenses: false,
+      violentCrimes: false,
+      misdemeanors: ["DUI", "disorderly_conduct", "petty_theft"],
+    });
+
+    const result = await service.runCheck(bgInput());
+
+    expect(result.result).toBe("review_required");
+    expect(result.details.misdemeanors).toBe(3);
+    expect(result.details.riskScore).toBe(75);
+    expectNoEngineKeys(result.details);
+  });
+
+  it("2 misdemeanors → pass (soft-risk 50), no engine keys", async () => {
+    jest.spyOn(service as any, "callScreeningAPI").mockResolvedValue({
+      felonies: 0,
+      sexOffenses: false,
+      violentCrimes: false,
+      misdemeanors: ["DUI", "petty_theft"],
+    });
+
+    const result = await service.runCheck(bgInput());
+
+    expect(result.result).toBe("pass");
+    expect(result.details.riskScore).toBe(50);
+    expectNoEngineKeys(result.details);
+  });
+
+  it("API throws → could_not_screen HOLD even with engine off (fail-loud unaffected)", async () => {
+    jest.spyOn(service as any, "callScreeningAPI").mockRejectedValue(
+      new Error("Network timeout")
+    );
+
+    const result = await service.runCheck(bgInput());
+
+    expect(result.result).toBe("could_not_screen");
+    expect(result.details.riskScore).toBe(-1);
   });
 });
 

--- a/src/modules/screening/background-check.ts
+++ b/src/modules/screening/background-check.ts
@@ -90,6 +90,63 @@ export class BackgroundCheckService {
   }
 
   private evaluateResults(response: any): BackgroundCheckResult {
+    // CRIMINAL_DECISION_ENGINE_ENABLED gates the HUD/FHA individualized-assessment
+    // engine. Default OFF → the pre-engine blanket-ban path runs and
+    // `background_check_details` is byte-identical to pre-engine behaviour (none
+    // of the engine keys are written), so the engine ships DARK: merging and
+    // deploying changes nothing until the flag is deliberately turned on. Flip it
+    // to "true" to activate the matrix-driven engine (mandatory federal floors
+    // auto-deny; discretionary in-lookback hits HOLD for individualized review).
+    if (process.env.CRIMINAL_DECISION_ENGINE_ENABLED === "true") {
+      return this.evaluateWithEngine(response);
+    }
+    return this.evaluateLegacy(response);
+  }
+
+  /**
+   * Pre-engine blanket-ban path — the flag-off default. Auto-fail on any felony /
+   * sex offense / violent crime; misdemeanor soft-risk scoring otherwise. Kept
+   * verbatim so flag-off is byte-identical to the historical behaviour.
+   */
+  private evaluateLegacy(response: any): BackgroundCheckResult {
+    const felonies = response.felonies || 0;
+    const sexOffenses = response.sexOffenses || false;
+    const violentCrimes = response.violentCrimes || false;
+    const misdemeanors = (response.misdemeanors || []).length;
+
+    // Auto-fail criteria
+    if (felonies > 0 || sexOffenses || violentCrimes) {
+      return {
+        result: "fail",
+        details: { felonies, sexOffenses, violentCrimes, misdemeanors, riskScore: 100, rawResponse: response },
+      };
+    }
+
+    // Risk scoring for misdemeanors
+    let riskScore = 0;
+    if (misdemeanors === 1) riskScore = 25;
+    else if (misdemeanors === 2) riskScore = 50;
+    else if (misdemeanors >= 3) riskScore = 75;
+
+    if (riskScore >= 75) {
+      return {
+        result: "review_required",
+        details: { felonies, sexOffenses, violentCrimes, misdemeanors, riskScore, rawResponse: response },
+      };
+    }
+
+    return {
+      result: "pass",
+      details: { felonies, sexOffenses, violentCrimes, misdemeanors, riskScore, rawResponse: response },
+    };
+  }
+
+  /**
+   * HUD/FHA individualized-assessment engine path (flag-on only). Mandatory
+   * federal floors → fail; discretionary in-lookback hits → review_required
+   * tagged decision="individualized_review" for the orchestrator to HOLD.
+   */
+  private evaluateWithEngine(response: any): BackgroundCheckResult {
     const felonies = response.felonies || 0;
     const sexOffenses = response.sexOffenses || false;
     const violentCrimes = response.violentCrimes || false;

--- a/src/modules/screening/hud-criminal-decision.ts
+++ b/src/modules/screening/hud-criminal-decision.ts
@@ -294,9 +294,24 @@ function processRecord(acc: Accumulator, record: CriminalRecord, policy: Lookbac
       return;
     case "drug_related_eviction": {
       const elapsed = yearsElapsed(record, asOf);
-      const within =
-        elapsed === null ? policy.undatedConvictionInLookback : elapsed <= policy.drugEvictionYears;
-      if (within) {
+      if (elapsed === null) {
+        // Undated eviction: the §960.204(a)(1) bar is date-gated (3 years from
+        // the date of the eviction), so an undated record can NEVER be proven
+        // inside the mandatory window. Do NOT auto-deny blind — route to
+        // individualized review (the missing-date fail-safe), where staff
+        // establish the eviction date before any denial. This branch ignores
+        // `undatedConvictionInLookback`: a mandatory floor must never auto-deny
+        // (legal exposure) nor silently auto-clear (compliance gap) on an
+        // undated record — holding for review is the only defensible outcome.
+        addAssessment(
+          acc,
+          `Drug-related eviction, date unknown (${label}) — cannot confirm the ${policy.drugEvictionYears}-yr §960.204(a)(1) window; individualized review required before any denial`,
+          "24 CFR §960.204(a)(1); Castro memo §III",
+          label,
+          null,
+          policy.drugEvictionYears
+        );
+      } else if (elapsed <= policy.drugEvictionYears) {
         addMandatory(
           acc,
           `Drug-related eviction within ${policy.drugEvictionYears} years (${label}) — mandatory denial (waivable on rehab/incarceration)`,


### PR DESCRIPTION
Two compliance-safety follow-ups to the HUD/FHA criminal-decision engine merged in #245. Both keep the engine **shipping dark** — flag-off is byte-identical, so this merges + deploys with zero behaviour change until the flag is deliberately turned on.

## 1. `CRIMINAL_DECISION_ENGINE_ENABLED` kill-switch (default OFF) — ARCH
#245 merged the engine **always-on**, deviating from the approved plan, which mandated *"ships dark behind `CRIMINAL_DECISION_ENGINE_ENABLED=false` — flag-off is byte-identical."* Restoring the flag matches the current (un-deployed) prod path, so the eventual deploy is a no-op until staff opt in.

- `evaluateResults()` now branches on `process.env.CRIMINAL_DECISION_ENGINE_ENABLED === "true"`:
  - **`evaluateLegacy`** (flag-off, default) — the pre-engine blanket-ban path, restored verbatim. Writes **none** of the engine keys (`decision` / `reasons` / `citations` / `assessmentFactors`) into `background_check_details` → byte-identical to historical behaviour.
  - **`evaluateWithEngine`** (flag-on) — the matrix-driven engine body, unchanged.

## 2. Undated drug-related eviction → `individualized_review`, not `mandatory_denial` — MEDIUM defect
`§960.204(a)(1)` is **date-gated** (3-yr window measured *from the eviction date*). An eviction record with no usable date can never be proven inside that window, so auto-denying it blind is legally unsupportable.

- Undated eviction (`elapsed === null`) now routes to a **HOLD** for individualized review (never auto-deny blind, never silent-pass).
- Dated eviction inside the window still auto-denies (`§960.204(a)(1)`); aged-out still clears.

## Tests
- **+2** undated-eviction regression tests (`hud-criminal-decision.test.ts`): undated → `individualized_review` with `timeElapsedYears === null`; stays a HOLD even with the `undatedConvictionInLookback` policy knob flipped (a mandatory floor never auto-clears on a policy knob).
- Split `screening-integrations.test.ts` into **engine-ON** (existing engine assertions; flag set in `beforeEach`) + a new **engine-OFF byte-identity** describe (legacy blanket-ban; asserts none of the engine keys are present).
- `STRIPE_LIVE_ENABLED=false npx jest hud-criminal-decision screening-service screening-integrations` → **111 passed**. `tsc --noEmit` clean.

## Safety
- **No migration, no enum change** — verdict still rides in `background_check_details` JSONB within the existing `screening_result` enum.
- Flags stay **OFF** in prod; nothing to deploy beyond the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)