### PR TITLE
feat(screening): Work Number employment vendor on the seam (dark)

### DIFF
--- a/src/__tests__/screening-extended-checks.test.ts
+++ b/src/__tests__/screening-extended-checks.test.ts
@@ -261,6 +261,33 @@ describe("ScreeningService — Phase 4a extended checks (SCREENING_EXTENDED_CHEC
     );
   });
 
+  // ── Demo runtime config: MOCK_MODE on, gate OPEN, tag drives the throw ────────
+  // This is the actual config behind the "one applicant lands in the Review tab"
+  // demo claim (vs the keyless case above which proves the prod failure mode).
+
+  it("flag ON + MOCK_MODE + declared employer + wn_vendor_outage tag → could_not_screen → screening_review (demo loop)", async () => {
+    process.env.SCREENING_EXTENDED_CHECKS_ENABLED = "true";
+    process.env.MOCK_MODE = "1"; // gate stays OPEN; the tag path runs before requireGate
+    setApp({ employer_name: "Acme Corp" }); // forces Work Number to run
+    mockTransition.mockResolvedValue({ changed: true, status: "screening_review" } as any);
+
+    // Must RESOLVE — the synthetic outage throw is contained at the call site.
+    const result = await service.runFullScreening(
+      "app-001",
+      "u1",
+      "leasing_agent",
+      "wn_vendor_outage"
+    );
+
+    expect(result.overallResult).toBe("could_not_screen");
+    expect(mockTransition).toHaveBeenCalledWith(
+      expect.objectContaining({ to: "screening_review", trigger: "could_not_screen" })
+    );
+    expect(mockTransition).not.toHaveBeenCalledWith(
+      expect.objectContaining({ to: "screening_passed" })
+    );
+  });
+
   it("flag ON + keyless production + NO declared employer → Plaid/NSOPW HOLD as review_required (no could_not_screen)", async () => {
     process.env.SCREENING_EXTENDED_CHECKS_ENABLED = "true";
     process.env.NODE_ENV = "production";

--- a/src/__tests__/screening-vendor-seam.test.ts
+++ b/src/__tests__/screening-vendor-seam.test.ts
@@ -17,6 +17,7 @@
 import { resolveVendor, resolveVendorName } from "../modules/screening/vendors/registry";
 import { SandboxVendor } from "../modules/screening/vendors/sandbox-vendor";
 import { PlaidVendor } from "../modules/screening/vendors/plaid-vendor";
+import { WorkNumberVendor } from "../modules/screening/vendors/work-number-vendor";
 import { STUB_GATE_ERROR } from "../modules/screening/stub-policy";
 
 jest.mock("../utils/logger", () => ({
@@ -36,6 +37,8 @@ const ENV_KEYS = [
   "PLAID_CLIENT_ID",
   "PLAID_SECRET",
   "PLAID_ENV",
+  "WORK_NUMBER_API_KEY",
+  "WORK_NUMBER_API_URL",
 ];
 
 const saved: Record<string, string | undefined> = {};
@@ -101,6 +104,17 @@ describe("registry.resolveVendor()", () => {
     process.env.SCREENING_VENDOR_INCOME = "  PLAID  ";
     expect(resolveVendorName("income")).toBe("plaid");
   });
+
+  it("resolves worknumber for employment but refuses it elsewhere", () => {
+    process.env.SCREENING_VENDOR_EMPLOYMENT = "worknumber";
+    expect(resolveVendor("employment").name).toBe("worknumber");
+    // Globally selecting worknumber must NOT silently pass non-employment checks.
+    process.env.SCREENING_VENDOR = "worknumber";
+    delete process.env.SCREENING_VENDOR_EMPLOYMENT;
+    expect(() => resolveVendor("background")).toThrow(/does not support the background check/i);
+    expect(() => resolveVendor("income")).toThrow(/does not support the income check/i);
+    expect(resolveVendor("employment").name).toBe("worknumber");
+  });
 });
 
 // ── SandboxVendor: self-gating fail-loud ───────────────────────────────────────
@@ -150,8 +164,25 @@ describe("SandboxVendor — self-gating (the reason 'sandbox' is a safe default)
     expect(nsopwMatch.records).toHaveLength(1);
     expect(nsopwMatch.records[0].riskTier).toBe("high");
 
+    // Employment demo tags (the Work Number end-to-end loop fixtures).
+    const empDispute = await v.employment({ ...person(), ssn: "123-45-6789", screeningTag: "wn_employer_dispute" });
+    expect(empDispute.result).toBe("review_required");
+    const empMismatch = await v.employment({ ...person(), ssn: "123-45-6789", screeningTag: "wn_income_mismatch" });
+    expect(empMismatch.result).toBe("verified");
+    expect(empMismatch.details.annualizedIncome).toBe(30000); // trips the >15% Plaid cross-check
+
     // Unknown tag → clean default (mirrors the old mockResponse fallthrough).
     expect((await v.income({ ...person(), screeningTag: "no_such_tag" })).annualIncomeCents).toBe(5400000);
+    expect((await v.employment({ ...person(), ssn: "1", screeningTag: "no_such_tag" })).result).toBe("verified");
+  });
+
+  it("the wn_vendor_outage employment tag THROWS (drives the fail-loud could_not_screen HOLD)", async () => {
+    process.env.NODE_ENV = "production";
+    process.env.MOCK_MODE = "1";
+    const v = new SandboxVendor();
+    await expect(
+      v.employment({ ...person(), ssn: "123-45-6789", screeningTag: "wn_vendor_outage" })
+    ).rejects.toThrow(/vendor outage/i);
   });
 
   it("supports() is true for every domain", () => {
@@ -270,6 +301,118 @@ describe("PlaidVendor — dormant without creds, live (mocked) with creds", () =
       // Only the transactions call — no create/exchange.
       expect(fetchMock).toHaveBeenCalledTimes(1);
       expect(fetchMock.mock.calls[0][0]).toBe("https://sandbox.plaid.com/transactions/get");
+    });
+  });
+});
+
+// ── WorkNumberVendor: dormant Equifax/TWN employment scaffold ──────────────────
+
+describe("WorkNumberVendor — dormant without a key, live (mocked) with a key", () => {
+  const emp = () => ({ firstName: "Jane", lastName: "Doe", ssn: "123-45-6789", dateOfBirth: "1990-06-15" });
+
+  it("supports only the employment domain", () => {
+    const v = new WorkNumberVendor();
+    expect(v.supports("employment")).toBe(true);
+    expect(v.supports("income")).toBe(false);
+    expect(v.supports("background")).toBe(false);
+    expect(v.supports("credit")).toBe(false);
+    expect(v.supports("nsopw")).toBe(false);
+  });
+
+  it("non-employment methods throw defensively", async () => {
+    const v = new WorkNumberVendor();
+    await expect(v.background({ ...person(), ssnLast4: "6789", state: "NV" })).rejects.toThrow(/supports only the employment check/i);
+    await expect(v.income(person())).rejects.toThrow(/supports only the employment check/i);
+  });
+
+  it("no key + gate closed → THROWS STUB_GATE_ERROR (stays dormant, fail-loud — propagates to could_not_screen)", async () => {
+    disableStub();
+    await expect(new WorkNumberVendor().employment(emp())).rejects.toThrow(STUB_GATE_ERROR);
+  });
+
+  it("no key + gate open → returns the deterministic stub (verified)", async () => {
+    // jest NODE_ENV=test keeps the gate open
+    const r = await new WorkNumberVendor().employment(emp());
+    expect(r.result).toBe("verified");
+    expect(r.details.currentEmployer).toBe("STUB Employer Inc.");
+  });
+
+  describe("with a key (mocked fetch)", () => {
+    let fetchMock: jest.Mock;
+    const origFetch = global.fetch;
+
+    beforeEach(() => {
+      disableStub(); // prove the live path runs even with the stub gate closed
+      process.env.WORK_NUMBER_API_KEY = "twn-test-key";
+      process.env.WORK_NUMBER_API_URL = "https://api.twn.test";
+      fetchMock = jest.fn();
+      (global as any).fetch = fetchMock;
+    });
+
+    afterEach(() => {
+      (global as any).fetch = origFetch;
+    });
+
+    function ok(json: unknown) {
+      return { ok: true, status: 200, json: async () => json };
+    }
+
+    it("POSTs to /v1/verifications with a Bearer token and the applicant body", async () => {
+      fetchMock.mockResolvedValueOnce(
+        ok({ employments: [{ status: "active", employerName: "Acme Co", annualizedIncome: 72000 }] })
+      );
+      const r = await new WorkNumberVendor().employment(emp());
+      expect(r.result).toBe("verified");
+      expect(r.details.currentEmployer).toBe("Acme Co");
+      expect(r.details.annualizedIncome).toBe(72000);
+
+      const [url, opts] = fetchMock.mock.calls[0];
+      expect(url).toBe("https://api.twn.test/v1/verifications");
+      expect((opts as any).method).toBe("POST");
+      expect((opts as any).headers.Authorization).toBe("Bearer twn-test-key");
+      const body = JSON.parse((opts as any).body);
+      expect(body.ssn).toBe("123-45-6789");
+      expect(body.firstName).toBe("Jane");
+    });
+
+    it("maps an empty employment list to no_record (a real verdict, not a failure)", async () => {
+      fetchMock.mockResolvedValueOnce(ok({ employments: [] }));
+      const r = await new WorkNumberVendor().employment(emp());
+      expect(r.result).toBe("no_record");
+    });
+
+    it("maps a record with no income to partial", async () => {
+      fetchMock.mockResolvedValueOnce(ok({ employments: [{ status: "active", employerName: "Acme Co" }] }));
+      const r = await new WorkNumberVendor().employment(emp());
+      expect(r.result).toBe("partial");
+      expect(r.details.currentEmployer).toBe("Acme Co");
+    });
+
+    it("maps multiple active employers to review_required", async () => {
+      fetchMock.mockResolvedValueOnce(
+        ok({
+          employments: [
+            { status: "active", employerName: "Acme Co", annualizedIncome: 50000 },
+            { status: "active", employerName: "Globex", annualizedIncome: 40000 },
+          ],
+        })
+      );
+      const r = await new WorkNumberVendor().employment(emp());
+      expect(r.result).toBe("review_required");
+    });
+
+    it("THROWS on a TWN HTTP error (→ propagates to could_not_screen, never a false pass)", async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: false,
+        status: 503,
+        json: async () => ({ code: "SERVICE_UNAVAILABLE", message: "down" }),
+      });
+      await expect(new WorkNumberVendor().employment(emp())).rejects.toThrow(/SERVICE_UNAVAILABLE/);
+    });
+
+    it("THROWS on a network error rather than fabricating a verdict", async () => {
+      fetchMock.mockRejectedValueOnce(new Error("ECONNRESET"));
+      await expect(new WorkNumberVendor().employment(emp())).rejects.toThrow(/ECONNRESET/);
     });
   });
 });

--- a/src/modules/screening/service.ts
+++ b/src/modules/screening/service.ts
@@ -453,6 +453,7 @@ export class ScreeningService {
                 lastName: app.last_name,
                 ssn: ssnDecrypted,
                 dateOfBirth: dob,
+                screeningTag,
               })
               .then((value) => ({ ok: true as const, value }))
               .catch((error: Error) => ({ ok: false as const, error }))
@@ -762,7 +763,10 @@ export class ScreeningService {
               identity_verification_details, identity_verification_completed_at,
               background_check_details, background_check_completed_at,
               credit_check_details, credit_check_completed_at,
-              compliance_check_details, compliance_check_completed_at
+              compliance_check_details, compliance_check_completed_at,
+              income_verification_result, income_verification_details,
+              work_number_result, work_number_details,
+              nsopw_result, nsopw_details
          FROM applications
         WHERE status = 'screening_review'
         ORDER BY created_at ASC`

--- a/src/modules/screening/vendors/index.ts
+++ b/src/modules/screening/vendors/index.ts
@@ -9,3 +9,4 @@ export * from "./types";
 export { resolveVendor, resolveVendorName, DEFAULT_SCREENING_VENDOR } from "./registry";
 export { SandboxVendor } from "./sandbox-vendor";
 export { PlaidVendor } from "./plaid-vendor";
+export { WorkNumberVendor } from "./work-number-vendor";

--- a/src/modules/screening/vendors/registry.ts
+++ b/src/modules/screening/vendors/registry.ts
@@ -1,5 +1,6 @@
 import { SandboxVendor } from "./sandbox-vendor";
 import { PlaidVendor } from "./plaid-vendor";
+import { WorkNumberVendor } from "./work-number-vendor";
 import type { ScreeningVendor, ScreeningCheckDomain } from "./types";
 
 /**
@@ -27,6 +28,7 @@ type VendorFactory = () => ScreeningVendor;
 const VENDOR_FACTORIES: Record<string, VendorFactory> = {
   sandbox: () => new SandboxVendor(),
   plaid: () => new PlaidVendor(),
+  worknumber: () => new WorkNumberVendor(),
 };
 
 export function resolveVendorName(domain: ScreeningCheckDomain): string {

--- a/src/modules/screening/vendors/sandbox-vendor.ts
+++ b/src/modules/screening/vendors/sandbox-vendor.ts
@@ -225,10 +225,22 @@ export class SandboxVendor implements ScreeningVendor {
 
   // ── employment ──────────────────────────────────────────────────────────────
 
-  async employment(_input: EmploymentVendorInput): Promise<EmploymentVendorResponse> {
-    // No demo tags for employment — work-number.ts never passed a screeningTag.
+  async employment(input: EmploymentVendorInput): Promise<EmploymentVendorResponse> {
+    if (process.env.MOCK_MODE === "1" && input.screeningTag) {
+      // Demo tags drive the end-to-end loop (one applicant into the Review tab +
+      // FCRA preview) without any vendor credentials. The "outage" tag THROWS on
+      // purpose so the P1 fail-loud path runs: work-number.ts has no catch, the
+      // throw propagates, and service.ts contains it as could_not_screen →
+      // screening_review. The non-throw tags exercise the verified / review
+      // verdict branches and the Plaid income cross-check.
+      return this.employmentFixture(input.screeningTag);
+    }
     this.requireGate();
     logger.warn("Using sandbox Work Number verification — deterministic stub (stub policy allows fallback)");
+    return this.employmentClean();
+  }
+
+  private employmentClean(): EmploymentVendorResponse {
     return {
       result: "verified",
       details: {
@@ -241,5 +253,45 @@ export class SandboxVendor implements ScreeningVendor {
         rawResponse: { stub: true },
       },
     };
+  }
+
+  private employmentFixture(tag: string): EmploymentVendorResponse {
+    if (tag === "wn_vendor_outage") {
+      // Synthetic hard vendor failure → exercises the fail-loud could_not_screen
+      // HOLD. Mirrors a real keyless-prod gate throw / TWN 5xx.
+      throw new Error(
+        "Work Number vendor outage (synthetic) — employment verification unavailable"
+      );
+    }
+    if (tag === "wn_employer_dispute") {
+      return {
+        result: "review_required",
+        details: {
+          currentEmployer: "Disputed Employer LLC",
+          employmentStatus: "unknown",
+          hireDate: "2022-06-01",
+          terminationDate: null,
+          incomeSource: "employer_reported",
+          rawResponse: { stub: true, tag },
+        },
+      };
+    }
+    if (tag === "wn_income_mismatch") {
+      // Verified, but W-2 income far below the Plaid bank figure → trips the
+      // >15% income cross-check in service.ts and forces review_required.
+      return {
+        result: "verified",
+        details: {
+          currentEmployer: "Acme Co",
+          employmentStatus: "active",
+          hireDate: "2021-03-15",
+          terminationDate: null,
+          annualizedIncome: 30000,
+          incomeSource: "employer_reported",
+          rawResponse: { stub: true, tag },
+        },
+      };
+    }
+    return this.employmentClean();
   }
 }

--- a/src/modules/screening/vendors/work-number-vendor.ts
+++ b/src/modules/screening/vendors/work-number-vendor.ts
@@ -1,0 +1,239 @@
+import { logger } from "../../../utils/logger";
+import { shouldUseScreeningStub, STUB_GATE_ERROR } from "../stub-policy";
+import type {
+  ScreeningVendor,
+  ScreeningCheckDomain,
+  BackgroundVendorInput,
+  BackgroundVendorResponse,
+  CreditVendorInput,
+  CreditVendorResponse,
+  IncomeVendorInput,
+  IncomeVendorResponse,
+  NsopwVendorInput,
+  NsopwVendorResponse,
+  EmploymentVendorInput,
+  EmploymentVendorResponse,
+} from "./types";
+
+/**
+ * The Work Number (Equifax) — real employment + income verification adapter.
+ * DORMANT until WORK_NUMBER_API_KEY is set.
+ *
+ * It supports ONLY the employment domain (Work Number is an employment/income
+ * product). The registry refuses to resolve worknumber for any other domain, so
+ * a misconfig like SCREENING_VENDOR=worknumber HOLDS the non-employment checks
+ * fail-loud rather than silently passing them.
+ *
+ * Activation:
+ *   SCREENING_VENDOR_EMPLOYMENT=worknumber   (route only employment here)
+ *   WORK_NUMBER_API_KEY=...                  (from the Equifax/TWN dashboard)
+ *   WORK_NUMBER_API_URL=...                  (optional; defaults to the TWN host)
+ *
+ * When the key is absent the adapter is inert: it defers to the same fail-loud
+ * stub gate as everything else (throw STUB_GATE_ERROR unless the gate is open),
+ * so adding this vendor to the registry cannot change behaviour until creds land.
+ *
+ * P1 fail-loud contract (employment is special): the service that calls this —
+ * work-number.ts — has NO internal try/catch, because employment is the one
+ * domain where the vendor returns a near-final verdict rather than raw facts (no
+ * evaluateResults step in the service; THIS adapter owns the mapping). A keyless
+ * or erroring call therefore PROPAGATES out of verifyEmployment, and the
+ * orchestrator's call-site wrapper in service.ts contains it as a
+ * could_not_screen HOLD. This adapter never fabricates a passing verdict: every
+ * HTTP / shape failure THROWS.
+ *
+ * ⚠️ HTTP SHAPE IS AN ASSUMPTION. The request/response below model the published
+ * "Employment & Income Verification" instant product with a Bearer token. The
+ * real TWN integration is most likely OAuth2 (client-credentials → short-lived
+ * access token) rather than a static API key, and the response envelope differs
+ * by contract tier. Before go-live the integrator MUST re-validate auth +
+ * request + response against the sandbox the Equifax contract grants. Until then
+ * this stays dormant (no key → gate throw) and ships dark.
+ */
+export class WorkNumberVendor implements ScreeningVendor {
+  readonly name = "worknumber";
+
+  supports(domain: ScreeningCheckDomain): boolean {
+    return domain === "employment";
+  }
+
+  async employment(input: EmploymentVendorInput): Promise<EmploymentVendorResponse> {
+    const apiKey = process.env.WORK_NUMBER_API_KEY || "";
+    const apiUrl = process.env.WORK_NUMBER_API_URL || "https://api.theworknumber.example.com";
+
+    if (!apiKey || apiKey === "changeme") {
+      // No credentials → dormant. Defer to the global fail-loud gate: throw in
+      // real production (so the call-site HOLDs as could_not_screen), return the
+      // deterministic stub only behind the gate (MOCK_MODE / ALLOW_STUB_SCREENING
+      // / test). Mirrors PlaidVendor + SandboxVendor.employment exactly.
+      if (!shouldUseScreeningStub()) {
+        throw new Error(STUB_GATE_ERROR);
+      }
+      logger.warn(
+        "Work Number vendor selected but no API key configured — returning stub (stub policy allows fallback)"
+      );
+      return {
+        result: "verified",
+        details: {
+          currentEmployer: "STUB Employer Inc.",
+          employmentStatus: "active",
+          hireDate: "2023-01-01",
+          terminationDate: null,
+          annualizedIncome: 45000,
+          incomeSource: "employer_reported",
+          rawResponse: { stub: true },
+        },
+      };
+    }
+
+    logger.info("Work Number live employment verification", {
+      applicant: `${input.firstName} ${input.lastName}`,
+    });
+
+    const raw = await this.callApi(apiUrl, apiKey, input);
+    return this.evaluateResults(raw);
+  }
+
+  /**
+   * Issue the instant-verification request. Any non-2xx THROWS — the absence of
+   * an internal catch (here and in work-number.ts) is the P1 fail-loud contract:
+   * a vendor outage must surface as could_not_screen, never as a silent pass.
+   */
+  private async callApi(
+    apiUrl: string,
+    apiKey: string,
+    input: EmploymentVendorInput
+  ): Promise<unknown> {
+    const res = await fetch(`${apiUrl}/v1/verifications`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify({
+        firstName: input.firstName,
+        lastName: input.lastName,
+        ssn: input.ssn,
+        dateOfBirth: input.dateOfBirth,
+      }),
+    });
+
+    if (!res.ok) {
+      let detail = `HTTP ${res.status}`;
+      try {
+        const err = (await res.json()) as any;
+        detail = err?.code ? `${err.code}: ${err.message ?? ""}` : JSON.stringify(err);
+      } catch {
+        /* keep HTTP status */
+      }
+      throw new Error(`Work Number /v1/verifications failed — ${detail}`);
+    }
+    return res.json();
+  }
+
+  /**
+   * Map a raw TWN response to an EmploymentVendorResponse verdict.
+   *
+   *   active record + employer + income  → verified
+   *   no employment record found         → no_record
+   *   record found but income missing    → partial
+   *   conflicting / ambiguous            → review_required
+   *
+   * A structurally unparseable response THROWS (fail-loud) rather than guessing a
+   * verdict. ⚠️ Field names follow the assumed published shape — re-validate at
+   * go-live (see class docblock).
+   */
+  private evaluateResults(raw: unknown): EmploymentVendorResponse {
+    const body = raw as any;
+    if (!body || typeof body !== "object") {
+      throw new Error("Work Number returned an unparseable verification response");
+    }
+
+    const records = Array.isArray(body.employments)
+      ? body.employments
+      : Array.isArray(body.records)
+        ? body.records
+        : [];
+
+    if (records.length === 0) {
+      // The vendor positively reported "no record on file" — a real, usable
+      // verdict (not a failure). The service maps no_record → review_required.
+      return {
+        result: "no_record",
+        details: { employmentStatus: "unknown", rawResponse: body },
+      };
+    }
+
+    // Conflicting active employers → let a human reconcile.
+    const active = records.filter(
+      (r: any) => (r?.status ?? "active") === "active"
+    );
+    if (active.length > 1) {
+      return {
+        result: "review_required",
+        details: {
+          employmentStatus: "active",
+          rawResponse: body,
+        },
+      };
+    }
+
+    const rec = active[0] || records[0];
+    const employer = rec?.employerName ?? rec?.employer ?? undefined;
+    const annualizedIncome =
+      typeof rec?.annualizedIncome === "number"
+        ? rec.annualizedIncome
+        : typeof rec?.annualIncome === "number"
+          ? rec.annualIncome
+          : undefined;
+    const status: "active" | "inactive" | "unknown" =
+      rec?.status === "inactive" ? "inactive" : rec?.status === "active" ? "active" : "unknown";
+
+    // Record present but no income figure → partial (service → review_required).
+    if (annualizedIncome === undefined) {
+      return {
+        result: "partial",
+        details: {
+          currentEmployer: employer,
+          employmentStatus: status,
+          hireDate: rec?.hireDate ?? undefined,
+          terminationDate: rec?.terminationDate ?? null,
+          incomeSource: "employer_reported",
+          rawResponse: body,
+        },
+      };
+    }
+
+    return {
+      result: "verified",
+      details: {
+        currentEmployer: employer,
+        employmentStatus: status,
+        hireDate: rec?.hireDate ?? undefined,
+        terminationDate: rec?.terminationDate ?? null,
+        annualizedIncome,
+        incomeSource: "employer_reported",
+        rawResponse: body,
+      },
+    };
+  }
+
+  // ── Unsupported domains — defensive throws (registry already refuses these) ──
+
+  private unsupported(domain: ScreeningCheckDomain): never {
+    throw new Error(`Work Number vendor supports only the employment check, not ${domain}`);
+  }
+  async background(_input: BackgroundVendorInput): Promise<BackgroundVendorResponse> {
+    return this.unsupported("background");
+  }
+  async credit(_input: CreditVendorInput): Promise<CreditVendorResponse> {
+    return this.unsupported("credit");
+  }
+  async income(_input: IncomeVendorInput): Promise<IncomeVendorResponse> {
+    return this.unsupported("income");
+  }
+  async nsopw(_input: NsopwVendorInput): Promise<NsopwVendorResponse> {
+    return this.unsupported("nsopw");
+  }
+}

--- a/src/modules/screening/work-number.ts
+++ b/src/modules/screening/work-number.ts
@@ -36,6 +36,9 @@ export class WorkNumberService {
     lastName: string;
     ssn: string;
     dateOfBirth: string;
+    // Threaded through to the vendor for MOCK_MODE demo fixtures (the sandbox
+    // employment tags). Absent on the real production path.
+    screeningTag?: string;
   }): Promise<WorkNumberResult> {
     logger.info("Initiating Work Number employment verification", {
       applicant: `${input.firstName} ${input.lastName}`,


### PR DESCRIPTION
## What

Adds the **real Work Number (Equifax) employment + income verification adapter** as a vendor on the screening seam (#243). Ships **dark** — `SCREENING_EXTENDED_CHECKS_ENABLED` OFF + sandbox default ⇒ byte-identical runtime.

> **Re-architected.** This PR originally inline-rewrote `work-number.ts`. While it was open, #243 refactored that file into a 49-line `resolveVendor("employment")` delegator. Forcing the inline version would have regressed the seam, so the adapter now lives **inside** `vendors/` where it belongs — same as `plaid-vendor.ts`.

## Changes
- **`vendors/work-number-vendor.ts`** (new) — real Equifax/TWN HTTP adapter, **DORMANT until `WORK_NUMBER_API_KEY` is set**. `supports()` only `employment`; other domains throw defensively. Keyless → fail-loud gate (throws `STUB_GATE_ERROR` unless the stub gate is open). Keyed → `POST /v1/verifications` (Bearer) → `evaluateResults` maps to `verified | no_record | partial | review_required`. Every HTTP/shape failure **THROWS** (P1 fail-loud contract: employment has no internal catch → propagates → `could_not_screen` → `screening_review`).
- **`vendors/registry.ts`** — register `worknumber`. `SCREENING_VENDOR_EMPLOYMENT=worknumber` routes only employment; a global `SCREENING_VENDOR=worknumber` HOLDS the other checks fail-loud rather than passing them.
- **`vendors/sandbox-vendor.ts`** — employment **demo tags**: `wn_vendor_outage` (throws → could_not_screen), `wn_employer_dispute` (review_required), `wn_income_mismatch` (verified w/ \$30k → trips the >15% Plaid cross-check). This is the **end-to-end demo loop**: `MOCK_MODE=1` + tag lands one applicant in the Review tab + FCRA preview, zero creds.
- **`work-number.ts`** — thread `screeningTag` into `verifyEmployment` (forwarded to the vendor).
- **`service.ts`** — pass `screeningTag` at the call site; surface `work_number` / `income` / `nsopw` result+details in `getReviewQueue` so the reviewer sees the hold reason.

## ⚠️ HTTP shape is an assumption
The request/response models the published instant-verification product with a Bearer token. The real TWN integration is most likely **OAuth2 (client-credentials)**, not a static key, and the envelope differs by contract tier. The integrator **must re-validate auth + request + response against the Equifax sandbox at go-live**. Until then it stays dormant and ships dark.

## Tests
- `screening-vendor-seam`: registry `worknumber` resolution + refusal, sandbox employment tags, `WorkNumberVendor` dormant/stub/live-mapping (verified/no_record/partial/review_required)/HTTP-error/network-error.
- `screening-extended-checks`: demo-config `could_not_screen → screening_review` case.
- **177 screening tests pass; `tsc --noEmit` clean. No migration (columns already exist).**

## Go-live (Alex-gated — in backlog)
Sign Equifax/TWN contract → provision `WORK_NUMBER_API_KEY` → re-validate HTTP shape vs sandbox → set `SCREENING_VENDOR_EMPLOYMENT=worknumber` + `SCREENING_EXTENDED_CHECKS_ENABLED=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)