### PR TITLE
fix(screening): cast Phase 4a enum binds to screening_result (HTTP 400 on flag-ON)

### DIFF
--- a/src/modules/screening/service.ts
+++ b/src/modules/screening/service.ts
@@ -492,16 +492,23 @@ export class ScreeningService {
       // 2026-05-30-extended-screening-columns.sql). Separate UPDATE so the
       // flag-off path leaves the existing persist block untouched.
       await query(
+        // $2/$4/$6 bind to the `screening_result` enum. $6 is referenced twice
+        // (the column assignment AND the completed_at CASE), so without an
+        // explicit cast Postgres cannot unify the two inferred types and fails
+        // PREPARE with "could not determine data type of parameter $6". Casting
+        // every enum param removes the ambiguity (and guards future reuse).
+        // NB: mocked unit tests don't exercise a real PREPARE, so this only
+        // surfaces against a live Postgres — caught on the staging deploy.
         `UPDATE applications SET
-           income_verification_result = $2,
+           income_verification_result = $2::screening_result,
            income_verification_details = $3,
            income_verification_completed_at = NOW(),
-           nsopw_result = $4,
+           nsopw_result = $4::screening_result,
            nsopw_details = $5,
            nsopw_completed_at = NOW(),
-           work_number_result = $6,
+           work_number_result = $6::screening_result,
            work_number_details = $7,
-           work_number_completed_at = CASE WHEN $6 IS NULL THEN NULL ELSE NOW() END
+           work_number_completed_at = CASE WHEN $6::screening_result IS NULL THEN NULL ELSE NOW() END
          WHERE id = $1`,
         [
           applicationId,


### PR DESCRIPTION
## Problem
The flag-gated **extended-results UPDATE** in `runFullScreening` (`src/modules/screening/service.ts` ~L492) binds `$2/$4/$6` to the `screening_result` enum. `$6` (`work_number_result`) is referenced at **two sites** — the column assignment **and** the `work_number_completed_at = CASE WHEN $6 IS NULL …` — so Postgres can't unify the two inferred types and fails `PREPARE` with:

```
could not determine data type of parameter $6   → HTTP 400
```

This is **dormant in prod today** (`SCREENING_EXTENDED_CHECKS_ENABLED` off), but **every screen would 400 the instant the flag is turned on**.

## Why #240's 44/44 missed it
Mocked unit tests never exercise a real Postgres `PREPARE`, so type unification is never tested. Same failure class as the prior "inconsistent types deduced for parameter" trap. It only surfaced when the code ran against a **live Postgres** on the new staging env.

## Fix
Add explicit `::screening_result` casts to `$2/$4/$6` at every site (incl. the `CASE`). 

- **Flag-off:** zero behavior change — the block doesn't run.
- **Flag-on:** the UPDATE now succeeds and persists `income_verification_result` / `nsopw_result` / `work_number_result`.

## Verification (staging, real Postgres, MOCK_MODE)
- Screen call returns `overallResult: review_required` (Plaid stub $54k vs self-reported $32k income cross-check > 15%) instead of HTTP 400.
- DB confirms all three columns persisted (`pass`/`pass`/`pass`) with `*_completed_at` timestamps set.

Patches already-merged #240 code; should land before any prod go-live of the extended-checks flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)