### PR TITLE
fix(screening): thread screeningTag into background check

### DIFF
--- a/src/__tests__/screening-service.test.ts
+++ b/src/__tests__/screening-service.test.ts
@@ -257,6 +257,18 @@ describe("ScreeningService.runFullScreening", () => {
     );
   });
 
+  it("threads screeningTag through to the background check (MOCK demo tags reach the criminal engine)", async () => {
+    await service.runFullScreening("app-001", "user-1", "leasing_agent", "deny_felony");
+
+    // Without this, a MOCK deny_felony tag never reaches the sandbox vendor's
+    // background fixture, so the HUD/FHA criminal-decision engine can't be
+    // exercised end-to-end. The vendor self-gates on MOCK_MODE, so this is a
+    // no-op in real keyless prod.
+    expect(mockBackground.runCheck).toHaveBeenCalledWith(
+      expect.objectContaining({ screeningTag: "deny_felony" })
+    );
+  });
+
   // ── Fail propagation ──────────────────────────────────────────────────────
 
   it("returns overallResult=fail when background check fails", async () => {

--- a/src/modules/screening/service.ts
+++ b/src/modules/screening/service.ts
@@ -325,6 +325,15 @@ export class ScreeningService {
         ssnLast4,
         dateOfBirth: dob,
         state: app.current_state || "NV",
+        // Thread the demo tag through to the background vendor, exactly as we
+        // already do for identity and the extended checks (plaid/nsopw/work-
+        // number). The sandbox vendor honors it ONLY under MOCK_MODE=1, so this
+        // is byte-identical in real keyless prod (the applicant funnel never
+        // sends a tag, and outside MOCK_MODE the vendor ignores it). It makes
+        // the documented MOCK background tags (deny_felony, deny_sex_offender,
+        // review_misdemeanors) reachable end-to-end — e.g. to exercise the
+        // HUD/FHA criminal-decision engine's individualized-review HOLD.
+        screeningTag,
       }),
       this.creditCheck.runCheck({
         firstName: app.first_name,


### PR DESCRIPTION
## What

The background check's `runCheck` payload in `runFullScreening` omitted `screeningTag`, so MOCK demo tags (`deny_felony` / `deny_sex_offender` / `review_misdemeanors`) never reached the sandbox vendor's background fixture. Identity and the extended checks (plaid/nsopw/work-number) already thread the tag; the background check was the gap — which made the HUD/FHA criminal-decision engine impossible to exercise end-to-end over HTTP (a tagged `/screen` call just returned a clean pass).

## Why it's safe (ships dark in real prod)

The sandbox vendor honors `screeningTag` **only** under `MOCK_MODE=1`. In real keyless prod:
- the applicant funnel never sends a tag, and
- outside `MOCK_MODE` the vendor ignores it entirely.

So this is byte-identical to current behaviour in real prod. It only changes the demo/`MOCK_MODE` posture, where it makes the documented background tags reachable.

## Tests

- `tsc --noEmit` clean
- `+1` focused test in `screening-service.test.ts` asserting `screeningTag` reaches `backgroundCheck.runCheck`
- screening-service + screening-integrations suites: 79/79 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)