### PR TITLE
feat(tape): BP-02 Phase 2 cutover — wire real TapeService into viewer route mount (ships dark)

### DIFF
--- a/src/__tests__/compliance-tape-flag.test.ts
+++ b/src/__tests__/compliance-tape-flag.test.ts
@@ -6,10 +6,14 @@
  * read at module-eval time, so the env var MUST be set BEFORE the app module is
  * required, and jest.resetModules() is used between flag states.
  *
- * Assertions:
- *   - flag === "true"  → routes mounted → stub service throws → 503 (unchanged).
+ * Phase 2 cutover: the mount now injects the REAL TapeService (Lane B) instead
+ * of the inert Phase-1 stub. Assertions:
+ *   - flag === "true"  → routes mounted → the real service runs against the
+ *     (mocked, empty) compliance_tape table → /verify?applicantId=<uuid> yields
+ *     a clean empty-chain result {ok:true, lastSequence:0} (200); a request with
+ *     no applicantId still 501s (global scope unimplemented in v1).
  *   - flag unset/false → routes NOT mounted → request falls through to the
- *     404 "Not found" handler (was: 503 stub always).
+ *     404 "Not found" handler.
  *
  * This mirrors the verify-cron gate asserted in scheduler-bp02-flag.test.ts.
  */
@@ -17,10 +21,33 @@
 import request from "supertest";
 import type { Express } from "express";
 
-// Mocks must be declared before the app module is required.
+/**
+ * config/database mock.  PgTapeRepository runs every read inside transaction(),
+ * so the mock invokes the callback with a fake client whose query() returns an
+ * empty result set.  repo.list() therefore resolves to [] and the real
+ * TapeService.verify() returns a clean empty-chain result.  The standalone
+ * query() (used by authenticate/RBAC, NOT the repo) is left as a bare jest.fn()
+ * the test arms per-case.
+ */
+function makeDbMock() {
+  return {
+    query: jest.fn(),
+    transaction: jest.fn(
+      async (cb: (client: { query: jest.Mock }) => unknown) =>
+        cb({ query: jest.fn().mockResolvedValue({ rows: [] }) })
+    ),
+  };
+}
+
+// Mocks must be declared before the app module is required. (jest.mock is
+// hoisted, so the factory cannot reference makeDbMock — inline the same shape.
+// Type annotations are erased, so `jest.Mock` as a type is safe here.)
 jest.mock("../config/database", () => ({
   query: jest.fn(),
-  transaction: jest.fn(),
+  transaction: jest.fn(
+    async (cb: (client: { query: jest.Mock }) => unknown) =>
+      cb({ query: jest.fn().mockResolvedValue({ rows: [] }) })
+  ),
 }));
 jest.mock("../utils/logger", () => ({
   logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
@@ -40,16 +67,56 @@ function loadAppWithFlag(flag: string | undefined): Express {
   } else {
     process.env.COMPLIANCE_TAPE_V2_ENABLED = flag;
   }
-  // Re-apply mocks against the freshly-reset registry.
-  jest.doMock("../config/database", () => ({
-    query: jest.fn(),
-    transaction: jest.fn(),
-  }));
+  // Re-apply mocks against the freshly-reset registry. jest.doMock is NOT
+  // hoisted, so it can use the shared makeDbMock() factory.
+  jest.doMock("../config/database", () => makeDbMock());
   jest.doMock("../utils/logger", () => ({
     logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
   }));
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   return require("../index").default as Express;
+}
+
+/**
+ * Load the app with the flag ON and arm the standalone query() mock with an
+ * operator user so authenticate + requirePermission("audit:view") pass.
+ * Returns the mounted app + a signed token for that operator.
+ */
+function loadMountedAppWithOperator(): { app: Express; token: string } {
+  const app = loadAppWithFlag("true");
+
+  // generateToken is re-required from the reset registry so it signs with the
+  // same JWT_SECRET the freshly-loaded app verifies against.
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { generateToken } = require("../middleware/auth");
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { query } = require("../config/database") as { query: jest.Mock };
+
+  const user = {
+    id: "user-rm-001",
+    email: "rm@example.com",
+    role: "regional_manager",
+    firstName: "Rita",
+    lastName: "Manager",
+    propertyIds: ["prop-001"],
+  };
+  // authenticate re-reads the user from the DB via the standalone query().
+  query.mockResolvedValue({
+    rows: [
+      {
+        id: user.id,
+        email: user.email,
+        role: user.role,
+        first_name: user.firstName,
+        last_name: user.lastName,
+        property_ids: user.propertyIds,
+        is_active: true,
+        email_verified_at: new Date().toISOString(),
+      },
+    ],
+  });
+
+  return { app, token: generateToken(user) };
 }
 
 beforeAll(() => {
@@ -85,50 +152,40 @@ describe("BP-02 compliance-tape viewer flag gate", () => {
     expect(res.body).toEqual({ error: "Not found" });
   });
 
-  it("mounts the viewer routes when the flag is \"true\" (stub → 503)", async () => {
-    const app = loadAppWithFlag("true");
+  it("mounts the viewer routes with the REAL service when the flag is \"true\"", async () => {
+    const { app, token } = loadMountedAppWithOperator();
 
-    // The routes require auth + audit:view, so a forged user is resolved from
-    // the mocked DB. generateToken is re-required from the reset registry so it
-    // signs with the same JWT_SECRET the freshly-loaded app verifies against.
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const { generateToken } = require("../middleware/auth");
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const { query } = require("../config/database") as { query: jest.Mock };
-
-    const user = {
-      id: "user-rm-001",
-      email: "rm@example.com",
-      role: "regional_manager",
-      firstName: "Rita",
-      lastName: "Manager",
-      propertyIds: ["prop-001"],
-    };
-    // authenticate re-reads the user from the DB.
-    query.mockResolvedValue({
-      rows: [
-        {
-          id: user.id,
-          email: user.email,
-          role: user.role,
-          first_name: user.firstName,
-          last_name: user.lastName,
-          property_ids: user.propertyIds,
-          is_active: true,
-          email_verified_at: new Date().toISOString(),
-        },
-      ],
-    });
-
-    const token = generateToken(user);
-    // verify route is the cleanest stub path (no zod global-scope short-circuit).
+    // Route IS mounted (not 404) and the real TapeService runs end-to-end
+    // against the mocked-empty compliance_tape table → clean empty-chain verify.
     const res = await request(app)
       .get(
         "/api/compliance-tape/verify?applicantId=11111111-1111-1111-1111-111111111111"
       )
       .set("Authorization", `Bearer ${token}`);
 
-    // Route IS mounted (not 404) and the stub service yields the 503.
-    expect(res.status).toBe(503);
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      ok: true,
+      scope: {
+        type: "applicant",
+        applicantId: "11111111-1111-1111-1111-111111111111",
+      },
+      lastSequence: 0,
+    });
+    // No longer the Phase-1 stub.
+    expect(res.status).not.toBe(503);
+  });
+
+  it("mounts the routes but 501s global scope (no applicantId) when the flag is \"true\"", async () => {
+    const { app, token } = loadMountedAppWithOperator();
+
+    const res = await request(app)
+      .get("/api/compliance-tape/verify")
+      .set("Authorization", `Bearer ${token}`);
+
+    // Proves the route is mounted (not 404) AND the real service path is hit:
+    // resolveScope(undefined) short-circuits to 501 before touching the repo.
+    expect(res.status).toBe(501);
+    expect(res.body).toMatchObject({ code: "global_scope_not_implemented" });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,8 @@ import tenantRoutes from "./modules/tenant/routes";
 import messagesRoutes from "./modules/messages/routes";
 import tapeRoutes from "./modules/tape/routes";
 import { createTapeViewerRoutes } from "./modules/tape/routes-viewer";
+import { createTapeService } from "./modules/tape/service";
+import { PgTapeRepository } from "./modules/tape/repository";
 import { qaRouter } from "./modules/qa/routes";
 import { housingQaRouter } from "./modules/housing-qa/routes";
 import acquisitionRoutes from "./modules/acquisitions/routes";
@@ -219,28 +221,18 @@ app.use("/api/saved", savedRoutes);
 app.use("/api/tape", tapeRoutes);
 
 // BP-02 compliance tape viewer (operator-only: list, verify, export.pdf).
-// TODO(BP-02-Phase-2): Replace the stub service below with the real TapeService
-// from Lane B once it is wired. The stub returns 503 for all calls so the
-// routes exist but remain inert until Phase 2 completes.
+// Phase 2 cutover: the real TapeService (Lane B) is wired here, replacing the
+// inert Phase-1 stub. The viewer now serves live hash-chain reads / verify /
+// PDF export against the compliance_tape table. The verify-cron in
+// src/scheduler.ts shares the same service + repository wiring.
 //
 // Flag-gated on COMPLIANCE_TAPE_V2_ENABLED (mirrors the verify-cron gate in
 // src/scheduler.ts). When the flag is off the routes are NOT mounted, so a
-// request to /api/compliance-tape/* falls through to the 404 handler below
-// rather than returning the 503 stub.
+// request to /api/compliance-tape/* falls through to the 404 handler below.
 if (process.env.COMPLIANCE_TAPE_V2_ENABLED === "true") {
   app.use(
     "/api/compliance-tape",
-    createTapeViewerRoutes({
-      async list() {
-        throw Object.assign(new Error("service not wired"), { stub: true });
-      },
-      async verify() {
-        throw Object.assign(new Error("service not wired"), { stub: true });
-      },
-      async exportPdf() {
-        throw Object.assign(new Error("service not wired"), { stub: true });
-      },
-    })
+    createTapeViewerRoutes(createTapeService(new PgTapeRepository()))
   );
   logger.info("BP-02 compliance-tape viewer routes mounted");
 } else {

--- a/src/modules/tape/__tests__/replay.spec.ts
+++ b/src/modules/tape/__tests__/replay.spec.ts
@@ -2,18 +2,18 @@
  * BP-02 Compliance Tape — apply-smoke replay tests.
  *
  * Replays the 5 BP-03b stamp kinds in the order an apply-smoke session emits
- * them, using the TapeService + an in-memory repository. Asserts the complete
- * chain comes out correctly formed.
+ * them, using the real TapeService (Lane B) + an in-memory repository. Asserts
+ * the complete chain comes out correctly formed.
  *
- * If Lane B (service.ts) or Lane C (events/) are not on this branch, the suite
- * is skipped gracefully — it will un-skip during Phase 2 integration.
- *
- * TODO: Skipped: Lane B (src/modules/tape/service.ts) not yet on this branch
- * — un-skip after Phase 2 integration.
+ * Lane B exports a FACTORY — createTapeService(repo) — not a class. The service
+ * resolves scope from event.payload.subjectId; makeApplyEvent sets subjectId to
+ * the applicantId, so every stamp lands in that applicant's chain.
  */
 
 import { randomUUID } from "node:crypto";
 import { GENESIS_HASH } from "../hashing";
+import { createTapeService } from "../service";
+import type { TapeService } from "../service";
 import type {
   TapeEntry,
   TapeEvent,
@@ -110,59 +110,17 @@ function makeApplyEvent(
   return { kind, payload };
 }
 
-// ── Service import (lazy — skip if Lane B not present) ───────────────────────
-//
-// We use a runtime require() via a variable-path trick so TypeScript does NOT
-// resolve the module statically — the file may not exist on this branch, and
-// a static import would cause a compile error.
-
-/* eslint-disable @typescript-eslint/no-require-imports */
-let TapeService: { new (repo: TapeRepository): { stamp: Function; verify: Function } } | null = null;
-
-beforeAll(() => {
-  try {
-    // Indirect require so tsc doesn't resolve the path statically.
-    const servicePath = require.resolve(__dirname + "/../service");
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const mod = require(servicePath) as { TapeService?: unknown; default?: unknown };
-    TapeService =
-      (mod.TapeService as typeof TapeService) ??
-      (mod.default as typeof TapeService) ??
-      null;
-  } catch {
-    TapeService = null;
-  }
-});
-
 // ── Replay tests ──────────────────────────────────────────────────────────────
 
 describe("Apply-smoke replay: 5 BP-03b stamps in sequence", () => {
-  it("module import check — passes gracefully whether Lane B is present or not", () => {
-    // Always passes. Communicates availability to the reader.
-    if (TapeService === null) {
-      console.log(
-        "[SKIP] TapeService not available on this branch — un-skip after Phase 2 integration."
-      );
-    }
-    expect(true).toBe(true);
-  });
-
   it("5 stamps in → 5 entries out with monotonically increasing sequence (1..5)", async () => {
-    if (TapeService === null) {
-      console.log(
-        "[SKIP] TapeService not available on this branch — un-skip after Phase 2."
-      );
-      return;
-    }
-
     const applicantId = "applicant-replay-01";
-    const scope: TapeScope = { type: "applicant", applicantId };
     const repo = new InMemoryTapeRepository();
-    const service = new TapeService(repo);
+    const service: TapeService = createTapeService(repo);
 
     const entries: TapeEntry[] = [];
     for (const kind of APPLY_SMOKE_KINDS) {
-      const entry = await service.stamp(makeApplyEvent(kind, applicantId), scope);
+      const entry = await service.stamp(makeApplyEvent(kind, applicantId));
       entries.push(entry);
     }
 
@@ -176,21 +134,13 @@ describe("Apply-smoke replay: 5 BP-03b stamps in sequence", () => {
   });
 
   it("all 5 entries have the correct prevHash chain", async () => {
-    if (TapeService === null) {
-      console.log(
-        "[SKIP] TapeService not available on this branch — un-skip after Phase 2."
-      );
-      return;
-    }
-
     const applicantId = "applicant-replay-02";
-    const scope: TapeScope = { type: "applicant", applicantId };
     const repo = new InMemoryTapeRepository();
-    const service = new TapeService(repo);
+    const service: TapeService = createTapeService(repo);
 
     const entries: TapeEntry[] = [];
     for (const kind of APPLY_SMOKE_KINDS) {
-      entries.push(await service.stamp(makeApplyEvent(kind, applicantId), scope));
+      entries.push(await service.stamp(makeApplyEvent(kind, applicantId)));
     }
 
     // First entry's prevHash = GENESIS_HASH hex
@@ -203,20 +153,13 @@ describe("Apply-smoke replay: 5 BP-03b stamps in sequence", () => {
   });
 
   it("verify() returns {ok:true, lastSequence:5} after the 5-stamp apply-smoke run", async () => {
-    if (TapeService === null) {
-      console.log(
-        "[SKIP] TapeService not available on this branch — un-skip after Phase 2."
-      );
-      return;
-    }
-
     const applicantId = "applicant-replay-03";
     const scope: TapeScope = { type: "applicant", applicantId };
     const repo = new InMemoryTapeRepository();
-    const service = new TapeService(repo);
+    const service: TapeService = createTapeService(repo);
 
     for (const kind of APPLY_SMOKE_KINDS) {
-      await service.stamp(makeApplyEvent(kind, applicantId), scope);
+      await service.stamp(makeApplyEvent(kind, applicantId));
     }
 
     const result = await service.verify(scope);
@@ -225,21 +168,13 @@ describe("Apply-smoke replay: 5 BP-03b stamps in sequence", () => {
   });
 
   it("each entry carries the correct HUD citation from TAPE_CITATIONS", async () => {
-    if (TapeService === null) {
-      console.log(
-        "[SKIP] TapeService not available on this branch — un-skip after Phase 2."
-      );
-      return;
-    }
-
     const applicantId = "applicant-replay-04";
-    const scope: TapeScope = { type: "applicant", applicantId };
     const repo = new InMemoryTapeRepository();
-    const service = new TapeService(repo);
+    const service: TapeService = createTapeService(repo);
 
     const entries: TapeEntry[] = [];
     for (const kind of APPLY_SMOKE_KINDS) {
-      entries.push(await service.stamp(makeApplyEvent(kind, applicantId), scope));
+      entries.push(await service.stamp(makeApplyEvent(kind, applicantId)));
     }
 
     for (let i = 0; i < APPLY_SMOKE_KINDS.length; i++) {

--- a/src/modules/tape/__tests__/service.spec.ts
+++ b/src/modules/tape/__tests__/service.spec.ts
@@ -1,17 +1,23 @@
 /**
  * BP-02 Compliance Tape — service contract tests.
  *
- * These tests validate the TapeService contract defined in Lane B
- * (src/modules/tape/service.ts). If Lane B has not yet been merged on this
- * branch, the suite is skipped gracefully — it will un-skip during Phase 2
- * integration when all lanes are merged together.
+ * Validates the TapeService contract (src/modules/tape/service.ts, Lane B):
+ * the hash-chain stamp() sequence/prevHash/entryHash invariants and verify()'s
+ * detection of payload mutation and fabricated entries.
  *
- * The in-memory TapeRepository fake mirrors the TapeRepository interface
- * exactly. No IO, no database required.
+ * Lane B exports a FACTORY — createTapeService(repo) — not a class, so the
+ * suite constructs the service via the factory against an in-memory repository
+ * fake that mirrors the TapeRepository interface exactly. No IO, no database.
+ *
+ * Scope note: the real stamp() resolves scope from event.payload.subjectId
+ * (the applicant id), so each fixture event's subjectId MUST match the scope it
+ * is later verified / mutated under.
  */
 
 import { randomUUID } from "node:crypto";
 import { computeEntryHash, GENESIS_HASH, hashToHex } from "../hashing";
+import { createTapeService } from "../service";
+import type { TapeService } from "../service";
 import type {
   TapeEntry,
   TapeEvent,
@@ -112,74 +118,22 @@ function makeScope(applicantId: string): TapeScope {
   return { type: "applicant", applicantId };
 }
 
-// ── Service import (lazy — skip if Lane B not present) ───────────────────────
-
-// TODO: Skipped: Lane B (src/modules/tape/service.ts) not yet on this branch
-// — un-skip after Phase 2 integration.
-//
-// We use a runtime require() via a variable-path trick so TypeScript does NOT
-// resolve the module statically — the file may not exist on this branch, and
-// a static import would cause a compile error.
-
-/* eslint-disable @typescript-eslint/no-require-imports */
-let TapeService: { new (repo: TapeRepository): { stamp: Function; verify: Function } } | null = null;
-
-beforeAll(() => {
-  try {
-    // Indirect require so tsc doesn't resolve the path statically.
-    const servicePath = require.resolve(__dirname + "/../service");
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const mod = require(servicePath) as { TapeService?: unknown; default?: unknown };
-    TapeService =
-      (mod.TapeService as typeof TapeService) ??
-      (mod.default as typeof TapeService) ??
-      null;
-  } catch {
-    TapeService = null;
-  }
-});
-
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 describe("TapeService", () => {
-  describe.skip(
-    "TODO: Skipped: Lane B (src/modules/tape/service.ts) not yet on this branch — un-skip after Phase 2 integration.",
-    () => {}
-  );
-
-  // We use a dynamic describe wrapper so skipping is decided at runtime.
-  // The outer describe always registers; inner ones check TapeService.
-  it("service module resolves or test suite is skipped gracefully", () => {
-    if (TapeService === null) {
-      // Not yet available — this is expected on bp-02/lane-f-tests standalone.
-      expect(true).toBe(true); // pass
-      return;
-    }
-    expect(typeof TapeService).toBe("function");
-  });
-
-  describe("stamp() — when Lane B is available", () => {
+  describe("stamp()", () => {
     let repo: InMemoryTapeRepository;
-    let service: { stamp: Function; verify: Function };
+    let service: TapeService;
 
     beforeEach(() => {
-      if (TapeService === null) return;
       repo = new InMemoryTapeRepository();
-      service = new TapeService(repo);
+      service = createTapeService(repo);
     });
 
     it("first stamp on an empty scope: sequence=1, prevHash=GENESIS_HASH hex, entryHash matches computeEntryHash", async () => {
-      if (TapeService === null) {
-        console.log(
-          "[SKIP] TapeService not available on this branch — un-skip after Phase 2."
-        );
-        return;
-      }
-
-      const scope = makeScope("applicant-001");
       const event = makeEvent("WELCOME_LETTER_DELIVERED");
 
-      const entry: TapeEntry = await service.stamp(event, scope);
+      const entry: TapeEntry = await service.stamp(event);
 
       expect(entry.sequence).toBe(1);
       expect(entry.prevHash).toBe(GENESIS_HASH.toString("hex"));
@@ -200,18 +154,11 @@ describe("TapeService", () => {
     });
 
     it("second stamp: sequence=2, prevHash=first entry's entryHash, entryHash recomputable", async () => {
-      if (TapeService === null) {
-        console.log(
-          "[SKIP] TapeService not available on this branch — un-skip after Phase 2."
-        );
-        return;
-      }
-
-      const scope = makeScope("applicant-002");
-      const first = await service.stamp(makeEvent("WELCOME_LETTER_DELIVERED"), scope);
+      // Both events default to subjectId "applicant-001", so both resolve to the
+      // same applicant scope and chain together.
+      const first = await service.stamp(makeEvent("WELCOME_LETTER_DELIVERED"));
       const second = await service.stamp(
-        makeEvent("HUD_928_1_FAIR_HOUSING_POSTED"),
-        scope
+        makeEvent("HUD_928_1_FAIR_HOUSING_POSTED")
       );
 
       expect(second.sequence).toBe(2);
@@ -229,27 +176,17 @@ describe("TapeService", () => {
     });
 
     it("scopes are independent: stamping for applicantA does NOT affect applicantB's sequence", async () => {
-      if (TapeService === null) {
-        console.log(
-          "[SKIP] TapeService not available on this branch — un-skip after Phase 2."
-        );
-        return;
-      }
-
-      const scopeA = makeScope("applicant-A");
-      const scopeB = makeScope("applicant-B");
-
-      // Stamp 3 events for A, then 1 for B.
-      await service.stamp(makeEvent("WELCOME_LETTER_DELIVERED", "applicant-A"), scopeA);
+      // Scope is resolved from each event's subjectId.
+      await service.stamp(makeEvent("WELCOME_LETTER_DELIVERED", "applicant-A"));
       await service.stamp(
-        makeEvent("HUD_928_1_FAIR_HOUSING_POSTED", "applicant-A"),
-        scopeA
+        makeEvent("HUD_928_1_FAIR_HOUSING_POSTED", "applicant-A")
       );
-      await service.stamp(makeEvent("WAITING_LIST_APP_CAPTURED", "applicant-A"), scopeA);
+      await service.stamp(
+        makeEvent("WAITING_LIST_APP_CAPTURED", "applicant-A")
+      );
 
       const firstB = await service.stamp(
-        makeEvent("WELCOME_LETTER_DELIVERED", "applicant-B"),
-        scopeB
+        makeEvent("WELCOME_LETTER_DELIVERED", "applicant-B")
       );
 
       // B's first stamp must start at sequence=1 regardless of A's chain.
@@ -258,25 +195,18 @@ describe("TapeService", () => {
     });
   });
 
-  describe("verify() — when Lane B is available", () => {
+  describe("verify()", () => {
     let repo: InMemoryTapeRepository;
-    let service: { stamp: Function; verify: Function };
+    let service: TapeService;
 
     beforeEach(() => {
-      if (TapeService === null) return;
       repo = new InMemoryTapeRepository();
-      service = new TapeService(repo);
+      service = createTapeService(repo);
     });
 
     it("verify() on a clean 5-entry chain returns {ok:true, lastSequence:5}", async () => {
-      if (TapeService === null) {
-        console.log(
-          "[SKIP] TapeService not available on this branch — un-skip after Phase 2."
-        );
-        return;
-      }
-
-      const scope = makeScope("applicant-verify-clean");
+      const applicantId = "applicant-verify-clean";
+      const scope = makeScope(applicantId);
       const kinds: Array<keyof typeof TAPE_CITATIONS> = [
         "WELCOME_LETTER_DELIVERED",
         "HUD_928_1_FAIR_HOUSING_POSTED",
@@ -285,7 +215,7 @@ describe("TapeService", () => {
         "POSITION_LETTER_SENT",
       ];
       for (const kind of kinds) {
-        await service.stamp(makeEvent(kind), scope);
+        await service.stamp(makeEvent(kind, applicantId));
       }
 
       const result = await service.verify(scope);
@@ -294,14 +224,8 @@ describe("TapeService", () => {
     });
 
     it("verify() on a chain with mutated payload at sequence=3 returns {ok:false, brokeAt:3, reason set}", async () => {
-      if (TapeService === null) {
-        console.log(
-          "[SKIP] TapeService not available on this branch — un-skip after Phase 2."
-        );
-        return;
-      }
-
-      const scope = makeScope("applicant-verify-tampered");
+      const applicantId = "applicant-verify-tampered";
+      const scope = makeScope(applicantId);
       const kinds: Array<keyof typeof TAPE_CITATIONS> = [
         "WELCOME_LETTER_DELIVERED",
         "HUD_928_1_FAIR_HOUSING_POSTED",
@@ -310,7 +234,7 @@ describe("TapeService", () => {
         "POSITION_LETTER_SENT",
       ];
       for (const kind of kinds) {
-        await service.stamp(makeEvent(kind), scope);
+        await service.stamp(makeEvent(kind, applicantId));
       }
 
       // Tamper: mutate the payload at sequence=3 without updating the hash.
@@ -331,20 +255,14 @@ describe("TapeService", () => {
     });
 
     it("verify() on a chain with a fabricated entry (wrong prevHash) returns {ok:false, brokeAt:<that seq>, reason set}", async () => {
-      if (TapeService === null) {
-        console.log(
-          "[SKIP] TapeService not available on this branch — un-skip after Phase 2."
-        );
-        return;
-      }
-
-      const scope = makeScope("applicant-verify-fabricated");
+      const applicantId = "applicant-verify-fabricated";
+      const scope = makeScope(applicantId);
       const kinds: Array<keyof typeof TAPE_CITATIONS> = [
         "WELCOME_LETTER_DELIVERED",
         "HUD_928_1_FAIR_HOUSING_POSTED",
       ];
       for (const kind of kinds) {
-        await service.stamp(makeEvent(kind), scope);
+        await service.stamp(makeEvent(kind, applicantId));
       }
 
       // Inject a fabricated entry at sequence=3 with a wrong prevHash.
@@ -371,7 +289,7 @@ describe("TapeService", () => {
         sequence: 3,
         kind: "WAITING_LIST_APP_CAPTURED",
         citation: TAPE_CITATIONS.WAITING_LIST_APP_CAPTURED,
-        applicantId: "applicant-verify-fabricated",
+        applicantId,
         payload: fakePayload,
         prevHash: wrongPrevHash,
         entryHash: fakeEntryHash,


### PR DESCRIPTION
## #4 — Compliance-Tape v2 Cutover (BP-02 Phase 2)

Last increment of the screening-hardening series (after #243 vendor seam, #245 HUD criminal engine, both merged + audited). The entire BP-02 tape v2 system — tamper-evident, SHA-256 hash-chained, Postgres-backed audit ledger with append-only trigger and self-verifying PDF export — was already built **dark** across 7 lanes. The **only** code gap was that `src/index.ts` mounted an inert Phase-1 **stub** service (threw `{stub:true}` → 503) instead of the real `TapeService`.

### The change
- **`src/index.ts`** — replace the inline stub passed to `createTapeViewerRoutes(...)` with the real `createTapeService(new PgTapeRepository())`, mirroring the verify-cron wiring already in `src/scheduler.ts`. Removes the `TODO(BP-02-Phase-2)` block. (+2 imports.)
- **`compliance-tape-flag.test.ts`** — the wire-up breaks the old "flag-ON → 503 stub" assertion. Rewrote it: flag-ON now exercises the real service over a mocked DB → empty-chain `verify` returns **200** for an applicant scope, and a no-`applicantId` request still **501s** (`global_scope_not_implemented`, v1 is applicant-scoped only). Flag unset / `"false"` → **404** (routes unmounted) — unchanged.
- **`service.spec.ts` / `replay.spec.ts`** — un-skipped now that Lane B is on-branch. Switched the lazy-`require` harness to a **static `createTapeService` factory import** (`TapeService` is a type-only `interface` — no runtime class / no default export, which is why the old `mod.TapeService ?? mod.default` resolved to null) and aligned each event's `subjectId` with the verified/mutated scope.

### Ships DARK
```
flag OFF (today + after merge):  routes NOT mounted → 404      | byte-identical prod
flag ON  (before this PR):       routes → STUB → 503           | ← the gap
flag ON  (after this PR):        routes → REAL service → 200 / verify / PDF
```
`COMPLIANCE_TAPE_V2_ENABLED` stays **OFF** in prod. The flag flip itself is a separate gated ops step (staging → `post-deploy-verify --verify-dual-write` parity → prod) per `docs/operator-runbook.md` + `docs/runbooks/bp02-rollback.md` — **not** this PR.

### Verification
- `tsc --noEmit` clean.
- Tape suites deterministically green: `compliance-tape-flag`, `scheduler-bp02-flag`, `tape/{service,replay,hashing}.spec`, `tape/events/*` → **45/45**.
- **Dark-ship invariant:** flag unset → `GET /api/compliance-tape/*` → 404; suite green.
- Remaining full-suite flakiness is **pre-existing ambient** jest-worker noise — base #248 flaked 2/6 in-band vs this branch 1/6, with random **non-tape** victims (auth-magic-link, voice-tool-callbacks, saved-properties, payment-refunds, waitlist-routes, turnstile-middleware) and no tape test ever among them. Confirmed by stashing to pristine base and reproducing the same class. Matches the documented repo flake ("re-run is authoritative").

### Out of scope (Phase 3)
No migration / backfill of historical NDJSON rows. No legacy-writer removal. Global scope stays 501. The two defined-but-unwired `stampV2*` wrappers stay as-is (the 5 wired callsites suffice for parity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
