### PR TITLE
docs(market-recon): NV Public Records Act request for housing-DB web analytics

### DIFF
--- a/docs/nv-housing-db-records-INSTRUCTIONS.md
+++ b/docs/nv-housing-db-records-INSTRUCTIONS.md
@@ -1,0 +1,55 @@
+# Task: File a Public Records Request for NV Housing Database Traffic Data
+
+**Goal:** Get the State of Nevada's actual website analytics (how many people visit
+their housing database, from where, and what they searched) for the page at
+`https://housing.nv.gov/Programs/Housing_Database/` and everything beneath it.
+
+**Why we can do this:** Nevada law (NRS 239) makes government website analytics a
+public record. We just have to ask correctly. It's free or near-free.
+
+**Time:** ~30 min of work, then a 5-business-day wait for their reply.
+
+---
+
+## Step 1 — Get the request letter
+- Open the file: `docs/nv-housing-db-records-request.md`
+- This is the letter we send. Don't change the legal wording.
+
+## Step 2 — Fill in the 3 blanks
+At the top of the letter, replace:
+1. `[Your name], [email], [phone]` → your contact info
+2. `[date]` → today's date
+3. `[start date] through [end date]` → use **the last 12 months** (e.g. "May 2025 through May 2026")
+
+## Step 3 — Find who to send it to (one phone call)
+- Call the Nevada Housing Division economist: **775-687-2240**
+- Say: *"I'd like to submit a public records request under NRS 239 for website
+  analytics. Who is your designated public records officer, and what email should
+  I send it to?"*
+- Write down the name + email they give you.
+- Put that name/email in the letter's "To:" line.
+
+## Step 4 — Send it
+Two options (Step 3's email is preferred):
+- **Email** the letter text to the records officer from Step 3. Subject line:
+  `Public Records Request — NRS 239 — Housing Database Web Analytics`
+- **OR** if they won't give an email, submit via the state portal:
+  https://www.admin.nv.gov/public-records-requests/ (paste the letter into the form).
+
+## Step 5 — Log it and set a reminder
+- Save a copy of what you sent + the date.
+- Set a calendar reminder for **5 business days out**. By law they must respond by then.
+- If they ask to narrow the request or mention a fee, loop in Alex before agreeing.
+
+## Step 6 — When the data arrives
+- They'll send CSV/Excel/PDF exports.
+- Drop the files in this repo under `docs/` and ping Alex. Done.
+
+---
+
+### If you get stuck
+- **They say "we don't track that":** Ask specifically for "Google Analytics or GA4
+  reports for that URL." State sites almost always run GA.
+- **They quote a fee:** Ask for it in writing and forward to Alex — don't pay yet.
+- **No response in 5 business days:** Reply to the same thread quoting
+  "NRS 239.0107 requires a response within 5 business days."

--- a/docs/nv-housing-db-records-request.md
+++ b/docs/nv-housing-db-records-request.md
@@ -1,0 +1,59 @@
+# Nevada Public Records Act Request — Housing Database Web Analytics
+
+**To:** Nevada Housing Division, Public Records Officer
+(Nevada Department of Business & Industry)
+**Cc:** Division Economist (775-687-2240)
+**From:** [Your name], [email], [phone]
+**Date:** [date]
+
+---
+
+This is a request under the Nevada Public Records Act, NRS Chapter 239.
+
+I am requesting copies of, or electronic export of, the **web analytics data**
+(e.g., Google Analytics / GA4, Adobe Analytics, or any web-traffic measurement
+system in use) for the Housing Division's "Housing Database" web section and all
+pages beneath it, for the period **[start date] through [end date]** (or the most
+recent 12 full months available).
+
+### Specific URLs / paths in scope
+- `https://housing.nv.gov/Programs/Housing_Database/` (landing)
+- All child pages under that path, including but not limited to:
+  - Housing Market Data 2(a)
+  - Housing Need & Inventory 2(b,c)
+  - Demographic & Economic Data 2(d,e,f)
+  - "Taking Stock" affordable housing surveys (2018–2022)
+  - Annual Housing Progress Reports (2018–2025)
+  - AB213 Annual Housing Report
+- Any linked report files (PDF/XLSX) and download events for the above.
+
+### Metrics requested (per page / path)
+1. **Quantity:** sessions, total users, new users, pageviews, and unique
+   pageviews, broken out by month.
+2. **Location:** geographic breakdown by country, US state, and city/metro
+   (Nevada metros — Las Vegas, Reno/Sparks, Carson City — itemized if available).
+3. **Acquisition / referral:** traffic source / medium (organic search, direct,
+   referral, social, email), and top referring domains.
+4. **Search terms:** any Google Search Console data linked to the property —
+   top queries, impressions, clicks, and average position for these pages.
+5. **Engagement:** avg. session duration / engagement time and bounce/exit data.
+6. **Downloads:** file-download event counts for any report files served from
+   these pages.
+
+### Format
+Please provide as CSV or XLSX export, or PDF dashboard exports, whichever is
+least burdensome to your office. Native GA report exports are acceptable.
+
+### Fee
+Please advise of any copy/extraction fee before incurring it. I request a fee
+waiver or reduction to the extent the records can be exported electronically at
+no cost.
+
+### Statutory note
+NRS 239.0107 requires a response within **5 business days**. If any portion is
+withheld, please cite the specific statutory exemption per NRS 239.0107(1)(d),
+and provide all reasonably segregable non-exempt portions.
+
+Thank you. I'm happy to narrow scope or clarify by phone — [your phone].
+
+[Your name]


### PR DESCRIPTION
## What
Adds two docs, salvaged from a working-tree stash during triage:

- **`docs/nv-housing-db-records-request.md`** — the NRS 239 (Nevada Public Records Act) request letter for the State's web-analytics on `housing.nv.gov/Programs/Housing_Database` (sessions, geo breakdown, referral/search terms, file downloads, last 12 months).
- **`docs/nv-housing-db-records-INSTRUCTIONS.md`** — step-by-step filing playbook (who to call, how to send, the 5-business-day statutory clock, fee handling).

## Why
Part of the `/market-recon` demand-evidence workstream — turns the Nevada housing-database traffic into a public-record we can cite. Docs-only; **no code impact**, no migration, no behavior change.

## Provenance
Recovered from `stash@{0}` (untracked tree) during a stash triage; the rest of that stash was throwaway screenshots + audit scratch and was dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)