### PR TITLE
feat(screening): background+credit CRA adapter — dark async scaffold (#4)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -240,6 +240,43 @@ SCREENING_ON_SUBMIT_ENABLED=false
 # Dashboard + identity.verification_session.* added to the webhook endpoint.
 IDENTITY_VERIFICATION_ENABLED=false
 
+# Consumer-report CRA screening (background + credit). When true, submitting an
+# application creates a Checkr background report + a TransUnion ShareAble credit
+# report, parks the app in `awaiting_consumer_report`, and the applicant
+# authorizes the pulls + passes KBA on the CRA's hosted flow. The verdicts arrive
+# via /api/webhooks/cra; the webhook lands them and advances
+# awaiting_consumer_report → screening (or → screening_review on a
+# could_not_screen HOLD; never an auto-pass). At screening time the SOURCE of the
+# background + credit signals flips from the synchronous vendor seam to reading
+# the webhook-persisted verdict (background/credit .resolve()).
+#
+# Independent of SCREENING_ON_SUBMIT_ENABLED. Default off ⇒ byte-identical to the
+# legacy synchronous path (runCheck via the vendor seam). One flag drives both
+# domains + the single `awaiting_consumer_report` state.
+#
+# SHIPS DARK: the report-create + the real CRA webhook signature verification are
+# credentialing-gated (no signed contract / sandbox keys yet) — createReport()
+# throws until configured (fail-loud, leaves the app in `submitted`), and the
+# webhook returns 503 until CRA_WEBHOOK_SECRET is set. Do NOT set this true in
+# prod until the CRA credentials below exist and the field paths marked
+# TODO(credentialing) are confirmed against a live sandbox.
+CONSUMER_REPORT_ENABLED=false
+
+# --- CRA credentials (credentialing-gated — leave unset until contracts signed) ---
+# Checkr (background/criminal). Signed contract + sandbox key required.
+# CHECKR_API_KEY=
+# CHECKR_WEBHOOK_SECRET=
+# TransUnion ShareAble (credit/eviction). Signed contract + sandbox key required.
+# TRANSUNION_SHAREABLE_API_KEY=
+# TRANSUNION_SHAREABLE_WEBHOOK_SECRET=
+# Shared CRA webhook signing secret (the receiver self-gates 503 until this is
+# set; the synthetic-payload tests set it to exercise the path).
+# CRA_WEBHOOK_SECRET=
+# FCRA-required CRA identification surfaced on adverse-action notices.
+# CRA_NAME=
+# CRA_ADDRESS=
+# CRA_PHONE=
+
 # Supabase Storage (optional — enables /api/qa/bundles, the operator QA viewer).
 # When unset, the QA viewer returns an empty list with a hint banner instead
 # of failing. Service role key is server-only — never expose to the client.

--- a/docs/screening/background-credit-cra-adapter.md
+++ b/docs/screening/background-credit-cra-adapter.md
@@ -1,0 +1,294 @@
+# Background + Credit (CRA) Adapter — Build Plan
+
+Status: Design, ready to build. Branch `feat/screening-background-credit`. Not deployed.
+Owner: Frank-Pilot CDPC engineering. Audience: Frank, engineering, compliance counsel.
+Created: 2026-06-01. Supersedes `custom-screening-engine.md` §7 vendor-SDK steps (see §0).
+
+This is the next vendor adapter after Stripe Identity (#244). It covers the two
+**consumer-report (FCRA-regulated) checks**: background/criminal and credit/eviction.
+The vendor selection was already ratified — **Checkr** (background/criminal) and
+**TransUnion ShareAble** (credit/eviction), per `custom-screening-engine.md` §3.1/§3.2.
+This doc does NOT re-open vendor choice; it corrects *how* they integrate given two
+things that landed after that doc was ratified: the #243 vendor seam and the #244
+async template.
+
+---
+
+## 0. What changed since `custom-screening-engine.md` (the correction)
+
+That doc (ratified 2026-05-27) says, in §7 "Vendor SDK implementations":
+
+> Replace the **synchronous stub** in `background-check.ts` with the Checkr SDK call.
+> Replace the **synchronous stub** in `credit-check.ts` with the TransUnion ShareAble call.
+
+Both halves of that instruction are now wrong:
+
+1. **#243 (vendor seam) moved the synchronous stub.** `background-check.ts` and
+   `credit-check.ts` no longer contain a `throw "Production API integration not yet
+   configured"` placeholder. They call `resolveVendor("background"|"credit").background|credit(input)`
+   (`background-check.ts:89`, `credit-check.ts:69`). The synchronous vendor code now
+   lives in `src/modules/screening/vendors/` (the `ScreeningVendor` interface,
+   `types.ts:157`).
+
+2. **More fundamental: Checkr and TU ShareAble are NOT synchronous.** They are
+   **asynchronous, applicant-mediated, webhook-completion CRAs** — the same shape as
+   Stripe Identity. A synchronous `background(input): Promise<BackgroundVendorResponse>`
+   that returns criminal/credit *facts in one call* cannot drive an applicant who must
+   authorize the pull, pass KBA identity questions, and wait minutes-to-hours for county
+   criminal searches to clear. The #243 seam method signature has **no `applicationId`
+   and no DB access** (`types.ts:33-48`) — it physically cannot read a webhook-delivered
+   report back. So the CRA pull does **not** belong in the seam at all.
+
+**The correct pattern is the one #244 just proved for Stripe Identity** — and note that
+identity is deliberately **not** in the vendor seam (the `ScreeningVendor` interface has
+`background/credit/income/nsopw/employment` methods, *no* `identity`). Async,
+applicant-mediated checks live in their own service with a `create → webhook → resolve`
+lifecycle, gated behind a flag, byte-identical when dark.
+
+---
+
+## 1. The architecture (mirror #244)
+
+```
+                                              ┌──────────── Checkr / TransUnion (hosted) ───────────┐
+ applicant submits        server             │                                                      │
+ ──────────────►  submit()  ──────────────►  createReport(applicationId)  ── invitation url ──►  applicant
+                    │  (armed path)            CRA report/order created          authorizes + KBA + (pays)
+                    │                                                                   │              │
+        status: submitted ─► awaiting_consumer_report                                  ▼              │
+                                                       report.completed / order.fulfilled (WEBHOOK)    │
+                                                                     │                                 │
+                       POST /api/screening/cra-webhook  ◄────────────┘  (NEW raw-body verified route)  │
+                                  │  map report → BackgroundVendorResponse / CreditVendorResponse-shaped │
+                                  │  persist categorical verdict + report ref onto application row       │
+                                  ▼                                                                      │
+                  awaiting_consumer_report ─► screening   ──►  runFullScreening()                        │
+                                                              background.resolve(applicationId) = READ ──┘
+                                                              credit.resolve(applicationId)     = READ
+                                                              (no report yet / pending → could_not_screen HOLD)
+                                                                       │
+                                                                       ▼
+                                       criminal records[] → hud-criminal-decision.ts (#245, CRIMINAL_DECISION_ENGINE_ENABLED)
+                                       any fail → screening_failed → adverse-action (§1681m, EXISTING)
+```
+
+- **Chosen:** create-at-submit · applicant-mediated authorization on the CRA's hosted
+  flow · webhook lands the report · screening **reads** the persisted verdict. Identical
+  to #244, extended to two reports.
+- **Rejected:** server-side synchronous pull (decrypt `ssn_encrypted`, POST full PII to
+  the CRA, block on the response). It (a) fits the seam but criminal county searches are
+  async anyway so it would still churn `could_not_screen`, (b) forces us to transmit and
+  hold full-SSN + raw consumer-report PII — directly against our PII rule and a far larger
+  FCRA/security burden, and (c) requires us to build standalone FCRA disclosure +
+  authorization capture ourselves. The applicant-mediated flow puts disclosure +
+  authorization + identity (KBA) on the CRA's compliant hosted flow.
+- **New state(s):** one of `awaiting_consumer_report` (between `submitted` and `screening`)
+  — analogous to `awaiting_identity` (`2026-06-01-applications-identity-session.sql:25`).
+  If identity and CRA both gate submit, the order is `submitted → awaiting_identity →
+  awaiting_consumer_report → screening`; a single combined `awaiting_screening` state is an
+  acceptable simplification (decide at build time — see §8 open items).
+
+### Why background and credit are ONE effort but TWO reports
+
+Checkr (background) and TU ShareAble (credit) are separate vendors with separate
+webhooks and separate report references, but they share: the same new state, the same
+submit-time "create both reports" step, the same consent capture, and the same resolve
+pattern. Build them together; persist two independent verdicts
+(`background_check_*` and `credit_check_*` columns already exist).
+
+---
+
+## 2. Vendor mapping (ratified — not re-opened here)
+
+| Domain | Primary | Fallback | Integration shape | Contract status |
+|---|---|---|---|---|
+| Background / criminal | **Checkr** | Certn | candidate + invitation → hosted consent → `report.completed` webhook | RFQ sent 2026-05-27; `vendor-scoring-matrix.md` **unfilled** → not signed |
+| Credit / eviction | **TransUnion ShareAble** | Experian Connect | applicant KBA + authorization → report-ready callback/webhook | same |
+
+`vendor-scoring-matrix.md` is a template with all cells `_/10` → **no contract is signed
+and no API credentials exist yet.** Credentialing + FCRA use-case review takes 2-6 weeks
+after signing (`vendor-scoring-matrix.md:49`). This gates the *live* integration, not the
+*structure* — see §4 split.
+
+---
+
+## 3. Field mapping (CRA report → existing response shapes)
+
+The vendor reports map onto the **existing** response/result shapes so
+`BackgroundCheckService.evaluateResults` + the #245 HUD engine + `CreditCheckService.evaluateResults`
+stay single-sourced and unchanged.
+
+**Checkr `report` → `BackgroundVendorResponse`** (`types.ts:42`) — but routed via
+`background-check.ts` resolve, not the seam:
+
+| Field | Source | Rule |
+|---|---|---|
+| `records[]` | `report.{ssn_trace,sex_offender_search,national_criminal_search,county_criminal_searches[],eviction_search}` | normalize each charge to the `CriminalRecord` shape `hud-criminal-decision.ts:128` consumes (category, disposition, date) — `records[]` is authoritative; summary flags are derived only as a fallback |
+| `sexOffenses` | `report.sex_offender_search.records` non-empty | → §5.856 mandatory denial path |
+| `felonies` / `violentCrimes` / `misdemeanors` | derived from `records[]` charge severity | feeds legacy path only when `CRIMINAL_DECISION_ENGINE_ENABLED` is off |
+| eviction | `report.eviction_search` | NOTE: evictions also arrive via TU credit; dedupe by case (see §8) |
+| `rawResponse` | — | persist **only** `{reportId, candidateId, status, per-search statuses, adjudication}` — never charge narratives, addresses, full DOB/SSN |
+
+**TU ShareAble → `CreditVendorResponse`** (`types.ts:60`):
+
+| Field | Source | Rule |
+|---|---|---|
+| `creditScore` | ShareAble ResidentScore / credit score | `>=600` pass (`credit-check.ts` threshold, unchanged) |
+| `evictions` | ShareAble eviction-history count | `>0` → auto-fail (unchanged) |
+| `bankruptcies` | public-records section | `>0` → auto-fail (unchanged) |
+| `collections` / `outstandingDebts` / `paymentHistory` | tradeline summary | informational + soft-risk |
+| `rawResponse` | — | persist **only** `{reportId, score, categorical counts}` — never tradeline detail |
+
+The exact JSON field paths are **credentialing-gated** (need the real API docs + a
+sandbox account). The mapper is written against Checkr's / TU's published report schema
+with a `// TODO(credentialing): confirm field path` marker on each path until verified
+against a live sandbox response.
+
+---
+
+## 4. Files to change — split by what gates them
+
+### Ships DARK now (contract-independent structure — same as #244 built before Stripe was live)
+
+1. `src/db/migrations/2026-06-0X-applications-consumer-report.sql` — `ALTER TYPE
+   application_status ADD VALUE IF NOT EXISTS 'awaiting_consumer_report'` (**outside a
+   txn** — same constraint as `2026-06-01-applications-identity-session.sql:25`) +
+   `background_report_id TEXT`, `credit_report_id TEXT`, `consumer_report_*_status TEXT`,
+   `screening_authorization_at TIMESTAMPTZ`. Background/credit verdict columns already
+   exist (`background_check_*`, `credit_check_*`, `credit_score`).
+2. `src/modules/screening/background-check.ts` — add `createReport(applicationId)` +
+   `resolve(applicationId)` (read webhook-persisted verdict, `could_not_screen` HOLD if
+   pending/missing) + pure `mapCheckrReportToResponse(report)`. **Keep `runCheck()` and the
+   seam path verbatim** for MOCK/stub/flag-off (byte-identical dark) — exactly how
+   `identity-verification.ts` kept `verify()` alongside `resolve()`.
+3. `src/modules/screening/credit-check.ts` — mirror: `createReport` / `resolve` /
+   `mapShareAbleReportToResponse`; keep `runCheck()` + seam path verbatim.
+4. `src/modules/screening/service.ts` — `runFullScreening` calls `background.resolve(id)` /
+   `credit.resolve(id)` on the armed path instead of `runCheck(...)` (identical result
+   shape; aggregation `service.ts:523-544` + the `individualized_assessment_required`
+   routing `service.ts:559-560` unchanged).
+5. `src/modules/screening/state-machine.ts` — register `awaiting_consumer_report` +
+   transitions (`submitted → awaiting_consumer_report`,
+   `awaiting_consumer_report → {screening, screening_review}`).
+6. `src/modules/application/service.ts` — `submit()`: on armed path call
+   `createReport()` for both domains and transition to `awaiting_consumer_report`. Flag-off
+   path unchanged.
+7. New flags in `.env.example`: `BACKGROUND_CHECK_ENABLED=false`,
+   `CREDIT_CHECK_ENABLED=false` (or a single `CONSUMER_REPORT_ENABLED`), independent of
+   `SCREENING_ON_SUBMIT_ENABLED`. Document that `SCREENING_VENDOR_BACKGROUND=checkr` /
+   `SCREENING_VENDOR_CREDIT=transunion` only matter for the (now sandbox-only) seam path.
+8. `src/__tests__/background-check-cra.test.ts`, `credit-check-cra.test.ts` — table-driven
+   `mapXReportToResponse` + `resolve` gating (pending → `could_not_screen`; mandatory-denial
+   record → fail; clean → pass) using **synthetic** report fixtures. No live calls.
+9. `src/__tests__/cra-webhook.test.ts` — mirror `payment-webhook.test.ts` /
+   `identity-webhook.test.ts`: signature verification, idempotency, the new event types.
+
+### Credentialing-gated (needs signed contract + sandbox keys — do NOT guess-and-ship)
+
+10. `src/modules/screening/cra/` (or inside the two services) — the real HTTP client:
+    Checkr candidate/invitation/report create; TU ShareAble order create; the exact field
+    paths in the two mappers (replace the `// TODO(credentialing)` markers); webhook
+    signature secrets (`CHECKR_WEBHOOK_SECRET`, TU equivalent).
+11. `src/modules/payment/webhook.ts` *or* a new `src/modules/screening/cra-webhook.ts`
+    route — the live event handlers. (Structure can ship dark with a `not-yet-configured`
+    guard; the live mapping is gated.)
+12. Set `CRA_NAME` / `CRA_ADDRESS` / `CRA_PHONE` (`adverse-action/service.ts:28-31`) to the
+    actual signed CRA — the adverse-action notice already renders them.
+
+---
+
+## 5. FCRA build delta
+
+What already exists (do not rebuild):
+
+- **§1681m adverse-action notice** — `adverse-action/service.ts` `buildNoticeText` renders
+  CRA name/address/phone + the right-to-free-report-within-60-days + dispute rights +
+  "CRA did not make this decision." Wired into the screening fail path
+  (`service.ts` automated `reasonDetail`). **EXISTING.**
+- **HUD individualized assessment** for criminal — `hud-criminal-decision.ts` (#245),
+  flag `CRIMINAL_DECISION_ENGINE_ENABLED`. Criminal `records[]` from the Checkr mapper feed
+  it directly. **EXISTING.**
+- **Permissible purpose** (§1681b(a)(3)(F)) — the rental application is a consumer-initiated
+  transaction; the CRA contract carries Frank's permissible-purpose certification.
+  **Vendor-side / contractual.**
+
+What is NEW for this adapter:
+
+- **Applicant authorization / consent capture.** There is currently NO CRA-specific
+  disclosure or authorization in the codebase (the only `consent` fields are ESIGN-lease
+  and voice-call consent). In the applicant-mediated model the CRA's hosted flow captures
+  the FCRA disclosure + written authorization, so we need only (a) an in-app consent
+  checkbox before redirect and (b) to stamp `screening_authorization_at`. We do **not**
+  build a standalone-disclosure document (the vendor hosts it). Several states (CA, NY,
+  others) and the CRA contract require the authorization regardless — this closes that gap.
+- **Pre-adverse-action window** (ratified 5 **business** days, `custom-screening-engine.md`
+  §8.3). Today only the final notice is sent. Needs `pre_adverse_action_sent_at` column +
+  a daily reaper that sends the final notice once 5 business days elapse + a pre-adverse
+  template in `AdverseActionService`. **NEW.**
+- **§1681i disputes** — ratified = link to the CRA's hosted dispute portal from the
+  adverse-action letter; receive resolution via webhook (`custom-screening-engine.md` §8.6).
+  Low lift. **NEW (small).**
+
+---
+
+## 6. Safety & flags
+
+- **New flag(s)** default OFF; flag-off = byte-identical (the seam → sandbox →
+  `STUB_GATE_ERROR` → `could_not_screen` HOLD path is untouched and remains the keyless-prod
+  behavior). The dark structure adds the `createReport`/`resolve`/webhook code but it is
+  unreachable until the flag is ON.
+- **Fail-loud, never silent pass:** `resolve` returns a stored verdict or
+  `could_not_screen`; an unmappable webhook → throw → DLQ + the app stays HOLD; the
+  `STUB_GATE_ERROR` gate is untouched. Aggregation precedence (`fail > could_not_screen >
+  review_required > pass`, `service.ts:523-544`) guarantees a misconfigured pipeline cannot
+  reach `screening_passed`.
+- **PII/FCRA:** full SSN + raw consumer-report PII (charge narratives, tradelines,
+  addresses) live on the CRA. We persist ONLY the report reference (`*_report_id`) +
+  categorical statuses + counts + error/adjudication codes. The applicant provides their
+  full SSN to the CRA's hosted flow — we never transmit `ssn_encrypted` to the vendor on
+  this path.
+
+---
+
+## 7. Verification + go-live sequence
+
+**Local/unit (now):** `STRIPE_LIVE_ENABLED=false npm test`. New suites green; `service`
+tests updated (`runCheck` → `resolve` on the armed path); assert mandatory-denial record →
+fail + adverse-action, pending → `could_not_screen` → `screening_review`, clean → pass.
+
+**Credentialing-gated (after contract):** Checkr + TU sandbox accounts → run a real
+applicant through each hosted flow → confirm the webhook lands `report.completed` /
+order-ready, the row gets the verdict, screening proceeds. Force a criminal hit → §5.856 /
+individualized-assessment. Force never-completed → `could_not_screen` → `screening_review`.
+
+**Prod go-live (ordered, after credentialing):**
+1. Apply the migration (ADD VALUE outside txn).
+2. `railway up` with the new flag(s) OFF (webhook cases ride dark) — deploy from the
+   `fp-deploy` production-linked worktree (`reference_frank_no_staging_env`).
+3. Register the Checkr + TU webhooks; set `CHECKR_API_KEY` / TU creds + webhook secrets +
+   `SCREENING_VENDOR_BACKGROUND`/`_CREDIT` + `CRA_*` env.
+4. Clear the demo posture (prod is `MOCK_MODE=1` — a flag flip alone runs MOCK, not the real
+   CRA; `reference_frank_no_staging_env`).
+5. Flip the new flag(s) ON (staff still manual `/screen`). After clean live reports, flip
+   `SCREENING_ON_SUBMIT_ENABLED`.
+6. **Rollback:** flag(s) OFF reverts to prior behavior, no redeploy.
+
+Deploy mechanics (memory): api = manual `railway up --ci --service api` from the
+production-linked `fp-deploy` worktree; `.railwayignore` required; new-route 404→401 =
+liveness canary.
+
+---
+
+## 8. Open items to decide at build time
+
+- **One new state or two?** `awaiting_consumer_report` alone, or split identity vs CRA
+  waits. Recommendation: one combined `awaiting_consumer_report` (identity already has its
+  own `awaiting_identity`; chaining two waits is fine, a single combined gate is simpler).
+- **Eviction dedupe.** Evictions surface from BOTH Checkr (`eviction_search`) and TU
+  (credit eviction history). Decide the authoritative source (recommend TU credit, since
+  eviction is a credit/public-records signal) to avoid double-counting in the verdict.
+- **Consent UX placement.** The apply-wizard `Step` union is a frozen contract behind the
+  required tenant-e2e gate (`project_tenant_e2e_gate`) — the consent checkbox + redirect
+  needs its own focused change, like #244's deferred Stripe redirect step.
+- **Combined create.** Whether `submit()` creates both reports eagerly or lazily at first
+  `/screen`. Recommend eager-at-submit (matches #244 createSession) when the flag is on.

--- a/src/__tests__/background-check-cra.test.ts
+++ b/src/__tests__/background-check-cra.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Consumer-report CRA adapter — Checkr background lifecycle unit tests.
+ *
+ * Covers:
+ *   - mapCheckrReportToResponse(): pure, table-driven; categorical-only output;
+ *     sex-offender + felony/misdemeanor classification; criminalRecords exposed
+ *     for the HUD engine.
+ *   - resolve(): reads the webhook-persisted verdict; could_not_screen HOLD when
+ *     no report / pending / wrong shape / lookup throws; re-runs evaluateResults.
+ *   - createReport(): fail-loud throw until credentialing exists.
+ *
+ * No network / no real DB: ../config/database query is mocked.
+ */
+
+const mockQuery = jest.fn();
+
+jest.mock("../config/database", () => ({ query: (...a: unknown[]) => mockQuery(...a) }));
+jest.mock("../utils/logger", () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+import { BackgroundCheckService } from "../modules/screening/background-check";
+
+describe("BackgroundCheckService — Checkr CRA mapping", () => {
+  let svc: BackgroundCheckService;
+  beforeEach(() => {
+    jest.clearAllMocks();
+    svc = new BackgroundCheckService();
+    delete process.env.CRIMINAL_DECISION_ENGINE_ENABLED;
+  });
+
+  describe("mapCheckrReportToResponse", () => {
+    it("clean report → zero felonies, no sex offense, no records", () => {
+      const r = svc.mapCheckrReportToResponse({
+        sex_offender_search: { records: [] },
+        national_criminal_search: { records: [] },
+        county_criminal_searches: [],
+      });
+      expect(r.felonies).toBe(0);
+      expect(r.sexOffenses).toBe(false);
+      expect(r.violentCrimes).toBe(false);
+      expect(r.misdemeanors).toEqual([]);
+      expect(r.criminalRecords).toEqual([]);
+    });
+
+    it("sex-offender registry hit → sexOffenses + lifetime-registrant record", () => {
+      const r = svc.mapCheckrReportToResponse({
+        sex_offender_search: { records: [{ registry: "NV" }] },
+      });
+      expect(r.sexOffenses).toBe(true);
+      expect(r.criminalRecords).toHaveLength(1);
+      expect(r.criminalRecords[0].category).toBe("sex_offense_lifetime_registrant");
+      expect(r.criminalRecords[0].lifetimeRegistrant).toBe(true);
+    });
+
+    it("a felony charge → felony count + felony_nonviolent record", () => {
+      const r = svc.mapCheckrReportToResponse({
+        national_criminal_search: {
+          records: [{ classification: "Felony", disposition: "convicted", charge: "theft" }],
+        },
+      });
+      expect(r.felonies).toBe(1);
+      expect(r.criminalRecords[0].category).toBe("felony_nonviolent");
+      expect(r.criminalRecords[0].disposition).toBe("convicted");
+    });
+
+    it("a violent felony → felony_violent + violentCrimes flag", () => {
+      const r = svc.mapCheckrReportToResponse({
+        national_criminal_search: {
+          charges: [{ classification: "felony", charge: "aggravated assault" }],
+        },
+      });
+      expect(r.felonies).toBe(1);
+      expect(r.violentCrimes).toBe(true);
+      expect(r.criminalRecords[0].category).toBe("felony_violent");
+    });
+
+    it("a misdemeanor → misdemeanors[] + misdemeanor record, no felony", () => {
+      const r = svc.mapCheckrReportToResponse({
+        county_criminal_searches: [
+          { records: [{ classification: "misdemeanor", charge: "trespass" }] },
+        ],
+      });
+      expect(r.felonies).toBe(0);
+      expect(r.misdemeanors).toHaveLength(1);
+      expect(r.criminalRecords[0].category).toBe("misdemeanor_nonviolent");
+    });
+
+    it("never throws on a malformed / empty report (defensive coercion)", () => {
+      expect(() => svc.mapCheckrReportToResponse(undefined)).not.toThrow();
+      expect(() => svc.mapCheckrReportToResponse({})).not.toThrow();
+      expect(svc.mapCheckrReportToResponse(null).criminalRecords).toEqual([]);
+    });
+
+    it("output carries no charge narratives — only categorical fields", () => {
+      const r = svc.mapCheckrReportToResponse({
+        national_criminal_search: {
+          records: [
+            {
+              classification: "Felony",
+              charge: "Possession of a controlled substance, 14g, 123 Main St",
+              ssn: "123-45-6789",
+            },
+          ],
+        },
+      });
+      const rec: any = r.criminalRecords[0];
+      // The structured record must not echo the free-text charge narrative or SSN.
+      expect(rec.charge).toBeUndefined();
+      expect(rec.ssn).toBeUndefined();
+      expect(rec.description).toBeUndefined();
+      expect(Object.keys(rec)).toEqual(
+        expect.arrayContaining(["category"])
+      );
+    });
+  });
+
+  describe("resolve", () => {
+    it("no report on file → could_not_screen HOLD", async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [{ background_report_id: null }] });
+      const r = await svc.resolve("app-1");
+      expect(r.result).toBe("could_not_screen");
+      expect(r.details.riskScore).toBe(-1);
+    });
+
+    it("report still pending (no completed_at) → could_not_screen HOLD", async () => {
+      mockQuery.mockResolvedValueOnce({
+        rows: [{ background_report_id: "rep_1", background_check_completed_at: null }],
+      });
+      const r = await svc.resolve("app-1");
+      expect(r.result).toBe("could_not_screen");
+    });
+
+    it("persisted clean verdict → pass (re-runs evaluateResults)", async () => {
+      mockQuery.mockResolvedValueOnce({
+        rows: [
+          {
+            background_report_id: "rep_1",
+            background_check_completed_at: new Date(),
+            background_check_details: {
+              reportId: "rep_1",
+              rawResponse: { felonies: 0, sexOffenses: false, violentCrimes: false, misdemeanors: [], records: [] },
+            },
+          },
+        ],
+      });
+      const r = await svc.resolve("app-1");
+      expect(r.result).toBe("pass");
+    });
+
+    it("persisted felony verdict → fail (legacy blanket-ban path)", async () => {
+      mockQuery.mockResolvedValueOnce({
+        rows: [
+          {
+            background_report_id: "rep_1",
+            background_check_completed_at: new Date(),
+            background_check_details: {
+              rawResponse: { felonies: 1, sexOffenses: false, violentCrimes: false, misdemeanors: [], records: [] },
+            },
+          },
+        ],
+      });
+      const r = await svc.resolve("app-1");
+      expect(r.result).toBe("fail");
+    });
+
+    it("malformed persisted detail (no rawResponse) → could_not_screen HOLD", async () => {
+      mockQuery.mockResolvedValueOnce({
+        rows: [
+          {
+            background_report_id: "rep_1",
+            background_check_completed_at: new Date(),
+            background_check_details: { reportId: "rep_1" },
+          },
+        ],
+      });
+      const r = await svc.resolve("app-1");
+      expect(r.result).toBe("could_not_screen");
+    });
+
+    it("DB lookup throws → could_not_screen HOLD (never a pass)", async () => {
+      mockQuery.mockRejectedValueOnce(new Error("connection reset"));
+      const r = await svc.resolve("app-1");
+      expect(r.result).toBe("could_not_screen");
+    });
+  });
+
+  describe("createReport", () => {
+    it("throws (fail-loud) until Checkr credentialing exists", async () => {
+      await expect(
+        svc.createReport({
+          applicationId: "app-1",
+          firstName: "Sam",
+          lastName: "Lee",
+          ssnLast4: "6789",
+          dateOfBirth: "1990-01-01",
+          state: "NV",
+        })
+      ).rejects.toThrow(/not yet configured/i);
+    });
+  });
+});

--- a/src/__tests__/cra-webhook.test.ts
+++ b/src/__tests__/cra-webhook.test.ts
@@ -1,0 +1,281 @@
+/**
+ * Webhook tests for the consumer-report CRA receiver (src/modules/screening/
+ * cra-webhook.ts). Synthetic payloads only — the real Checkr / TransUnion
+ * signature scheme + envelope shape are credentialing-gated, so these exercise
+ * the receiver's routing / persistence / HOLD / idempotency behavior against the
+ * internal synthetic envelope the parser accepts.
+ *
+ * Mocked: DB (SQL-routed), state-machine transition, audit, the screening
+ * pipeline. The real (pure) BackgroundCheck/CreditCheck mappers run so the
+ * webhook's map→persist integration is exercised.
+ */
+
+import express from "express";
+import request from "supertest";
+
+const mockTransition = jest.fn();
+const mockRunFullScreening = jest.fn();
+
+jest.mock("../config/database", () => ({ query: jest.fn() }));
+jest.mock("../utils/logger", () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+jest.mock("../middleware/audit", () => ({ writeAuditLog: jest.fn().mockResolvedValue(undefined) }));
+jest.mock("../modules/screening/state-machine", () => ({
+  transitionApplicationStatus: (...a: unknown[]) => mockTransition(...a),
+}));
+jest.mock("../modules/screening/service", () => ({
+  ScreeningService: jest.fn().mockImplementation(() => ({ runFullScreening: mockRunFullScreening })),
+}));
+
+import { query } from "../config/database";
+import craWebhookRouter from "../modules/screening/cra-webhook";
+
+const mockQuery = query as jest.MockedFunction<typeof query>;
+const flush = () => new Promise((resolve) => setImmediate(resolve));
+
+const SECRET = "test_cra_secret";
+const APP_ID = "11111111-2222-3333-4444-555555555555";
+
+function buildApp() {
+  const app = express();
+  app.use("/webhook", craWebhookRouter);
+  return app;
+}
+const app = buildApp();
+
+function bgEvent(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "cra_evt_bg_1",
+    domain: "background",
+    applicationId: APP_ID,
+    reportId: "rep_1",
+    status: "complete",
+    report: {
+      sex_offender_search: { records: [] },
+      national_criminal_search: { records: [] },
+      county_criminal_searches: [],
+    },
+    ...overrides,
+  };
+}
+function creditEvent(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "cra_evt_cr_1",
+    domain: "credit",
+    applicationId: APP_ID,
+    reportId: "tu_1",
+    status: "complete",
+    report: { creditScore: 700, evictions: [], bankruptcies: [], collections: [] },
+    ...overrides,
+  };
+}
+
+function post(event: object, opts: { sig?: boolean } = {}) {
+  const req = request(app)
+    .post("/webhook")
+    .set("Content-Type", "application/json");
+  if (opts.sig !== false) req.set("x-cra-signature", "sig-present");
+  return req.send(JSON.stringify(event));
+}
+
+const originalSecret = process.env.CRA_WEBHOOK_SECRET;
+const originalScreenFlag = process.env.SCREENING_ON_SUBMIT_ENABLED;
+
+afterAll(() => {
+  process.env.CRA_WEBHOOK_SECRET = originalSecret;
+  process.env.SCREENING_ON_SUBMIT_ENABLED = originalScreenFlag;
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  process.env.CRA_WEBHOOK_SECRET = SECRET;
+  delete process.env.SCREENING_ON_SUBMIT_ENABLED;
+
+  // SQL-routed DB mock. Default: not a duplicate; persist guarded UPDATE hits a
+  // row (app is awaiting_consumer_report); the both-reports-in ctx says only the
+  // current report has landed (so no advance unless a test overrides it).
+  mockQuery.mockImplementation((sql: any) => {
+    const s = String(sql);
+    if (/cra_processed_events/i.test(s) && /SELECT/i.test(s)) {
+      return Promise.resolve({ rows: [] }) as any; // alreadyProcessed → not a dup
+    }
+    if (/UPDATE applications SET/i.test(s) && /RETURNING id/i.test(s)) {
+      return Promise.resolve({ rows: [{ id: APP_ID }] }) as any; // persist in awaiting_consumer_report
+    }
+    if (/FROM applications a/i.test(s) && /LEFT JOIN users/i.test(s)) {
+      // advanceIfBothReportsIn ctx — only ONE report in by default.
+      return Promise.resolve({
+        rows: [
+          {
+            status: "awaiting_consumer_report",
+            background_check_completed_at: new Date(),
+            credit_check_completed_at: null,
+            submitted_by: "99999999-8888-7777-6666-555555555555",
+            submitter_role: "applicant",
+          },
+        ],
+      }) as any;
+    }
+    return Promise.resolve({ rows: [] }) as any; // markProcessed, overall update
+  });
+
+  mockTransition.mockResolvedValue({ changed: true, status: "screening" });
+  mockRunFullScreening.mockResolvedValue({});
+});
+
+describe("POST /webhook — secret + signature gating", () => {
+  it("503 when CRA_WEBHOOK_SECRET unset (fail-closed)", async () => {
+    delete process.env.CRA_WEBHOOK_SECRET;
+    const res = await post(bgEvent());
+    expect(res.status).toBe(503);
+  });
+
+  it("503 when secret is the placeholder", async () => {
+    process.env.CRA_WEBHOOK_SECRET = "changeme";
+    const res = await post(bgEvent());
+    expect(res.status).toBe(503);
+  });
+
+  it("400 when signature header missing", async () => {
+    const res = await post(bgEvent(), { sig: false });
+    expect(res.status).toBe(400);
+  });
+
+  it("400 on unparseable envelope (unknown domain)", async () => {
+    const res = await post(bgEvent({ domain: "nonsense" }));
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("POST /webhook — background report completed", () => {
+  it("persists the mapped verdict guarded to awaiting_consumer_report, 200", async () => {
+    const res = await post(bgEvent());
+    expect(res.status).toBe(200);
+    const persist = mockQuery.mock.calls.find(
+      (c) => /UPDATE applications SET/i.test(String(c[0])) && /background_check_details/i.test(String(c[0]))
+    );
+    expect(persist).toBeTruthy();
+    expect(String(persist![0])).toMatch(/status = 'awaiting_consumer_report'/);
+    // Persisted detail is categorical-only (mapped response under rawResponse).
+    const detailJson = (persist![1] as any[])[2] as string;
+    expect(detailJson).toContain("rawResponse");
+    expect(detailJson).toContain("rep_1");
+  });
+
+  it("does NOT advance when only one report has landed", async () => {
+    await post(bgEvent());
+    await flush();
+    expect(mockTransition).not.toHaveBeenCalled();
+  });
+
+  it("verdict ignored (no advance) when persist guard matches 0 rows", async () => {
+    mockQuery.mockImplementation((sql: any) => {
+      const s = String(sql);
+      if (/cra_processed_events/i.test(s) && /SELECT/i.test(s)) return Promise.resolve({ rows: [] }) as any;
+      if (/UPDATE applications SET/i.test(s) && /RETURNING id/i.test(s)) return Promise.resolve({ rows: [] }) as any; // CAS miss
+      return Promise.resolve({ rows: [] }) as any;
+    });
+    const res = await post(bgEvent());
+    expect(res.status).toBe(200);
+    expect(mockTransition).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /webhook — both reports in → advance", () => {
+  beforeEach(() => {
+    mockQuery.mockImplementation((sql: any) => {
+      const s = String(sql);
+      if (/cra_processed_events/i.test(s) && /SELECT/i.test(s)) return Promise.resolve({ rows: [] }) as any;
+      if (/UPDATE applications SET/i.test(s) && /RETURNING id/i.test(s)) return Promise.resolve({ rows: [{ id: APP_ID }] }) as any;
+      if (/FROM applications a/i.test(s) && /LEFT JOIN users/i.test(s)) {
+        return Promise.resolve({
+          rows: [
+            {
+              status: "awaiting_consumer_report",
+              background_check_completed_at: new Date(),
+              credit_check_completed_at: new Date(), // BOTH in
+              submitted_by: "99999999-8888-7777-6666-555555555555",
+              submitter_role: "applicant",
+            },
+          ],
+        }) as any;
+      }
+      return Promise.resolve({ rows: [] }) as any;
+    });
+  });
+
+  it("transitions awaiting_consumer_report → screening (consumer_report_resolved)", async () => {
+    const res = await post(creditEvent());
+    expect(res.status).toBe(200);
+    await flush();
+    expect(mockTransition).toHaveBeenCalledWith(
+      expect.objectContaining({
+        from: "awaiting_consumer_report",
+        to: "screening",
+        trigger: "consumer_report_resolved",
+      })
+    );
+  });
+
+  it("kicks runFullScreening only when SCREENING_ON_SUBMIT_ENABLED", async () => {
+    await post(creditEvent());
+    await flush();
+    expect(mockRunFullScreening).not.toHaveBeenCalled();
+
+    jest.clearAllMocks();
+    mockTransition.mockResolvedValue({ changed: true, status: "screening" });
+    process.env.SCREENING_ON_SUBMIT_ENABLED = "true";
+    await post(creditEvent({ id: "cra_evt_cr_2" }));
+    await flush();
+    expect(mockRunFullScreening).toHaveBeenCalledWith(
+      APP_ID,
+      "99999999-8888-7777-6666-555555555555",
+      "applicant"
+    );
+  });
+
+  it("does not kick screening when the CAS transition is a no-op", async () => {
+    process.env.SCREENING_ON_SUBMIT_ENABLED = "true";
+    mockTransition.mockResolvedValue({ changed: false, status: "screening" });
+    await post(creditEvent());
+    await flush();
+    expect(mockRunFullScreening).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /webhook — terminal failure → could_not_screen HOLD", () => {
+  it("canceled status → HOLD in screening_review (never auto-pass)", async () => {
+    const res = await post(bgEvent({ status: "canceled", id: "cra_evt_bg_cancel" }));
+    expect(res.status).toBe(200);
+    await flush();
+    expect(mockTransition).toHaveBeenCalledWith(
+      expect.objectContaining({
+        from: "awaiting_consumer_report",
+        to: "screening_review",
+        trigger: "could_not_screen",
+      })
+    );
+    // It must NOT have persisted a background verdict / advanced to screening.
+    expect(mockTransition).not.toHaveBeenCalledWith(
+      expect.objectContaining({ to: "screening" })
+    );
+  });
+});
+
+describe("POST /webhook — idempotency", () => {
+  it("duplicate event_id short-circuits with 200 + no persist", async () => {
+    mockQuery.mockImplementation((sql: any) => {
+      const s = String(sql);
+      if (/cra_processed_events/i.test(s) && /SELECT/i.test(s)) return Promise.resolve({ rows: [{ "?column?": 1 }] }) as any; // already processed
+      return Promise.resolve({ rows: [] }) as any;
+    });
+    const res = await post(bgEvent());
+    expect(res.status).toBe(200);
+    expect(res.body.duplicate).toBe(true);
+    const persisted = mockQuery.mock.calls.some(
+      (c) => /UPDATE applications SET/i.test(String(c[0])) && /RETURNING id/i.test(String(c[0]))
+    );
+    expect(persisted).toBe(false);
+  });
+});

--- a/src/__tests__/credit-check-cra.test.ts
+++ b/src/__tests__/credit-check-cra.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Consumer-report CRA adapter — TransUnion ShareAble credit lifecycle unit tests.
+ *
+ * Covers:
+ *   - mapShareAbleReportToResponse(): pure, table-driven; categorical/integer-only
+ *     output; eviction + bankruptcy counts; score + payment-history derivation.
+ *   - resolve(): reads the webhook-persisted verdict; could_not_screen HOLD when
+ *     no report / pending / wrong shape / lookup throws; re-runs evaluateResults.
+ *   - createReport(): fail-loud throw until credentialing exists.
+ *
+ * No network / no real DB: ../config/database query is mocked.
+ */
+
+const mockQuery = jest.fn();
+
+jest.mock("../config/database", () => ({ query: (...a: unknown[]) => mockQuery(...a) }));
+jest.mock("../utils/logger", () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+import { CreditCheckService } from "../modules/screening/credit-check";
+
+describe("CreditCheckService — TransUnion ShareAble CRA mapping", () => {
+  let svc: CreditCheckService;
+  beforeEach(() => {
+    jest.clearAllMocks();
+    svc = new CreditCheckService();
+  });
+
+  describe("mapShareAbleReportToResponse", () => {
+    it("strong score, no public records → score + good/excellent history, zero counts", () => {
+      const r = svc.mapShareAbleReportToResponse({
+        creditScore: 720,
+        evictions: [],
+        bankruptcies: [],
+        collections: [],
+      });
+      expect(r.creditScore).toBe(720);
+      expect(r.evictions).toBe(0);
+      expect(r.bankruptcies).toBe(0);
+      expect(r.collections).toBe(0);
+      expect(r.paymentHistory).toBe("excellent");
+    });
+
+    it("eviction records → eviction COUNT (not the records themselves)", () => {
+      const r = svc.mapShareAbleReportToResponse({
+        score: 640,
+        evictions: [{ filedOn: "2023-01-01" }, { filedOn: "2024-02-02" }],
+      });
+      expect(r.evictions).toBe(2);
+    });
+
+    it("bankruptcy + collection counts from arrays or integers", () => {
+      const fromArrays = svc.mapShareAbleReportToResponse({
+        score: 600,
+        bankruptcies: [{ chapter: 7 }],
+        collections: [{ amount: 100 }, { amount: 200 }],
+      });
+      expect(fromArrays.bankruptcies).toBe(1);
+      expect(fromArrays.collections).toBe(2);
+
+      const fromInts = svc.mapShareAbleReportToResponse({
+        score: 600,
+        bankruptcies: 2,
+        collections: 1,
+      });
+      expect(fromInts.bankruptcies).toBe(2);
+      expect(fromInts.collections).toBe(1);
+    });
+
+    it("missing score → 0 and unknown history (HOLD-leaning, never fabricated pass)", () => {
+      const r = svc.mapShareAbleReportToResponse({});
+      expect(r.creditScore).toBe(0);
+      expect(r.paymentHistory).toBe("unknown");
+    });
+
+    it("explicit paymentHistory passes through; otherwise derived from score", () => {
+      expect(svc.mapShareAbleReportToResponse({ score: 700, paymentHistory: "fair" }).paymentHistory).toBe("fair");
+      expect(svc.mapShareAbleReportToResponse({ score: 670 }).paymentHistory).toBe("good");
+      expect(svc.mapShareAbleReportToResponse({ score: 610 }).paymentHistory).toBe("fair");
+      expect(svc.mapShareAbleReportToResponse({ score: 540 }).paymentHistory).toBe("poor");
+    });
+
+    it("never throws on malformed / empty input", () => {
+      expect(() => svc.mapShareAbleReportToResponse(undefined)).not.toThrow();
+      expect(() => svc.mapShareAbleReportToResponse(null)).not.toThrow();
+    });
+
+    it("output carries only categorical/integer fields — no tradeline detail", () => {
+      const r: any = svc.mapShareAbleReportToResponse({
+        score: 700,
+        tradelines: [{ creditor: "Big Bank", account: "****1234", balance: 5000 }],
+        evictions: [{ landlord: "Acme Properties", address: "123 Main St" }],
+      });
+      expect(r.tradelines).toBeUndefined();
+      expect(JSON.stringify(r)).not.toContain("Big Bank");
+      expect(JSON.stringify(r)).not.toContain("123 Main St");
+      expect(r.evictions).toBe(1); // count only
+      expect(Object.keys(r).sort()).toEqual(
+        ["bankruptcies", "collections", "creditScore", "evictions", "outstandingDebts", "paymentHistory"].sort()
+      );
+    });
+  });
+
+  describe("resolve", () => {
+    it("no report on file → could_not_screen HOLD", async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [{ credit_report_id: null }] });
+      const r = await svc.resolve("app-1");
+      expect(r.result).toBe("could_not_screen");
+      expect(r.creditScore).toBe(0);
+    });
+
+    it("report still pending → could_not_screen HOLD", async () => {
+      mockQuery.mockResolvedValueOnce({
+        rows: [{ credit_report_id: "tu_1", credit_check_completed_at: null }],
+      });
+      const r = await svc.resolve("app-1");
+      expect(r.result).toBe("could_not_screen");
+    });
+
+    it("persisted strong verdict → pass", async () => {
+      mockQuery.mockResolvedValueOnce({
+        rows: [
+          {
+            credit_report_id: "tu_1",
+            credit_check_completed_at: new Date(),
+            credit_check_details: {
+              reportId: "tu_1",
+              rawResponse: { creditScore: 720, paymentHistory: "excellent", outstandingDebts: 1000, collections: 0, evictions: 0, bankruptcies: 0 },
+            },
+          },
+        ],
+      });
+      const r = await svc.resolve("app-1");
+      expect(r.result).toBe("pass");
+      expect(r.creditScore).toBe(720);
+    });
+
+    it("persisted eviction → fail (auto-fail on eviction)", async () => {
+      mockQuery.mockResolvedValueOnce({
+        rows: [
+          {
+            credit_report_id: "tu_1",
+            credit_check_completed_at: new Date(),
+            credit_check_details: {
+              rawResponse: { creditScore: 700, evictions: 1, bankruptcies: 0, collections: 0 },
+            },
+          },
+        ],
+      });
+      const r = await svc.resolve("app-1");
+      expect(r.result).toBe("fail");
+    });
+
+    it("malformed persisted detail → could_not_screen HOLD", async () => {
+      mockQuery.mockResolvedValueOnce({
+        rows: [
+          {
+            credit_report_id: "tu_1",
+            credit_check_completed_at: new Date(),
+            credit_check_details: { reportId: "tu_1" },
+          },
+        ],
+      });
+      const r = await svc.resolve("app-1");
+      expect(r.result).toBe("could_not_screen");
+    });
+
+    it("DB lookup throws → could_not_screen HOLD (never a pass)", async () => {
+      mockQuery.mockRejectedValueOnce(new Error("timeout"));
+      const r = await svc.resolve("app-1");
+      expect(r.result).toBe("could_not_screen");
+    });
+  });
+
+  describe("createReport", () => {
+    it("throws (fail-loud) until ShareAble credentialing exists", async () => {
+      await expect(
+        svc.createReport({
+          applicationId: "app-1",
+          firstName: "Sam",
+          lastName: "Lee",
+          ssnLast4: "6789",
+          dateOfBirth: "1990-01-01",
+        })
+      ).rejects.toThrow(/not yet configured/i);
+    });
+  });
+});

--- a/src/__tests__/state-machine.test.ts
+++ b/src/__tests__/state-machine.test.ts
@@ -169,18 +169,31 @@ describe("transitionApplicationStatus (application_status chokepoint)", () => {
     jest.clearAllMocks();
   });
 
-  it("APP_STATUS_TRANSITIONS fans out from submitted/awaiting_identity/screening (+screening_review hold) into the screening terminals", () => {
+  it("APP_STATUS_TRANSITIONS fans out from submitted/awaiting_identity/awaiting_consumer_report/screening (+screening_review hold) into the screening terminals", () => {
     // screening_review is a non-terminal hold: a could-not-screen pipeline
     // lands there, and staff resolve it forward to passed/failed. It is both a
     // `to` (from screening) and a `from` (manual override out).
     // awaiting_identity (Phase 4b) sits between submitted and screening: the app
     // waits there for the applicant's Stripe Identity capture, then the webhook
     // advances it into `screening` (or `screening_review` on could_not_screen).
+    // awaiting_consumer_report (CRA: Checkr background + TransUnion ShareAble
+    // credit) is the analogous gate: the app waits for the applicant to authorize
+    // the consumer-report pulls + pass KBA, then the CRA webhook advances it into
+    // `screening` (or `screening_review` on could_not_screen).
     const froms = new Set(APP_STATUS_TRANSITIONS.map((t) => t.from));
-    expect(froms).toEqual(new Set(["submitted", "awaiting_identity", "screening", "screening_review"]));
+    expect(froms).toEqual(
+      new Set(["submitted", "awaiting_identity", "awaiting_consumer_report", "screening", "screening_review"])
+    );
     expect(
       APP_STATUS_TRANSITIONS.every((t) =>
-        ["awaiting_identity", "screening", "screening_review", "screening_passed", "screening_failed"].includes(t.to)
+        [
+          "awaiting_identity",
+          "awaiting_consumer_report",
+          "screening",
+          "screening_review",
+          "screening_passed",
+          "screening_failed",
+        ].includes(t.to)
       )
     ).toBe(true);
   });

--- a/src/db/migrations/2026-06-01-applications-consumer-report.sql
+++ b/src/db/migrations/2026-06-01-applications-consumer-report.sql
@@ -1,0 +1,63 @@
+-- 2026-06-01 applications-consumer-report (background + credit CRA adapter)
+--
+-- Checkr (background/criminal) and TransUnion ShareAble (credit/eviction) are
+-- asynchronous + applicant-mediated, the same shape as Stripe Identity (#244):
+-- submit() creates the report order(s), the applicant authorizes + completes
+-- KBA on the CRA's hosted flow, and the verdict arrives later by WEBHOOK. We
+-- therefore need:
+--
+--   1. A new application_status `awaiting_consumer_report` — the state between
+--      `submitted` and `screening` that means "waiting on the applicant to
+--      authorize + complete their Checkr / TransUnion consumer reports". A
+--      report still in progress is NOT a problem to surface in the
+--      screening_review HOLD queue, it's a pending capture. Screening only
+--      begins once the webhook lands a verdict and transitions
+--      awaiting_consumer_report -> screening (or -> screening_review on a
+--      could_not_screen HOLD; never an auto-pass).
+--
+--   2. Columns tracking the two report references + their categorical session
+--      statuses + the applicant authorization timestamp. We persist ONLY a
+--      report-reference id + categorical statuses — never charge narratives,
+--      tradeline detail, addresses, full DOB/SSN. Those high-sensitivity PII
+--      artifacts live exclusively on the CRA; the mapped categorical verdicts
+--      land in the EXISTING background_check_* / credit_check_* / credit_score
+--      columns (added 2026-05-30-applications-extended-screening-columns.sql and
+--      the original applications schema).
+--
+-- NOTE: ALTER TYPE ... ADD VALUE cannot run inside a transaction block.
+-- Apply this file OUTSIDE a transaction, e.g.:
+--   psql "$DATABASE_URL" -f src/db/migrations/2026-06-01-applications-consumer-report.sql
+-- (Do NOT wrap in BEGIN/COMMIT; do NOT run via a migration runner that opens a txn.)
+
+ALTER TYPE application_status ADD VALUE IF NOT EXISTS 'awaiting_consumer_report';
+
+ALTER TABLE applications
+  ADD COLUMN IF NOT EXISTS background_report_id              TEXT,
+  ADD COLUMN IF NOT EXISTS credit_report_id                 TEXT,
+  ADD COLUMN IF NOT EXISTS consumer_report_background_status TEXT,
+  ADD COLUMN IF NOT EXISTS consumer_report_credit_status     TEXT,
+  ADD COLUMN IF NOT EXISTS screening_authorization_at        TIMESTAMPTZ;
+
+-- CRA webhook idempotency + dead-letter queue. Mirrors the BP-08 Stripe webhook
+-- pattern (stripe_processed_events / stripe_webhook_dlq): a redelivered event_id
+-- short-circuits with a 200, and any dispatch throw parks the payload here rather
+-- than 5xx-ing the CRA into an infinite retry. raw_payload is the synthetic /
+-- vendor envelope (categorical metadata) — it MUST NOT contain charge narratives,
+-- tradeline detail, addresses, or full DOB/SSN (those never leave the CRA).
+CREATE TABLE IF NOT EXISTS cra_processed_events (
+  event_id       TEXT PRIMARY KEY,
+  domain         TEXT NOT NULL,
+  application_id UUID,
+  processed_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS cra_webhook_dlq (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  event_id        TEXT UNIQUE NOT NULL,
+  domain          TEXT NOT NULL,
+  raw_payload     JSONB NOT NULL,
+  error_message   TEXT,
+  attempt_count   INT NOT NULL DEFAULT 1,
+  first_failed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  last_failed_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1249,6 +1249,28 @@ CREATE TABLE IF NOT EXISTS stripe_webhook_dlq (
   last_failed_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
+-- Consumer-report CRA webhook idempotency + DLQ (Checkr background + TransUnion
+-- ShareAble credit). Same pattern as the Stripe receiver above. See
+-- src/modules/screening/cra-webhook.ts and
+-- src/db/migrations/2026-06-01-applications-consumer-report.sql.
+CREATE TABLE IF NOT EXISTS cra_processed_events (
+  event_id       TEXT PRIMARY KEY,
+  domain         TEXT NOT NULL,
+  application_id UUID,
+  processed_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS cra_webhook_dlq (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  event_id        TEXT UNIQUE NOT NULL,
+  domain          TEXT NOT NULL,
+  raw_payload     JSONB NOT NULL,
+  error_message   TEXT,
+  attempt_count   INT NOT NULL DEFAULT 1,
+  first_failed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  last_failed_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
 -- ============================================================
 -- Voice intake — ElevenLabs Conv. AI post-call persistence
 -- See src/modules/voice-intake/webhook.ts and

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ import screeningRoutes from "./modules/screening/routes";
 import approvalRoutes from "./modules/approval/routes";
 import paymentRoutes from "./modules/payment/routes";
 import paymentWebhookRouter from "./modules/payment/webhook";
+import craWebhookRouter from "./modules/screening/cra-webhook";
 import { assertStripeProdConfig } from "./modules/payment/boot-guard";
 import {
   voiceIntakeWebhookRouter,
@@ -114,6 +115,13 @@ app.use("/api/webhooks/elevenlabs/post-call", voiceIntakeWebhookRouter);
 // independently of the post-call flag so the receiver can ride along into
 // prod (dark, returning 503) before any tool handler is wired.
 app.use("/api/webhooks/elevenlabs/tools", voiceToolCallbackRouter);
+
+// Consumer-report CRA webhook (Checkr background + TransUnion ShareAble credit) —
+// same raw-body constraint as the receivers above (signature verification needs
+// the unparsed bytes). The router self-gates on CRA_WEBHOOK_SECRET (503 until a
+// contract is signed), so it can ride into prod dark. Do not move below the JSON
+// parser. See modules/screening/cra-webhook.ts.
+app.use("/api/webhooks/cra", craWebhookRouter);
 
 app.use(express.json({ limit: "1mb" }));
 

--- a/src/modules/application/service.ts
+++ b/src/modules/application/service.ts
@@ -1,5 +1,5 @@
 import { query, transaction } from "../../config/database";
-import { encrypt, hashSSN, maskSSN } from "../../utils/encryption";
+import { encrypt, decrypt, hashSSN, maskSSN } from "../../utils/encryption";
 import { writeAuditLog } from "../../middleware/audit";
 import { logger } from "../../utils/logger";
 import { CreateApplicationInput, UpdateApplicationInput } from "./validation";
@@ -282,6 +282,111 @@ export class ApplicationService {
         // `submitted` — staff/poll see no session — and surface loudly. This is
         // fail-loud, not fail-open.
         logger.error("Failed to create Stripe Identity session on submit", {
+          error: (err as Error).message,
+          applicationId,
+        });
+        return result.rows[0];
+      }
+    }
+
+    // Consumer-report CRA capture on submit — dark behind CONSUMER_REPORT_ENABLED
+    // (independent of SCREENING_ON_SUBMIT_ENABLED). When armed: create the Checkr
+    // background + TransUnion ShareAble credit report orders and park the app in
+    // `awaiting_consumer_report` until the applicant authorizes the pulls + passes
+    // KBA and the webhook(s) land verdicts (which then advance it into screening).
+    // The hosted authorization url(s) are returned so the caller can redirect.
+    // This branch sits AFTER the identity gate (identity, if armed, returns first)
+    // and BEFORE the legacy auto-screen path — screening is kicked by the webhook
+    // once the reports resolve, not synchronously here.
+    if (process.env.CONSUMER_REPORT_ENABLED === "true") {
+      try {
+        const { BackgroundCheckService } = await import(
+          "../screening/background-check"
+        );
+        const { CreditCheckService } = await import("../screening/credit-check");
+
+        const appRow = await query(
+          `SELECT first_name, last_name, ssn_encrypted, date_of_birth_encrypted, current_state
+             FROM applications WHERE id = $1`,
+          [applicationId]
+        );
+        const a = appRow.rows[0] || {};
+        // PII stays minimal even when handed to the CRA: only the last 4 of SSN.
+        const ssnLast4 = a.ssn_encrypted ? decrypt(a.ssn_encrypted).slice(-4) : "";
+        const dob = a.date_of_birth_encrypted
+          ? decrypt(a.date_of_birth_encrypted)
+          : "";
+
+        // Create both report orders. A throw here (e.g. credentialing not yet
+        // configured) is fail-loud: we do NOT fall through to a normal submit,
+        // which would skip the consumer-report gate. The app stays in `submitted`.
+        const [background, credit] = await Promise.all([
+          new BackgroundCheckService().createReport({
+            applicationId,
+            firstName: a.first_name,
+            lastName: a.last_name,
+            ssnLast4,
+            dateOfBirth: dob,
+            state: a.current_state || "NV",
+            returnUrl,
+          }),
+          new CreditCheckService().createReport({
+            applicationId,
+            firstName: a.first_name,
+            lastName: a.last_name,
+            ssnLast4,
+            dateOfBirth: dob,
+            returnUrl,
+          }),
+        ]);
+
+        await transitionApplicationStatus({
+          applicationId,
+          from: "submitted",
+          to: "awaiting_consumer_report",
+          trigger: "consumer_report_started",
+          actorId: submittedBy,
+          actorRole: submitterRole,
+          evidence: {
+            source: "submit_consumer_report_capture",
+            backgroundReportId: background.reportId,
+            creditReportId: credit.reportId,
+          },
+        });
+
+        // Persist ONLY the report references + categorical statuses + the
+        // applicant-authorization timestamp. NEVER charge narratives, tradeline
+        // detail, addresses, or full DOB/SSN — those live on the CRA.
+        await query(
+          `UPDATE applications SET
+             background_report_id = $2,
+             credit_report_id = $3,
+             consumer_report_background_status = $4,
+             consumer_report_credit_status = $5,
+             screening_authorization_at = NOW()
+           WHERE id = $1`,
+          [
+            applicationId,
+            background.reportId,
+            credit.reportId,
+            background.status,
+            credit.status,
+          ]
+        );
+
+        return {
+          ...result.rows[0],
+          status: "awaiting_consumer_report",
+          consumerReport: {
+            background: { url: background.url, status: background.status },
+            credit: { url: credit.url, status: credit.status },
+          },
+        };
+      } catch (err) {
+        // Report creation failed. Do NOT silently fall through to a normal submit
+        // (that would skip the consumer-report gate entirely). Leave the app in
+        // `submitted` and surface loudly. Fail-loud, not fail-open.
+        logger.error("Failed to create consumer-report orders on submit", {
           error: (err as Error).message,
           applicationId,
         });

--- a/src/modules/screening/background-check.ts
+++ b/src/modules/screening/background-check.ts
@@ -1,9 +1,11 @@
 import { logger } from "../../utils/logger";
+import { query } from "../../config/database";
 import { resolveVendor } from "./vendors";
 import {
   evaluateCriminalHistory,
   type CriminalDecision,
   type CriminalAssessmentFactors,
+  type CriminalRecord,
 } from "./hud-criminal-decision";
 
 export interface BackgroundCheckResult {
@@ -26,8 +28,33 @@ export interface BackgroundCheckResult {
   };
 }
 
+/** Categorical report reference + status returned by createReport(). */
+export interface BackgroundReportHandle {
+  /** The CRA report/order reference id (e.g. Checkr `rep_…`). */
+  reportId: string;
+  /** CRA-reported categorical status (e.g. `pending`, `complete`). */
+  status: string;
+  /** The hosted invitation/consent url the applicant completes, when provided. */
+  url: string | null;
+}
+
 /**
  * Third-party background check integration.
+ *
+ * Two lifecycles coexist behind `CONSUMER_REPORT_ENABLED`:
+ *
+ *   - **Checkr CRA (production, flag ON)** — asynchronous + applicant-mediated.
+ *     submit() calls `createReport()` → the applicant authorizes the pull +
+ *     passes KBA on Checkr's hosted flow → the report arrives by WEBHOOK
+ *     (`report.completed`), which maps + persists a categorical verdict onto the
+ *     application row. At screening time `resolve()` READS that persisted verdict
+ *     (it never initiates the pull); a report still pending → `could_not_screen`
+ *     HOLD (never an auto-pass).
+ *
+ *   - **Legacy synchronous (flag OFF / MOCK / stub)** — `runCheck()` pulls the
+ *     raw response from the vendor seam (resolveVendor("background")) inline.
+ *     This path is byte-identical to the pre-CRA behaviour; the seam self-gates
+ *     on the stub policy (keyless prod → STUB_GATE_ERROR → caught → HOLD).
  *
  * The denial logic is the HUD/FHA individualized-assessment engine
  * (hud-criminal-decision.ts), NOT a blanket ban:
@@ -37,11 +64,233 @@ export interface BackgroundCheckResult {
  *     screening_review for a Castro §III.B assessment (never auto-fail, never auto-pass)
  *   - everything else ("clear") → the legacy misdemeanor soft-risk score
  *
- * The raw vendor response comes from the screening vendor seam
- * (resolveVendor("background")); this service owns only Frank's evaluation
- * policy (evaluateResults) and the fail-loud catch → could_not_screen HOLD.
+ * Both paths converge on the same evaluateResults(), so the verdict math is
+ * single-sourced regardless of how the raw response was produced.
  */
 export class BackgroundCheckService {
+  // ── Checkr CRA lifecycle (background + credit adapter) ───────────────────────
+
+  /**
+   * Create a Checkr background report/order for an application. Called from
+   * submit() on the armed path; returns the report reference + hosted invitation
+   * `url` the applicant uses to authorize the pull and complete KBA.
+   *
+   * CREDENTIALING-GATED: the real Checkr candidate→invitation→report create is a
+   * signed-contract + sandbox-key task (see docs/screening/background-credit-cra-adapter.md
+   * §4 "Credentialing-gated"). Until those credentials exist the create throws —
+   * this is fail-loud, never a fabricated handle. submit() catches the throw and
+   * leaves the app in `submitted` (no silent screening skip).
+   */
+  async createReport(_input: {
+    applicationId: string;
+    firstName: string;
+    lastName: string;
+    ssnLast4: string;
+    dateOfBirth: string;
+    state: string;
+    returnUrl?: string;
+  }): Promise<BackgroundReportHandle> {
+    // TODO(credentialing): replace with the real Checkr candidate + invitation +
+    // report create once a contract is signed and CHECKR_API_KEY exists. The
+    // hosted invitation url + report id come back from that call.
+    throw new Error("Checkr background report integration not yet configured");
+  }
+
+  /**
+   * Screening-time background entry point under CONSUMER_REPORT_ENABLED — reads
+   * the webhook-persisted Checkr verdict off the application row and re-evaluates
+   * it through the SAME evaluateResults() the synchronous path uses. Returns
+   * `could_not_screen` (a HOLD, never a pass) when:
+   *   - no report was ever created (`background_report_id` null), or
+   *   - the report hasn't completed yet (`background_check_completed_at` null —
+   *     applicant still authorizing / Checkr still running county searches), or
+   *   - the persisted detail isn't in the expected shape, or
+   *   - the lookup itself throws.
+   *
+   * The webhook stores the FULL mapped vendor response in
+   * `background_check_details.rawResponse` (categorical only), so re-running
+   * evaluateResults() here yields a verdict identical to what the webhook would
+   * have computed — the HUD engine flag (CRIMINAL_DECISION_ENGINE_ENABLED) is
+   * applied at screening time, not frozen at webhook time.
+   */
+  async resolve(applicationId: string): Promise<BackgroundCheckResult> {
+    try {
+      const res = await query(
+        `SELECT background_report_id,
+                background_check_completed_at,
+                background_check_details
+           FROM applications
+          WHERE id = $1`,
+        [applicationId]
+      );
+      const row = res.rows[0];
+
+      if (!row || !row.background_report_id) {
+        return this.couldNotScreen("no Checkr background report on file");
+      }
+      if (!row.background_check_completed_at) {
+        return this.couldNotScreen("Checkr background report still pending");
+      }
+
+      const stored = row.background_check_details;
+      const raw =
+        stored && typeof stored === "object"
+          ? (stored as Record<string, unknown>).rawResponse
+          : undefined;
+      if (raw && typeof raw === "object") {
+        return this.evaluateResults(raw);
+      }
+      return this.couldNotScreen("Checkr background verdict not in expected shape");
+    } catch (err) {
+      logger.error("Failed to resolve Checkr background report", {
+        error: (err as Error).message,
+        applicationId,
+      });
+      return this.couldNotScreen("Checkr background lookup failed");
+    }
+  }
+
+  /**
+   * Map a Checkr `report` to the BackgroundVendorResponse shape evaluateResults()
+   * consumes. Pure + side-effect-free — the webhook calls this then persists the
+   * result; the unit tests exercise it table-driven.
+   *
+   * `criminalRecords` is authoritative (the HUD engine reads it directly);
+   * `felonies`/`sexOffenses`/`violentCrimes`/`misdemeanors` are DERIVED summary
+   * flags that drive the legacy (engine-off) path.
+   *
+   * PII discipline: nothing here is persisted except what evaluateResults() folds
+   * into `rawResponse`, which the caller MUST restrict to categorical fields
+   * (reportId, candidateId, status, per-search statuses, adjudication) — never
+   * charge narratives, addresses, or full DOB/SSN, which live on Checkr.
+   */
+  mapCheckrReportToResponse(report: any): {
+    felonies: number;
+    sexOffenses: boolean;
+    violentCrimes: boolean;
+    misdemeanors: unknown[];
+    records: unknown[];
+    criminalRecords: CriminalRecord[];
+  } {
+    // TODO(credentialing): confirm field paths against a live Checkr sandbox
+    // report. The paths below follow Checkr's published report schema
+    // (sex_offender_search, national_criminal_search, county_criminal_searches[])
+    // but are unverified until a sandbox account exists.
+    const sexOffenderRecords = this.asArray(report?.sex_offender_search?.records);
+    const sexOffenses = sexOffenderRecords.length > 0;
+
+    // Aggregate the criminal search sections into a flat charge list. Checkr
+    // splits results across national + county searches; each carries a `records`
+    // (or `charges`) array.
+    const charges: any[] = [
+      ...this.asArray(report?.national_criminal_search?.records),
+      ...this.asArray(report?.national_criminal_search?.charges),
+      ...this.asArray(report?.county_criminal_searches).flatMap((s: any) => [
+        ...this.asArray(s?.records),
+        ...this.asArray(s?.charges),
+      ]),
+    ];
+
+    const criminalRecords: CriminalRecord[] = [];
+    // Sex-offender registry hits map to the §5.856 lifetime-registrant mandatory
+    // floor regardless of how the criminal searches classify them.
+    for (const _hit of sexOffenderRecords) {
+      criminalRecords.push({
+        category: "sex_offense_lifetime_registrant",
+        disposition: "convicted",
+        lifetimeRegistrant: true,
+      });
+    }
+    for (const charge of charges) {
+      criminalRecords.push(this.mapCheckrCharge(charge));
+    }
+
+    // Derived summary flags for the legacy (engine-off) path.
+    let felonies = 0;
+    let violentCrimes = false;
+    const misdemeanors: unknown[] = [];
+    for (const rec of criminalRecords) {
+      if (rec.category.startsWith("felony")) felonies += 1;
+      if (rec.category === "felony_violent" || rec.category === "misdemeanor_violent") {
+        violentCrimes = true;
+      }
+      if (rec.category.startsWith("misdemeanor")) misdemeanors.push({ category: rec.category });
+    }
+
+    return {
+      felonies,
+      sexOffenses,
+      violentCrimes,
+      misdemeanors,
+      // `records` is the legacy summary array; `criminalRecords` is the
+      // engine-authoritative structured list. evaluateWithEngine reads the latter.
+      records: criminalRecords,
+      criminalRecords,
+    };
+  }
+
+  /** Map one Checkr charge to a CriminalRecord. CREDENTIALING-GATED field paths. */
+  private mapCheckrCharge(charge: any): CriminalRecord {
+    // TODO(credentialing): confirm Checkr charge field paths (classification,
+    // disposition, offense_date, etc.) against a live sandbox response.
+    const classification = String(charge?.classification ?? charge?.type ?? "").toLowerCase();
+    const isFelony = classification.includes("felony");
+    const isViolent =
+      /violen|assault|battery|homicide|robbery|weapon/.test(
+        String(charge?.charge ?? charge?.description ?? "").toLowerCase()
+      );
+
+    let category: CriminalRecord["category"];
+    if (isFelony) {
+      category = isViolent ? "felony_violent" : "felony_nonviolent";
+    } else {
+      category = isViolent ? "misdemeanor_violent" : "misdemeanor_nonviolent";
+    }
+
+    return {
+      category,
+      // Default to the conservative "convicted" only when Checkr reports a
+      // conviction disposition; otherwise leave undefined so the engine's
+      // undated/open handling (never silent-clear) applies.
+      disposition: this.mapCheckrDisposition(charge?.disposition),
+      offenseDate: typeof charge?.offense_date === "string" ? charge.offense_date : undefined,
+      dispositionDate:
+        typeof charge?.disposition_date === "string" ? charge.disposition_date : undefined,
+    };
+  }
+
+  private mapCheckrDisposition(d: unknown): CriminalRecord["disposition"] {
+    const s = String(d ?? "").toLowerCase();
+    if (s.includes("convict") || s.includes("guilty")) return "convicted";
+    if (s.includes("dismiss")) return "dismissed";
+    if (s.includes("acquit")) return "acquitted";
+    if (s.includes("expunge")) return "expunged";
+    if (s.includes("pending")) return "pending";
+    if (s) return "unknown";
+    return undefined;
+  }
+
+  private asArray(v: unknown): any[] {
+    return Array.isArray(v) ? v : [];
+  }
+
+  /** Standard `could_not_screen` HOLD result (reason is categorical, no PII). */
+  private couldNotScreen(reason: string): BackgroundCheckResult {
+    return {
+      result: "could_not_screen",
+      details: {
+        felonies: 0,
+        sexOffenses: false,
+        violentCrimes: false,
+        misdemeanors: 0,
+        riskScore: -1,
+        rawResponse: { reason },
+      },
+    };
+  }
+
+  // ── Legacy synchronous path (flag OFF / MOCK / stub) — unchanged ─────────────
+
   async runCheck(input: {
     firstName: string;
     lastName: string;

--- a/src/modules/screening/cra-webhook.ts
+++ b/src/modules/screening/cra-webhook.ts
@@ -1,0 +1,432 @@
+import { Router, Request, Response } from "express";
+import express from "express";
+import { query } from "../../config/database";
+import { writeAuditLog } from "../../middleware/audit";
+import { logger } from "../../utils/logger";
+import { transitionApplicationStatus } from "./state-machine";
+import { BackgroundCheckService } from "./background-check";
+import { CreditCheckService } from "./credit-check";
+
+/**
+ * Consumer-report CRA webhook receiver (Checkr background + TransUnion ShareAble
+ * credit). This is the async leg of the applicant-mediated flow: submit() creates
+ * the report orders and parks the app in `awaiting_consumer_report`; the CRA later
+ * POSTs here when a report completes, we map + persist a categorical verdict, and
+ * advance the app into `screening` (or HOLD it in `screening_review`).
+ *
+ * SECURITY-CRITICAL: like the Stripe receiver, this router MUST be mounted BEFORE
+ * `express.json()` in src/index.ts — signature verification operates on the raw
+ * request bytes, and any JSON parsing before us mutates the buffer.
+ *
+ * Idempotency mirrors the Stripe receiver: a `cra_processed_events` table
+ * short-circuits a redelivered event_id with a 200, and the persist + transitions
+ * are CAS-guarded on `status = 'awaiting_consumer_report'` so a late/duplicate
+ * delivery after the app already advanced is a no-op.
+ *
+ * CREDENTIALING-GATED PARTS (NOT built here — see
+ * docs/screening/background-credit-cra-adapter.md §4 vs "Credentialing-gated"):
+ *   - Real HMAC signature verification against CHECKR_WEBHOOK_SECRET /
+ *     the TransUnion equivalent. Until those secrets exist, the route refuses to
+ *     process (503) rather than trust an unsigned payload — fail-closed.
+ *   - The exact CRA event envelope shape (event type names, where the report
+ *     object + application reference live). The synthetic envelope parsed below
+ *     is what the unit tests exercise; the real field paths are marked
+ *     `// TODO(credentialing)` and confirmed against a live sandbox before arming.
+ *
+ * Error handling: any throw during dispatch parks the payload in `cra_webhook_dlq`
+ * and returns 200 — we NEVER 5xx a CRA (it would just retry the broken event).
+ */
+
+type Domain = "background" | "credit";
+
+interface CraEventEnvelope {
+  /** Unique event id for idempotency (CRA delivery retries reuse it). */
+  id: string;
+  /** Which report domain completed. */
+  domain: Domain;
+  /** Our application id, carried on the report order we created at submit(). */
+  applicationId: string;
+  /** The CRA report reference id. */
+  reportId: string;
+  /** Categorical CRA status (e.g. `complete`, `canceled`, `suspended`). */
+  status: string;
+  /** The raw CRA report object (mapped to a categorical verdict; never persisted whole). */
+  report?: unknown;
+}
+
+// ── idempotency + DLQ (mirror payment/webhook.ts) ─────────────────────────────
+
+async function alreadyProcessed(eventId: string): Promise<boolean> {
+  const result = await query(
+    `SELECT 1 FROM cra_processed_events WHERE event_id = $1 LIMIT 1`,
+    [eventId]
+  );
+  return result.rows.length > 0;
+}
+
+async function markProcessed(
+  eventId: string,
+  domain: string,
+  applicationId: string | null
+): Promise<void> {
+  await query(
+    `INSERT INTO cra_processed_events (event_id, domain, application_id)
+     VALUES ($1, $2, $3)
+     ON CONFLICT (event_id) DO NOTHING`,
+    [eventId, domain, applicationId]
+  );
+}
+
+const DLQ_ACTIVE_ROW_CAP = 10_000;
+
+async function activeDlqRowCount(): Promise<number> {
+  const result = await query(
+    `SELECT COUNT(*)::int AS count FROM cra_webhook_dlq WHERE attempt_count < 5`,
+    []
+  );
+  return Number(result.rows[0]?.count ?? 0);
+}
+
+async function recordDlq(
+  eventId: string,
+  domain: string,
+  rawPayload: unknown,
+  err: Error
+): Promise<void> {
+  try {
+    const alreadyParked = await query(
+      `SELECT 1 FROM cra_webhook_dlq WHERE event_id = $1 LIMIT 1`,
+      [eventId]
+    );
+    if (alreadyParked.rows.length === 0) {
+      const activeCount = await activeDlqRowCount();
+      if (activeCount >= DLQ_ACTIVE_ROW_CAP) {
+        logger.warn("CRA webhook DLQ at capacity — skipping new row", {
+          eventId,
+          domain,
+          activeCount,
+          cap: DLQ_ACTIVE_ROW_CAP,
+        });
+        return;
+      }
+    }
+    await query(
+      `INSERT INTO cra_webhook_dlq
+         (event_id, domain, raw_payload, error_message)
+       VALUES ($1, $2, $3::jsonb, $4)
+       ON CONFLICT (event_id) DO UPDATE
+         SET attempt_count = cra_webhook_dlq.attempt_count + 1,
+             last_failed_at = NOW(),
+             error_message = EXCLUDED.error_message`,
+      [eventId, domain, JSON.stringify(rawPayload), err.message]
+    );
+  } catch (dlqErr) {
+    logger.error("CRA webhook DLQ insert failed", {
+      eventId,
+      error: (dlqErr as Error).message,
+    });
+  }
+}
+
+// ── envelope parsing (CREDENTIALING-GATED shape) ──────────────────────────────
+
+/**
+ * Normalize the incoming CRA payload to our internal envelope. The real Checkr /
+ * TransUnion envelopes differ from this synthetic shape; this is the seam where
+ * the per-vendor adapter would translate.
+ */
+function parseEnvelope(body: unknown): CraEventEnvelope | null {
+  // TODO(credentialing): confirm the real Checkr (`{ type, data: { object } }`)
+  // and TransUnion event envelopes and translate them into this internal shape.
+  // The synthetic shape below is what the unit tests post.
+  if (!body || typeof body !== "object") return null;
+  const b = body as Record<string, unknown>;
+  const domain = b.domain;
+  if (domain !== "background" && domain !== "credit") return null;
+  if (typeof b.id !== "string" || typeof b.applicationId !== "string") return null;
+  if (typeof b.reportId !== "string" || typeof b.status !== "string") return null;
+  return {
+    id: b.id,
+    domain,
+    applicationId: b.applicationId,
+    reportId: b.reportId,
+    status: b.status,
+    report: b.report,
+  };
+}
+
+/** A CRA status the applicant can never recover from on their own → HOLD. */
+function isTerminalFailure(status: string): boolean {
+  const s = status.toLowerCase();
+  return s === "canceled" || s === "cancelled" || s === "suspended" || s === "disputed";
+}
+
+// ── dispatch ──────────────────────────────────────────────────────────────────
+
+/**
+ * Map + persist a completed report's categorical verdict, then advance the app.
+ *
+ * PII discipline: we persist ONLY the mapped categorical response (counts,
+ * statuses, the report reference) into the JSONB `*_details.rawResponse`. The
+ * mappers (mapCheckrReportToResponse / mapShareAbleReportToResponse) strip
+ * everything else; charge narratives / tradeline detail / addresses / full
+ * DOB+SSN never leave the CRA.
+ */
+async function dispatch(env: CraEventEnvelope): Promise<void> {
+  // A terminal failure status means the CRA never produced a verdict → HOLD.
+  if (isTerminalFailure(env.status)) {
+    await holdCouldNotScreen(env, `${env.domain} report ${env.status}`);
+    return;
+  }
+
+  if (env.domain === "background") {
+    const response = new BackgroundCheckService().mapCheckrReportToResponse(env.report);
+    // Re-use the SAME evaluation policy as the synchronous path. We persist the
+    // categorical-only mapped response; resolve() reads it back at screening time
+    // and re-runs evaluateResults() (so the HUD-engine flag is applied then).
+    const persisted = await query(
+      `UPDATE applications SET
+          consumer_report_background_status = $2,
+          background_check_details = $3,
+          background_check_completed_at = NOW()
+        WHERE id = $1 AND status = 'awaiting_consumer_report'
+        RETURNING id`,
+      [
+        env.applicationId,
+        env.status,
+        JSON.stringify({ reportId: env.reportId, rawResponse: response }),
+      ]
+    );
+    if (persisted.rows.length === 0) {
+      logger.info("CRA background verdict ignored — app not awaiting consumer report", {
+        applicationId: env.applicationId,
+        reportId: env.reportId,
+      });
+      return;
+    }
+    await writeAuditLog({
+      action: "background_check_completed",
+      applicationId: env.applicationId,
+      resourceType: "application",
+      details: {
+        actor: "cra-webhook",
+        vendor: "checkr",
+        reportId: env.reportId,
+        status: env.status,
+        // categorical summary only
+        felonies: response.felonies,
+        sexOffenses: response.sexOffenses,
+        violentCrimes: response.violentCrimes,
+      },
+    });
+  } else {
+    const response = new CreditCheckService().mapShareAbleReportToResponse(env.report);
+    const persisted = await query(
+      `UPDATE applications SET
+          consumer_report_credit_status = $2,
+          credit_score = $3,
+          credit_check_details = $4,
+          credit_check_completed_at = NOW()
+        WHERE id = $1 AND status = 'awaiting_consumer_report'
+        RETURNING id`,
+      [
+        env.applicationId,
+        env.status,
+        response.creditScore,
+        JSON.stringify({ reportId: env.reportId, rawResponse: response }),
+      ]
+    );
+    if (persisted.rows.length === 0) {
+      logger.info("CRA credit verdict ignored — app not awaiting consumer report", {
+        applicationId: env.applicationId,
+        reportId: env.reportId,
+      });
+      return;
+    }
+    await writeAuditLog({
+      action: "credit_check_completed",
+      applicationId: env.applicationId,
+      resourceType: "application",
+      details: {
+        actor: "cra-webhook",
+        vendor: "transunion",
+        reportId: env.reportId,
+        status: env.status,
+        creditScore: response.creditScore,
+        evictions: response.evictions,
+        bankruptcies: response.bankruptcies,
+      },
+    });
+  }
+
+  // Both reports must be in before we advance into screening — a single report
+  // landing leaves the app in awaiting_consumer_report waiting on its sibling.
+  await advanceIfBothReportsIn(env.applicationId);
+}
+
+/**
+ * Advance awaiting_consumer_report -> screening once BOTH the background and
+ * credit reports have completed (both `*_completed_at` set). Kicks the full
+ * screening pipeline when auto-on-submit is armed; otherwise the app rests in
+ * `screening` for staff to run manual /screen. resolve() will read the verdicts
+ * we just persisted.
+ */
+async function advanceIfBothReportsIn(applicationId: string): Promise<void> {
+  const ctx = await query(
+    `SELECT a.status,
+            a.background_check_completed_at,
+            a.credit_check_completed_at,
+            a.submitted_by,
+            u.role AS submitter_role
+       FROM applications a
+       LEFT JOIN users u ON u.id = a.submitted_by
+      WHERE a.id = $1`,
+    [applicationId]
+  );
+  const row = ctx.rows[0];
+  if (!row || row.status !== "awaiting_consumer_report") return;
+  if (!row.background_check_completed_at || !row.credit_check_completed_at) {
+    // Still waiting on the other report.
+    return;
+  }
+
+  const advanced = await transitionApplicationStatus({
+    applicationId,
+    from: "awaiting_consumer_report",
+    to: "screening",
+    trigger: "consumer_report_resolved",
+    actorId: row.submitted_by ?? undefined,
+    actorRole: row.submitter_role ?? undefined,
+    evidence: { source: "cra_webhook" },
+  });
+  if (!advanced.changed) return;
+
+  if (process.env.SCREENING_ON_SUBMIT_ENABLED === "true" && row.submitted_by) {
+    const initiatedBy = row.submitted_by as string;
+    const initiatorRole = (row.submitter_role as string) ?? "applicant";
+    void (async () => {
+      try {
+        const { ScreeningService } = await import("./service");
+        await new ScreeningService().runFullScreening(applicationId, initiatedBy, initiatorRole);
+      } catch (err) {
+        logger.error("Post-consumer-report screening pipeline failed", {
+          applicationId,
+          error: (err as Error).message,
+        });
+      }
+    })();
+  }
+}
+
+/**
+ * HOLD the application in screening_review for a could_not_screen — a terminal
+ * CRA failure (canceled / suspended) means we never got a verdict. NEVER an
+ * auto-pass. Guarded on awaiting_consumer_report so a late/duplicate event is a
+ * no-op.
+ */
+async function holdCouldNotScreen(env: CraEventEnvelope, reason: string): Promise<void> {
+  const statusCol =
+    env.domain === "background"
+      ? "consumer_report_background_status"
+      : "consumer_report_credit_status";
+  const persisted = await query(
+    `UPDATE applications SET ${statusCol} = $2
+      WHERE id = $1 AND status = 'awaiting_consumer_report'
+      RETURNING id`,
+    [env.applicationId, env.status]
+  );
+  if (persisted.rows.length === 0) {
+    logger.info("CRA could_not_screen ignored — app not awaiting consumer report", {
+      applicationId: env.applicationId,
+      reportId: env.reportId,
+    });
+    return;
+  }
+
+  await transitionApplicationStatus({
+    applicationId: env.applicationId,
+    from: "awaiting_consumer_report",
+    to: "screening_review",
+    trigger: "could_not_screen",
+    evidence: { source: "cra_webhook", domain: env.domain, reason },
+  });
+  await query(
+    `UPDATE applications SET overall_screening_result = 'could_not_screen'
+      WHERE id = $1 AND overall_screening_result IS NULL`,
+    [env.applicationId]
+  );
+}
+
+// ── router ──────────────────────────────────────────────────────────────────
+
+const router = Router();
+
+router.post(
+  "/",
+  express.raw({ type: "application/json", limit: "1mb" }),
+  async (req: Request, res: Response): Promise<void> => {
+    // CREDENTIALING-GATED: real signature verification. Until a CRA contract is
+    // signed and CHECKR_WEBHOOK_SECRET (+ the TransUnion equivalent) exist, we
+    // refuse to process — fail-closed, so an unsigned payload is never trusted.
+    // The synthetic-payload tests set CRA_WEBHOOK_SECRET to exercise the path.
+    const secret = process.env.CRA_WEBHOOK_SECRET ?? "";
+    if (!secret || secret === "changeme") {
+      res.status(503).json({ error: "CRA webhook secret not configured" });
+      return;
+    }
+
+    // TODO(credentialing): verify the HMAC signature header against `secret`
+    // using each vendor's documented scheme (Checkr `X-Checkr-Signature`,
+    // TransUnion equivalent). For now we require the header to be present so the
+    // contract is exercised, but the real constant-time HMAC compare is gated on
+    // having a documented signing scheme + a live secret.
+    const sig = req.headers["x-cra-signature"];
+    if (!sig || Array.isArray(sig)) {
+      res.status(400).json({ error: "Missing CRA signature header" });
+      return;
+    }
+
+    let body: unknown;
+    try {
+      body = JSON.parse((req.body as Buffer).toString("utf8"));
+    } catch {
+      res.status(400).json({ error: "Invalid JSON" });
+      return;
+    }
+
+    const env = parseEnvelope(body);
+    if (!env) {
+      logger.warn("CRA webhook unparseable envelope");
+      res.status(400).json({ error: "Unrecognized event" });
+      return;
+    }
+
+    if (await alreadyProcessed(env.id)) {
+      logger.info("CRA webhook duplicate event short-circuited", { eventId: env.id });
+      res.status(200).json({ received: true, duplicate: true });
+      return;
+    }
+
+    let dispatchError: Error | null = null;
+    try {
+      await dispatch(env);
+    } catch (err) {
+      dispatchError = err as Error;
+      logger.error("CRA webhook dispatch failed", {
+        eventId: env.id,
+        domain: env.domain,
+        error: dispatchError.message,
+      });
+      await recordDlq(env.id, env.domain, body, dispatchError);
+    }
+
+    if (!dispatchError) {
+      await markProcessed(env.id, env.domain, env.applicationId);
+    }
+
+    // Always 200 — DLQ is the recovery path, not retry.
+    res.status(200).json({ received: true });
+  }
+);
+
+export default router;

--- a/src/modules/screening/credit-check.ts
+++ b/src/modules/screening/credit-check.ts
@@ -1,4 +1,5 @@
 import { logger } from "../../utils/logger";
+import { query } from "../../config/database";
 import { resolveVendor } from "./vendors";
 
 export interface CreditCheckResult {
@@ -14,15 +15,214 @@ export interface CreditCheckResult {
   };
 }
 
+/** Categorical report reference + status returned by createReport(). */
+export interface CreditReportHandle {
+  /** The CRA report/order reference id (e.g. TransUnion ShareAble request id). */
+  reportId: string;
+  /** CRA-reported categorical status (e.g. `pending`, `complete`). */
+  status: string;
+  /** The hosted exam/consent url the applicant completes (KBA), when provided. */
+  url: string | null;
+}
+
 /**
  * Credit check integration.
  * Threshold: 600+ preferred, decision matrix allows exceptions.
  *
- * The raw vendor response comes from the screening vendor seam
- * (resolveVendor("credit")); this service owns only Frank's evaluation policy
- * (evaluateResults) and the fail-loud catch → could_not_screen HOLD.
+ * Two lifecycles coexist behind `CONSUMER_REPORT_ENABLED` (mirrors
+ * background-check.ts):
+ *
+ *   - **TransUnion ShareAble CRA (production, flag ON)** — asynchronous +
+ *     applicant-mediated. submit() calls `createReport()` → the applicant
+ *     authorizes the pull + passes ShareAble's KBA exam → the credit + eviction
+ *     report arrives by WEBHOOK, which maps + persists a categorical verdict onto
+ *     the application row. At screening time `resolve()` READS that persisted
+ *     verdict (it never initiates the pull); a report still pending →
+ *     `could_not_screen` HOLD (never an auto-pass).
+ *
+ *   - **Legacy synchronous (flag OFF / MOCK / stub)** — `runCheck()` pulls the
+ *     raw response from the vendor seam (resolveVendor("credit")) inline,
+ *     byte-identical to the pre-CRA behaviour.
+ *
+ * Both paths converge on the same evaluateResults(): score >= 600 → pass,
+ * evictions/bankruptcies > 0 → fail, otherwise review_required.
  */
 export class CreditCheckService {
+  // ── TransUnion ShareAble CRA lifecycle ───────────────────────────────────────
+
+  /**
+   * Create a TransUnion ShareAble credit + eviction report for an application.
+   * Called from submit() on the armed path; returns the report reference + the
+   * hosted KBA exam url the applicant must complete to authorize the pull.
+   *
+   * CREDENTIALING-GATED: the real ShareAble applicant + exam + report request is
+   * a signed-contract + sandbox-key task (see
+   * docs/screening/background-credit-cra-adapter.md §4 "Credentialing-gated").
+   * Until those credentials exist the create throws — fail-loud, never a
+   * fabricated handle. submit() catches the throw and leaves the app in
+   * `submitted` (no silent screening skip).
+   */
+  async createReport(_input: {
+    applicationId: string;
+    firstName: string;
+    lastName: string;
+    ssnLast4: string;
+    dateOfBirth: string;
+    returnUrl?: string;
+  }): Promise<CreditReportHandle> {
+    // TODO(credentialing): replace with the real TransUnion ShareAble applicant +
+    // exam + report request once a contract is signed and the ShareAble
+    // credentials exist. The hosted exam url + report id come back from that call.
+    throw new Error("TransUnion ShareAble credit report integration not yet configured");
+  }
+
+  /**
+   * Screening-time credit entry point under CONSUMER_REPORT_ENABLED — reads the
+   * webhook-persisted ShareAble verdict off the application row and re-evaluates
+   * it through the SAME evaluateResults() the synchronous path uses. Returns
+   * `could_not_screen` (a HOLD, never a pass) when:
+   *   - no report was ever created (`credit_report_id` null), or
+   *   - the report hasn't completed yet (`credit_check_completed_at` null —
+   *     applicant still completing the KBA exam / TU still assembling), or
+   *   - the persisted detail isn't in the expected shape, or
+   *   - the lookup itself throws.
+   *
+   * The webhook stores the FULL mapped vendor response (categorical only) in
+   * `credit_check_details.rawResponse`, so re-running evaluateResults() here
+   * yields the same verdict the webhook computed.
+   */
+  async resolve(applicationId: string): Promise<CreditCheckResult> {
+    try {
+      const res = await query(
+        `SELECT credit_report_id,
+                credit_check_completed_at,
+                credit_check_details
+           FROM applications
+          WHERE id = $1`,
+        [applicationId]
+      );
+      const row = res.rows[0];
+
+      if (!row || !row.credit_report_id) {
+        return this.couldNotScreen("no TransUnion credit report on file");
+      }
+      if (!row.credit_check_completed_at) {
+        return this.couldNotScreen("TransUnion credit report still pending");
+      }
+
+      const stored = row.credit_check_details;
+      const raw =
+        stored && typeof stored === "object"
+          ? (stored as Record<string, unknown>).rawResponse
+          : undefined;
+      if (raw && typeof raw === "object") {
+        return this.evaluateResults(raw);
+      }
+      return this.couldNotScreen("TransUnion credit verdict not in expected shape");
+    } catch (err) {
+      logger.error("Failed to resolve TransUnion credit report", {
+        error: (err as Error).message,
+        applicationId,
+      });
+      return this.couldNotScreen("TransUnion credit lookup failed");
+    }
+  }
+
+  /**
+   * Map a TransUnion ShareAble report to the CreditVendorResponse shape
+   * evaluateResults() consumes. Pure + side-effect-free — the webhook calls this
+   * then persists the result; the unit tests exercise it table-driven.
+   *
+   * PII discipline: this returns ONLY the categorical / integer summary fields
+   * (score, eviction count, bankruptcy count, collections count, payment-history
+   * label, aggregate debt). The caller persists exactly these (folded into
+   * `rawResponse`) — never individual tradeline detail, account numbers,
+   * creditor names, or addresses, which live exclusively on TransUnion.
+   */
+  mapShareAbleReportToResponse(report: any): {
+    creditScore: number;
+    paymentHistory: string;
+    outstandingDebts: number;
+    collections: number;
+    evictions: number;
+    bankruptcies: number;
+  } {
+    // TODO(credentialing): confirm field paths against a live ShareAble sandbox
+    // report. The paths below follow TU ShareAble's documented response sections
+    // (creditScore / public records / tradeline summary) but are unverified until
+    // a sandbox account exists.
+    const creditScore = this.asInt(
+      report?.creditScore ?? report?.score ?? report?.scoreModel?.score
+    );
+
+    // Eviction + bankruptcy COUNTS only — never the underlying records.
+    const evictions = this.countOf(
+      report?.evictions ?? report?.evictionRecords ?? report?.publicRecords?.evictions
+    );
+    const bankruptcies = this.countOf(
+      report?.bankruptcies ?? report?.bankruptcyRecords ?? report?.publicRecords?.bankruptcies
+    );
+    const collections = this.countOf(
+      report?.collections ?? report?.collectionAccounts
+    );
+
+    const outstandingDebts = this.asInt(
+      report?.outstandingDebts ?? report?.totalBalance ?? report?.summary?.totalBalance
+    );
+    const paymentHistory =
+      typeof report?.paymentHistory === "string"
+        ? report.paymentHistory
+        : this.derivePaymentHistory(creditScore);
+
+    return {
+      creditScore,
+      paymentHistory,
+      outstandingDebts,
+      collections,
+      evictions,
+      bankruptcies,
+    };
+  }
+
+  /** Coerce a numeric field to a non-negative integer (0 when absent/invalid). */
+  private asInt(v: unknown): number {
+    const n = typeof v === "number" ? v : Number(v);
+    return Number.isFinite(n) && n > 0 ? Math.floor(n) : 0;
+  }
+
+  /** Count of records — accepts an array, a numeric count, or absence. */
+  private countOf(v: unknown): number {
+    if (Array.isArray(v)) return v.length;
+    return this.asInt(v);
+  }
+
+  /** Coarse payment-history label when ShareAble doesn't supply one. */
+  private derivePaymentHistory(score: number): string {
+    if (score >= 720) return "excellent";
+    if (score >= 660) return "good";
+    if (score >= 600) return "fair";
+    if (score > 0) return "poor";
+    return "unknown";
+  }
+
+  /** Standard `could_not_screen` HOLD result (reason is categorical, no PII). */
+  private couldNotScreen(reason: string): CreditCheckResult {
+    return {
+      result: "could_not_screen",
+      creditScore: 0,
+      details: {
+        paymentHistory: "unknown",
+        outstandingDebts: 0,
+        collections: 0,
+        evictions: 0,
+        bankruptcies: 0,
+        rawResponse: { reason },
+      },
+    };
+  }
+
+  // ── Legacy synchronous path (flag OFF / MOCK / stub) — unchanged ─────────────
+
   async runCheck(input: {
     firstName: string;
     lastName: string;

--- a/src/modules/screening/service.ts
+++ b/src/modules/screening/service.ts
@@ -317,30 +317,54 @@ export class ScreeningService {
       }
     }
 
+    // Background + credit SOURCE selection.
+    //
+    // CONSUMER_REPORT_ENABLED gates whether background/credit are pulled
+    // synchronously here (the historical path) or READ from a webhook-persisted
+    // CRA verdict (Checkr / TransUnion ShareAble, applicant-mediated).
+    //
+    //   - flag OFF (default) → `runCheck(...)`: byte-identical to today. The
+    //     vendor seam produces the raw response inline (sandbox stub / MOCK /
+    //     real income vendor) and the service evaluates it. Ships DARK.
+    //   - flag ON → `resolve(applicationId)`: the CRA report was created at
+    //     submit() and its verdict landed via webhook onto the application row;
+    //     resolve() reads it. A report still pending → could_not_screen HOLD.
+    //
+    // Either source returns the IDENTICAL BackgroundCheckResult / CreditCheckResult
+    // shape, so the persist + aggregation below are unchanged regardless of source.
+    const consumerReportEnabled = process.env.CONSUMER_REPORT_ENABLED === "true";
+
     // Run all checks in parallel
     const [backgroundResult, creditResult, complianceResult] = await Promise.all([
-      this.backgroundCheck.runCheck({
-        firstName: app.first_name,
-        lastName: app.last_name,
-        ssnLast4,
-        dateOfBirth: dob,
-        state: app.current_state || "NV",
-        // Thread the demo tag through to the background vendor, exactly as we
-        // already do for identity and the extended checks (plaid/nsopw/work-
-        // number). The sandbox vendor honors it ONLY under MOCK_MODE=1, so this
-        // is byte-identical in real keyless prod (the applicant funnel never
-        // sends a tag, and outside MOCK_MODE the vendor ignores it). It makes
-        // the documented MOCK background tags (deny_felony, deny_sex_offender,
-        // review_misdemeanors) reachable end-to-end — e.g. to exercise the
-        // HUD/FHA criminal-decision engine's individualized-review HOLD.
-        screeningTag,
-      }),
-      this.creditCheck.runCheck({
-        firstName: app.first_name,
-        lastName: app.last_name,
-        ssnLast4,
-        dateOfBirth: dob,
-      }),
+      // When the consumer-report flag is ON, the verdict was ordered at submit()
+      // and landed via the CRA webhook; resolve() reads it back. When OFF, fall
+      // through to the synchronous sandbox seam — byte-identical to pre-#4 main.
+      consumerReportEnabled
+        ? this.backgroundCheck.resolve(applicationId)
+        : this.backgroundCheck.runCheck({
+            firstName: app.first_name,
+            lastName: app.last_name,
+            ssnLast4,
+            dateOfBirth: dob,
+            state: app.current_state || "NV",
+            // Thread the demo tag through to the background vendor, exactly as we
+            // already do for identity and the extended checks (plaid/nsopw/work-
+            // number). The sandbox vendor honors it ONLY under MOCK_MODE=1, so this
+            // is byte-identical in real keyless prod (the applicant funnel never
+            // sends a tag, and outside MOCK_MODE the vendor ignores it). It makes
+            // the documented MOCK background tags (deny_felony, deny_sex_offender,
+            // review_misdemeanors) reachable end-to-end — e.g. to exercise the
+            // HUD/FHA criminal-decision engine's individualized-review HOLD.
+            screeningTag,
+          }),
+      consumerReportEnabled
+        ? this.creditCheck.resolve(applicationId)
+        : this.creditCheck.runCheck({
+            firstName: app.first_name,
+            lastName: app.last_name,
+            ssnLast4,
+            dateOfBirth: dob,
+          }),
       this.compliance.runCheck({
         propertyId: app.property_id,
         annualIncome: parseFloat(app.annual_income || "0"),

--- a/src/modules/screening/state-machine.ts
+++ b/src/modules/screening/state-machine.ts
@@ -148,6 +148,7 @@ export async function transition(input: TransitionInput): Promise<void> {
 export type AppStatus =
   | "submitted"
   | "awaiting_identity"
+  | "awaiting_consumer_report"
   | "screening"
   | "screening_passed"
   | "screening_failed"
@@ -169,6 +170,16 @@ export const APP_STATUS_TRANSITIONS: ReadonlyArray<AppStatusTransition> = [
   { from: "submitted", to: "awaiting_identity", trigger: "identity_verification_started" },
   { from: "awaiting_identity", to: "screening", trigger: "identity_session_resolved" },
   { from: "awaiting_identity", to: "screening_review", trigger: "could_not_screen" },
+  // Consumer-report CRA (Checkr background + TransUnion ShareAble credit):
+  // submit() creates the report order(s) and parks the app in
+  // awaiting_consumer_report until the webhook lands a verdict. The webhook then
+  // advances awaiting_consumer_report -> screening (verdict in hand, run the
+  // checks) or -> screening_review (could_not_screen HOLD: report
+  // pending/canceled/unmappable — never an auto-pass). Mirrors the identity
+  // triple above.
+  { from: "submitted", to: "awaiting_consumer_report", trigger: "consumer_report_started" },
+  { from: "awaiting_consumer_report", to: "screening", trigger: "consumer_report_resolved" },
+  { from: "awaiting_consumer_report", to: "screening_review", trigger: "could_not_screen" },
   { from: "screening", to: "screening_passed", trigger: "all_checks_passed" },
   { from: "screening", to: "screening_passed", trigger: "review_required_passthrough" },
   { from: "screening", to: "screening_failed", trigger: "any_check_failed" },


### PR DESCRIPTION
## What

Adds the **background + credit consumer-report (CRA) adapter** — increment #4 in the screening-vendor series (after #243 seam, #245 HUD engine, #244 Stripe Identity). Checkr (background) + TransUnion ShareAble (credit) are **async, applicant-mediated, webhook-completion CRAs**, so they follow the **#244 create→webhook→resolve** pattern, **not** the synchronous #243 seam (the seam's `runCheck()` has no applicationId/DB and physically can't host an async CRA).

Ships **dark and contract-independent**. Nothing here is activatable until vendor credentialing + the FCRA delta land.

## Flag — `CONSUMER_REPORT_ENABLED` (default OFF)

Single flag gates both domains and the one combined `awaiting_consumer_report` state.

- **OFF (default): byte-identical to pre-#4 main.** `runFullScreening` still calls the synchronous `runCheck()` seam path; the `screeningTag` MOCK demo-tag threading from #249 is preserved on the flag-OFF background branch.
- **ON:** `submit()` orders reports for both domains → app parks in `awaiting_consumer_report` → CRA webhook maps + persists the categorical verdict → advances to `screening` → `resolve()` reads it back. Pending / missing / wrong-shape / throw → `could_not_screen` HOLD (never a silent pass).

## Built (ships dark)

- Migration `2026-06-01-applications-consumer-report.sql` — `ADD VALUE` outside-txn + report-ref/status cols + `cra_processed_events` / `cra_webhook_dlq`. **No destructive statements.**
- `background-check.ts` / `credit-check.ts` gain `createReport` / `resolve` / pure mappers; the `runCheck` seam path is **untouched**, reusing `evaluateResults` + the #245 HUD individualized-assessment engine via `criminalRecords`.
- New raw-body route `cra-webhook.ts` — idempotency, DLQ-always-200, CAS-guard on `status='awaiting_consumer_report'`, signature **fails CLOSED 503** until `CRA_WEBHOOK_SECRET` is set.
- State machine: `awaiting_consumer_report` + 3 transitions.
- `audit_action` already has `background_check_completed` / `credit_check_completed` — no enum trap.

## Credentialing-gated (NOT built — 8 `TODO(credentialing)` markers)

Real Checkr/TU HTTP clients, exact report field paths, and real HMAC signature verification are blocked on signed contracts (zero API keys today; credentialing is 2–6 wks after signing).

## FCRA delta still owed (separate, contract-independent)

In-app CRA consent capture, the pre-adverse 5-business-day window (§8.3, ratified not built), and the §1681i dispute link are **not** in this PR. Adverse-action notice + individualized assessment (#245) already exist.

## Verification

- `tsc --noEmit` clean.
- Full server suite: **100 suites / 1604 passed, 0 failed** (`STRIPE_LIVE_ENABLED=false npx jest`), incl. 40 new CRA tests + regression.
- Rebased onto current `main` (`76476f8`); the only conflict was the `service.ts` check fan-out — resolved by keeping the `consumerReportEnabled` ternary and re-grafting #249's `screeningTag` onto the flag-OFF background branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)