### PR TITLE
test(voice): fix flaky tamper-signature tests (intermittent CI flake)

### DIFF
--- a/src/__tests__/encryption.test.ts
+++ b/src/__tests__/encryption.test.ts
@@ -46,7 +46,9 @@ describe("encrypt / decrypt", () => {
   it("throws on tampered ciphertext", () => {
     const ciphertext = encrypt("sensitive");
     const [iv, tag, data] = ciphertext.split(":");
-    const tampered = `${iv}:${tag}:${data.slice(0, -2)}ff`; // corrupt last byte
+    // Corrupt the last byte to a *guaranteed-different* value — forcing "ff"
+    // is a no-op the ~1/256 of the time the ciphertext already ends in "ff".
+    const tampered = `${iv}:${tag}:${data.slice(0, -2)}${data.endsWith("ff") ? "00" : "ff"}`;
     expect(() => decrypt(tampered)).toThrow();
   });
 });

--- a/src/__tests__/voice-intake-webhook.test.ts
+++ b/src/__tests__/voice-intake-webhook.test.ts
@@ -65,7 +65,12 @@ function signedBody(
     .update(`${ts}.`)
     .update(body, "utf8")
     .digest("hex");
-  const finalSig = opts?.tamper ? sig.replace(/.$/, "0") : sig;
+  // Tamper by flipping the last hex char to a *guaranteed-different* value.
+  // (Naively forcing it to "0" is a no-op ~1/16 of the time — when the real
+  // signature already ends in "0" — which made this test flake in CI.)
+  const finalSig = opts?.tamper
+    ? sig.slice(0, -1) + (sig.endsWith("0") ? "1" : "0")
+    : sig;
   return { body, header: `t=${ts},v0=${finalSig}`, ts };
 }
 

--- a/src/__tests__/voice-tool-callbacks.test.ts
+++ b/src/__tests__/voice-tool-callbacks.test.ts
@@ -63,7 +63,12 @@ function signedBody(
     .update(`${ts}.`)
     .update(body, "utf8")
     .digest("hex");
-  const finalSig = opts?.tamper ? sig.replace(/.$/, "0") : sig;
+  // Tamper by flipping the last hex char to a *guaranteed-different* value.
+  // (Naively forcing it to "0" is a no-op ~1/16 of the time — when the real
+  // signature already ends in "0" — which made this test flake in CI.)
+  const finalSig = opts?.tamper
+    ? sig.slice(0, -1) + (sig.endsWith("0") ? "1" : "0")
+    : sig;
   return { body, header: `t=${ts},v0=${finalSig}`, ts };
 }
 


### PR DESCRIPTION
## Problem
The `api (tsc + jest)` required check fails intermittently (~6% of runs) on:
- `voice-intake-webhook.test.ts › rejects tampered signature with 400`
- `voice-tool-callbacks.test.ts › rejects tampered signature with 400`

Failure count varies run-to-run (2 → 1 → 0), and the tests pass in isolation — the hallmark of a nondeterministic test, not a code regression. `main` lands green most of the time but this flake intermittently blocks unrelated PRs (it red-flagged #251, a bash-only change).

## Root cause
The test `signedBody(..., { tamper: true })` helper tampered the HMAC by forcing the **last hex char to `"0"`**:
```js
sig.replace(/.$/, "0")
```
When the genuine signature already ends in `"0"` (1/16 of signatures), this is a **no-op** → the "tampered" signature is byte-identical to the valid one → the route correctly returns `200` → `expect(400)` fails. The signed timestamp uses `Date.now()`, so the trailing char is effectively random per run → ~6.25% flake per tampered test.

## Fix
Flip the last char to a **guaranteed-different** value:
```js
sig.slice(0, -1) + (sig.endsWith("0") ? "1" : "0")
```
Same no-op-collision class also fixed in `encryption.test.ts` (it forced the last ciphertext byte to `"ff"`, a no-op ~1/256 — rarer latent cousin).

Audited the other 4 `tamper`-using suites (`payment-webhook`, `screening-*`) — those tamper by semantic field-swap, never a no-op. Safe, untouched.

## Proof
- Deterministic: OLD logic = **1/16 no-ops**, NEW = **0/16** across all possible trailing hex chars.
- 20/20 consecutive runs of all 3 suites green.
- `tsc --noEmit` clean.

Test-only change. No runtime/src behavior touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)