### PR TITLE
fix(screening): retain exact FCRA disclosure text per authorization row

### DIFF
--- a/docs/screening/background-credit-cra-adapter.md
+++ b/docs/screening/background-credit-cra-adapter.md
@@ -218,9 +218,13 @@ What is NEW for this adapter:
   `CONSUMER_REPORT_ENABLED`.** `screening/consumer-report-consent.ts` holds a versioned
   clear-and-conspicuous disclosure (`FCRA_DISCLOSURE_VERSION` / `_TEXT` + SHA-256
   `fcraDisclosureHash`) and `recordAuthorization()` writes a durable
-  `consumer_report_authorizations` row (who / when / version / text-hash / method / IP /
-  UA — same evidentiary shape as `lease_signatures`) + a `consumer_report_authorized`
-  audit entry. `submit()` now **gates** the Checkr/TU pull on a valid authorization:
+  `consumer_report_authorizations` row (who / when / version / the **exact disclosure
+  text shown** + its SHA-256 hash / method / IP / UA — same evidentiary shape as
+  `lease_signatures`) + a `consumer_report_authorized` audit entry. The text is retained
+  **per-row**, not merely referenced by version, so the recorded hash stays pre-imageable
+  against immutable text forever — even after `FCRA_DISCLOSURE_TEXT` is later bumped and
+  the old wording leaves source; `verifyStoredAuthorization()` re-derives the hash from the
+  retained text to prove integrity on demand. `submit()` now **gates** the Checkr/TU pull on a valid authorization:
   honor one already on file (idempotent re-submit) or capture a freshly-affirmed consent;
   absent/stale ⇒ no orders, app stays `submitted`, and the route returns 400 +
   `{disclosure}` (fail-loud, never an unauthorized pull). `screening_authorization_at`

--- a/src/__tests__/consumer-report-consent.test.ts
+++ b/src/__tests__/consumer-report-consent.test.ts
@@ -17,6 +17,7 @@ import {
   getAuthorization,
   hasValidAuthorization,
   recordAuthorization,
+  verifyStoredAuthorization,
 } from "../modules/screening/consumer-report-consent";
 import { query } from "../config/database";
 import { writeAuditLog } from "../middleware/audit";
@@ -79,9 +80,11 @@ describe("recordAuthorization", () => {
       alreadyRecorded: false,
     });
 
-    // INSERT ... ON CONFLICT DO NOTHING with the current version + the text hash.
+    // INSERT ... ON CONFLICT DO NOTHING persists the version, the text hash, AND
+    // the exact disclosure text whose hash it is.
     const [sql, params] = mockQuery.mock.calls[0];
     expect(sql).toMatch(/INSERT INTO consumer_report_authorizations/i);
+    expect(sql).toMatch(/disclosure_text/i);
     expect(sql).toMatch(/ON CONFLICT \(application_id\) DO NOTHING/i);
     expect(params).toEqual([
       "app-1",
@@ -89,10 +92,13 @@ describe("recordAuthorization", () => {
       "applicant",
       FCRA_DISCLOSURE_VERSION,
       fcraDisclosureHash(),
+      FCRA_DISCLOSURE_TEXT,
       "in_app_checkbox",
       "1.2.3.4",
       "UA/1.0",
     ]);
+    // The retained text hashes to the recorded hash — self-provable.
+    expect(fcraDisclosureHash(params![5] as string)).toBe(params![4]);
 
     expect(mockWriteAuditLog).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -121,6 +127,7 @@ describe("recordAuthorization", () => {
           applicant_id: "u1",
           disclosure_version: FCRA_DISCLOSURE_VERSION,
           disclosure_hash: fcraDisclosureHash(),
+          disclosure_text: FCRA_DISCLOSURE_TEXT,
           method: "in_app_checkbox",
           authorized_at: new Date("2026-05-30T09:00:00.000Z"),
         },
@@ -187,5 +194,86 @@ describe("hasValidAuthorization", () => {
     mockQuery.mockResolvedValue(qr([])); // both hasValid + getAuthorization read empty
     await expect(hasValidAuthorization("app-1")).resolves.toBe(false);
     await expect(getAuthorization("app-1")).resolves.toBeNull();
+  });
+});
+
+describe("verifyStoredAuthorization", () => {
+  it("intact for a current-version authorization (retained text re-hashes to recorded hash)", async () => {
+    mockQuery.mockResolvedValueOnce(
+      qr([
+        {
+          application_id: "app-1",
+          applicant_id: "u1",
+          disclosure_version: FCRA_DISCLOSURE_VERSION,
+          disclosure_hash: fcraDisclosureHash(),
+          disclosure_text: FCRA_DISCLOSURE_TEXT,
+          method: "in_app_checkbox",
+          authorized_at: new Date("2026-06-01T10:00:00.000Z"),
+        },
+      ])
+    );
+    await expect(verifyStoredAuthorization("app-1")).resolves.toEqual({
+      found: true,
+      intact: true,
+    });
+  });
+
+  it("intact for a SUPERSEDED version whose text is gone from source — the retention guarantee", async () => {
+    // Simulate an authorization captured before a wording bump: the disclosure
+    // text below no longer matches the current FCRA_DISCLOSURE_TEXT constant, so
+    // it cannot be reconstructed from source. Because the exact text is RETAINED
+    // on the row, its recorded hash is still pre-imageable — closing the gap.
+    const oldText =
+      "CONSUMER REPORT AUTHORIZATION (v2024)\n\nSuperseded disclosure wording that " +
+      "no longer exists anywhere in the current source tree.";
+    const oldHash = createHash("sha256").update(oldText).digest("hex");
+    expect(oldText).not.toBe(FCRA_DISCLOSURE_TEXT);
+    expect(oldHash).not.toBe(fcraDisclosureHash());
+
+    mockQuery.mockResolvedValueOnce(
+      qr([
+        {
+          application_id: "app-old",
+          applicant_id: "u1",
+          disclosure_version: "2024-01-01",
+          disclosure_hash: oldHash,
+          disclosure_text: oldText,
+          method: "in_app_checkbox",
+          authorized_at: new Date("2024-01-01T00:00:00.000Z"),
+        },
+      ])
+    );
+    await expect(verifyStoredAuthorization("app-old")).resolves.toEqual({
+      found: true,
+      intact: true,
+    });
+  });
+
+  it("not intact when the retained text and recorded hash disagree (tamper/corruption)", async () => {
+    mockQuery.mockResolvedValueOnce(
+      qr([
+        {
+          application_id: "app-1",
+          applicant_id: "u1",
+          disclosure_version: FCRA_DISCLOSURE_VERSION,
+          disclosure_hash: fcraDisclosureHash(), // hash of the canonical text...
+          disclosure_text: FCRA_DISCLOSURE_TEXT + "\nTAMPERED LINE", // ...but text differs
+          method: "in_app_checkbox",
+          authorized_at: new Date("2026-06-01T10:00:00.000Z"),
+        },
+      ])
+    );
+    await expect(verifyStoredAuthorization("app-1")).resolves.toEqual({
+      found: true,
+      intact: false,
+    });
+  });
+
+  it("found:false / intact:false when there is no authorization to verify", async () => {
+    mockQuery.mockResolvedValueOnce(qr([]));
+    await expect(verifyStoredAuthorization("app-1")).resolves.toEqual({
+      found: false,
+      intact: false,
+    });
   });
 });

--- a/src/db/migrations/2026-06-01-fcra-consent.sql
+++ b/src/db/migrations/2026-06-01-fcra-consent.sql
@@ -11,9 +11,12 @@
 -- order-creation WITHOUT ever capturing an authorization — a compliance gap.
 -- This migration adds the durable authorization record that gates the pull.
 --
--- We persist the evidentiary trail (who, when, which disclosure version, a
--- SHA-256 hash of the exact disclosure text shown, capture method, IP, UA) —
--- the same shape as the ESIGN/UETA `lease_signatures` record. One authorization
+-- We persist the evidentiary trail (who, when, which disclosure version, the
+-- exact disclosure text shown AND its SHA-256 hash, capture method, IP, UA) —
+-- the same shape as the ESIGN/UETA `lease_signatures` record. The exact text is
+-- retained on the row (not merely referenced by version) so the recorded hash
+-- stays verifiable against immutable text forever — even after the disclosure
+-- wording is bumped and the source constant changes. One authorization
 -- per application: `application_id` is UNIQUE and writes are ON CONFLICT DO
 -- NOTHING, so the FIRST authorization wins and re-submits are idempotent.
 --
@@ -31,6 +34,7 @@ CREATE TABLE IF NOT EXISTS consumer_report_authorizations (
   applicant_role     TEXT,
   disclosure_version TEXT NOT NULL,
   disclosure_hash    TEXT NOT NULL,
+  disclosure_text    TEXT NOT NULL,
   method             TEXT NOT NULL DEFAULT 'in_app_checkbox',
   authorized_ip      TEXT,
   user_agent         TEXT,

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1275,12 +1275,14 @@ CREATE TABLE IF NOT EXISTS cra_webhook_dlq (
 -- FCRA §1681b(b)(2) consumer-report authorization capture. Before Frank (the
 -- end user) procures a Checkr/TransUnion consumer report it must obtain the
 -- applicant's clear-and-conspicuous disclosure + written authorization. This is
--- the durable evidentiary record (who/when/disclosure version + SHA-256 hash of
--- the exact text shown/method/IP/UA) — same shape as lease_signatures. One
--- authorization per application (application_id UNIQUE, written ON CONFLICT DO
--- NOTHING so the first authorization wins and re-submits are idempotent). See
--- src/modules/screening/consumer-report-consent.ts and
--- src/db/migrations/2026-06-01-fcra-consent.sql.
+-- the durable evidentiary record (who/when/disclosure version + the exact text
+-- shown AND its SHA-256 hash/method/IP/UA) — same shape as lease_signatures. The
+-- exact text is retained on the row (not merely referenced by version) so the
+-- recorded hash stays verifiable against immutable text forever, even after the
+-- disclosure wording is bumped. One authorization per application (application_id
+-- UNIQUE, written ON CONFLICT DO NOTHING so the first authorization wins and
+-- re-submits are idempotent). See src/modules/screening/consumer-report-consent.ts
+-- and src/db/migrations/2026-06-01-fcra-consent.sql.
 CREATE TABLE IF NOT EXISTS consumer_report_authorizations (
   id                 UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   application_id     UUID NOT NULL UNIQUE,
@@ -1288,6 +1290,7 @@ CREATE TABLE IF NOT EXISTS consumer_report_authorizations (
   applicant_role     TEXT,
   disclosure_version TEXT NOT NULL,
   disclosure_hash    TEXT NOT NULL,
+  disclosure_text    TEXT NOT NULL,
   method             TEXT NOT NULL DEFAULT 'in_app_checkbox',
   authorized_ip      TEXT,
   user_agent         TEXT,

--- a/src/modules/screening/consumer-report-consent.ts
+++ b/src/modules/screening/consumer-report-consent.ts
@@ -14,9 +14,13 @@
  * posts the affirmation to /me/applications/submit-draft, which calls
  * recordAuthorization() before any report order is created.
  *
- * The evidentiary record (who / when / which disclosure version / a SHA-256 hash
- * of the exact text shown / capture method / IP / UA) mirrors the ESIGN/UETA
- * `lease_signatures` record. One authorization per application — first wins,
+ * The evidentiary record (who / when / which disclosure version / the exact
+ * disclosure text shown AND its SHA-256 hash / capture method / IP / UA) mirrors
+ * the ESIGN/UETA `lease_signatures` record. The exact text is retained on the
+ * row — not merely referenced by version — so the recorded hash stays verifiable
+ * against immutable text forever, even after FCRA_DISCLOSURE_VERSION is bumped
+ * and the source constant below changes (see verifyStoredAuthorization).
+ * One authorization per application — first wins,
  * re-submits idempotent (consumer_report_authorizations.application_id UNIQUE,
  * written ON CONFLICT DO NOTHING).
  *
@@ -83,6 +87,7 @@ export interface StoredAuthorization {
   applicantId: string | null;
   disclosureVersion: string;
   disclosureHash: string;
+  disclosureText: string;
   method: string;
   authorizedAt: string; // ISO-8601
 }
@@ -92,7 +97,8 @@ export async function getAuthorization(
   applicationId: string
 ): Promise<StoredAuthorization | null> {
   const res = await query(
-    `SELECT application_id, applicant_id, disclosure_version, disclosure_hash, method, authorized_at
+    `SELECT application_id, applicant_id, disclosure_version, disclosure_hash,
+            disclosure_text, method, authorized_at
        FROM consumer_report_authorizations
       WHERE application_id = $1`,
     [applicationId]
@@ -104,9 +110,26 @@ export async function getAuthorization(
     applicantId: (r.applicant_id as string) ?? null,
     disclosureVersion: r.disclosure_version as string,
     disclosureHash: r.disclosure_hash as string,
+    disclosureText: r.disclosure_text as string,
     method: r.method as string,
     authorizedAt: new Date(r.authorized_at as string).toISOString(),
   };
+}
+
+/**
+ * Re-derive the hash from the disclosure text RETAINED on the authorization row
+ * and confirm it matches the hash recorded at authorization time. Because the
+ * exact text is persisted per-row, this remains verifiable indefinitely — even
+ * for a superseded disclosure version whose text no longer exists in source.
+ * `intact: false` means the retained text and recorded hash disagree (tamper or
+ * corruption); `found: false` means there is no authorization to verify.
+ */
+export async function verifyStoredAuthorization(
+  applicationId: string
+): Promise<{ found: boolean; intact: boolean }> {
+  const a = await getAuthorization(applicationId);
+  if (!a) return { found: false, intact: false };
+  return { found: true, intact: fcraDisclosureHash(a.disclosureText) === a.disclosureHash };
 }
 
 /**
@@ -150,11 +173,13 @@ export async function recordAuthorization(input: {
   const disclosureHash = fcraDisclosureHash();
   const method = input.method ?? "in_app_checkbox";
 
+  // Retain the EXACT text whose hash we record, so the authorization stays
+  // self-provably verifiable even after FCRA_DISCLOSURE_TEXT is later changed.
   const inserted = await query(
     `INSERT INTO consumer_report_authorizations
        (application_id, applicant_id, applicant_role, disclosure_version,
-        disclosure_hash, method, authorized_ip, user_agent)
-     VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+        disclosure_hash, disclosure_text, method, authorized_ip, user_agent)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
      ON CONFLICT (application_id) DO NOTHING
      RETURNING authorized_at`,
     [
@@ -163,6 +188,7 @@ export async function recordAuthorization(input: {
       input.applicantRole ?? null,
       version,
       disclosureHash,
+      FCRA_DISCLOSURE_TEXT,
       method,
       input.ip ?? null,
       input.userAgent ?? null,


### PR DESCRIPTION
## What

Closes the **MEDIUM evidentiary gap** surfaced by the post-merge adversarial audit of #255 (FCRA §1681b consent capture).

The `consumer_report_authorizations` row recorded `disclosure_version` + a SHA-256 `disclosure_hash`, but the disclosure **text** lived only as a mutable source constant (`FCRA_DISCLOSURE_TEXT`, "bump in place when wording changes"). Once the version is bumped and the text replaced, an old authorization's hash can no longer be pre-imaged against the text it authorized — defeating the hash's evidentiary purpose for §1681b disputes.

## Fix

Persist the **byte-exact disclosure text** on each authorization row, so the record is self-contained and litigation-grade forever (no registry join, no dependency on source history).

- **migration `.sql` + `schema.ts` mirror** — add `disclosure_text TEXT NOT NULL` to the `consumer_report_authorizations` CREATE TABLE. The migration is **unapplied in every env**, so it's amended in place (no separate ALTER).
- **`consumer-report-consent.ts`** — `recordAuthorization()` now INSERTs the exact `FCRA_DISCLOSURE_TEXT` whose hash it records; `getAuthorization()` reads it back (`disclosureText` on `StoredAuthorization`); new **`verifyStoredAuthorization(applicationId) → {found, intact}`** re-derives the hash from the retained text and confirms it matches the stored hash — provable integrity even for a superseded version whose wording has left source.
- **adapter doc** — note per-row text retention + `verifyStoredAuthorization`.

## Tests

4 new cases. The centerpiece proves a **superseded-version row** (old text + `sha256(old text)`, with the current constant differing) still verifies `intact: true` — directly demonstrating the gap is closed. Plus: current-version intact, tamper → `intact:false`, no-row → `found:false`.

## Safety

- Still dark behind `CONSUMER_REPORT_ENABLED` (default **OFF**) — flag-off byte-identical.
- Migration unapplied in every env → no in-place schema change on a populated table; the column ships with the table whenever #253→#255→this are applied together at activation time.
- `tsc --noEmit` clean · consent suite 13/13 · application-service 52/52 · **full suite 101 suites / 1634 tests green**, zero regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)