### PR TITLE
fix(db): converge schema.ts base with prod — units.ami_designation TEXT not VARCHAR(10)

### DIFF
--- a/src/db/migrations/2026-06-08-units-ami-designation-text.sql
+++ b/src/db/migrations/2026-06-08-units-ami-designation-text.sql
@@ -1,0 +1,27 @@
+-- 2026-06-08 units.ami_designation → TEXT (provisioning convergence)
+--
+-- Root-cause fix for a SCHEMA_SQL↔delta type disagreement that made fresh
+-- `migrate up` provisions diverge from prod:
+--
+--   * src/db/schema.ts (SCHEMA_SQL, the base) originally created
+--       units.ami_designation VARCHAR(10)
+--   * 2026-05-25-acq-awards-and-designations.sql does
+--       ALTER TABLE units ADD COLUMN IF NOT EXISTS ami_designation TEXT
+--
+-- On a FRESH install the base runs first, so the column already exists as
+-- VARCHAR(10) and the delta's ADD COLUMN IF NOT EXISTS no-ops → fresh ends up
+-- VARCHAR(10). Prod was built delta-first (column added as TEXT) → prod is TEXT.
+-- A three-way information_schema diff (fresh local PG16 vs prod kodama PG18,
+-- 2026-06-08) confirmed this was the ONLY real column-level divergence across
+-- 42 tables / 622 columns / 145 indexes / 154 constraints.
+--
+-- schema.ts is now TEXT too (so future fresh installs converge), and this delta
+-- ALTERs any already-provisioned DB (e.g. staging) onto TEXT. Both directions
+-- are no-ops where the column is already TEXT (prod, post-fix fresh): widening
+-- VARCHAR(10)→TEXT is binary-compatible and needs no table rewrite. The CHECK
+-- constraint ('30','50','60','market') is preserved by the type change.
+--
+-- Idempotent: re-running ALTER ... TYPE TEXT on a TEXT column is a harmless
+-- catalog no-op.
+
+ALTER TABLE units ALTER COLUMN ami_designation TYPE TEXT;

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -584,7 +584,12 @@ CREATE TABLE IF NOT EXISTS units (
   available_from DATE,
   -- QAP acquisitions Phase 3: per-unit AMI designation from a bound award's
   -- election/unit-mix. NULL = undesignated. See 2026-05-25-acq-awards-and-designations.sql.
-  ami_designation VARCHAR(10) CHECK (ami_designation IN ('30','50','60','market')),
+  -- TYPE is TEXT (not VARCHAR) to match that delta's ADD COLUMN ... TEXT: on a
+  -- fresh migrate-up SCHEMA_SQL creates this column first, so the delta's
+  -- ADD COLUMN IF NOT EXISTS no-ops — if the base type disagreed, fresh installs
+  -- would diverge from prod (which was built delta-first as TEXT). See
+  -- 2026-06-08-units-ami-designation-text.sql.
+  ami_designation TEXT CHECK (ami_designation IN ('30','50','60','market')),
   -- LIHTC §42 Phase A: link to the unit's building (nullable). See 2026-05-30-buildings-bin.sql.
   building_id UUID REFERENCES buildings(id) ON DELETE SET NULL,
   created_at TIMESTAMPTZ DEFAULT NOW(),


### PR DESCRIPTION
## Problem

`SCHEMA_SQL` (the migrate base in `src/db/schema.ts`) created `units.ami_designation` as `VARCHAR(10)`, but `2026-05-25-acq-awards-and-designations.sql` adds the same column as `TEXT` via `ADD COLUMN IF NOT EXISTS`.

`migrate.ts` runs `SCHEMA_SQL` **first**, then ordered deltas. So on a **fresh** `migrate up` the column already exists (as `VARCHAR(10)`) by the time the delta runs → the `ADD COLUMN IF NOT EXISTS` no-ops → fresh installs end up `VARCHAR(10)`. Prod was built delta-first (column added as `TEXT`) → prod is `TEXT`. Silent base↔prod drift.

A three-way `information_schema` diff (fresh local PG16 vs prod kodama PG18, 2026-06-08) confirmed this was the **only** real column-level divergence across **42 tables / 622 columns / 145 indexes / 154 constraints**.

## Fix

- **`schema.ts`**: `ami_designation VARCHAR(10)` → `TEXT` so future fresh installs converge with prod (+ an explanatory comment so the base↔delta agreement is intentional and won't regress).
- **`2026-06-08-units-ami-designation-text.sql`**: `ALTER TABLE units ALTER COLUMN ami_designation TYPE TEXT;` to heal already-provisioned DBs (e.g. staging, which is `varchar(10)`). No-op where already `TEXT` (prod, post-fix fresh).

`VARCHAR(10)→TEXT` is binary-coercible — Postgres skips the table rewrite (catalog-only, brief `ACCESS EXCLUSIVE` on a 17-row table). The `CHECK (ami_designation IN ('30','50','60','market'))` is preserved by the type change.

## Verification

**Empirical — all three provisioning states:**
- **Fresh** `migrate up` (post-fix) → `units.ami_designation = text`; full column diff vs prod = **622/622 identical, zero drift**.
- **Prod** (already `text`) → `ALTER ... TYPE TEXT` is a no-op.
- **Staging-sim** (`varchar(10)` + data) → widens to `text` cleanly; CHECK survives **and is still enforced** (rejects out-of-set values); re-run idempotent.
- `npx tsc --noEmit` → exit 0.

**Adversarial review** (multi-agent, 3 lenses, 0 confirmed findings):
- *Bug-class hunt*: grepped all 50+ `ADD COLUMN` sites against `SCHEMA_SQL` — `ami_designation` is the sole true type-drift; `INT≡INTEGER` / `NUMERIC≡DECIMAL` are exact PG aliases, not drift. No other latent instances of this bug class.
- *Code coupling*: nothing in the codebase assumes the `VARCHAR(10)` width — every guard is value-set membership (DB CHECK, Zod `z.enum`, runtime `.includes()`, TS union). Widest legal value `'market'` is 6 chars.
- *Migration correctness*: delta ordering (`2026-05-25` < `2026-06-08`), single-apply tracking, prod no-op, idempotency, and template-literal integrity all verified.

## Out of scope (pre-existing, noted for follow-up — not touched here)
- 7 delta-added columns (`properties.latitude/longitude`, 5 consumer-report columns on `applications`) are absent from `SCHEMA_SQL` entirely. This is the **safe** variant (the delta is the sole creator → identical on fresh and prod), but it's a base↔delta documentation-parity gap worth closing later.
- `client-acq/src/types/index.ts:196` — a narrow `AmiDesignation` TS union omits `'60'` (the 4-value `UnitDesignation` is the one actually used by the grid). Unrelated app-layer staleness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)