### PR TITLE
docs(intel): NV Energy Stage-4 send-ready email — GPMG portfolio (17 parcels)

### DIFF
--- a/docs/intel/nv-energy-stage4-email.md
+++ b/docs/intel/nv-energy-stage4-email.md
@@ -1,0 +1,93 @@
+# NV Energy Stage-4 — send-ready email (GPMG portfolio)
+
+> Distilled from `nv-energy-service-request.md` for sending. **Fill the 4 bracketed fields**
+> (name · title · email · phone), attach the signed authorization (Attachment A), then send via
+> NV Energy Builder & Developer Services. Read the 3 ownership caveats below **before** signing.
+
+---
+
+## Cover email (copy-paste)
+
+**To:** NV Energy — Builder & Developer Services / Service Planning
+*(submit at nvenergy.com/cleanenergy/builders-developers → Builder Services intake, or email your assigned NV Energy service planner)*
+
+**Subject:** Existing service & transformer (kVA) confirmation + load/storage interconnection inquiry — GPMG affordable-housing portfolio (17 parcels, southern NV)
+
+---
+
+To whom it may concern,
+
+GPMG owns and operates the southern-Nevada affordable- and senior-housing portfolio listed below — **17 buildings on 17 parcels, ~1,157 dwelling units**. We are validating the existing electrical service at each property and evaluating a potential on-site load addition and battery energy storage. The as-built service facts we need are not in any public record, so we are requesting them directly.
+
+**For each premise / meter below, please confirm:**
+
+1. **Serving transformer rating (kVA)** and configuration (pad-mount / pole / vault).
+2. **Service voltage and phase** (e.g., 120/208 V 3Φ, 277/480 V 3Φ).
+3. **Number of meters / services** on the parcel — and whether these two adjacent, commonly-owned clusters share service or are metered separately: (a) **1327 H St** = 3 parcels (UT 1/2/3); (b) **Donna Louise 1 & 2** (6225 / 6275 Donna St).
+4. **Available / spare capacity** on the serving transformer, the **current measured peak demand** of record, and any **recent service-upgrade history**.
+5. **Load addition:** whether a service-planning study is required to add a **firm ~180 kW behind-the-meter load** (edge compute) per site against the existing service, and how to file an **Electric Service Request**.
+6. **Storage interconnection:** the pathway to interconnect a **~250 kW / ~400–500 kWh battery** per site (**Rule 15 South / RE-1** design standard, via **PowerClerk**). We understand a BESS > 25 kW triggers engineering review against the **15%-of-feeder-peak** screen — please confirm the current process, whether a **non-export (behind-the-meter)** configuration expedites review, and the **feeder hosting capacity** of record at each premise (or point us to DRP / hosting-capacity map access).
+
+| # | Property | Service address | City | APN | Owner of record | Units |
+|---|----------|-----------------|------|-----|-----------------|-------|
+| 1 | Donna Louise 1 | 6225 Donna St | North Las Vegas 89081 | 12426103004 | DONNALOUISE LLC | 48 |
+| 2 | Donna Louise 2 | 6275 Donna St | North Las Vegas 89081 | 12426103002 | DONNA LOUISE 2 LLC | 48 |
+| 3 | Owens Senior Housing | 1626 Davis Pl | North Las Vegas 89030 | 13922810039 | OWENS 2 LP | 72 |
+| 4 | Yale Keyes Senior | 1705 Yale St | North Las Vegas 89030 | 13922810051 | YALE KEYES LP | 70 |
+| 5 | Aldene Kline Barlow (1327 H St UT 1) | 1327 H St | Las Vegas 89106 | 13928503028 | CDPC NL LLC | 39 |
+| 6 | Ethel Mae Robinson (1327 H St UT 2) | 1327 H St | Las Vegas 89106 | 13928503027 | CDPC NL LLC | 82 |
+| 7 | Sarann Knight (1327 H St UT 3) | 1327 H St | Las Vegas 89106 | 13928503026 | CDPC NL LLC | 38 |
+| 8 | David J. Hoggard Family | 1100 W Monroe Ave | Las Vegas 89106 | 13928503022 | SOUTHERN NV HOUSING AUTHORITY | 100 |
+| 9 | Luther Mack, Jr. Senior | 8158 Giles St | Las Vegas 89123 (unincorp.) | 17716101027 | MIXED INCOME LLC | 48 |
+| 10 | Dr. Paul Meacham Senior | 65 E Windmill Ln | Las Vegas 89123 (unincorp.) | 17716101026 | MIXED INCOME 2 LLC | 57 |
+| 11 | Ethel Mae Fletcher | 1503 Laurelhurst Dr | Las Vegas 89108 | 13825504001 | VGAS 1 DCATUR LLC | 18 |
+| 12 | Mike O'Callaghan Legacy | 1502 Laurelhurst Dr | Las Vegas 89108 | 13825518004 | 1501 LLC | 40 |
+| 13 | Juan Garcia Garden | 2851 Sunrise Ave | Las Vegas 89101 | 13936402015 | ERNIE CRAGIN LP | 52 |
+| 14 | Louise Shell Senior | 2101 N MLK Blvd | Las Vegas 89106 | 13921202007 | LSHP LP | 100 |
+| 15 | Senator Harry Reid Senior | 334 N 11th St (mail 328) | Las Vegas 89101 | 13935201001 | 11TH STREET LP | 100 |
+| 16 | Senator Richard Bryan Senior | 2651 Searles Ave | Las Vegas 89101 | 13925101022 | SOUTHERN NV HOUSING AUTHORITY | 165 |
+| 17 | Smith Williams Senior | 575 E Lake Mead Pkwy | Henderson 89015 | 17908301011 | CHURCH COMMUNITY BAPTIST (fee) | 80 |
+
+Signed owner-of-record authorizations for the entities named above are attached. We can provide account numbers, premise IDs, or a site contact on request to speed records lookup.
+
+Thank you,
+
+**[Name] · [Title]**, GPMG
+**[email]** · **[phone]**
+
+---
+
+## Attachment A — authorization letter (sign & attach)
+
+NV Energy releases facility data only to the owner-of-record or authorized agent. The 17 parcels span **14 owning entities**. If a single GPMG agent is authorized across all of them, **one combined signature** is enough; otherwise sign one copy per entity (list that entity's APNs).
+
+> **Date:** ______   **Re:** Authorization to release existing service & transformer facility information
+>
+> I, **[name]**, as **[title]** of **[GPMG entity / authorized agent]**, am authorized to act for the owner(s)-of-record of the parcels listed in the attached request. I authorize NV Energy to release the existing electrical service, transformer rating (kVA), voltage/phase, metering, and feeder hosting-capacity information of record for those premises to **[requestor name / email]**.
+>
+> Signature: __________________   Date: __________
+> **[Name] · [Title]** — on behalf of: **[entity name(s) / APNs]**
+
+**The 14 owning entities** (combined letter lists all APNs; per-entity letters list only that entity's):
+
+- CDPC NL LLC — 13928503028, 13928503027, 13928503026 (1327 H St UT 1/2/3)
+- SOUTHERN NV HOUSING AUTHORITY — 13928503022 (Hoggard), 13925101022 (Bryan)
+- DONNALOUISE LLC — 12426103004 · DONNA LOUISE 2 LLC — 12426103002
+- OWENS 2 LP — 13922810039 · YALE KEYES LP — 13922810051
+- MIXED INCOME LLC — 17716101027 · MIXED INCOME 2 LLC — 17716101026
+- VGAS 1 DCATUR LLC — 13825504001 · 1501 LLC — 13825518004
+- ERNIE CRAGIN LP — 13936402015 · LSHP LP — 13921202007
+- 11TH STREET LP — 13935201001 · CHURCH COMMUNITY BAPTIST — 17908301011
+
+---
+
+## ⚠ Before you sign — 3 ownership caveats (confirm the signer, not the email)
+
+These don't change the email to NV Energy — they change **who signs Attachment A**:
+
+1. **Fletcher (APN 13825504001, 1503 Laurelhurst, 18u)** — a same-owner parcel `13825504002` at **1403** Laurelhurst (42u) also exists. If GPMG's "Fletcher" is the larger 1403 building, authorize that APN instead/also.
+2. **O'Callaghan (APN 13825518004, 1502 Laurelhurst, 40u)** — correct operating building. Do **not** authorize the adjacent vacant lot `13825518005`.
+3. **Smith Williams (APN 17908301011)** — fee owner of record is **Church Community Baptist**; GPMG likely holds a ground lease. NV Energy's **service-account holder may be the GPMG operator, not the fee owner** — confirm who holds the meter and authorize that entity.
+
+## After it sends
+Log the send date; set each Stage-4 row to *"Likely + NV Energy request pending."* On reply, transcribe kVA / voltage / meter count per premise — those rows graduate to **Confirmed** (the only rows that ever can), and feeder hosting capacity moves each interconnect verdict off provisional AMBER.


### PR DESCRIPTION
## What

Send-ready NV Energy **Stage-4** artifact for the GPMG portfolio — a copy-paste cover email plus a signable owner authorization — distilled from `nv-energy-service-request.md`. This is the **single action that converts the 17 Likely-3-phase parcels into Confirmed** kVA + voltage + phase and lifts every interconnect verdict off provisional AMBER (white paper §1.5).

## The 6 asks (per premise)
1. Transformer **kVA** + configuration
2. **Voltage / phase** of record
3. **Meter count** — incl. whether 1327 H St (×3) and Donna Louise (×2) share service
4. **Spare capacity** + measured peak + upgrade history
5. Path to add a firm **~180 kW load** (Electric Service Request / load letter)
6. **~250 kW BESS interconnect** (Rule 15 South / RE-1 / PowerClerk, 15%-of-feeder screen, non-export, feeder hosting capacity)

## Contents
- **Cover email** — all 17 parcels tabled (APN + address + owner + units), verified, no placeholders.
- **Attachment A** — signable owner authorization + entity→APN map (NV Energy releases data only to owner-of-record; 17 parcels = 14 entities).
- **3 ownership caveats** to confirm before signing: Fletcher 1503 (18u) vs same-owner 1403 (42u) · O'Callaghan 1502 (40u) vs adjacent vacant lot · Smith Williams fee owner is the church.

## Operator step
Fill 4 bracketed fields (name / title / email / phone), attach the signed authorization, send via NV Energy Builder & Developer Services. Docs-only PR — no code paths touched.

Builds on #267 (electrical E2E) and #258 (AHJ resolution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
