### PR TITLE
feat(intel): repo→Notion sync for GPMG NV Parcels DB (P7, source-derived, one-way)

### DIFF
--- a/docs/intel/notion-sync/.env.example
+++ b/docs/intel/notion-sync/.env.example
@@ -1,0 +1,10 @@
+# Copy to .env (this dir) and fill in. .env is gitignored — never commit a token.
+#
+# A Notion internal-integration token. The integration MUST be connected to the
+# "GPMG NV Parcels" page in Notion (Notion: ··· menu -> Connections -> add it),
+# or every API call 404s. Create one at notion.so/my-integrations.
+NOTION_TOKEN=
+
+# Optional overrides (defaults are correct for the live DB):
+# GPMG_DS_ID=72aafa8d-405e-4bd3-a511-f3b092813687
+# NOTION_VERSION=2025-09-03

--- a/docs/intel/notion-sync/README.md
+++ b/docs/intel/notion-sync/README.md
@@ -1,0 +1,67 @@
+# GPMG NV Parcels — repo → Notion sync
+
+One-way sync that keeps the **auto** (source-derived) fields of the *GPMG NV
+Parcels* Notion DB in agreement with the authoritative repo file
+[`../electrical-service-validation.md`](../electrical-service-validation.md).
+
+**The repo `.md` is the single source of truth.** Notion is a read/collaboration
+surface. This tool only ever pushes repo → Notion; it never reads judgment back.
+
+## What it touches
+
+| Field | Owned? | Behaviour |
+|---|---|---|
+| `3-Phase (inferred)`, `Interconnect (provisional)`, `Transformer`, `Transformer kVA`, `Parcel`, `NV Energy`, `Last verified` | **OWNED** | patched, and only when the value actually changed |
+| `Flag`, `Authorization`, `Program tier`, `Assigned entity`, `Credits in play`, `Capacity fee`, `BESS kW/kWh`, `Site type`, every identity column | **never** | not in the payload — the tool is structurally incapable of writing them |
+
+Two protections, belt-and-suspenders:
+1. **Field allowlist** — the PATCH payload is built only from the OWNED list.
+2. **Row guard** — any row whose `Sync source = manual` is skipped entirely, so a
+   row can be pinned for hand-maintenance and the sync will leave the *whole* row
+   alone.
+
+Rows are matched to sites by **APN**. Old Windsor Park (the 18th, a redevelopment
+proposal with no electrical service) is in neither source table, so it is never
+touched.
+
+## The NV-Energy flip is automatic
+
+Transformer stays `Unknown` until the source states a kVA (the hard rule). When NV
+Energy returns, edit the evidence row in the `.md`:
+
+```
+… · Transformer: **Confirmed (300 kVA, NV Energy 2026-07-14)**
+```
+
+The next `--apply` run derives `Transformer=Confirmed`, `Transformer kVA=300`,
+`NV Energy=Returned` from that line and bumps `Last verified`. No code change, no
+hand-editing in Notion — one edit to the source of truth propagates.
+
+## Usage
+
+```bash
+cd docs/intel/notion-sync
+cp .env.example .env          # paste a NOTION_TOKEN connected to the GPMG NV Parcels page
+python3 sync.py               # DRY RUN — prints the before→after diff, writes nothing
+python3 sync.py --apply       # writes the auto fields to Notion
+python3 sync.py --check       # dry run; exits 1 if any site has no matching Notion row (CI)
+```
+
+Stdlib only (Python 3.10+, `urllib`) — no `pip install`. The token is read from
+`.env` then the shell env, and is never logged.
+
+## Self-test (no token needed)
+
+```bash
+python3 validation.py         # parses the .md, prints the 17 site records, fails loud on drift
+```
+
+The parser refuses to emit a partial/empty result: if either source table changes
+shape it raises `ValidationParseError` rather than silently syncing 0 rows.
+
+## Files
+
+- `validation.py` — fail-loud parser for the two source tables (Stage 4b matrix +
+  Stage 4 evidence), joined by building name.
+- `notion.py` — stdlib Notion REST client (2025-09-03 data_source API).
+- `sync.py` — orchestrator: parse → match by APN → diff → patch owned fields.

--- a/docs/intel/notion-sync/notion.py
+++ b/docs/intel/notion-sync/notion.py
@@ -1,0 +1,122 @@
+"""Minimal Notion REST client for the GPMG NV Parcels sync — stdlib only (urllib).
+
+Mirrors the pattern proven in `the-stack/status/notion.py`: talks the 2025-09-03
+data_source-native API (the surface the interactive MCP used to build this DB).
+The auth token is read from this dir's `.env` first (loaded by sync.py), then
+falls back to NOTION_TOKEN already in the shell environment — so the token never
+has to be written to disk to run interactively. The token value is NEVER logged.
+
+The integration whose token this is MUST be connected to the "GPMG NV Parcels"
+page/DB in Notion, or every call 404s. See README.
+
+Endpoints used:
+  POST /v1/data_sources/{ds}/query   — page through every row (no filter)
+  PATCH /v1/pages/{page_id}          — patch a row's auto properties
+"""
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.request
+
+API = "https://api.notion.com/v1"
+VERSION = os.environ.get("NOTION_VERSION", "2025-09-03")
+
+
+class NotionError(RuntimeError):
+    pass
+
+
+def _token() -> str:
+    tok = os.environ.get("NOTION_TOKEN", "").strip()
+    if not tok:
+        raise NotionError(
+            "NOTION_TOKEN not set. Add it to docs/intel/notion-sync/.env or export "
+            "it. The integration must also be connected to the 'GPMG NV Parcels' "
+            "page in Notion — see README.")
+    return tok
+
+
+def _req(method: str, path: str, body: dict | None = None) -> dict:
+    url = f"{API}{path}"
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(url, data=data, method=method)
+    req.add_header("Authorization", f"Bearer {_token()}")
+    req.add_header("Notion-Version", VERSION)
+    req.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return json.loads(resp.read().decode())
+    except urllib.error.HTTPError as e:
+        detail = e.read().decode(errors="replace")[:600]
+        # never echo the token; only the API's own error payload
+        raise NotionError(f"{method} {path} -> HTTP {e.code}: {detail}") from None
+    except urllib.error.URLError as e:
+        raise NotionError(f"{method} {path} -> network error: {e.reason}") from None
+
+
+# ---- property builders (standard Notion property objects) --------------------
+
+def rich_text(text: str) -> dict:
+    return {"rich_text": [{"text": {"content": text}}]} if text else {"rich_text": []}
+
+
+def select(name: str | None) -> dict:
+    return {"select": {"name": name} if name else None}
+
+
+def number(n) -> dict:
+    return {"number": n}
+
+
+def date(iso: str | None) -> dict:
+    return {"date": {"start": iso} if iso else None}
+
+
+# ---- read helpers (tolerant of None / empty) ---------------------------------
+
+def _first_plain(items: list) -> str:
+    for it in items or []:
+        t = it.get("plain_text") or it.get("text", {}).get("content")
+        if t:
+            return t
+    return ""
+
+
+def prop_text(page: dict, name: str) -> str:
+    p = page.get("properties", {}).get(name, {})
+    if "rich_text" in p:
+        return _first_plain(p["rich_text"])
+    if "title" in p:
+        return _first_plain(p["title"])
+    return ""
+
+
+def prop_select(page: dict, name: str) -> str | None:
+    sel = page.get("properties", {}).get(name, {}).get("select")
+    return sel.get("name") if sel else None
+
+
+def prop_number(page: dict, name: str):
+    return page.get("properties", {}).get(name, {}).get("number")
+
+
+# ---- operations --------------------------------------------------------------
+
+def query_all(ds_id: str) -> list:
+    """Return every row page in the data source (pages through has_more)."""
+    rows, cursor = [], None
+    while True:
+        body = {"page_size": 100}
+        if cursor:
+            body["start_cursor"] = cursor
+        res = _req("POST", f"/data_sources/{ds_id}/query", body)
+        rows.extend(res.get("results", []))
+        if not res.get("has_more"):
+            return rows
+        cursor = res.get("next_cursor")
+
+
+def patch_row(page_id: str, props: dict) -> dict:
+    return _req("PATCH", f"/pages/{page_id}", {"properties": props})

--- a/docs/intel/notion-sync/sync.py
+++ b/docs/intel/notion-sync/sync.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Repo -> Notion sync for the GPMG NV Parcels DB (one-way, auto fields only).
+
+The repo .md (docs/intel/electrical-service-validation.md) is authoritative. This
+pushes ONLY the source-derived electrical/parcel fields into the matching Notion
+row (matched by APN). It is deliberately incapable of touching judgment fields.
+
+  OWNED (patched, only when changed):
+      3-Phase (inferred), Interconnect (provisional), Transformer,
+      Transformer kVA, Parcel, NV Energy, Last verified
+  NEVER SENT (not in the payload at all):
+      Flag, Authorization, Program tier, Assigned entity, Credits in play,
+      Capacity fee, BESS kW/kWh, Site type, and every identity column
+  ROW-LEVEL GUARD:
+      any row whose "Sync source" select == "manual" is skipped entirely
+
+The NV-Energy-returns-kVA flip is automatic: edit the .md evidence row to
+  Transformer: **Confirmed (300 kVA, NV Energy 2026-07-xx)**
+and the next run sets Transformer=Confirmed, Transformer kVA=300, NV Energy=Returned,
+and bumps Last verified — because the parser derives all of that from the source.
+
+Default mode is DRY-RUN (prints the diff, writes nothing). Pass --apply to write.
+
+  python3 sync.py            # dry run: show what would change
+  python3 sync.py --apply    # write the auto fields to Notion
+  python3 sync.py --check    # dry run; exit 1 if any site row is missing/unmatched
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+
+import notion
+import validation
+
+DS_ID = os.environ.get("GPMG_DS_ID", "72aafa8d-405e-4bd3-a511-f3b092813687")
+
+OWNED = [
+    "3-Phase (inferred)", "Interconnect (provisional)", "Transformer",
+    "Transformer kVA", "Parcel", "NV Energy", "Last verified",
+]
+
+
+def load_env(path: str) -> None:
+    """Load KEY=VALUE from .env; existing shell env wins (setdefault)."""
+    if not os.path.exists(path):
+        return
+    with open(path, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            k, v = line.split("=", 1)
+            os.environ.setdefault(k.strip(), v.strip().strip('"').strip("'"))
+
+
+def _apn11(s: str) -> str | None:
+    m = re.search(r"\d{11}", s or "")
+    return m.group(0) if m else None
+
+
+def _current(page: dict, field: str):
+    if field == "Transformer kVA":
+        return notion.prop_number(page, field)
+    if field == "Last verified":
+        d = page.get("properties", {}).get(field, {}).get("date")
+        return d.get("start") if d else None
+    return notion.prop_select(page, field)
+
+
+def _desired(site: dict, field: str):
+    if field == "Last verified":
+        return site["last_verified"]
+    return site["auto"][field]
+
+
+def _prop_for(site: dict, field: str) -> dict:
+    if field == "Transformer kVA":
+        return notion.number(site["auto"][field])
+    if field == "Last verified":
+        return notion.date(site["last_verified"])
+    return notion.select(site["auto"][field])
+
+
+def _eq(a, b) -> bool:
+    if isinstance(a, float) or isinstance(b, float):
+        return a is not None and b is not None and float(a) == float(b)
+    return a == b
+
+
+def main(argv: list[str]) -> int:
+    apply = "--apply" in argv
+    check = "--check" in argv
+
+    load_env(os.path.join(os.path.dirname(__file__), ".env"))
+
+    try:
+        sites = validation.build_sites()
+    except validation.ValidationParseError as e:
+        print(f"PARSE ERROR: {e}", file=sys.stderr)
+        return 1
+
+    print(f"Parsed {len(sites)} sites from {os.path.relpath(validation.DOC)}")
+    print(f"Mode: {'APPLY (writing)' if apply else 'DRY-RUN (no writes)'}  DS={DS_ID}\n")
+
+    try:
+        rows = notion.query_all(DS_ID)
+    except notion.NotionError as e:
+        print(f"NOTION ERROR: {e}", file=sys.stderr)
+        return 1
+
+    by_apn = {}
+    for r in rows:
+        apn = _apn11(notion.prop_text(r, "APN"))
+        if apn:
+            by_apn[apn] = r
+
+    changed = unchanged = skipped = patched = 0
+    missing: list[str] = []
+
+    for site in sites:
+        bld, apn = site["building"], site["APN"]
+        page = by_apn.get(apn)
+        if not page:
+            missing.append(f"{bld} (APN {apn})")
+            print(f"  MISSING  {bld:<30} no Notion row with APN {apn}")
+            continue
+
+        if notion.prop_select(page, "Sync source") == "manual":
+            skipped += 1
+            print(f"  SKIP     {bld:<30} Sync source = manual (row is hand-maintained)")
+            continue
+
+        diffs = [(f, _current(page, f), _desired(site, f))
+                 for f in OWNED if not _eq(_current(page, f), _desired(site, f))]
+        if not diffs:
+            unchanged += 1
+            continue
+
+        changed += 1
+        print(f"  CHANGE   {bld}")
+        for f, cur, des in diffs:
+            print(f"             {f}: {cur!r} -> {des!r}")
+
+        if apply:
+            props = {f: _prop_for(site, f) for f, _, _ in diffs}
+            assert set(props) <= set(OWNED), "refusing to write a non-owned field"
+            notion.patch_row(page["id"], props)
+            patched += 1
+
+    print(f"\nSummary: {changed} changed, {unchanged} unchanged, {skipped} manual-skip, "
+          f"{len(missing)} missing"
+          + (f", {patched} patched" if apply else ""))
+    if missing:
+        print("Missing rows: " + "; ".join(missing), file=sys.stderr)
+
+    if check and missing:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/docs/intel/notion-sync/validation.py
+++ b/docs/intel/notion-sync/validation.py
@@ -1,0 +1,223 @@
+"""Parse the authoritative source — docs/intel/electrical-service-validation.md.
+
+The repo .md is the single source of truth; this module reads it fail-loud (like
+the-stack's site_reality.py — never silently emits 0 rows) and returns one record
+per GPMG building with the auto fields the Notion sync is allowed to own.
+
+Two tables in the .md are the spine — joined on normalized building name:
+  * Stage 4b matrix   (header "Inferred service") -> 3-phase + interconnect verdict
+  * Stage 4 evidence  (header "Property | Address | APN") -> APN, transformer state,
+                        kVA (if ever stated), parcel confidence
+
+The APN comes only from the evidence table (the matrix has none); the sync matches
+Notion rows by APN. Old Windsor Park (the 18th, redevelopment) is in neither table,
+so it is never touched — correct.
+
+HARD RULE mirrored from the doc: Transformer is "Confirmed" ONLY when a kVA is
+stated (or NV Energy confirms). Until then Unknown, kVA empty.
+"""
+from __future__ import annotations
+
+import os
+import re
+
+DOC = os.path.normpath(os.path.join(os.path.dirname(__file__), "..", "electrical-service-validation.md"))
+EXPECTED = 17  # the 17 GPMG buildings; Old Windsor Park is not electrical
+
+
+class ValidationParseError(RuntimeError):
+    pass
+
+
+def _fail(reason: str):
+    raise ValidationParseError(
+        f"electrical-service-validation.md parse failed: {reason}. "
+        f"The source table shape changed — fix the parser before syncing "
+        f"(refusing to emit a partial/empty result).")
+
+
+def _read() -> str:
+    if not os.path.exists(DOC):
+        _fail(f"source not found at {DOC}")
+    with open(DOC, encoding="utf-8") as f:
+        return f.read()
+
+
+def _norm(name: str) -> str:
+    return re.sub(r"[^a-z0-9]", "", name.lower())
+
+
+def _cells(line: str) -> list[str]:
+    return [c.strip() for c in line.strip().strip("|").split("|")]
+
+
+def _is_sep(cells: list[str]) -> bool:
+    return all(re.fullmatch(r"[-:\s]+", c or "-") for c in cells)
+
+
+def _table_rows(text: str, header_substr: str) -> list[list[str]]:
+    """Return data-row cell-lists for the table whose header contains header_substr."""
+    lines = text.splitlines()
+    hdr = next((i for i, ln in enumerate(lines)
+                if ln.lstrip().startswith("|") and header_substr in ln), None)
+    if hdr is None:
+        _fail(f"table header containing '{header_substr}' not found")
+    rows = []
+    for ln in lines[hdr + 1:]:
+        if not ln.lstrip().startswith("|"):
+            break
+        cells = _cells(ln)
+        if _is_sep(cells):
+            continue
+        rows.append(cells)
+    if not rows:
+        _fail(f"table '{header_substr}' had a header but zero data rows")
+    return rows
+
+
+# ---- field mappers (raw .md token -> exact Notion select option) -------------
+
+def _service_select(cell: str) -> str:
+    m = re.search(r"(277/480|120/208)", cell)  # first voltage wins (handles "poss. 480 step-down")
+    if not m:
+        _fail(f"unrecognized inferred-service cell: {cell!r}")
+    return "Likely 277/480V 3-phase" if m.group(1) == "277/480" else "Likely 120/208V 3-phase"
+
+
+def _interconnect_select(cell: str) -> str:
+    if "▲" in cell:   # ▲
+        return "AMBER (leans feasible)"
+    if "▼" in cell:   # ▼
+        return "AMBER (upgrade likely)"
+    if "AMBER" in cell.upper():
+        return "AMBER (study)"
+    _fail(f"unrecognized interconnect cell: {cell!r}")
+
+
+def _transformer_state(confidence: str) -> tuple[str, float | None]:
+    m = re.search(r"Transformer:\s*\*\*([^*]+)\*\*", confidence)
+    if not m:
+        _fail(f"no Transformer token in confidence cell: {confidence!r}")
+    tok = m.group(1).strip()
+    if tok.startswith("Unknown"):
+        return "Unknown", None
+    if tok.startswith("Likely"):
+        return "Likely", None
+    if tok.startswith("Confirmed"):
+        kva = re.search(r"(\d+(?:\.\d+)?)\s*kVA", tok)
+        return "Confirmed", (float(kva.group(1)) if kva else None)
+    _fail(f"unrecognized Transformer state: {tok!r}")
+
+
+def _parcel_select(confidence: str) -> str | None:
+    m = re.search(r"Parcel:\s*\*\*([^*]+)\*\*", confidence)
+    if m and m.group(1).strip().startswith("Confirmed"):
+        return "Confirmed (owner-verified)"
+    return None
+
+
+def _nv_energy_state(transformer: str, confidence: str, gaps: str) -> str:
+    """Confirmed transformer => NV Energy returned; an explicit 'sent' note => Sent;
+    otherwise the current real-world state: owners verified, request ready to send."""
+    if transformer == "Confirmed":
+        return "Returned"
+    if re.search(r"NV Energy[^.]*\b(sent|request sent|submitted)\b", f"{confidence} {gaps}", re.I):
+        return "Sent"
+    return "Owner-verified — ready"
+
+
+def _apn(text: str) -> str | None:
+    m = re.search(r"\d{11}", text)
+    return m.group(0) if m else None
+
+
+def last_verified(text: str) -> str:
+    m = re.search(r"Stage 4b.*?✅\s*(\d{4}-\d{2}-\d{2})", text)
+    if not m:
+        _fail("could not read the Stage 4b verification date (✅ YYYY-MM-DD)")
+    return m.group(1)
+
+
+# ---- public: build the 17 site records ---------------------------------------
+
+def build_sites() -> list[dict]:
+    text = _read()
+    verified = last_verified(text)
+
+    matrix = {}
+    for c in _table_rows(text, "Inferred service"):
+        if not (c and c[0].isdigit()):
+            continue
+        if len(c) < 8:
+            _fail(f"matrix row has {len(c)} cells (<8): {c}")
+        matrix[_norm(c[1])] = {
+            "building": c[1],
+            "3-Phase (inferred)": _service_select(c[4]),
+            "Interconnect (provisional)": _interconnect_select(c[7]),
+        }
+
+    evidence = {}
+    for c in _table_rows(text, "Gaps / follow-up"):  # substring unique to the Stage 4 evidence table
+        if not c or c[0] in ("Property", "") or _is_sep(c):
+            continue
+        if len(c) < 9:
+            _fail(f"evidence row has {len(c)} cells (<9): {c}")
+        apn = _apn(c[2])
+        if not apn:
+            _fail(f"no 11-digit APN in evidence row: {c[0]!r} / {c[2]!r}")
+        transformer, kva = _transformer_state(c[7])
+        evidence[_norm(c[0])] = {
+            "building": c[0],
+            "APN": apn,
+            "Transformer": transformer,
+            "Transformer kVA": kva,
+            "Parcel": _parcel_select(c[7]),
+            "NV Energy": _nv_energy_state(transformer, c[7], c[8]),
+        }
+
+    if len(matrix) != EXPECTED:
+        _fail(f"expected {EXPECTED} matrix rows, parsed {len(matrix)}")
+    if len(evidence) != EXPECTED:
+        _fail(f"expected {EXPECTED} evidence rows, parsed {len(evidence)}")
+
+    sites = []
+    for mkey, mrow in matrix.items():
+        ekey = _join(mkey, evidence)
+        if ekey is None:
+            _fail(f"matrix building {mrow['building']!r} has no evidence-table match")
+        erow = evidence[ekey]
+        sites.append({
+            "building": mrow["building"],
+            "APN": erow["APN"],
+            "last_verified": verified,
+            "auto": {
+                "3-Phase (inferred)": mrow["3-Phase (inferred)"],
+                "Interconnect (provisional)": mrow["Interconnect (provisional)"],
+                "Transformer": erow["Transformer"],
+                "Transformer kVA": erow["Transformer kVA"],
+                "Parcel": erow["Parcel"],
+                "NV Energy": erow["NV Energy"],
+            },
+        })
+    if len(sites) != EXPECTED:
+        _fail(f"joined {len(sites)} sites, expected {EXPECTED}")
+    return sites
+
+
+def _join(mkey: str, evidence: dict) -> str | None:
+    """Match a matrix building to its evidence row by normalized name, tolerating a
+    suffix difference (evidence 'David J. Hoggard Family' vs matrix 'David J. Hoggard').
+    Bidirectional prefix is safe here — no GPMG building name is a prefix of another."""
+    if mkey in evidence:
+        return mkey
+    hits = [k for k in evidence if k.startswith(mkey) or mkey.startswith(k)]
+    return hits[0] if len(hits) == 1 else None
+
+
+if __name__ == "__main__":  # token-free self-test
+    import json
+    _sites = build_sites()
+    print(f"OK — parsed {len(_sites)} sites; verified {_sites[0]['last_verified']}\n")
+    for _s in _sites:
+        print(f"  {_s['building']:<30} APN {_s['APN']}")
+        print("      " + json.dumps(_s["auto"], ensure_ascii=False))


### PR DESCRIPTION
## What

P7 of the Frank Energy "one source of truth" build: a one-way sync that keeps the **auto / source-derived** fields of the private **GPMG NV Parcels** Notion DB in agreement with the authoritative repo file `docs/intel/electrical-service-validation.md`.

Notion stays a read/collaboration surface — the tool only ever pushes **repo → Notion**, never reads judgment back. The repo `.md` remains the single source of truth ("one authoritative source per datum").

## How it's structured

- **`validation.py`** — fail-loud parser of the Stage-4b *"Inferred service"* matrix + the Stage-4 evidence table, joined by building name (APN sourced from the evidence table only). Asserts **17/17**; refuses to emit a partial/empty result if either source table changes shape (raises `ValidationParseError` rather than silently syncing zero rows).
- **`sync.py`** — matches Notion rows by **APN**; patches **only** the `OWNED` allowlist (`3-Phase (inferred)`, `Interconnect (provisional)`, `Transformer`, `Transformer kVA`, `Parcel`, `NV Energy`, `Last verified`) and only when a value actually changed. Default **dry-run**; `--apply` writes; `--check` exits 1 on a missing/unmatched row (CI gate).
- **`notion.py`** — stdlib-only Notion REST client (2025-09-03 data_source API). Token read from `.env` then shell env, **never logged**.
- **`README.md`** / **`.env.example`** — usage + the OWNED-vs-never-sent field contract.

## Two belt-and-suspenders guards

Manual judgment (program tier, gap notes, counsel notes) is **structurally untouchable**:
1. **Field allowlist** — the PATCH payload is built only from the `OWNED` list (`assert set(props) <= set(OWNED)`).
2. **Per-row manual guard** — any row whose `Sync source = manual` is skipped entirely (Old Windsor Park, the 18th pin, is `manual` + has no APN → doubly protected).

## NV-Energy kVA flip is automatic

Transformer stays `Unknown` until the source states a kVA (the hard rule — never Confirmed without stated kVA or NV Energy confirmation). One edit to the source `.md`:

```
… · Transformer: **Confirmed (300 kVA, NV Energy 2026-07-14)**
```

propagates `Transformer=Confirmed` / `Transformer kVA=300` / `NV Energy=Returned` and bumps `Last verified` on the next `--apply`. No code change, no Notion hand-edit.

## Safety / blast radius

- **Inert until armed** — no token, no `--apply` ⇒ writes nothing. Default run is a read-only dry-run diff.
- No app code touched — Python tooling under `docs/intel/` only.
- `.env` is gitignored; no token or secret is committed.

## Test

```bash
cd docs/intel/notion-sync
python3 validation.py        # token-free self-test — prints all 17 site records
```

Verified green: **17/17 parsed** against the current source (including after the new Stage-4c CLV-portal section was appended — the fail-loud join was unaffected).