### PR TITLE
chore(db): backport delta-only objects into SCHEMA_SQL base (snapshot parity)

### DIFF
--- a/client-acq/src/types/index.ts
+++ b/client-acq/src/types/index.ts
@@ -193,8 +193,6 @@ export interface ScoredProject {
 
 // ── Awards + compliance bridge (Phase 3, mirrors award-service.ts) ────────────
 
-export type AmiDesignation = '30' | '50' | 'market';
-// The persisted designation also allows '60'; kept as a union for the grid.
 export type UnitDesignation = '30' | '50' | '60' | 'market';
 export type AwardStatus = 'reserved' | 'placed_in_service' | 'in_service' | 'closed';
 

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -33,6 +33,11 @@ CREATE TYPE application_status AS ENUM (
   -- 'screening' once a verdict lands. Distinguishes "pending capture" from
   -- "screening running" so the screening_review HOLD queue stays clean.
   'awaiting_identity',
+  -- Consumer reports (Checkr background + TransUnion credit, 2026-06-01): the
+  -- applicant authorizes + completes the CRA's hosted flow; the verdict arrives
+  -- by webhook, which advances this to 'screening'. Like 'awaiting_identity',
+  -- separates "pending capture" from "screening running" for a clean HOLD queue.
+  'awaiting_consumer_report',
   'screening',
   'screening_passed',
   'screening_failed',
@@ -376,9 +381,20 @@ CREATE TABLE IF NOT EXISTS properties (
   is_qct BOOLEAN NOT NULL DEFAULT false,
   is_dda BOOLEAN NOT NULL DEFAULT false,
 
+  -- Geocoordinates (2026-05-22-property-geo.sql): one shared dataset for the
+  -- statewide map + /discover funnel. Nullable; backfilled by seed-property-geo.ts.
+  latitude  DOUBLE PRECISION,
+  longitude DOUBLE PRECISION,
+
   created_at TIMESTAMPTZ DEFAULT NOW(),
   updated_at TIMESTAMPTZ DEFAULT NOW()
 );
+
+-- Markers API (GET /api/applicants/properties/map) only returns rows with both
+-- coords set; this partial index keeps that scan cheap as the catalog grows.
+CREATE INDEX IF NOT EXISTS idx_properties_geo
+  ON properties (latitude, longitude)
+  WHERE latitude IS NOT NULL AND longitude IS NOT NULL;
 
 -- Tenant Applications
 CREATE TABLE IF NOT EXISTS applications (
@@ -456,6 +472,17 @@ CREATE TABLE IF NOT EXISTS applications (
   identity_session_id TEXT,
   identity_session_status TEXT,
   identity_session_created_at TIMESTAMPTZ,
+
+  -- Consumer-report (Checkr background + TransUnion credit) async references
+  -- (2026-06-01-applications-consumer-report.sql). Persist ONLY report-reference
+  -- ids + categorical statuses + the applicant authorization timestamp — never
+  -- charge narratives, tradelines, addresses, or full DOB/SSN (those live on the
+  -- CRA). Mapped verdicts land in the background_check_*/credit_check_* columns.
+  background_report_id              TEXT,
+  credit_report_id                 TEXT,
+  consumer_report_background_status TEXT,
+  consumer_report_credit_status     TEXT,
+  screening_authorization_at        TIMESTAMPTZ,
 
   background_check_result screening_result,
   background_check_details JSONB,


### PR DESCRIPTION
## What

Finishes the schema.ts ↔ migrations convergence story (closed in #257/#268) by making `SCHEMA_SQL` a true self-contained snapshot. Two deltas were never folded into the base table definitions, so anyone reading `schema.ts` to learn "what a fresh DB looks like" got an incomplete picture.

Backported into `src/db/schema.ts`:
- **properties:** `latitude` / `longitude` (`DOUBLE PRECISION`) + `idx_properties_geo` partial index — from `2026-05-22-property-geo.sql`
- **applications:** 5 consumer-report reference columns (`background_report_id`, `credit_report_id`, `consumer_report_background_status`, `consumer_report_credit_status`, `screening_authorization_at`) — from `2026-06-01-applications-consumer-report.sql`
- **application_status enum:** `'awaiting_consumer_report'` — same delta

Also removed the **dead** `AmiDesignation` type in `client-acq/src/types/index.ts` (unused; it omitted `'60'`). All real UI code uses `UnitDesignation`, which already carries the full 4-value union. The backend `compliance-bridge.ts` `AmiDesignation` is a separate, correct, in-use type and is **untouched**.

## Why it's safe (behavior-neutral)

`migrate up` runs `SCHEMA_SQL` first, then tracked deltas with `IF NOT EXISTS` / `ADD VALUE IF NOT EXISTS` guards. Every provisioned DB (including prod) already has these objects; this PR only changes what a `SCHEMA_SQL`-only provision contains, and the deltas still run after → identical end state. Same convergence pattern as #268.

## Verification (local)

- `tsc --noEmit` clean — root **and** client-acq
- **Parity proof:** applied `SCHEMA_SQL` *only* (no deltas) to a fresh DB → all backported objects present (geo cols, 5 consumer-report cols with correct types, the enum value, the index)
- **End-to-end:** full `migrate up` on a fresh DB → 35/35 deltas applied, `status` = **0 pending**, second run idempotent (the two now-also-in-base deltas no-op cleanly)

No prod action required — prod already has all of this; this is source-hygiene only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)