### PR TITLE
feat(screening): TransUnion ShareAble credit adapter — real outbound + inbound webhook (Chunk 4)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -269,6 +269,8 @@ CONSUMER_REPORT_ENABLED=false
 # TransUnion ShareAble (credit/eviction). Signed contract + sandbox key required.
 # TRANSUNION_SHAREABLE_API_KEY=
 # TRANSUNION_SHAREABLE_WEBHOOK_SECRET=
+# TRANSUNION_SHAREABLE_API_URL=https://api.shareable.com  # default; override per sandbox
+# TRANSUNION_SHAREABLE_PRODUCT_BUNDLE=credit_eviction     # account-specific bundle slug
 # Shared CRA webhook signing secret (the receiver self-gates 503 until this is
 # set; the synthetic-payload tests set it to exercise the path).
 # CRA_WEBHOOK_SECRET=

--- a/src/__tests__/cra-webhook.test.ts
+++ b/src/__tests__/cra-webhook.test.ts
@@ -426,3 +426,150 @@ describe("POST /webhook — real Checkr path (X-Checkr-Signature)", () => {
     );
   });
 });
+
+describe("POST /webhook — real TransUnion ShareAble path (X-ShareAble-Signature)", () => {
+  const SHAREABLE_SECRET = "shareable_whsec_test";
+  const REQUEST_ID = "req_abc123";
+  const originalSecret = process.env.TRANSUNION_SHAREABLE_WEBHOOK_SECRET;
+  const originalKey = process.env.TRANSUNION_SHAREABLE_API_KEY;
+
+  afterAll(() => {
+    process.env.TRANSUNION_SHAREABLE_WEBHOOK_SECRET = originalSecret;
+    process.env.TRANSUNION_SHAREABLE_API_KEY = originalKey;
+  });
+
+  beforeEach(() => {
+    // Override the SQL mock so the ShareAble screening-request id resolves to our
+    // application (via credit_report_id), dedup misses, persist hits, and only the
+    // credit report has landed (no advance) by default.
+    process.env.TRANSUNION_SHAREABLE_WEBHOOK_SECRET = SHAREABLE_SECRET;
+    delete process.env.TRANSUNION_SHAREABLE_API_KEY;
+    mockQuery.mockImplementation((sql: any, params?: any) => {
+      const s = String(sql);
+      if (/credit_report_id = \$1/i.test(s)) {
+        // translateShareAbleEvent: request_id → application id.
+        return Promise.resolve({
+          rows: params?.[0] === REQUEST_ID ? [{ id: APP_ID }] : [],
+        }) as any;
+      }
+      if (/cra_processed_events/i.test(s) && /SELECT/i.test(s)) return Promise.resolve({ rows: [] }) as any;
+      if (/UPDATE applications SET/i.test(s) && /RETURNING id/i.test(s)) return Promise.resolve({ rows: [{ id: APP_ID }] }) as any;
+      if (/FROM applications a/i.test(s) && /LEFT JOIN users/i.test(s)) {
+        return Promise.resolve({
+          rows: [
+            {
+              status: "awaiting_consumer_report",
+              background_check_completed_at: null, // only the CREDIT report in
+              credit_check_completed_at: new Date(),
+              submitted_by: "99999999-8888-7777-6666-555555555555",
+              submitter_role: "applicant",
+            },
+          ],
+        }) as any;
+      }
+      return Promise.resolve({ rows: [] }) as any;
+    });
+  });
+
+  // A real ShareAble event envelope: { id, type, data: { object } }. The object
+  // carries request_id (our join key) + the categorical credit report fields.
+  function shareAbleEvent(type: string, objectOverrides: Record<string, unknown> = {}) {
+    return {
+      id: `tu_evt_${type}`,
+      type,
+      data: {
+        object: {
+          report_id: "rep_tu_1",
+          request_id: REQUEST_ID,
+          creditScore: 700,
+          evictions: [],
+          bankruptcies: [],
+          collections: [],
+          ...objectOverrides,
+        },
+      },
+    };
+  }
+
+  // Post on the ShareAble path. Default = a valid HMAC-SHA256 hex signature over
+  // the raw body; `sign:false` sends a present-but-invalid signature.
+  function shareAblePost(event: object, opts: { sign?: boolean } = {}) {
+    const raw = JSON.stringify(event);
+    const sig =
+      opts.sign === false
+        ? "deadbeef"
+        : crypto.createHmac("sha256", SHAREABLE_SECRET).update(raw).digest("hex");
+    return request(app)
+      .post("/webhook")
+      .set("Content-Type", "application/json")
+      .set("x-shareable-signature", sig)
+      .send(raw);
+  }
+
+  it("503 when neither webhook secret nor API key is set (fail-closed)", async () => {
+    delete process.env.TRANSUNION_SHAREABLE_WEBHOOK_SECRET;
+    delete process.env.TRANSUNION_SHAREABLE_API_KEY;
+    const res = await shareAblePost(shareAbleEvent("report.completed"));
+    expect(res.status).toBe(503);
+  });
+
+  it("401 on an invalid X-ShareAble-Signature (never trust an unverified payload)", async () => {
+    const res = await shareAblePost(shareAbleEvent("report.completed"), { sign: false });
+    expect(res.status).toBe(401);
+  });
+
+  it("accepts a sha256= prefixed signature", async () => {
+    const raw = JSON.stringify(shareAbleEvent("report.completed"));
+    const hex = crypto.createHmac("sha256", SHAREABLE_SECRET).update(raw).digest("hex");
+    const res = await request(app)
+      .post("/webhook")
+      .set("Content-Type", "application/json")
+      .set("x-shareable-signature", `sha256=${hex}`)
+      .send(raw);
+    expect(res.status).toBe(200);
+  });
+
+  it("report.completed + known request → resolves application, persists credit verdict, 200", async () => {
+    const res = await shareAblePost(shareAbleEvent("report.completed"));
+    expect(res.status).toBe(200);
+    // request_id was looked up via credit_report_id...
+    const resolved = mockQuery.mock.calls.find((c) => /credit_report_id = \$1/i.test(String(c[0])));
+    expect(resolved).toBeTruthy();
+    expect((resolved![1] as any[])[0]).toBe(REQUEST_ID);
+    // ...and the mapped verdict persisted, guarded to awaiting_consumer_report.
+    const persist = mockQuery.mock.calls.find(
+      (c) => /UPDATE applications SET/i.test(String(c[0])) && /credit_check_details/i.test(String(c[0]))
+    );
+    expect(persist).toBeTruthy();
+    expect(String(persist![0])).toMatch(/status = 'awaiting_consumer_report'/);
+  });
+
+  it("unknown request id → 200 ignored, no persist (ShareAble would otherwise retry)", async () => {
+    const res = await shareAblePost(shareAbleEvent("report.completed", { request_id: "req_unknown" }));
+    expect(res.status).toBe(200);
+    expect(res.body.ignored).toBe(true);
+    const persisted = mockQuery.mock.calls.some(
+      (c) => /UPDATE applications SET/i.test(String(c[0])) && /RETURNING id/i.test(String(c[0]))
+    );
+    expect(persisted).toBe(false);
+  });
+
+  it("an unhandled event type (applicant.created) → 200 ignored, no side effects", async () => {
+    const res = await shareAblePost(shareAbleEvent("applicant.created"));
+    expect(res.status).toBe(200);
+    expect(res.body.ignored).toBe(true);
+    expect(mockTransition).not.toHaveBeenCalled();
+  });
+
+  it("report.canceled → terminal HOLD in screening_review (never auto-pass)", async () => {
+    const res = await shareAblePost(shareAbleEvent("report.canceled"));
+    expect(res.status).toBe(200);
+    await flush();
+    expect(mockTransition).toHaveBeenCalledWith(
+      expect.objectContaining({ to: "screening_review", trigger: "could_not_screen" })
+    );
+    expect(mockTransition).not.toHaveBeenCalledWith(
+      expect.objectContaining({ to: "screening" })
+    );
+  });
+});

--- a/src/__tests__/credit-check-cra.test.ts
+++ b/src/__tests__/credit-check-cra.test.ts
@@ -6,9 +6,11 @@
  *     output; eviction + bankruptcy counts; score + payment-history derivation.
  *   - resolve(): reads the webhook-persisted verdict; could_not_screen HOLD when
  *     no report / pending / wrong shape / lookup throws; re-runs evaluateResults.
- *   - createReport(): fail-loud throw until credentialing exists.
+ *   - createReport(): keyless → fail-loud throw (no fabricated handle); keyed →
+ *     real ShareAble applicant + screening-request flow over a mocked fetch.
  *
- * No network / no real DB: ../config/database query is mocked.
+ * No network / no real DB: ../config/database query is mocked; the keyed
+ * createReport tests mock global fetch.
  */
 
 const mockQuery = jest.fn();
@@ -25,6 +27,10 @@ describe("CreditCheckService — TransUnion ShareAble CRA mapping", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     svc = new CreditCheckService();
+    // Keep the keyless createReport contract test deterministic even if a sibling
+    // test file in the same worker left the key set. The keyed describe re-sets it
+    // in its own beforeEach (runs after this one).
+    delete process.env.TRANSUNION_SHAREABLE_API_KEY;
   });
 
   describe("mapShareAbleReportToResponse", () => {
@@ -184,6 +190,97 @@ describe("CreditCheckService — TransUnion ShareAble CRA mapping", () => {
           dateOfBirth: "1990-01-01",
         })
       ).rejects.toThrow(/not yet configured/i);
+    });
+  });
+
+  describe("createReport — keyed (real ShareAble two-step over mocked fetch)", () => {
+    const realFetch = global.fetch;
+    let fetchMock: jest.Mock;
+
+    beforeEach(() => {
+      // Outer beforeEach deletes the key and runs FIRST; arm it here.
+      process.env.TRANSUNION_SHAREABLE_API_KEY = "tu_test_abc";
+      delete process.env.TRANSUNION_SHAREABLE_API_URL;
+      delete process.env.TRANSUNION_SHAREABLE_PRODUCT_BUNDLE;
+      fetchMock = jest.fn();
+      (global as any).fetch = fetchMock;
+    });
+    afterEach(() => {
+      (global as any).fetch = realFetch;
+      delete process.env.TRANSUNION_SHAREABLE_API_KEY;
+    });
+
+    const ok = (body: unknown) => ({ ok: true, status: 200, json: async () => body });
+
+    const input = {
+      applicationId: "app-1",
+      firstName: "Sam",
+      lastName: "Lee",
+      ssnLast4: "6789",
+      dateOfBirth: "1990-01-01",
+      email: "sam@example.com",
+    };
+
+    it("applicant → screening-request; returns request.id as the webhook join key", async () => {
+      fetchMock
+        .mockResolvedValueOnce(ok({ id: "appl_123" }))
+        .mockResolvedValueOnce(
+          ok({ id: "req_456", exam_url: "https://exam.shareable.com/x", status: "pending" })
+        );
+
+      const handle = await svc.createReport(input);
+
+      // request.id is the durable join key (the report id does not exist yet).
+      expect(handle.reportId).toBe("req_456");
+      expect(handle.url).toBe("https://exam.shareable.com/x");
+      expect(handle.status).toBe("pending");
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+
+      const [applUrl, applOpts] = fetchMock.mock.calls[0];
+      expect(String(applUrl)).toMatch(/\/v1\/applicants$/);
+      expect((applOpts.headers as any).Authorization).toBe("Bearer tu_test_abc");
+      const applBody = JSON.parse(applOpts.body);
+      expect(applBody.email).toBe("sam@example.com");
+      expect(applBody.first_name).toBe("Sam");
+      expect(applBody.date_of_birth).toBe("1990-01-01");
+      // Full SSN / last-4 are NEVER sent — the hosted KBA exam collects it.
+      expect(applBody.ssn).toBeUndefined();
+      expect(applBody.ssn_last4).toBeUndefined();
+      expect(JSON.stringify(applBody)).not.toContain("6789");
+
+      const [reqUrl, reqOpts] = fetchMock.mock.calls[1];
+      expect(String(reqUrl)).toMatch(/\/v1\/screening-requests$/);
+      expect(JSON.parse(reqOpts.body).applicant_id).toBe("appl_123");
+    });
+
+    it("missing email → fail-loud throw, no applicant created", async () => {
+      await expect(
+        svc.createReport({ ...input, email: undefined })
+      ).rejects.toThrow(/requires an email/i);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("applicant create returns no id → throws (no phantom order)", async () => {
+      fetchMock.mockResolvedValueOnce(ok({}));
+      await expect(svc.createReport(input)).rejects.toThrow(/applicant create returned no id/i);
+      expect(fetchMock).toHaveBeenCalledTimes(1); // never reached the screening request
+    });
+
+    it("screening-request returns no id → throws (no phantom order)", async () => {
+      fetchMock
+        .mockResolvedValueOnce(ok({ id: "appl_123" }))
+        .mockResolvedValueOnce(ok({ exam_url: "https://exam" }));
+      await expect(svc.createReport(input)).rejects.toThrow(/screening request returned no id/i);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it("non-2xx from ShareAble → fail-loud throw with categorical detail", async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: false,
+        status: 422,
+        json: async () => ({ error: "bad bundle" }),
+      });
+      await expect(svc.createReport(input)).rejects.toThrow(/ShareAble.*failed.*bad bundle/i);
     });
   });
 });

--- a/src/modules/application/service.ts
+++ b/src/modules/application/service.ts
@@ -391,6 +391,7 @@ export class ApplicationService {
             lastName: a.last_name,
             ssnLast4,
             dateOfBirth: dob,
+            email: a.email,
             returnUrl,
           }),
         ]);

--- a/src/modules/screening/cra-webhook.ts
+++ b/src/modules/screening/cra-webhook.ts
@@ -24,22 +24,27 @@ import { CreditCheckService } from "./credit-check";
  * are CAS-guarded on `status = 'awaiting_consumer_report'` so a late/duplicate
  * delivery after the app already advanced is a no-op.
  *
- * TWO RECEIVE PATHS, selected by header:
+ * THREE RECEIVE PATHS, selected by header:
  *   - REAL CHECKR (`X-Checkr-Signature` present): HMAC-SHA256 verify against
  *     CHECKR_WEBHOOK_SECRET (or CHECKR_API_KEY), then translate Checkr's
  *     `{ id, type, data: { object } }` event — resolving our application by the
  *     report/invitation `candidate_id` (createReport persisted candidate.id as
  *     background_report_id, since the invitation flow yields no report id at
  *     create time). Built + tested here; arms when the secret is set.
+ *   - REAL TRANSUNION SHAREABLE (`X-ShareAble-Signature` present): HMAC-SHA256
+ *     verify against TRANSUNION_SHAREABLE_WEBHOOK_SECRET (or the API key), then
+ *     translate ShareAble's `{ id, type, data: { object } }` event — resolving
+ *     our application by the screening-request id (createReport persisted
+ *     request.id as credit_report_id, since no report id exists until the
+ *     applicant passes the hosted KBA exam). Built + tested here; arms when the
+ *     secret is set. CREDENTIALING-GATED shape: the exact header, digest, event
+ *     vocabulary, and object fields are confirmed against a live sandbox at arm
+ *     time (TODO(credentialing) markers below).
  *   - SYNTHETIC (`x-cra-signature` present): a TEST-ONLY fixture envelope the
  *     unit tests post. It carries NO per-vendor HMAC, so it is gated to
  *     NODE_ENV=test and is unreachable (404) in any deployed environment — see
  *     the router below. Real vendors sign their payloads (Checkr above;
- *     TransUnion credit with the Chunk-4 adapter).
- *
- * STILL CREDENTIALING-GATED: the TransUnion ShareAble credit event envelope +
- * its signing scheme (the credit half of `parseEnvelope`/dispatch is wired, but
- * the real TU webhook translation lands with the Chunk-4 credit adapter).
+ *     TransUnion credit, this adapter).
  *
  * Error handling: any throw during dispatch parks the payload in `cra_webhook_dlq`
  * and returns 200 — we NEVER 5xx a CRA (it would just retry the broken event).
@@ -249,6 +254,103 @@ async function translateCheckrEvent(body: unknown): Promise<CraEventEnvelope | n
   // candidate id so the envelope always carries a stable reference.
   const reportId = typeof object.id === "string" ? object.id : candidateId;
   return { id, domain: "background", applicationId, reportId, status, report: object };
+}
+
+/**
+ * Verify TransUnion ShareAble's `X-ShareAble-Signature` — HMAC-SHA256 of the RAW
+ * request body, keyed by the ShareAble webhook secret (or the API key), hex
+ * encoded. Constant-time compare; an optional `sha256=` prefix is tolerated. A
+ * SEPARATE fn from verifyCheckrSignature so the per-vendor scheme can diverge —
+ * malformed input → false (reject), never throws.
+ * TODO(credentialing): confirm ShareAble's signature header + digest/encoding.
+ */
+function verifyShareAbleSignature(rawBody: Buffer, header: string, secret: string): boolean {
+  const provided = header.startsWith("sha256=") ? header.slice(7) : header;
+  const expected = crypto.createHmac("sha256", secret).update(rawBody).digest("hex");
+  let a: Buffer;
+  try {
+    a = Buffer.from(provided, "hex");
+  } catch {
+    return false;
+  }
+  const b = Buffer.from(expected, "hex");
+  if (a.length === 0 || a.length !== b.length) return false;
+  return crypto.timingSafeEqual(a, b);
+}
+
+/**
+ * Map a TransUnion ShareAble event `type` to our categorical status. Returns null
+ * for types we don't act on (e.g. `applicant.created`, `report.created`) so they
+ * ack 200 with no side effects. Mirrors checkrEventStatus for the credit domain.
+ * TODO(credentialing): confirm ShareAble's event-type vocabulary.
+ */
+function shareAbleEventStatus(type: string): string | null {
+  switch (type) {
+    case "report.completed":
+    case "screening.completed":
+      return "complete";
+    case "report.canceled":
+    case "report.cancelled":
+    case "screening.canceled":
+      return "canceled";
+    case "report.suspended":
+      return "suspended";
+    case "report.disputed":
+      return "disputed";
+    // The applicant never passed the hosted KBA exam → terminal, HOLD.
+    case "exam.expired":
+    case "exam.failed":
+      return "canceled";
+    default:
+      return null;
+  }
+}
+
+/**
+ * Translate a real TransUnion ShareAble event (`{ id, type, data: { object } }`)
+ * into our internal CraEventEnvelope, resolving our applicationId from the
+ * object's screening-request id — createReport persisted request.id as
+ * credit_report_id (the durable join key; no report id exists until the applicant
+ * passes the KBA exam and TU assembles the report). Returns null for an event
+ * type we don't act on, a malformed object, or an unknown request (→ 200 ack,
+ * no-op).
+ * TODO(credentialing): confirm the event envelope, the request-id field on the
+ * object, and where the report data is carried.
+ */
+async function translateShareAbleEvent(body: unknown): Promise<CraEventEnvelope | null> {
+  if (!body || typeof body !== "object") return null;
+  const b = body as Record<string, any>;
+  const id = typeof b.id === "string" ? b.id : "";
+  const type = typeof b.type === "string" ? b.type : "";
+  const object = b.data && typeof b.data === "object" ? b.data.object : undefined;
+  if (!id || !object || typeof object !== "object") return null;
+
+  const status = shareAbleEventStatus(type);
+  if (!status) return null;
+
+  const requestId =
+    typeof object.request_id === "string"
+      ? object.request_id
+      : typeof object.screening_request_id === "string"
+        ? object.screening_request_id
+        : "";
+  if (!requestId) return null;
+
+  const appRes = await query(
+    `SELECT id FROM applications WHERE credit_report_id = $1 LIMIT 1`,
+    [requestId]
+  );
+  const applicationId = appRes.rows[0]?.id;
+  if (!applicationId || typeof applicationId !== "string") return null;
+
+  // The completed event carries the credit + eviction report; the mapper extracts
+  // categorical-only fields. Fall back to the object itself if the report isn't
+  // nested under `report`.
+  const report = object.report && typeof object.report === "object" ? object.report : object;
+  // The report's own id once it exists; else fall back to the request id so the
+  // envelope always carries a stable reference.
+  const reportId = typeof object.report_id === "string" ? object.report_id : requestId;
+  return { id, domain: "credit", applicationId, reportId, status, report };
 }
 
 // ── dispatch ──────────────────────────────────────────────────────────────────
@@ -531,13 +633,56 @@ router.post(
       return;
     }
 
+    // ── Real TransUnion ShareAble path — discriminated by X-ShareAble-Signature ──
+    // HMAC-verify against TRANSUNION_SHAREABLE_WEBHOOK_SECRET (or the API key)
+    // over the RAW body, then translate ShareAble's event envelope (credit domain;
+    // resolves the application by the screening-request id == credit_report_id).
+    const shareAbleSig = req.headers["x-shareable-signature"];
+    if (shareAbleSig !== undefined) {
+      const shareAbleSecret =
+        process.env.TRANSUNION_SHAREABLE_WEBHOOK_SECRET ||
+        process.env.TRANSUNION_SHAREABLE_API_KEY ||
+        "";
+      if (!shareAbleSecret || shareAbleSecret === "changeme") {
+        // Fail-closed: never trust a payload we cannot verify.
+        res.status(503).json({ error: "TransUnion ShareAble webhook secret not configured" });
+        return;
+      }
+      if (
+        Array.isArray(shareAbleSig) ||
+        !verifyShareAbleSignature(raw, shareAbleSig, shareAbleSecret)
+      ) {
+        res.status(401).json({ error: "Invalid ShareAble signature" });
+        return;
+      }
+
+      let body: unknown;
+      try {
+        body = JSON.parse(raw.toString("utf8"));
+      } catch {
+        res.status(400).json({ error: "Invalid JSON" });
+        return;
+      }
+
+      const env = await translateShareAbleEvent(body);
+      if (!env) {
+        // An event type we don't act on, a malformed object, or an unknown
+        // request → ack 200 with no side effects (ShareAble would otherwise retry).
+        res.status(200).json({ received: true, ignored: true });
+        return;
+      }
+
+      await processAndRespond(env, body, res);
+      return;
+    }
+
     // ── Synthetic path — a TEST-ONLY fixture seam ──
     // This envelope carries NO per-vendor HMAC (it predates the real Checkr path
     // above), so it is verified only by header *presence*. That is safe ONLY
     // under test: in a deployed env, once CRA_WEBHOOK_SECRET is set to arm the
     // receiver, an unauthenticated caller could forge a verdict with a crafted
     // body + any `x-cra-signature` header. Gate it to NODE_ENV=test; real
-    // vendors (Checkr above; TransUnion credit, Chunk 4) sign their payloads.
+    // vendors (Checkr + TransUnion credit above) sign their payloads.
     if (process.env.NODE_ENV !== "test") {
       res.status(404).json({ error: "Not found" });
       return;

--- a/src/modules/screening/credit-check.ts
+++ b/src/modules/screening/credit-check.ts
@@ -55,25 +55,141 @@ export class CreditCheckService {
    * Called from submit() on the armed path; returns the report reference + the
    * hosted KBA exam url the applicant must complete to authorize the pull.
    *
-   * CREDENTIALING-GATED: the real ShareAble applicant + exam + report request is
-   * a signed-contract + sandbox-key task (see
-   * docs/screening/background-credit-cra-adapter.md §4 "Credentialing-gated").
-   * Until those credentials exist the create throws — fail-loud, never a
-   * fabricated handle. submit() catches the throw and leaves the app in
-   * `submitted` (no silent screening skip).
+   * Two-step ShareAble flow (applicant-mediated — we hold ssnLast4, NOT the full
+   * SSN; ShareAble's hosted KBA exam collects the full SSN/DOB from the applicant
+   * directly, so no full SSN ever leaves us):
+   *   1. POST /v1/applicants → applicant id (name + email; DOB lifts match rate).
+   *   2. POST /v1/screening-requests → the hosted `exam_url`. ShareAble assembles
+   *      the credit + eviction report only AFTER the applicant passes the KBA
+   *      exam; the completion webhook then carries the screening-request id — our
+   *      durable join key — so we persist request.id as the report handle
+   *      (`reportId`) and the webhook resolves the application by it.
+   *
+   * KEYLESS ⇒ FAIL-LOUD: with no TRANSUNION_SHAREABLE_API_KEY the create throws
+   * (never a fabricated exam handle — that would be a phantom consumer-report
+   * order). submit() catches the throw and leaves the app in `submitted` (no
+   * silent screening skip), so flag-off / keyless is byte-identical to today.
+   *
+   * Activation: TRANSUNION_SHAREABLE_API_KEY (+ optional
+   * TRANSUNION_SHAREABLE_API_URL, TRANSUNION_SHAREABLE_PRODUCT_BUNDLE). The
+   * webhook half verifies TRANSUNION_SHAREABLE_WEBHOOK_SECRET — see cra-webhook.ts.
+   *
+   * CREDENTIALING-GATED shape: ShareAble's exact endpoints, auth scheme, the
+   * request-id field, and the exam-url field are confirmed against a live sandbox
+   * at arm time (docs/screening/background-credit-cra-adapter.md §4). The
+   * structure below follows ShareAble's documented applicant + screening-request
+   * model; each assumed path carries a TODO(credentialing) marker.
    */
-  async createReport(_input: {
+  async createReport(input: {
     applicationId: string;
     firstName: string;
     lastName: string;
     ssnLast4: string;
     dateOfBirth: string;
+    email?: string;
     returnUrl?: string;
   }): Promise<CreditReportHandle> {
-    // TODO(credentialing): replace with the real TransUnion ShareAble applicant +
-    // exam + report request once a contract is signed and the ShareAble
-    // credentials exist. The hosted exam url + report id come back from that call.
-    throw new Error("TransUnion ShareAble credit report integration not yet configured");
+    const apiKey = process.env.TRANSUNION_SHAREABLE_API_KEY || "";
+    if (!apiKey || apiKey === "changeme") {
+      // Dormant. Fail-loud, NEVER a fabricated handle — a fake exam url is a
+      // phantom order. Keep the historical message so the keyless contract test
+      // (`/not yet configured/i`) stays green.
+      throw new Error("TransUnion ShareAble credit report integration not yet configured");
+    }
+    // ShareAble needs an email to create the applicant + deliver the hosted KBA
+    // exam link. Missing email is fail-loud — we never create a half-formed
+    // applicant.
+    if (!input.email) {
+      throw new Error("TransUnion ShareAble applicant requires an email");
+    }
+
+    const base = (
+      process.env.TRANSUNION_SHAREABLE_API_URL || "https://api.shareable.com"
+    ).replace(/\/$/, "");
+    // The product bundle slug is account-specific; MUST be set to a real bundle
+    // at arm time. The default is a placeholder, not a guarantee.
+    const bundle =
+      process.env.TRANSUNION_SHAREABLE_PRODUCT_BUNDLE || "credit_eviction";
+
+    // 1) Applicant — name + email (+ DOB to lift match rate). The full SSN is
+    //    NOT sent: the hosted KBA exam collects it from the applicant directly.
+    // TODO(credentialing): confirm the applicant endpoint + field names.
+    const applicant = (await this.shareAbleFetch(base, apiKey, "/v1/applicants", {
+      first_name: input.firstName,
+      last_name: input.lastName,
+      email: input.email,
+      ...(input.dateOfBirth ? { date_of_birth: input.dateOfBirth } : {}),
+    })) as { id?: string };
+    if (!applicant?.id) {
+      throw new Error("TransUnion ShareAble applicant create returned no id");
+    }
+
+    // 2) Screening request — credit + eviction bundle. Returns the hosted KBA
+    //    exam url + the request id (our durable webhook join key; no report id
+    //    exists until the applicant passes the exam and TU assembles the report).
+    // TODO(credentialing): confirm the screening-request endpoint, the request-id
+    // field, and the hosted exam-url field.
+    const request = (await this.shareAbleFetch(
+      base,
+      apiKey,
+      "/v1/screening-requests",
+      {
+        applicant_id: applicant.id,
+        products: [bundle],
+        ...(input.returnUrl ? { return_url: input.returnUrl } : {}),
+      }
+    )) as { id?: string; exam_url?: string; status?: string };
+    if (!request?.id) {
+      throw new Error("TransUnion ShareAble screening request returned no id");
+    }
+
+    return {
+      // request.id (NOT the not-yet-existent report id) is the webhook join key.
+      reportId: request.id,
+      status: request.status || "pending",
+      url: request.exam_url || null,
+    };
+  }
+
+  /**
+   * POST to the TransUnion ShareAble API with a Bearer API key. Any non-2xx
+   * THROWS with a categorical detail — the submit() caller turns that into a
+   * fail-loud HOLD, never a fabricated handle. Mirrors background-check.ts's
+   * checkrFetch idiom (ShareAble uses Bearer auth rather than Checkr's HTTP
+   * Basic).
+   * TODO(credentialing): confirm ShareAble's auth scheme (Bearer vs HTTP Basic /
+   * partner-id header) against the sandbox.
+   */
+  private async shareAbleFetch(
+    base: string,
+    apiKey: string,
+    path: string,
+    body: Record<string, unknown>
+  ): Promise<unknown> {
+    const res = await fetch(`${base}${path}`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      let detail = `HTTP ${res.status}`;
+      try {
+        const err = (await res.json()) as any;
+        detail = err?.error
+          ? String(err.error)
+          : Array.isArray(err?.errors)
+            ? err.errors.join("; ")
+            : JSON.stringify(err);
+      } catch {
+        /* keep HTTP status */
+      }
+      throw new Error(`TransUnion ShareAble ${path} failed — ${detail}`);
+    }
+    return res.json();
   }
 
   /**


### PR DESCRIPTION
**Chunk 4 of 4** of the consumer-report CRA work. Stacked on #270 (Checkr background adapter, base `feat/checkr-cra-adapter`) — GitHub auto-retargets this to `main` when #270 merges. The credit half now mirrors the Chunk-3 Checkr pattern.

## What

**Outbound — `credit-check.ts` `createReport()`** replaces the fail-loud stub with the real TransUnion ShareAble two-step flow over `fetch`:
1. `POST /v1/applicants` — name + email + DOB. **No full SSN** (we hold only `ssnLast4`; ShareAble's hosted KBA exam collects the full SSN/DOB from the applicant directly).
2. `POST /v1/screening-requests` → hosted `exam_url` + the request id. We persist `request.id` as the report handle — the durable webhook join key (no report id exists until the applicant passes the KBA exam and TU assembles the report).
   - **Keyless ⇒ fail-loud** (never a fabricated handle — that's a phantom consumer-report order); missing email / no id / non-2xx all throw. `submit()` catches the throw and leaves the app in `submitted`, so flag-off/keyless stays **byte-identical** to today.
   - New private `shareAbleFetch` (Bearer auth).

**Inbound — `cra-webhook.ts`** adds the real TransUnion receive path, discriminated by `X-ShareAble-Signature`: HMAC-SHA256 verify over the raw body against `TRANSUNION_SHAREABLE_WEBHOOK_SECRET` (or the API key), then `translateShareAbleEvent` resolves the app by the screening-request id (`== credit_report_id`), `domain: "credit"`. `503` fail-closed unconfigured, `401` bad signature, `200`-ignored for unknown/unhandled events. The map→persist→advance/HOLD dispatch was already credit-aware (Chunk 3).

**Wiring — `service.ts`** passes `email` into the credit `createReport` call (required by ShareAble to create the applicant + deliver the exam link).

**Env** — documents `TRANSUNION_SHAREABLE_API_URL` + `_PRODUCT_BUNDLE` alongside the existing `_API_KEY` + `_WEBHOOK_SECRET`.

## PII discipline
Only `ssnLast4` is ever held; the hosted exam collects the full SSN/DOB. The mapper persists categorical/integer summary fields only — never tradeline detail, account numbers, creditor names, or addresses.

## Tests
- +6 keyed `createReport` tests (applicant→request happy path, never-SSN, missing-email / no-id / non-2xx throws).
- Full `X-ShareAble-Signature` webhook-path describe (503 / 401 / `sha256=` prefix / completed-persist / unknown-ignored / unhandled-ignored / canceled→HOLD).
- `tsc` clean; **118/118** across the four affected suites (`credit-check-cra`, `cra-webhook`, `background-check-cra`, `application-service`).

## Credentialing-gated
ShareAble's exact endpoints, auth scheme, request-id field, exam-url field, signature header + event vocabulary are **assumed** and confirmed against a live sandbox at arm time — each assumed path carries a `TODO(credentialing)` marker (same precedent as the Work Number adapter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)