### PR TITLE
chore(notion-sync): scripted, idempotent installer for the daily GPMG NV Parcels sync cron

### DIFF
--- a/docs/intel/notion-sync/README.md
+++ b/docs/intel/notion-sync/README.md
@@ -59,9 +59,41 @@ python3 validation.py         # parses the .md, prints the 17 site records, fail
 The parser refuses to emit a partial/empty result: if either source table changes
 shape it raises `ValidationParseError` rather than silently syncing 0 rows.
 
+## Daily cron (macOS / launchd)
+
+One command installs an unattended daily sync:
+
+```bash
+NOTION_TOKEN=ntn_… ./install-cron.sh        # idempotent; --run to also kick one now
+```
+
+It reproduces the whole "worktree dance":
+
+1. a **dedicated detached worktree** pinned to `origin/main` at `~/.frank-notion-sync/worktree`
+   — the unattended `--apply` always runs against **committed** main, never an
+   interactive working tree, so it can't push half-finished edits to the live DB;
+2. your `NOTION_TOKEN` written to that worktree's gitignored `.env` (chmod 600, never
+   echoed) — and the script refuses to continue unless the `.env` is gitignored;
+3. the version-controlled `cron-run.sh` wrapper copied to `~/.frank-notion-sync/run.sh`
+   (kept **outside** the worktree so a `git reset --hard` mid-run can't rewrite it);
+4. a launchd LaunchAgent (`com.a13x.frank-notion-sync`) firing daily at 07:00 local.
+
+Each run does `git fetch && reset --hard origin/main` then `python3 sync.py --apply`,
+logging to `~/.frank-notion-sync/sync.log` (capped at 1000 lines).
+
+```bash
+./install-cron.sh --uninstall                # remove agent + worktree + ~/.frank-notion-sync
+launchctl kickstart -k gui/$(id -u)/com.a13x.frank-notion-sync   # run now
+launchctl bootout   gui/$(id -u)/com.a13x.frank-notion-sync      # disable
+```
+
+Overrides: `SYNC_HOME`, `SYNC_LABEL`, `SYNC_HOUR`, `SYNC_MINUTE`.
+
 ## Files
 
 - `validation.py` — fail-loud parser for the two source tables (Stage 4b matrix +
   Stage 4 evidence), joined by building name.
 - `notion.py` — stdlib Notion REST client (2025-09-03 data_source API).
 - `sync.py` — orchestrator: parse → match by APN → diff → patch owned fields.
+- `cron-run.sh` — the daily wrapper launchd runs (refresh worktree → `sync.py --apply`).
+- `install-cron.sh` — idempotent installer/uninstaller for the launchd agent.

--- a/docs/intel/notion-sync/cron-run.sh
+++ b/docs/intel/notion-sync/cron-run.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Daily repo→Notion sync for the private GPMG NV Parcels DB.
+#
+# install-cron.sh copies this file to $SYNC_HOME/run.sh (outside any worktree, so a
+# `git reset --hard` during a run can never rewrite the script mid-execution) and
+# launchd invokes it once a day.
+#
+# It syncs from COMMITTED origin/main via a dedicated detached worktree — never from
+# an interactive working tree — so the unattended `--apply` can't push half-finished
+# edits to the live source-of-truth DB. The NOTION_TOKEN lives in that worktree's
+# gitignored docs/intel/notion-sync/.env. sync.py --apply writes only the OWNED auto
+# fields, skips any `Sync source=manual` row, and is idempotent (0 writes when
+# nothing changed).
+set -uo pipefail
+export PATH="/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin:/opt/homebrew/bin"
+
+# ROOT = the dir this script lives in ($SYNC_HOME), so it is location-independent.
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WT="$ROOT/worktree"
+LOG="$ROOT/sync.log"
+
+ts()  { date '+%Y-%m-%dT%H:%M:%S%z'; }
+log() { echo "[$(ts)] $*" >> "$LOG"; }
+
+log "── run start ──"
+cd "$WT" || { log "FATAL: worktree $WT missing — re-run install-cron.sh"; exit 1; }
+
+# Refresh to committed main. Untracked .env survives `reset --hard` (only `clean` removes it).
+if git fetch -q origin main 2>>"$LOG"; then
+  git reset --hard -q origin/main 2>>"$LOG" || log "WARN: reset --hard failed"
+  log "worktree @ origin/main $(git rev-parse --short HEAD)"
+else
+  log "WARN: git fetch failed — running last-known checkout $(git rev-parse --short HEAD)"
+fi
+
+cd docs/intel/notion-sync || { log "FATAL: notion-sync dir missing at $(pwd)"; exit 1; }
+/usr/bin/python3 sync.py --apply >>"$LOG" 2>&1
+rc=$?
+log "── run end (exit $rc) ──"
+
+# keep the log bounded
+tail -n 1000 "$LOG" > "$LOG.tmp" 2>/dev/null && mv "$LOG.tmp" "$LOG"
+exit $rc

--- a/docs/intel/notion-sync/install-cron.sh
+++ b/docs/intel/notion-sync/install-cron.sh
@@ -1,0 +1,142 @@
+#!/bin/bash
+# Idempotent installer for the daily GPMG NV Parcels repo→Notion sync (macOS/launchd).
+#
+# Reproduces the full "worktree dance" so the unattended sync is safe by construction:
+#   1. a dedicated DETACHED git worktree pinned to origin/main — the sync always runs
+#      against COMMITTED main, never an interactive working tree, so it can't push
+#      half-finished edits to the private source-of-truth DB
+#   2. the NOTION_TOKEN dropped into that worktree's gitignored .env (chmod 600)
+#   3. the version-controlled cron-run.sh wrapper copied to $SYNC_HOME/run.sh
+#   4. a launchd LaunchAgent that fires the wrapper once a day
+#
+# Re-running is safe: an existing worktree / .env is left in place, the wrapper and
+# plist are refreshed, and the agent is reloaded.
+#
+# Usage:
+#   NOTION_TOKEN=ntn_… ./install-cron.sh           # install / reconcile
+#   SYNC_HOUR=6 NOTION_TOKEN=… ./install-cron.sh    # custom hour (default 7, local)
+#   NOTION_TOKEN=… ./install-cron.sh --run          # install, then kick one run now
+#   ./install-cron.sh --uninstall                   # remove agent + worktree + $SYNC_HOME
+#
+# Env overrides: SYNC_HOME (~/.frank-notion-sync), SYNC_LABEL
+# (com.a13x.frank-notion-sync), SYNC_HOUR (7), SYNC_MINUTE (0).
+#
+# The token is read from $NOTION_TOKEN and written straight to the .env — it is never
+# echoed, logged, or passed on a command line.
+set -euo pipefail
+
+[ "$(uname)" = "Darwin" ] || { echo "ERROR: launchd setup is macOS-only." >&2; exit 1; }
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+
+SYNC_HOME="${SYNC_HOME:-$HOME/.frank-notion-sync}"
+SYNC_LABEL="${SYNC_LABEL:-com.a13x.frank-notion-sync}"
+SYNC_HOUR="${SYNC_HOUR:-7}"
+SYNC_MINUTE="${SYNC_MINUTE:-0}"
+WT="$SYNC_HOME/worktree"
+PLIST="$HOME/Library/LaunchAgents/$SYNC_LABEL.plist"
+DOMAIN="gui/$(id -u)"
+
+uninstall() {
+  echo "Uninstalling $SYNC_LABEL …"
+  launchctl bootout "$DOMAIN/$SYNC_LABEL" 2>/dev/null || true
+  rm -f "$PLIST"
+  if git -C "$REPO_ROOT" worktree list --porcelain 2>/dev/null | grep -Fxq "worktree $WT"; then
+    git -C "$REPO_ROOT" worktree remove --force "$WT" 2>/dev/null || true
+  fi
+  rm -rf "$SYNC_HOME"
+  echo "Removed agent, worktree, and $SYNC_HOME."
+}
+
+if [ "${1:-}" = "--uninstall" ]; then uninstall; exit 0; fi
+
+mkdir -p "$SYNC_HOME" "$(dirname "$PLIST")"
+
+# 1. worktree pinned to origin/main (idempotent) ------------------------------
+git -C "$REPO_ROOT" fetch -q origin main
+if git -C "$REPO_ROOT" worktree list --porcelain | grep -Fxq "worktree $WT"; then
+  echo "✓ worktree exists: $WT"
+else
+  git -C "$REPO_ROOT" worktree add --detach "$WT" origin/main
+  echo "✓ created worktree pinned to origin/main: $WT"
+fi
+
+# 2. token → worktree's gitignored .env (never clobber an existing one) --------
+ENVF="$WT/docs/intel/notion-sync/.env"
+if [ -f "$ENVF" ]; then
+  echo "✓ .env already present — leaving it"
+elif [ -n "${NOTION_TOKEN:-}" ]; then
+  printf 'NOTION_TOKEN=%s\n' "$NOTION_TOKEN" > "$ENVF"
+  chmod 600 "$ENVF"
+  echo "✓ wrote NOTION_TOKEN → .env (600)"
+else
+  echo "ERROR: $ENVF missing and \$NOTION_TOKEN not set." >&2
+  echo "  Export an internal-integration token connected to the GPMG NV Parcels page, then re-run:" >&2
+  echo "    NOTION_TOKEN=ntn_… $0" >&2
+  exit 1
+fi
+# belt-and-suspenders: the .env must be gitignored so a stray `git add` can't commit it
+if ! git -C "$WT" check-ignore -q docs/intel/notion-sync/.env; then
+  echo "ERROR: .env is NOT gitignored — refusing to proceed (would risk committing the token)." >&2
+  exit 1
+fi
+echo "✓ .env confirmed gitignored"
+
+# 3. wrapper → $SYNC_HOME/run.sh (outside the worktree, never reset mid-run) ---
+cp "$SCRIPT_DIR/cron-run.sh" "$SYNC_HOME/run.sh"
+chmod +x "$SYNC_HOME/run.sh"
+echo "✓ installed wrapper: $SYNC_HOME/run.sh"
+
+# 4. launchd plist ------------------------------------------------------------
+cat > "$PLIST" <<PLIST_EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>$SYNC_LABEL</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>$SYNC_HOME/run.sh</string>
+    </array>
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>$SYNC_HOUR</integer>
+        <key>Minute</key>
+        <integer>$SYNC_MINUTE</integer>
+    </dict>
+    <key>RunAtLoad</key>
+    <false/>
+    <key>StandardOutPath</key>
+    <string>$SYNC_HOME/launchd.out.log</string>
+    <key>StandardErrorPath</key>
+    <string>$SYNC_HOME/launchd.err.log</string>
+    <key>ProcessType</key>
+    <string>Background</string>
+</dict>
+</plist>
+PLIST_EOF
+plutil -lint "$PLIST" >/dev/null
+echo "✓ wrote plist: $PLIST"
+
+# (re)load the agent
+launchctl bootout "$DOMAIN/$SYNC_LABEL" 2>/dev/null || true
+launchctl bootstrap "$DOMAIN" "$PLIST"
+printf '✓ launchd agent loaded — fires daily %02d:%02d local\n' "$SYNC_HOUR" "$SYNC_MINUTE"
+
+if [ "${1:-}" = "--run" ]; then
+  launchctl kickstart -k "$DOMAIN/$SYNC_LABEL"
+  echo "✓ kicked a run now — tail $SYNC_HOME/sync.log"
+fi
+
+cat <<INFO
+
+Manage:
+  run now:   launchctl kickstart -k $DOMAIN/$SYNC_LABEL
+  disable:   launchctl bootout $DOMAIN/$SYNC_LABEL
+  uninstall: $0 --uninstall
+  logs:      $SYNC_HOME/sync.log   (launchd backstop: $SYNC_HOME/launchd.{out,err}.log)
+INFO


### PR DESCRIPTION
Captures the manual "worktree dance" used to stand up the daily repo→Notion sync (private GPMG NV Parcels DB) as committed, reproducible scripts.

## What
- **`cron-run.sh`** — version-controlled daily wrapper launchd invokes: refresh a dedicated detached worktree to committed `origin/main`, then `sync.py --apply`. `ROOT` derived from its own path (location-independent); installed **outside** the worktree so a `git reset --hard` mid-run can't rewrite the running script.
- **`install-cron.sh`** — idempotent macOS/launchd installer. Reproduces the dance:
  1. detached worktree pinned to `origin/main` — the unattended apply only ever runs against **committed** main, never an interactive working tree;
  2. `NOTION_TOKEN` → that worktree's gitignored `.env` (chmod 600, never echoed; **refuses to proceed unless the `.env` is gitignored**);
  3. wrapper → `~/.frank-notion-sync/run.sh`;
  4. launchd agent (`com.a13x.frank-notion-sync`), daily 07:00 local.
  Re-runnable (leaves existing worktree/`.env`, refreshes wrapper+plist+reload); supports `--run` and `--uninstall`. Overrides: `SYNC_HOME`/`SYNC_LABEL`/`SYNC_HOUR`/`SYNC_MINUTE`.
- **`README.md`** — install/uninstall/manage docs.

## Safety
- No token or `.env` is committed (`.env` stays gitignored; installer hard-fails if it isn't).
- Unattended `--apply` runs only against committed `origin/main` — can't push half-finished edits to the live source-of-truth DB.
- Sync writes only OWNED auto fields, skips any `Sync source=manual` row, idempotent.

## Verification
Reconciled the live install from these scripts and kicked a launchd run: `exit 0`, `runs = 1`, `0 changed / 17 unchanged / 0 patched`. Live `run.sh` byte-identical to the committed `cron-run.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)