### PR TITLE
feat(screening): real Checkr CRA integration (dark) — outbound + dual-path webhook

### DIFF
--- a/src/__tests__/background-check-cra.test.ts
+++ b/src/__tests__/background-check-cra.test.ts
@@ -7,9 +7,11 @@
  *     for the HUD engine.
  *   - resolve(): reads the webhook-persisted verdict; could_not_screen HOLD when
  *     no report / pending / wrong shape / lookup throws; re-runs evaluateResults.
- *   - createReport(): fail-loud throw until credentialing exists.
+ *   - createReport(): keyless → fail-loud throw (no fabricated handle); keyed →
+ *     real Checkr candidate + invitation flow over a mocked fetch.
  *
- * No network / no real DB: ../config/database query is mocked.
+ * No network / no real DB: ../config/database query is mocked; the keyed
+ * createReport tests mock global fetch.
  */
 
 const mockQuery = jest.fn();
@@ -27,6 +29,10 @@ describe("BackgroundCheckService — Checkr CRA mapping", () => {
     jest.clearAllMocks();
     svc = new BackgroundCheckService();
     delete process.env.CRIMINAL_DECISION_ENGINE_ENABLED;
+    // Keep the keyless createReport contract test deterministic even if a sibling
+    // test file in the same worker left CHECKR_API_KEY set. The keyed describe
+    // re-sets it in its own beforeEach (runs after this one).
+    delete process.env.CHECKR_API_KEY;
   });
 
   describe("mapCheckrReportToResponse", () => {

--- a/src/__tests__/background-check-cra.test.ts
+++ b/src/__tests__/background-check-cra.test.ts
@@ -205,4 +205,92 @@ describe("BackgroundCheckService — Checkr CRA mapping", () => {
       ).rejects.toThrow(/not yet configured/i);
     });
   });
+
+  describe("createReport — keyed (real Checkr two-step over mocked fetch)", () => {
+    const realFetch = global.fetch;
+    let fetchMock: jest.Mock;
+
+    beforeEach(() => {
+      // Outer beforeEach deletes CHECKR_API_KEY and runs FIRST; arm it here.
+      process.env.CHECKR_API_KEY = "ck_test_abc";
+      delete process.env.CHECKR_API_URL;
+      delete process.env.CHECKR_PACKAGE;
+      fetchMock = jest.fn();
+      (global as any).fetch = fetchMock;
+    });
+    afterEach(() => {
+      (global as any).fetch = realFetch;
+      delete process.env.CHECKR_API_KEY;
+    });
+
+    const ok = (body: unknown) =>
+      ({ ok: true, status: 200, json: async () => body });
+
+    const input = {
+      applicationId: "app-1",
+      firstName: "Sam",
+      lastName: "Lee",
+      ssnLast4: "6789",
+      dateOfBirth: "1990-01-01",
+      state: "NV",
+      email: "sam@example.com",
+    };
+
+    it("candidate → invitation; returns candidate.id as the webhook join key", async () => {
+      fetchMock
+        .mockResolvedValueOnce(ok({ id: "cand_123" }))
+        .mockResolvedValueOnce(
+          ok({ invitation_url: "https://apply.checkr.com/x", status: "pending" })
+        );
+
+      const handle = await svc.createReport(input);
+
+      // candidate.id is the durable join key (the report id does not exist yet).
+      expect(handle.reportId).toBe("cand_123");
+      expect(handle.url).toBe("https://apply.checkr.com/x");
+      expect(handle.status).toBe("pending");
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+
+      const [candUrl, candOpts] = fetchMock.mock.calls[0];
+      expect(String(candUrl)).toMatch(/\/v1\/candidates$/);
+      // HTTP Basic: base64(apiKey + ":") — empty password.
+      expect((candOpts.headers as any).Authorization).toBe(
+        "Basic " + Buffer.from("ck_test_abc:").toString("base64")
+      );
+      const candBody = JSON.parse(candOpts.body);
+      expect(candBody.email).toBe("sam@example.com");
+      expect(candBody.first_name).toBe("Sam");
+      expect(candBody.dob).toBe("1990-01-01");
+      // Full SSN / last-4 are NEVER sent — the hosted invitation collects it.
+      expect(candBody.ssn).toBeUndefined();
+      expect(candBody.ssn_last4).toBeUndefined();
+      expect(JSON.stringify(candBody)).not.toContain("6789");
+
+      const [invUrl, invOpts] = fetchMock.mock.calls[1];
+      expect(String(invUrl)).toMatch(/\/v1\/invitations$/);
+      expect(JSON.parse(invOpts.body).candidate_id).toBe("cand_123");
+    });
+
+    it("missing email → fail-loud throw, no candidate created", async () => {
+      await expect(
+        svc.createReport({ ...input, email: undefined })
+      ).rejects.toThrow(/requires an applicant email/i);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("candidate create returns no id → throws (no phantom order)", async () => {
+      fetchMock.mockResolvedValueOnce(ok({}));
+      await expect(svc.createReport(input)).rejects.toThrow(/returned no id/i);
+      expect(fetchMock).toHaveBeenCalledTimes(1); // never reached the invitation
+    });
+
+    it("non-2xx from Checkr → fail-loud throw with categorical detail", async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: false,
+        status: 422,
+        json: async () => ({ error: "bad package" }),
+      });
+      await expect(svc.createReport(input)).rejects.toThrow(/Checkr.*failed.*bad package/i);
+    });
+  });
 });

--- a/src/__tests__/cra-webhook-checkr.test.ts
+++ b/src/__tests__/cra-webhook-checkr.test.ts
@@ -243,3 +243,60 @@ describe("POST /webhook — Checkr idempotency", () => {
     expect(persisted).toBe(false);
   });
 });
+
+describe("POST /webhook — Checkr DLQ PII discipline", () => {
+  // The raw Checkr report carries PII (charge narratives, full DOB/SSN). On a
+  // dispatch failure the DLQ must park ONLY the categorical envelope — never
+  // env.report — per the cra_webhook_dlq.raw_payload contract.
+  const PII_CHARGE = "POSSESSION_NARRATIVE_DO_NOT_PARK";
+  const PII_SSN = "123-45-6789";
+  const PII_DOB = "1990-01-01";
+
+  it("parks the categorical envelope, NOT the raw report PII, when dispatch throws", async () => {
+    mockQuery.mockImplementation((sql: any) => {
+      const s = String(sql);
+      if (/cra_processed_events/i.test(s) && /SELECT/i.test(s)) return Promise.resolve({ rows: [] }) as any;
+      if (/SELECT id FROM applications WHERE background_report_id/i.test(s)) {
+        return Promise.resolve({ rows: [{ id: APP_ID }] }) as any;
+      }
+      // Force the verdict persist to fail → dispatch throws → DLQ path.
+      if (/UPDATE applications SET/i.test(s) && /background_check_details/i.test(s)) {
+        return Promise.reject(new Error("db write boom")) as any;
+      }
+      if (/INSERT INTO\s+cra_webhook_dlq/i.test(s)) return Promise.resolve({ rows: [] }) as any;
+      if (/cra_webhook_dlq/i.test(s) && /COUNT/i.test(s)) return Promise.resolve({ rows: [{ count: 0 }] }) as any;
+      if (/cra_webhook_dlq/i.test(s)) return Promise.resolve({ rows: [] }) as any; // alreadyParked SELECT
+      return Promise.resolve({ rows: [] }) as any;
+    });
+
+    const event = checkrEvent("report.completed", {
+      dob: PII_DOB,
+      national_criminal_search: {
+        records: [{ classification: "Felony", charge: PII_CHARGE, ssn: PII_SSN }],
+      },
+    });
+
+    const res = await postCheckr(event);
+    expect(res.status).toBe(200); // never 5xx a CRA
+
+    const dlqInsert = mockQuery.mock.calls.find((c) =>
+      /INSERT INTO\s+cra_webhook_dlq/i.test(String(c[0]))
+    );
+    expect(dlqInsert).toBeTruthy();
+
+    const parked = (dlqInsert![1] as any[])[2] as string; // $3 = JSON.stringify(rawPayload)
+    // Raw report PII must NOT leave the CRA via the DLQ.
+    expect(parked).not.toContain(PII_CHARGE);
+    expect(parked).not.toContain(PII_SSN);
+    expect(parked).not.toContain(PII_DOB);
+    // Categorical envelope IS parked (enough to replay by re-fetching the report).
+    expect(parked).toContain(APP_ID);
+    expect(parked).toContain("complete");
+
+    // Failure path → event NOT marked processed (a retry can re-run it).
+    const marked = mockQuery.mock.calls.some((c) =>
+      /INSERT INTO cra_processed_events/i.test(String(c[0]))
+    );
+    expect(marked).toBe(false);
+  });
+});

--- a/src/__tests__/cra-webhook-checkr.test.ts
+++ b/src/__tests__/cra-webhook-checkr.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Real Checkr receive-path tests for the consumer-report CRA webhook
+ * (src/modules/screening/cra-webhook.ts). The sibling suite cra-webhook.test.ts
+ * covers the SYNTHETIC (`x-cra-signature`) envelope; this one drives the
+ * PRODUCTION path: the `X-Checkr-Signature` header, constant-time HMAC over the
+ * RAW body, Checkr event-type → categorical status, and candidate_id →
+ * application resolution (createReport persists candidate.id as
+ * background_report_id, the durable join key for the invitation flow).
+ *
+ * Mocked: DB (SQL-routed), state-machine transition, audit, screening pipeline.
+ * The real (pure) BackgroundCheck mapper runs so the map→persist leg is real.
+ */
+
+import express from "express";
+import request from "supertest";
+import crypto from "crypto";
+
+const mockTransition = jest.fn();
+const mockRunFullScreening = jest.fn();
+
+jest.mock("../config/database", () => ({ query: jest.fn() }));
+jest.mock("../utils/logger", () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+jest.mock("../middleware/audit", () => ({ writeAuditLog: jest.fn().mockResolvedValue(undefined) }));
+jest.mock("../modules/screening/state-machine", () => ({
+  transitionApplicationStatus: (...a: unknown[]) => mockTransition(...a),
+}));
+jest.mock("../modules/screening/service", () => ({
+  ScreeningService: jest.fn().mockImplementation(() => ({ runFullScreening: mockRunFullScreening })),
+}));
+
+import { query } from "../config/database";
+import craWebhookRouter from "../modules/screening/cra-webhook";
+
+const mockQuery = query as jest.MockedFunction<typeof query>;
+const flush = () => new Promise((resolve) => setImmediate(resolve));
+
+const CHECKR_SECRET = "test_checkr_secret";
+const CANDIDATE_ID = "cand_abc123";
+const APP_ID = "11111111-2222-3333-4444-555555555555";
+
+const app = express();
+app.use("/webhook", craWebhookRouter);
+
+function checkrEvent(type: string, objectOverrides: Record<string, unknown> = {}) {
+  return {
+    id: "chk_evt_" + type.replace(/\./g, "_"),
+    type,
+    data: {
+      object: {
+        id: "rep_xyz",
+        candidate_id: CANDIDATE_ID,
+        sex_offender_search: { records: [] },
+        national_criminal_search: { records: [] },
+        county_criminal_searches: [],
+        ...objectOverrides,
+      },
+    },
+  };
+}
+
+// Signs the EXACT bytes it sends — express.raw hands the handler this same
+// buffer, so the HMAC the verifier recomputes must be over this string.
+function postCheckr(event: object, opts: { sign?: boolean; secret?: string } = {}) {
+  const raw = JSON.stringify(event);
+  const req = request(app).post("/webhook").set("Content-Type", "application/json");
+  if (opts.sign === false) {
+    req.set("x-checkr-signature", "deadbeef"); // present but wrong length → reject
+  } else {
+    const sig = crypto.createHmac("sha256", opts.secret ?? CHECKR_SECRET).update(raw).digest("hex");
+    req.set("x-checkr-signature", sig);
+  }
+  return req.send(raw);
+}
+
+const originalWebhookSecret = process.env.CHECKR_WEBHOOK_SECRET;
+const originalApiKey = process.env.CHECKR_API_KEY;
+const originalScreenFlag = process.env.SCREENING_ON_SUBMIT_ENABLED;
+
+afterAll(() => {
+  process.env.CHECKR_WEBHOOK_SECRET = originalWebhookSecret;
+  process.env.CHECKR_API_KEY = originalApiKey;
+  process.env.SCREENING_ON_SUBMIT_ENABLED = originalScreenFlag;
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  process.env.CHECKR_WEBHOOK_SECRET = CHECKR_SECRET;
+  delete process.env.CHECKR_API_KEY;
+  delete process.env.SCREENING_ON_SUBMIT_ENABLED;
+
+  // SQL-routed DB mock. Default: candidate is known (→ APP_ID), not a duplicate,
+  // persist guard hits a row (awaiting_consumer_report), only ONE report in.
+  mockQuery.mockImplementation((sql: any) => {
+    const s = String(sql);
+    if (/cra_processed_events/i.test(s) && /SELECT/i.test(s)) return Promise.resolve({ rows: [] }) as any;
+    if (/SELECT id FROM applications WHERE background_report_id/i.test(s)) {
+      return Promise.resolve({ rows: [{ id: APP_ID }] }) as any;
+    }
+    if (/UPDATE applications SET/i.test(s) && /RETURNING id/i.test(s)) {
+      return Promise.resolve({ rows: [{ id: APP_ID }] }) as any;
+    }
+    if (/FROM applications a/i.test(s) && /LEFT JOIN users/i.test(s)) {
+      return Promise.resolve({
+        rows: [
+          {
+            status: "awaiting_consumer_report",
+            background_check_completed_at: new Date(),
+            credit_check_completed_at: null,
+            submitted_by: "99999999-8888-7777-6666-555555555555",
+            submitter_role: "applicant",
+          },
+        ],
+      }) as any;
+    }
+    return Promise.resolve({ rows: [] }) as any;
+  });
+
+  mockTransition.mockResolvedValue({ changed: true, status: "screening" });
+  mockRunFullScreening.mockResolvedValue({});
+});
+
+describe("POST /webhook — Checkr signature gating", () => {
+  it("503 when X-Checkr-Signature present but no Checkr secret configured (fail-closed)", async () => {
+    delete process.env.CHECKR_WEBHOOK_SECRET;
+    delete process.env.CHECKR_API_KEY;
+    const res = await postCheckr(checkrEvent("report.completed"), { sign: false });
+    expect(res.status).toBe(503);
+  });
+
+  it("401 on an invalid Checkr signature", async () => {
+    const res = await postCheckr(checkrEvent("report.completed"), { sign: false });
+    expect(res.status).toBe(401);
+  });
+
+  it("401 when signed with the wrong secret (HMAC mismatch)", async () => {
+    const res = await postCheckr(checkrEvent("report.completed"), { secret: "not_the_secret" });
+    expect(res.status).toBe(401);
+  });
+
+  it("falls back to CHECKR_API_KEY as the signing secret", async () => {
+    delete process.env.CHECKR_WEBHOOK_SECRET;
+    process.env.CHECKR_API_KEY = CHECKR_SECRET;
+    const res = await postCheckr(checkrEvent("report.completed"));
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("POST /webhook — Checkr event translation + persist", () => {
+  it("accepts a valid HMAC over the raw body and persists the verdict (200)", async () => {
+    const res = await postCheckr(checkrEvent("report.completed"));
+    expect(res.status).toBe(200);
+    const persist = mockQuery.mock.calls.find(
+      (c) => /UPDATE applications SET/i.test(String(c[0])) && /background_check_details/i.test(String(c[0]))
+    );
+    expect(persist).toBeTruthy();
+    expect(String(persist![0])).toMatch(/status = 'awaiting_consumer_report'/);
+    // categorical-only detail, keyed by the REPORT id (object.id), not candidate id
+    const detailJson = (persist![1] as any[])[2] as string;
+    expect(detailJson).toContain("rawResponse");
+    expect(detailJson).toContain("rep_xyz");
+  });
+
+  it("resolves the application by candidate_id (background_report_id join key)", async () => {
+    await postCheckr(checkrEvent("report.completed"));
+    const lookup = mockQuery.mock.calls.find((c) =>
+      /SELECT id FROM applications WHERE background_report_id/i.test(String(c[0]))
+    );
+    expect(lookup).toBeTruthy();
+    expect((lookup![1] as any[])[0]).toBe(CANDIDATE_ID);
+  });
+
+  it("acks 200 + ignored for an event type we don't act on (no persist)", async () => {
+    const res = await postCheckr(checkrEvent("report.created"));
+    expect(res.status).toBe(200);
+    expect(res.body.ignored).toBe(true);
+    const persisted = mockQuery.mock.calls.some(
+      (c) => /UPDATE applications SET/i.test(String(c[0])) && /RETURNING id/i.test(String(c[0]))
+    );
+    expect(persisted).toBe(false);
+  });
+
+  it("acks 200 + ignored for an unknown candidate (no app, no persist)", async () => {
+    mockQuery.mockImplementation((sql: any) => {
+      const s = String(sql);
+      if (/SELECT id FROM applications WHERE background_report_id/i.test(s)) return Promise.resolve({ rows: [] }) as any;
+      return Promise.resolve({ rows: [] }) as any;
+    });
+    const res = await postCheckr(checkrEvent("report.completed", { candidate_id: "cand_unknown" }));
+    expect(res.status).toBe(200);
+    expect(res.body.ignored).toBe(true);
+    expect(mockTransition).not.toHaveBeenCalled();
+  });
+
+  it("acks 200 + ignored for a malformed event (missing data.object)", async () => {
+    const res = await postCheckr({ id: "chk_evt_bad", type: "report.completed" });
+    expect(res.status).toBe(200);
+    expect(res.body.ignored).toBe(true);
+    expect(mockTransition).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /webhook — Checkr terminal failures → could_not_screen HOLD", () => {
+  it("report.canceled → HOLD in screening_review (never auto-pass)", async () => {
+    const res = await postCheckr(checkrEvent("report.canceled"));
+    expect(res.status).toBe(200);
+    await flush();
+    expect(mockTransition).toHaveBeenCalledWith(
+      expect.objectContaining({
+        from: "awaiting_consumer_report",
+        to: "screening_review",
+        trigger: "could_not_screen",
+      })
+    );
+    expect(mockTransition).not.toHaveBeenCalledWith(expect.objectContaining({ to: "screening" }));
+  });
+
+  it("invitation.expired → terminal HOLD (applicant never completed the hosted apply)", async () => {
+    const res = await postCheckr(checkrEvent("invitation.expired"));
+    expect(res.status).toBe(200);
+    await flush();
+    expect(mockTransition).toHaveBeenCalledWith(
+      expect.objectContaining({ to: "screening_review", trigger: "could_not_screen" })
+    );
+  });
+});
+
+describe("POST /webhook — Checkr idempotency", () => {
+  it("duplicate event_id short-circuits with 200 + no persist", async () => {
+    mockQuery.mockImplementation((sql: any) => {
+      const s = String(sql);
+      if (/cra_processed_events/i.test(s) && /SELECT/i.test(s)) return Promise.resolve({ rows: [{ "?column?": 1 }] }) as any;
+      if (/SELECT id FROM applications WHERE background_report_id/i.test(s)) return Promise.resolve({ rows: [{ id: APP_ID }] }) as any;
+      return Promise.resolve({ rows: [] }) as any;
+    });
+    const res = await postCheckr(checkrEvent("report.completed"));
+    expect(res.status).toBe(200);
+    expect(res.body.duplicate).toBe(true);
+    const persisted = mockQuery.mock.calls.some(
+      (c) => /UPDATE applications SET/i.test(String(c[0])) && /RETURNING id/i.test(String(c[0]))
+    );
+    expect(persisted).toBe(false);
+  });
+});

--- a/src/modules/application/service.ts
+++ b/src/modules/application/service.ts
@@ -352,9 +352,16 @@ export class ApplicationService {
         );
         const { CreditCheckService } = await import("../screening/credit-check");
 
+        // Email comes from the applicant's user record (submitted_by → users) —
+        // the same join the CRA webhook uses to resolve the actor. Checkr needs
+        // it to create + invite the candidate; the hosted invitation then
+        // collects the full SSN/DOB from the applicant directly.
         const appRow = await query(
-          `SELECT first_name, last_name, ssn_encrypted, date_of_birth_encrypted, current_state
-             FROM applications WHERE id = $1`,
+          `SELECT a.first_name, a.last_name, a.ssn_encrypted, a.date_of_birth_encrypted,
+                  a.current_state, u.email
+             FROM applications a
+             LEFT JOIN users u ON u.id = a.submitted_by
+            WHERE a.id = $1`,
           [applicationId]
         );
         const a = appRow.rows[0] || {};
@@ -375,6 +382,7 @@ export class ApplicationService {
             ssnLast4,
             dateOfBirth: dob,
             state: a.current_state || "NV",
+            email: a.email,
             returnUrl,
           }),
           new CreditCheckService().createReport({

--- a/src/modules/screening/background-check.ts
+++ b/src/modules/screening/background-check.ts
@@ -75,25 +75,118 @@ export class BackgroundCheckService {
    * submit() on the armed path; returns the report reference + hosted invitation
    * `url` the applicant uses to authorize the pull and complete KBA.
    *
-   * CREDENTIALING-GATED: the real Checkr candidate→invitation→report create is a
-   * signed-contract + sandbox-key task (see docs/screening/background-credit-cra-adapter.md
-   * §4 "Credentialing-gated"). Until those credentials exist the create throws —
-   * this is fail-loud, never a fabricated handle. submit() catches the throw and
-   * leaves the app in `submitted` (no silent screening skip).
+   * Two-step Checkr flow (the only one usable here — we hold ssnLast4, NOT the
+   * full SSN the direct report API needs):
+   *   1. POST /v1/candidates  → candidate id (name + email; the hosted flow
+   *      collects the full SSN from the applicant — no full SSN leaves us).
+   *   2. POST /v1/invitations → the hosted `invitation_url`. Checkr auto-creates
+   *      the report only AFTER the applicant completes the invitation; the
+   *      `report.completed` webhook then carries `candidate_id` — our durable
+   *      join key — so we persist candidate.id as the report handle (`reportId`)
+   *      and the webhook resolves the application by it.
+   *
+   * KEYLESS ⇒ FAIL-LOUD: with no CHECKR_API_KEY the create throws (never a
+   * fabricated invitation handle — that would be a phantom consumer-report
+   * order). submit() catches the throw and leaves the app in `submitted` (no
+   * silent screening skip), so flag-off / keyless is byte-identical to today.
+   *
+   * Activation: CHECKR_API_KEY (+ optional CHECKR_API_URL, CHECKR_PACKAGE). The
+   * webhook half verifies CHECKR_WEBHOOK_SECRET — see cra-webhook.ts.
    */
-  async createReport(_input: {
+  async createReport(input: {
     applicationId: string;
     firstName: string;
     lastName: string;
     ssnLast4: string;
     dateOfBirth: string;
     state: string;
+    email?: string;
     returnUrl?: string;
   }): Promise<BackgroundReportHandle> {
-    // TODO(credentialing): replace with the real Checkr candidate + invitation +
-    // report create once a contract is signed and CHECKR_API_KEY exists. The
-    // hosted invitation url + report id come back from that call.
-    throw new Error("Checkr background report integration not yet configured");
+    const apiKey = process.env.CHECKR_API_KEY || "";
+    if (!apiKey || apiKey === "changeme") {
+      // Dormant. Fail-loud, NEVER a fabricated handle. Unlike the synchronous
+      // vendor seam there is no meaningful "stub handle" to return — a fake
+      // invitation url is a phantom order. Keep the historical message so the
+      // keyless contract test (`/not yet configured/i`) stays green.
+      throw new Error("Checkr background report integration not yet configured");
+    }
+    // Checkr needs an email to create + invite the candidate. Missing email is
+    // fail-loud — we never create a half-formed candidate.
+    if (!input.email) {
+      throw new Error("Checkr candidate requires an applicant email");
+    }
+
+    const base = (process.env.CHECKR_API_URL || "https://api.checkr.com").replace(/\/$/, "");
+    // Package slug is account-specific; MUST be set to a real package at arm
+    // time. The default is a common Checkr test package, not a guarantee.
+    const pkg = process.env.CHECKR_PACKAGE || "tasker_standard";
+
+    // 1) Candidate — name + email (+ DOB to lift match rate; Checkr is the
+    //    authorized CRA recipient). The full SSN is NOT sent: the hosted
+    //    invitation collects it from the applicant directly.
+    const candidate = (await this.checkrFetch(base, apiKey, "/v1/candidates", {
+      first_name: input.firstName,
+      last_name: input.lastName,
+      email: input.email,
+      ...(input.dateOfBirth ? { dob: input.dateOfBirth } : {}),
+    })) as { id?: string };
+    if (!candidate?.id) {
+      throw new Error("Checkr candidate create returned no id");
+    }
+
+    // 2) Invitation — hand the applicant the hosted apply flow for `package`.
+    const invitation = (await this.checkrFetch(base, apiKey, "/v1/invitations", {
+      candidate_id: candidate.id,
+      package: pkg,
+      work_locations: [{ country: "US", state: input.state || "NV" }],
+    })) as { invitation_url?: string; status?: string };
+
+    return {
+      // candidate.id (NOT the not-yet-existent report id) is the webhook join key.
+      reportId: candidate.id,
+      status: invitation.status || "pending",
+      url: invitation.invitation_url || null,
+    };
+  }
+
+  /**
+   * POST to the Checkr API with HTTP Basic auth (API key as username, empty
+   * password: `Basic base64(key + ":")`). Any non-2xx THROWS with a categorical
+   * detail — the submit() caller turns that into a fail-loud HOLD, never a
+   * fabricated handle. Mirrors the plaid/work-number fetch idiom.
+   */
+  private async checkrFetch(
+    base: string,
+    apiKey: string,
+    path: string,
+    body: Record<string, unknown>
+  ): Promise<unknown> {
+    const auth = Buffer.from(`${apiKey}:`).toString("base64");
+    const res = await fetch(`${base}${path}`, {
+      method: "POST",
+      headers: {
+        Authorization: `Basic ${auth}`,
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      let detail = `HTTP ${res.status}`;
+      try {
+        const err = (await res.json()) as any;
+        detail = err?.error
+          ? String(err.error)
+          : Array.isArray(err?.errors)
+            ? err.errors.join("; ")
+            : JSON.stringify(err);
+      } catch {
+        /* keep HTTP status */
+      }
+      throw new Error(`Checkr ${path} failed — ${detail}`);
+    }
+    return res.json();
   }
 
   /**

--- a/src/modules/screening/cra-webhook.ts
+++ b/src/modules/screening/cra-webhook.ts
@@ -446,27 +446,98 @@ async function holdCouldNotScreen(env: CraEventEnvelope, reason: string): Promis
 
 // ── router ──────────────────────────────────────────────────────────────────
 
+/**
+ * Shared tail for BOTH receive paths once an envelope is in hand: dedup the
+ * event id, dispatch (DLQ + 200 on throw — we NEVER 5xx a CRA), mark processed.
+ * `body` is the parsed payload, parked verbatim in the DLQ on failure.
+ */
+async function processAndRespond(
+  env: CraEventEnvelope,
+  body: unknown,
+  res: Response
+): Promise<void> {
+  if (await alreadyProcessed(env.id)) {
+    logger.info("CRA webhook duplicate event short-circuited", { eventId: env.id });
+    res.status(200).json({ received: true, duplicate: true });
+    return;
+  }
+
+  let dispatchError: Error | null = null;
+  try {
+    await dispatch(env);
+  } catch (err) {
+    dispatchError = err as Error;
+    logger.error("CRA webhook dispatch failed", {
+      eventId: env.id,
+      domain: env.domain,
+      error: dispatchError.message,
+    });
+    await recordDlq(env.id, env.domain, body, dispatchError);
+  }
+
+  if (!dispatchError) {
+    await markProcessed(env.id, env.domain, env.applicationId);
+  }
+
+  // Always 200 — DLQ is the recovery path, not retry.
+  res.status(200).json({ received: true });
+}
+
 const router = Router();
 
 router.post(
   "/",
   express.raw({ type: "application/json", limit: "1mb" }),
   async (req: Request, res: Response): Promise<void> => {
-    // CREDENTIALING-GATED: real signature verification. Until a CRA contract is
-    // signed and CHECKR_WEBHOOK_SECRET (+ the TransUnion equivalent) exist, we
-    // refuse to process — fail-closed, so an unsigned payload is never trusted.
-    // The synthetic-payload tests set CRA_WEBHOOK_SECRET to exercise the path.
+    const raw = req.body as Buffer;
+
+    // ── Real Checkr path — discriminated by the X-Checkr-Signature header ──
+    // HMAC-verify against CHECKR_WEBHOOK_SECRET (or the API key, per Checkr's
+    // scheme) over the RAW body, then translate Checkr's event envelope.
+    const checkrSig = req.headers["x-checkr-signature"];
+    if (checkrSig !== undefined) {
+      const checkrSecret =
+        process.env.CHECKR_WEBHOOK_SECRET || process.env.CHECKR_API_KEY || "";
+      if (!checkrSecret || checkrSecret === "changeme") {
+        // Fail-closed: never trust a payload we cannot verify.
+        res.status(503).json({ error: "Checkr webhook secret not configured" });
+        return;
+      }
+      if (Array.isArray(checkrSig) || !verifyCheckrSignature(raw, checkrSig, checkrSecret)) {
+        res.status(401).json({ error: "Invalid Checkr signature" });
+        return;
+      }
+
+      let body: unknown;
+      try {
+        body = JSON.parse(raw.toString("utf8"));
+      } catch {
+        res.status(400).json({ error: "Invalid JSON" });
+        return;
+      }
+
+      const env = await translateCheckrEvent(body);
+      if (!env) {
+        // An event type we don't act on, a malformed object, or an unknown
+        // candidate → ack 200 with no side effects (Checkr would otherwise retry).
+        res.status(200).json({ received: true, ignored: true });
+        return;
+      }
+
+      await processAndRespond(env, body, res);
+      return;
+    }
+
+    // ── Synthetic path — the internal envelope the unit tests post ──
+    // Gated on CRA_WEBHOOK_SECRET; the `x-cra-signature` header must be present
+    // (trusted internal caller). The real per-vendor HMAC lives on the Checkr
+    // path above; the TransUnion credit envelope + signing arrives with Chunk 4.
     const secret = process.env.CRA_WEBHOOK_SECRET ?? "";
     if (!secret || secret === "changeme") {
       res.status(503).json({ error: "CRA webhook secret not configured" });
       return;
     }
 
-    // TODO(credentialing): verify the HMAC signature header against `secret`
-    // using each vendor's documented scheme (Checkr `X-Checkr-Signature`,
-    // TransUnion equivalent). For now we require the header to be present so the
-    // contract is exercised, but the real constant-time HMAC compare is gated on
-    // having a documented signing scheme + a live secret.
     const sig = req.headers["x-cra-signature"];
     if (!sig || Array.isArray(sig)) {
       res.status(400).json({ error: "Missing CRA signature header" });
@@ -475,7 +546,7 @@ router.post(
 
     let body: unknown;
     try {
-      body = JSON.parse((req.body as Buffer).toString("utf8"));
+      body = JSON.parse(raw.toString("utf8"));
     } catch {
       res.status(400).json({ error: "Invalid JSON" });
       return;
@@ -488,31 +559,7 @@ router.post(
       return;
     }
 
-    if (await alreadyProcessed(env.id)) {
-      logger.info("CRA webhook duplicate event short-circuited", { eventId: env.id });
-      res.status(200).json({ received: true, duplicate: true });
-      return;
-    }
-
-    let dispatchError: Error | null = null;
-    try {
-      await dispatch(env);
-    } catch (err) {
-      dispatchError = err as Error;
-      logger.error("CRA webhook dispatch failed", {
-        eventId: env.id,
-        domain: env.domain,
-        error: dispatchError.message,
-      });
-      await recordDlq(env.id, env.domain, body, dispatchError);
-    }
-
-    if (!dispatchError) {
-      await markProcessed(env.id, env.domain, env.applicationId);
-    }
-
-    // Always 200 — DLQ is the recovery path, not retry.
-    res.status(200).json({ received: true });
+    await processAndRespond(env, body, res);
   }
 );
 

--- a/src/modules/screening/cra-webhook.ts
+++ b/src/modules/screening/cra-webhook.ts
@@ -31,8 +31,11 @@ import { CreditCheckService } from "./credit-check";
  *     report/invitation `candidate_id` (createReport persisted candidate.id as
  *     background_report_id, since the invitation flow yields no report id at
  *     create time). Built + tested here; arms when the secret is set.
- *   - SYNTHETIC (`x-cra-signature` present): the internal envelope the unit
- *     tests post, gated on CRA_WEBHOOK_SECRET. Preserved byte-identical.
+ *   - SYNTHETIC (`x-cra-signature` present): a TEST-ONLY fixture envelope the
+ *     unit tests post. It carries NO per-vendor HMAC, so it is gated to
+ *     NODE_ENV=test and is unreachable (404) in any deployed environment — see
+ *     the router below. Real vendors sign their payloads (Checkr above;
+ *     TransUnion credit with the Chunk-4 adapter).
  *
  * STILL CREDENTIALING-GATED: the TransUnion ShareAble credit event envelope +
  * its signing scheme (the credit half of `parseEnvelope`/dispatch is wired, but
@@ -528,10 +531,18 @@ router.post(
       return;
     }
 
-    // ── Synthetic path — the internal envelope the unit tests post ──
-    // Gated on CRA_WEBHOOK_SECRET; the `x-cra-signature` header must be present
-    // (trusted internal caller). The real per-vendor HMAC lives on the Checkr
-    // path above; the TransUnion credit envelope + signing arrives with Chunk 4.
+    // ── Synthetic path — a TEST-ONLY fixture seam ──
+    // This envelope carries NO per-vendor HMAC (it predates the real Checkr path
+    // above), so it is verified only by header *presence*. That is safe ONLY
+    // under test: in a deployed env, once CRA_WEBHOOK_SECRET is set to arm the
+    // receiver, an unauthenticated caller could forge a verdict with a crafted
+    // body + any `x-cra-signature` header. Gate it to NODE_ENV=test; real
+    // vendors (Checkr above; TransUnion credit, Chunk 4) sign their payloads.
+    if (process.env.NODE_ENV !== "test") {
+      res.status(404).json({ error: "Not found" });
+      return;
+    }
+
     const secret = process.env.CRA_WEBHOOK_SECRET ?? "";
     if (!secret || secret === "changeme") {
       res.status(503).json({ error: "CRA webhook secret not configured" });

--- a/src/modules/screening/cra-webhook.ts
+++ b/src/modules/screening/cra-webhook.ts
@@ -1,5 +1,6 @@
 import { Router, Request, Response } from "express";
 import express from "express";
+import crypto from "crypto";
 import { query } from "../../config/database";
 import { writeAuditLog } from "../../middleware/audit";
 import { logger } from "../../utils/logger";
@@ -23,15 +24,19 @@ import { CreditCheckService } from "./credit-check";
  * are CAS-guarded on `status = 'awaiting_consumer_report'` so a late/duplicate
  * delivery after the app already advanced is a no-op.
  *
- * CREDENTIALING-GATED PARTS (NOT built here — see
- * docs/screening/background-credit-cra-adapter.md §4 vs "Credentialing-gated"):
- *   - Real HMAC signature verification against CHECKR_WEBHOOK_SECRET /
- *     the TransUnion equivalent. Until those secrets exist, the route refuses to
- *     process (503) rather than trust an unsigned payload — fail-closed.
- *   - The exact CRA event envelope shape (event type names, where the report
- *     object + application reference live). The synthetic envelope parsed below
- *     is what the unit tests exercise; the real field paths are marked
- *     `// TODO(credentialing)` and confirmed against a live sandbox before arming.
+ * TWO RECEIVE PATHS, selected by header:
+ *   - REAL CHECKR (`X-Checkr-Signature` present): HMAC-SHA256 verify against
+ *     CHECKR_WEBHOOK_SECRET (or CHECKR_API_KEY), then translate Checkr's
+ *     `{ id, type, data: { object } }` event — resolving our application by the
+ *     report/invitation `candidate_id` (createReport persisted candidate.id as
+ *     background_report_id, since the invitation flow yields no report id at
+ *     create time). Built + tested here; arms when the secret is set.
+ *   - SYNTHETIC (`x-cra-signature` present): the internal envelope the unit
+ *     tests post, gated on CRA_WEBHOOK_SECRET. Preserved byte-identical.
+ *
+ * STILL CREDENTIALING-GATED: the TransUnion ShareAble credit event envelope +
+ * its signing scheme (the credit half of `parseEnvelope`/dispatch is wired, but
+ * the real TU webhook translation lands with the Chunk-4 credit adapter).
  *
  * Error handling: any throw during dispatch parks the payload in `cra_webhook_dlq`
  * and returns 200 — we NEVER 5xx a CRA (it would just retry the broken event).
@@ -159,6 +164,88 @@ function parseEnvelope(body: unknown): CraEventEnvelope | null {
 function isTerminalFailure(status: string): boolean {
   const s = status.toLowerCase();
   return s === "canceled" || s === "cancelled" || s === "suspended" || s === "disputed";
+}
+
+// ── real Checkr ingestion (X-Checkr-Signature + { id, type, data: { object } }) ─
+
+/**
+ * Verify Checkr's `X-Checkr-Signature` — HMAC-SHA256 of the RAW request body,
+ * keyed by the Checkr webhook secret (or the API key, per Checkr's scheme), hex
+ * encoded. Constant-time compare on the raw bytes; an optional `sha256=` prefix
+ * is tolerated. Any malformed input → false (reject), never throws.
+ */
+function verifyCheckrSignature(rawBody: Buffer, header: string, secret: string): boolean {
+  const provided = header.startsWith("sha256=") ? header.slice(7) : header;
+  const expected = crypto.createHmac("sha256", secret).update(rawBody).digest("hex");
+  let a: Buffer;
+  try {
+    a = Buffer.from(provided, "hex");
+  } catch {
+    return false;
+  }
+  const b = Buffer.from(expected, "hex");
+  if (a.length === 0 || a.length !== b.length) return false;
+  return crypto.timingSafeEqual(a, b);
+}
+
+/**
+ * Map a Checkr event `type` to our categorical status. Returns null for types we
+ * don't act on (e.g. `report.created`, `invitation.created`) so they ack 200 with
+ * no side effects. Credit (TransUnion) is NOT handled here — separate adapter.
+ */
+function checkrEventStatus(type: string): string | null {
+  switch (type) {
+    case "report.completed":
+      return "complete";
+    case "report.canceled":
+    case "report.cancelled":
+      return "canceled";
+    case "report.suspended":
+      return "suspended";
+    case "report.disputed":
+      return "disputed";
+    // The applicant never completed the hosted invitation → terminal, HOLD.
+    case "invitation.expired":
+    case "invitation.deleted":
+      return "canceled";
+    default:
+      return null;
+  }
+}
+
+/**
+ * Translate a real Checkr event (`{ id, type, data: { object } }`) into our
+ * internal CraEventEnvelope, resolving our applicationId from the report /
+ * invitation object's `candidate_id` — createReport persisted candidate.id as
+ * background_report_id (the invitation flow yields no report id at create time,
+ * so candidate_id is the durable join key). Returns null for an event type we
+ * don't act on, a malformed object, or an unknown candidate (→ 200 ack, no-op).
+ */
+async function translateCheckrEvent(body: unknown): Promise<CraEventEnvelope | null> {
+  if (!body || typeof body !== "object") return null;
+  const b = body as Record<string, any>;
+  const id = typeof b.id === "string" ? b.id : "";
+  const type = typeof b.type === "string" ? b.type : "";
+  const object = b.data && typeof b.data === "object" ? b.data.object : undefined;
+  if (!id || !object || typeof object !== "object") return null;
+
+  const status = checkrEventStatus(type);
+  if (!status) return null;
+
+  const candidateId = typeof object.candidate_id === "string" ? object.candidate_id : "";
+  if (!candidateId) return null;
+
+  const appRes = await query(
+    `SELECT id FROM applications WHERE background_report_id = $1 LIMIT 1`,
+    [candidateId]
+  );
+  const applicationId = appRes.rows[0]?.id;
+  if (!applicationId || typeof applicationId !== "string") return null;
+
+  // The report's own id once it exists (report.completed); else fall back to the
+  // candidate id so the envelope always carries a stable reference.
+  const reportId = typeof object.id === "string" ? object.id : candidateId;
+  return { id, domain: "background", applicationId, reportId, status, report: object };
 }
 
 // ── dispatch ──────────────────────────────────────────────────────────────────

--- a/src/modules/screening/cra-webhook.ts
+++ b/src/modules/screening/cra-webhook.ts
@@ -452,11 +452,16 @@ async function holdCouldNotScreen(env: CraEventEnvelope, reason: string): Promis
 /**
  * Shared tail for BOTH receive paths once an envelope is in hand: dedup the
  * event id, dispatch (DLQ + 200 on throw — we NEVER 5xx a CRA), mark processed.
- * `body` is the parsed payload, parked verbatim in the DLQ on failure.
+ *
+ * PII discipline: on dispatch failure we park ONLY the categorical envelope in
+ * the DLQ — NEVER `env.report`, the raw CRA report (charge narratives, court /
+ * county detail, addresses, full DOB/SSN). The `cra_webhook_dlq.raw_payload`
+ * contract forbids that data leaving the CRA (see
+ * migrations/2026-06-01-applications-consumer-report.sql); id + reportId +
+ * applicationId are enough to replay by re-fetching from the CRA.
  */
 async function processAndRespond(
   env: CraEventEnvelope,
-  body: unknown,
   res: Response
 ): Promise<void> {
   if (await alreadyProcessed(env.id)) {
@@ -475,7 +480,15 @@ async function processAndRespond(
       domain: env.domain,
       error: dispatchError.message,
     });
-    await recordDlq(env.id, env.domain, body, dispatchError);
+    // Strip env.report — categorical fields only into the DLQ.
+    const scrubbedPayload = {
+      id: env.id,
+      domain: env.domain,
+      applicationId: env.applicationId,
+      reportId: env.reportId,
+      status: env.status,
+    };
+    await recordDlq(env.id, env.domain, scrubbedPayload, dispatchError);
   }
 
   if (!dispatchError) {
@@ -527,7 +540,7 @@ router.post(
         return;
       }
 
-      await processAndRespond(env, body, res);
+      await processAndRespond(env, res);
       return;
     }
 
@@ -570,7 +583,7 @@ router.post(
       return;
     }
 
-    await processAndRespond(env, body, res);
+    await processAndRespond(env, res);
   }
 );
 


### PR DESCRIPTION
## What

Lands the **real Checkr** consumer-report (CRA) integration the screening epic
has been building toward — the real vendor behind the same dark flag
(`CONSUMER_REPORT_ENABLED`) the synthetic adapter (#253) and FCRA consent (#255)
already shipped under.

**Outbound** (`background-check.ts`) — two-step Checkr flow:
`POST /v1/candidates` → `POST /v1/invitations`, HTTP Basic auth
(`Basic base64(apiKey + ":")`). The candidate id is persisted as
`background_report_id` — the durable webhook join key, since the invitation flow
yields no report id at create time. **Full SSN is never sent by us** — Checkr's
hosted invitation collects it.

**Inbound** (`cra-webhook.ts`) — dual-path router:
- **Real Checkr** (`X-Checkr-Signature`): HMAC-SHA256 over the **raw** body,
  constant-time compare, **fail-closed 503** if the secret is missing/`changeme`,
  **401** on mismatch. Router is mounted before `express.json()` so the HMAC sees
  the raw bytes.
- **Synthetic** (`x-cra-signature`): the pre-existing TEST-ONLY fixture seam,
  now gated to `NODE_ENV==='test'` (404 otherwise) so it can't be used to forge a
  verdict in a deployed env.

**Fail-safe posture:** terminal Checkr events (`canceled`/`suspended`/expired
invitation) **HOLD** in `screening_review` — never an auto-pass. Idempotency via
`cra_processed_events`; DLQ via `cra_webhook_dlq`; CAS guard on
`status='awaiting_consumer_report'`; advances to screening only once **both**
background + credit reports land. We **never 5xx a CRA** (it would just retry a
broken event) — a dispatch throw parks in the DLQ and returns 200.

## Dark by default

With `CONSUMER_REPORT_ENABLED` unset, `application/service.ts:submit()` takes the
legacy synchronous `runCheck()` path — **byte-identical to pre-CRA**. Nothing in
this PR is reachable in prod until the flag is armed.

## No new migration

The schema it needs (`awaiting_consumer_report` status, `cra_processed_events` /
`cra_webhook_dlq`, the `background_report_id` column) is **already in prod** from
the 2026-06-01 reconcile (`2026-06-01-applications-consumer-report.sql`).

## Pre-merge audit (Opus)

Verdict: **SHIP-WITH-NITS** — zero CRITICAL/HIGH.
- **[MEDIUM] DLQ PII leak — FIXED in this PR (`3232995`).** The DLQ parked the
  full parsed `body`; for the Checkr path that's the whole event whose
  `data.object` is the raw report (charge narratives, county/court detail,
  address, full DOB/SSN), violating the `cra_webhook_dlq.raw_payload` contract.
  Now `processAndRespond` parks only the categorical envelope
  (`{ id, domain, applicationId, reportId, status }`); `env.report` never reaches
  the DLQ. Regression test added asserting the parked payload excludes the charge
  narrative / SSN / DOB and that a failed event is not marked processed.
- LOW + 2 NITs: noted, non-blocking while dark.

## Tests

- `cra-webhook-checkr.test.ts` (new): signature gating (503/401/fallback),
  event translation + categorical persist, candidate_id resolution, terminal
  HOLD, idempotency, **DLQ PII discipline** (new).
- `background-check-cra.test.ts`: keyed `createReport()` two-step over mocked
  fetch (Basic auth header, candidate→invitation order, SSN never sent),
  keyless fail-loud throw, mappers, `resolve()` HOLD paths.
- Full local suite: **1650 passed** (1 pre-existing local-only `.env` flake in
  `compliance-tape-flag.test.ts`, CI-safe — CI has no `.env`). `tsc --noEmit`
  clean.

## Follow-ups (NOT in this PR)

- **Validate Checkr report field-paths against a live sandbox** before arming —
  `TODO(credentialing)` at `background-check.ts` (`mapCheckrReportToResponse` /
  `mapCheckrCharge`).
- **TransUnion ShareAble credit adapter** (Chunk 4) — the credit half of
  `dispatch`/`parseEnvelope` is wired but the real TU translation is stubbed.
- **Arming runbook** (post-contract): `CONSUMER_REPORT_ENABLED=true` +
  `CHECKR_API_KEY` + `CHECKR_WEBHOOK_SECRET` (+ `CRA_*` issuer fields) on Railway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)