### PR TITLE
chore(notion-sync): install-cron.sh re-arms a disabled agent (enable before bootstrap)

### DIFF
--- a/docs/intel/notion-sync/install-cron.sh
+++ b/docs/intel/notion-sync/install-cron.sh
@@ -122,8 +122,11 @@ PLIST_EOF
 plutil -lint "$PLIST" >/dev/null
 echo "✓ wrote plist: $PLIST"
 
-# (re)load the agent
+# (re)load the agent. `enable` clears any persistent `launchctl disable` override
+# (e.g. the agent was parked off until vendors went live) — without it bootstrap
+# would silently refuse to load a disabled label.
 launchctl bootout "$DOMAIN/$SYNC_LABEL" 2>/dev/null || true
+launchctl enable "$DOMAIN/$SYNC_LABEL" 2>/dev/null || true
 launchctl bootstrap "$DOMAIN" "$PLIST"
 printf '✓ launchd agent loaded — fires daily %02d:%02d local\n' "$SYNC_HOUR" "$SYNC_MINUTE"
 


### PR DESCRIPTION
Follow-up to #275. The daily sync agent is currently parked off via `launchctl disable` (held until vendors go live). A plain `bootstrap` won't load a label that carries a persistent disable override, so re-running `install-cron.sh` wouldn't actually re-arm it.

Adds `launchctl enable "$DOMAIN/$SYNC_LABEL"` between `bootout` and `bootstrap`, making the installer self-healing — re-running it always re-arms the agent whether or not it was previously disabled.

One line + comment. No behavior change for the normal (never-disabled) path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)