### PR TITLE
docs(intel): NV Energy Stage-4 receiver kit — §7 dry-run validation log

### DIFF
--- a/docs/intel/nv-energy-stage4-response.md
+++ b/docs/intel/nv-energy-stage4-response.md
@@ -146,3 +146,37 @@ The reply can't arrive until the request is sent. The send checklist lives in `n
 fill 4 fields, resolve the **3 ownership caveats** (Fletcher 1503 vs 1403 · O'Callaghan 1502 vs vacant lot ·
 Smith Williams fee owner = the church), and collect **Attachment A** signatures across the **14 owning
 entities**. That is the real critical path; this file picks up the moment NV Energy responds.
+
+---
+
+## 7 · Pipeline validation (dry-run, 2026-06-09)
+
+Before any real reply, the receiver and its auto-sync chain were proven end-to-end with **zero side effects**
+(two read-only checks + one working-tree flip, reverted — no commit, no Notion write, no push). Re-run any time
+to re-confirm; each test is deterministic.
+
+**① Structural integrity** (read-only, parsed from `origin/main` blobs) — **10/10 invariants pass.** §1 intake
+= §2 verdict = roster (`nv-energy-stage4-email.md`) = §4b matrix (`electrical-service-validation.md:290-308`),
+all **17 rows**; APN sets identical across all four; §1 order mirrors the roster; the §2 **§4b-row column is a
+true bijection of 1..17**; and every APN→§4b-row cross-map resolves to the matching building. No drift.
+
+**② Parser baseline** (read-only) — `cd ~/projects/the-stack && python3 status/site_reality.py` reads §1.5
+cleanly: `site:service 0/17 Confirmed` · `site:interconnection 0/17 GREEN / 17 AMBER`. Confirms the kit (Track
+A) introduced **no accidental flip** — counts still match the pre-kit baseline.
+
+**③ End-to-end flip** (working-tree only, auto-reverted) — simulated NV Energy confirming **Donna Louise 1**
+(§4b r5): edited its §1.5 cell `Likely 120/208 V 3φ → Confirmed … (300 kVA)` and `AMBER▼ → GREEN`, re-ran the
+parser, then `git checkout --` to revert. The System-Status rows moved exactly as designed and snapped back:
+
+| row | baseline | after 1-row flip | after revert |
+|-----|----------|------------------|--------------|
+| `site:service` | 0/17 Confirmed | **1/17 Confirmed** (Likely 16/17) | 0/17 ✓ |
+| `site:interconnection` | 0/17 GREEN · 17 AMBER (▼7) | **1/17 GREEN** · 16 AMBER (▼6) | 0/17 · 17 AMBER (▼7) ✓ |
+
+The `▼` upgrade-lean count correctly dropped 7→6 (Donna Louise 1 was AMBER▼). This is the exact upsert
+`status/sync.py` performs on commit, so editing one §1.5 literal flows deterministically into the Notion
+System-Status rows — **Track B is turnkey.**
+
+> ⚠️ The flip test must stay **working-tree-only**. A *commit* on the-stack fires the post-commit hook →
+> `sync.py` → real Notion write + `git push` auto-backup. Use `git checkout --` (not a commit) to revert a
+> dry-run. The only element still untested is the real reply data, which doesn't exist until NV Energy responds.


### PR DESCRIPTION
Adds **§7 · Pipeline validation** to the Stage-4 receiver kit (`docs/intel/nv-energy-stage4-response.md`), recording the 2026-06-09 end-to-end dry run that proves the receiver + auto-sync chain works **before** any real NV Energy reply. Docs-only; follows #274.

## What was tested (zero side effects — read-only checks + one reverted working-tree flip)

- **① Structural integrity** — 10/10 invariants: §1 intake = §2 verdict = roster = §4b matrix (all 17 rows); APN sets identical; §1 order mirrors the roster; the §2 `§4b-row` column is a true bijection of 1..17; every APN→§4b-row cross-map resolves to the matching building. No drift.
- **② Parser baseline** — `status/site_reality.py` reads §1.5 cleanly → `site:service 0/17`, `site:interconnection 0/17 GREEN / 17 AMBER`. Track A added no accidental flip.
- **③ End-to-end flip** — simulated NV Energy confirming Donna Louise 1 (`Likely→Confirmed (300 kVA)`, `AMBER▼→GREEN`); dashboard rows moved `site:service 0→1/17` and `site:interconnection 0→1/17 GREEN` (▼7→▼6), then `git checkout --` reverted clean. Proves Track B is turnkey.

Also documents the footgun: the flip test must stay working-tree-only — a *commit* on the-stack fires the post-commit hook (real Notion write + auto-push).

🤖 Generated with [Claude Code](https://claude.com/claude-code)