### PR TITLE
fix(screening): atomic CRA readiness preflight — never orphan a Checkr order

### DIFF
--- a/src/__tests__/application-service.test.ts
+++ b/src/__tests__/application-service.test.ts
@@ -87,6 +87,8 @@ const mockGetAuthorization = jest.fn();
 const mockRecordAuthorization = jest.fn();
 const mockBgCreateReport = jest.fn();
 const mockCreditCreateReport = jest.fn();
+const mockBgIsConfigured = jest.fn();
+const mockCreditIsConfigured = jest.fn();
 jest.mock("../modules/screening/consumer-report-consent", () => ({
   getAuthorization: (...a: unknown[]) => mockGetAuthorization(...a),
   recordAuthorization: (...a: unknown[]) => mockRecordAuthorization(...a),
@@ -96,11 +98,13 @@ jest.mock("../modules/screening/consumer-report-consent", () => ({
 jest.mock("../modules/screening/background-check", () => ({
   BackgroundCheckService: jest.fn().mockImplementation(() => ({
     createReport: (...a: unknown[]) => mockBgCreateReport(...a),
+    isConfigured: (...a: unknown[]) => mockBgIsConfigured(...a),
   })),
 }));
 jest.mock("../modules/screening/credit-check", () => ({
   CreditCheckService: jest.fn().mockImplementation(() => ({
     createReport: (...a: unknown[]) => mockCreditCreateReport(...a),
+    isConfigured: (...a: unknown[]) => mockCreditIsConfigured(...a),
   })),
 }));
 
@@ -453,9 +457,16 @@ describe("ApplicationService.submit() — FCRA consumer-report consent", () => {
     mockRecordAuthorization.mockReset();
     mockBgCreateReport.mockReset();
     mockCreditCreateReport.mockReset();
+    mockBgIsConfigured.mockReset();
+    mockCreditIsConfigured.mockReset();
     mockTransition.mockResolvedValue({ changed: true, status: "awaiting_consumer_report" } as any);
     mockBgCreateReport.mockResolvedValue({ reportId: "bg_1", status: "pending", url: "https://bg" });
     mockCreditCreateReport.mockResolvedValue({ reportId: "cr_1", status: "pending", url: "https://cr" });
+    // Default: both CRA vendors armed so the readiness preflight passes and the
+    // existing happy-path order-creation tests behave as before. Partial-arm is
+    // exercised explicitly below.
+    mockBgIsConfigured.mockReturnValue(true);
+    mockCreditIsConfigured.mockReturnValue(true);
   });
 
   afterEach(() => {
@@ -530,6 +541,32 @@ describe("ApplicationService.submit() — FCRA consumer-report consent", () => {
     const params = authStampParams();
     expect(params).toBeDefined();
     expect(params![5]).toBe(authorizedAt);
+  });
+
+  it("flag on + consent affirmed but a CRA vendor NOT configured ⇒ no orders, no transition, app stays submitted (no orphaned Checkr candidate)", async () => {
+    process.env.CONSUMER_REPORT_ENABLED = "true";
+    // The partial-arm reality: Checkr armed, TransUnion credit not yet credentialed.
+    mockBgIsConfigured.mockReturnValue(true);
+    mockCreditIsConfigured.mockReturnValue(false);
+    mockRecordAuthorization.mockResolvedValue({
+      authorizedAt: "2026-06-01T10:00:00.000Z",
+      alreadyRecorded: false,
+    });
+    mockQuery.mockResolvedValue(qr([submittedRow])); // status UPDATE; preflight returns before appRow SELECT
+
+    const service = makeService();
+    const result = await service.submit("app-001", "user-001", "applicant", undefined, {
+      authorized: true,
+      disclosureVersion: "2026-06-01",
+    });
+
+    // Refuse loudly BEFORE any outbound side effect: no Checkr/TU order is created,
+    // so no candidate is orphaned and the applicant is never emailed a half-armed
+    // pull. The app stays in `submitted` and is never advanced.
+    expect(result.status).toBe("submitted");
+    expect(mockBgCreateReport).not.toHaveBeenCalled();
+    expect(mockCreditCreateReport).not.toHaveBeenCalled();
+    expect(mockTransition).not.toHaveBeenCalled();
   });
 
   it("flag on + valid authorization already on file (no fresh consent) ⇒ uses stored authorizedAt, creates orders", async () => {

--- a/src/__tests__/background-check-cra.test.ts
+++ b/src/__tests__/background-check-cra.test.ts
@@ -206,6 +206,24 @@ describe("BackgroundCheckService — Checkr CRA mapping", () => {
     });
   });
 
+  describe("isConfigured — readiness preflight predicate", () => {
+    afterEach(() => {
+      delete process.env.CHECKR_API_KEY;
+    });
+    it("false with no key (keyless ⇒ submit() refuses to fire a Checkr order)", () => {
+      delete process.env.CHECKR_API_KEY;
+      expect(svc.isConfigured()).toBe(false);
+    });
+    it('false when the key is the "changeme" placeholder', () => {
+      process.env.CHECKR_API_KEY = "changeme";
+      expect(svc.isConfigured()).toBe(false);
+    });
+    it("true with a real key — lockstep with createReport()'s gate", () => {
+      process.env.CHECKR_API_KEY = "ck_test_abc";
+      expect(svc.isConfigured()).toBe(true);
+    });
+  });
+
   describe("createReport — keyed (real Checkr two-step over mocked fetch)", () => {
     const realFetch = global.fetch;
     let fetchMock: jest.Mock;

--- a/src/__tests__/credit-check-cra.test.ts
+++ b/src/__tests__/credit-check-cra.test.ts
@@ -193,6 +193,24 @@ describe("CreditCheckService — TransUnion ShareAble CRA mapping", () => {
     });
   });
 
+  describe("isConfigured — readiness preflight predicate", () => {
+    afterEach(() => {
+      delete process.env.TRANSUNION_SHAREABLE_API_KEY;
+    });
+    it("false with no key (keyless ⇒ submit() refuses to fire a partial pull)", () => {
+      delete process.env.TRANSUNION_SHAREABLE_API_KEY;
+      expect(svc.isConfigured()).toBe(false);
+    });
+    it('false when the key is the "changeme" placeholder', () => {
+      process.env.TRANSUNION_SHAREABLE_API_KEY = "changeme";
+      expect(svc.isConfigured()).toBe(false);
+    });
+    it("true with a real key — lockstep with createReport()'s gate", () => {
+      process.env.TRANSUNION_SHAREABLE_API_KEY = "tu_test_abc";
+      expect(svc.isConfigured()).toBe(true);
+    });
+  });
+
   describe("createReport — keyed (real ShareAble two-step over mocked fetch)", () => {
     const realFetch = global.fetch;
     let fetchMock: jest.Mock;

--- a/src/modules/application/service.ts
+++ b/src/modules/application/service.ts
@@ -352,6 +352,27 @@ export class ApplicationService {
         );
         const { CreditCheckService } = await import("../screening/credit-check");
 
+        // Atomic readiness preflight. BOTH CRA vendors must be armed before we
+        // fire ANY outbound order. Checkr's createReport creates a candidate AND
+        // emails the applicant a hosted invitation — a real, billable, applicant-
+        // facing side effect — so creating it while the credit order throws (e.g.
+        // TransUnion not yet credentialed) would orphan a Checkr order, and every
+        // resubmit would orphan another. Refuse loudly here, leaving the app in
+        // `submitted`; we never half-arm a partial consumer-report pull.
+        const backgroundCheck = new BackgroundCheckService();
+        const creditCheck = new CreditCheckService();
+        if (!backgroundCheck.isConfigured() || !creditCheck.isConfigured()) {
+          logger.error(
+            "Consumer-report capture armed but a CRA vendor is not configured — refusing to create partial orders",
+            {
+              applicationId,
+              backgroundConfigured: backgroundCheck.isConfigured(),
+              creditConfigured: creditCheck.isConfigured(),
+            }
+          );
+          return result.rows[0];
+        }
+
         // Email comes from the applicant's user record (submitted_by → users) —
         // the same join the CRA webhook uses to resolve the actor. Checkr needs
         // it to create + invite the candidate; the hosted invitation then
@@ -375,7 +396,7 @@ export class ApplicationService {
         // configured) is fail-loud: we do NOT fall through to a normal submit,
         // which would skip the consumer-report gate. The app stays in `submitted`.
         const [background, credit] = await Promise.all([
-          new BackgroundCheckService().createReport({
+          backgroundCheck.createReport({
             applicationId,
             firstName: a.first_name,
             lastName: a.last_name,
@@ -385,7 +406,7 @@ export class ApplicationService {
             email: a.email,
             returnUrl,
           }),
-          new CreditCheckService().createReport({
+          creditCheck.createReport({
             applicationId,
             firstName: a.first_name,
             lastName: a.last_name,

--- a/src/modules/screening/background-check.ts
+++ b/src/modules/screening/background-check.ts
@@ -151,6 +151,19 @@ export class BackgroundCheckService {
   }
 
   /**
+   * Is the Checkr CRA armed? True only when a real CHECKR_API_KEY is present —
+   * the SAME predicate createReport() gates its keyless fail-loud throw on.
+   * submit() uses this as an atomic preflight: creating a Checkr candidate also
+   * emails the applicant a hosted invitation (a real, billable, applicant-facing
+   * side effect), so it must never fire unless every required CRA vendor can also
+   * produce its report. Keep this in lockstep with createReport()'s key check.
+   */
+  isConfigured(): boolean {
+    const apiKey = process.env.CHECKR_API_KEY || "";
+    return !!apiKey && apiKey !== "changeme";
+  }
+
+  /**
    * POST to the Checkr API with HTTP Basic auth (API key as username, empty
    * password: `Basic base64(key + ":")`). Any non-2xx THROWS with a categorical
    * detail — the submit() caller turns that into a fail-loud HOLD, never a

--- a/src/modules/screening/credit-check.ts
+++ b/src/modules/screening/credit-check.ts
@@ -152,6 +152,18 @@ export class CreditCheckService {
   }
 
   /**
+   * Is the TransUnion ShareAble CRA armed? True only with a real
+   * TRANSUNION_SHAREABLE_API_KEY — the SAME predicate createReport() gates its
+   * keyless fail-loud throw on. submit() preflights this alongside the Checkr
+   * check so it never creates a Checkr order it cannot pair with a credit order.
+   * Keep this in lockstep with createReport()'s key check.
+   */
+  isConfigured(): boolean {
+    const apiKey = process.env.TRANSUNION_SHAREABLE_API_KEY || "";
+    return !!apiKey && apiKey !== "changeme";
+  }
+
+  /**
    * POST to the TransUnion ShareAble API with a Bearer API key. Any non-2xx
    * THROWS with a categorical detail — the submit() caller turns that into a
    * fail-loud HOLD, never a fabricated handle. Mirrors background-check.ts's


### PR DESCRIPTION
## What

Adds an **atomic readiness preflight** to `ApplicationService.submit()`'s `CONSUMER_REPORT_ENABLED` block: it now refuses to fire **any** outbound CRA order unless **both** vendors (Checkr background + TransUnion ShareAble credit) are armed.

This is the **Finding-2** fix from the #270 adversarial review. It was meant to land on #277, but #277 (`21c75a2`) merged before the port was ready — so this is the clean follow-up onto current `main`.

## Why

`submit()` fires both `createReport` calls in a `Promise.all`. Checkr's `createReport` creates a candidate **and emails the applicant a hosted invitation** — a real, billable, applicant-facing side effect — *before* the credit order resolves. With only one vendor armed (e.g. Checkr live, TransUnion not yet credentialed), the credit call throws, but the Checkr order is **already placed**. Every resubmit then orphans **another** billed order.

## How

- `BackgroundCheckService.isConfigured()` and `CreditCheckService.isConfigured()` — each the **exact logical complement** of its own `createReport()` keyless gate (`!!key && key !== "changeme"`). Kept in lockstep by construction.
- `submit()` constructs both services, preflights `isConfigured()` on each, and if either is unarmed it `logger.error`s and returns with the app left in `submitted` — we never half-arm a partial consumer-report pull. The two instances are reused for the subsequent `createReport` calls (no double-construction).
- No DLQ changes — main's PII-scrubbed `cra_webhook_dlq` parking is preserved untouched.

## Tests

- `isConfigured` lockstep specs on both adapters (no key / `changeme` / real key).
- A partial-arm `submit()` case: Checkr armed, credit not → **no orders, no transition, app stays `submitted`** (no orphaned Checkr candidate).
- Typecheck: my 6 files compile clean. The 7 `stripe` TS7016 errors visible in a local symlinked-`node_modules` typecheck are **pre-existing on `main`** (stale `node_modules` has stripe 17.7 vs `^22.2` from #278) — plain `origin/main` produces the identical output; CI's `npm ci` resolves them.
- **130/130** across the 5 affected suites (`application-service`, `background-check-cra`, `credit-check-cra`, `cra-webhook`, `cra-webhook-checkr`) with `--runInBand`.

## Notes

- Dark by default — gated behind `CONSUMER_REPORT_ENABLED`. Zero runtime change until both CRA keys are set.
- Supersedes the Finding-2 portion of the now-closed #270/#273.

🤖 Generated with [Claude Code](https://claude.com/claude-code)