### PR TITLE
feat(screening): flag-gated FCRA pre-adverse-action window (default OFF, dark)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -279,6 +279,18 @@ CONSUMER_REPORT_ENABLED=false
 # CRA_ADDRESS=
 # CRA_PHONE=
 
+# --- Pre-adverse-action window (best-practice / state-law-ready, default OFF) ---
+# When true, a consumer-report-derived denial parks in 'pending_adverse_action'
+# with an intent-to-deny notice + a dispute window before the daily finalizer
+# (6 AM) moves it to 'screening_failed' + the § 1681m final notice. Default off
+# ⇒ denials go straight to screening_failed exactly as before (byte-identical).
+# NOTE: § 1681b(b)(3) (FCRA pre-adverse) is EMPLOYMENT-only; rental's federal
+# duty is the § 1681m POST notice. This window is a configurable courtesy.
+# Run the 2026-06-09 delta in every env (the enum value must exist) BEFORE
+# flipping this on.
+FCRA_PRE_ADVERSE_ENABLED=false
+FCRA_PRE_ADVERSE_WINDOW_DAYS=5
+
 # Supabase Storage (optional — enables /api/qa/bundles, the operator QA viewer).
 # When unset, the QA viewer returns an empty list with a hint banner instead
 # of failing. Service role key is server-only — never expose to the client.

--- a/src/__tests__/adverse-action-finalizer.test.ts
+++ b/src/__tests__/adverse-action-finalizer.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Tests for AdverseActionService.finalizeDuePreAdverseActions()
+ * (src/modules/adverse-action/service.ts — pre-adverse-action window finalizer).
+ *
+ * The daily 6 AM scheduler calls this to close out every pre-adverse hold whose
+ * dispute window has elapsed. Each due application is CAS-moved
+ * pending_adverse_action -> screening_failed (system actor) and — ONLY if the
+ * CAS wins — sent the final § 1681m notice carrying the stored pre_adverse
+ * reason_detail (preview === sent).
+ *
+ * Load-bearing guarantees under test:
+ *   - side effects are gated on the CAS result, not the SELECT (TOCTOU-safe:
+ *     overlapping runs / multiple instances finalize each app exactly once)
+ *   - the final notice reuses the pre_adverse reason_detail (preview === sent)
+ *   - system actor -> actorId undefined (nullable UUID FK)
+ *   - one bad application never stalls the sweep (per-row try/catch)
+ *   - empty due set is a clean no-op
+ */
+
+jest.mock("../config/database", () => ({ query: jest.fn(), transaction: jest.fn() }));
+jest.mock("../utils/logger", () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+jest.mock("../middleware/audit", () => ({
+  writeAuditLog: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock("../modules/integrations/twilio", () => ({
+  TwilioService: jest.fn().mockImplementation(() => ({
+    notifyDenied: jest.fn().mockResolvedValue(undefined),
+  })),
+}));
+jest.mock("../modules/screening/state-machine", () => ({
+  transitionApplicationStatus: jest.fn(),
+}));
+
+import { AdverseActionService } from "../modules/adverse-action/service";
+import { query } from "../config/database";
+import { transitionApplicationStatus } from "../modules/screening/state-machine";
+
+const mockQuery = query as jest.MockedFunction<typeof query>;
+const mockTransition = transitionApplicationStatus as jest.MockedFunction<
+  typeof transitionApplicationStatus
+>;
+
+function mockDueRows(rows: Array<{ id: string; pre_adverse_reason_detail: string | null }>) {
+  mockQuery.mockResolvedValueOnce({ rows } as any);
+}
+
+describe("AdverseActionService.finalizeDuePreAdverseActions()", () => {
+  let service: AdverseActionService;
+  let sendNoticeSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new AdverseActionService();
+    // Isolate the finalizer from sendNotice's own DB/SMS work — that path is
+    // covered by adverse-action-service.test.ts.
+    sendNoticeSpy = jest
+      .spyOn(service, "sendNotice")
+      .mockResolvedValue({
+        noticeId: "final-notice",
+        applicationId: "x",
+        sentAt: new Date("2026-06-15T06:00:00Z"),
+        reason: "screening_failed",
+      });
+  });
+
+  it("is a clean no-op when nothing is due", async () => {
+    mockDueRows([]);
+
+    const stats = await service.finalizeDuePreAdverseActions();
+
+    expect(stats).toEqual({ scanned: 0, finalized: 0, noticesSent: 0 });
+    expect(mockTransition).not.toHaveBeenCalled();
+    expect(sendNoticeSpy).not.toHaveBeenCalled();
+  });
+
+  it("SELECTs only due pending_adverse_action rows with the pre_adverse reason_detail", async () => {
+    mockDueRows([]);
+
+    await service.finalizeDuePreAdverseActions();
+
+    const sql = mockQuery.mock.calls[0]![0] as string;
+    expect(sql).toMatch(/status = 'pending_adverse_action'/);
+    expect(sql).toMatch(/adverse_action_eligible_at IS NOT NULL/);
+    expect(sql).toMatch(/adverse_action_eligible_at <= NOW\(\)/);
+    // correlated subquery pulls the most recent pre_adverse notice's reason_detail
+    expect(sql).toMatch(/stage = 'pre_adverse'/);
+    expect(sql).toMatch(/reason_detail/);
+  });
+
+  it("CAS-finalizes a due row and sends the final notice with the stored reason_detail (preview === sent)", async () => {
+    mockDueRows([{ id: "app-1", pre_adverse_reason_detail: "Automated screening denial: failed credit check" }]);
+    mockTransition.mockResolvedValue({ changed: true, status: "screening_failed" } as any);
+
+    const stats = await service.finalizeDuePreAdverseActions();
+
+    expect(mockTransition).toHaveBeenCalledWith(
+      expect.objectContaining({
+        applicationId: "app-1",
+        from: "pending_adverse_action",
+        to: "screening_failed",
+        trigger: "adverse_action_finalized",
+        actorId: undefined, // system actor — nullable UUID FK
+        actorRole: "system",
+      })
+    );
+    expect(sendNoticeSpy).toHaveBeenCalledWith(
+      "app-1",
+      null,
+      "system",
+      "screening_failed",
+      "Automated screening denial: failed credit check"
+    );
+    expect(stats).toEqual({ scanned: 1, finalized: 1, noticesSent: 1 });
+  });
+
+  it("does NOT send the final notice when the CAS is lost (changed:false) — exactly-once", async () => {
+    mockDueRows([{ id: "app-1", pre_adverse_reason_detail: "x" }]);
+    mockTransition.mockResolvedValue({ changed: false, status: "pending_adverse_action" } as any);
+
+    const stats = await service.finalizeDuePreAdverseActions();
+
+    expect(sendNoticeSpy).not.toHaveBeenCalled();
+    expect(stats).toEqual({ scanned: 1, finalized: 0, noticesSent: 0 });
+  });
+
+  it("passes undefined reasonDetail when the row has no stored pre_adverse detail", async () => {
+    mockDueRows([{ id: "app-1", pre_adverse_reason_detail: null }]);
+    mockTransition.mockResolvedValue({ changed: true, status: "screening_failed" } as any);
+
+    await service.finalizeDuePreAdverseActions();
+
+    expect(sendNoticeSpy).toHaveBeenCalledWith("app-1", null, "system", "screening_failed", undefined);
+  });
+
+  it("isolates per-row failures: a throwing notice does not stall the rest of the sweep", async () => {
+    mockDueRows([
+      { id: "app-1", pre_adverse_reason_detail: "r1" },
+      { id: "app-2", pre_adverse_reason_detail: "r2" },
+    ]);
+    mockTransition.mockResolvedValue({ changed: true, status: "screening_failed" } as any);
+    sendNoticeSpy
+      .mockRejectedValueOnce(new Error("notice send blew up"))
+      .mockResolvedValueOnce({
+        noticeId: "n2",
+        applicationId: "app-2",
+        sentAt: new Date(),
+        reason: "screening_failed",
+      });
+
+    const stats = await service.finalizeDuePreAdverseActions();
+
+    // Both rows were CAS-finalized (finalized++ precedes the notice send) ...
+    expect(mockTransition).toHaveBeenCalledTimes(2);
+    expect(sendNoticeSpy).toHaveBeenCalledTimes(2);
+    // ... but only the second notice actually went out.
+    expect(stats).toEqual({ scanned: 2, finalized: 2, noticesSent: 1 });
+  });
+
+  it("processes due rows oldest-window-first", async () => {
+    mockDueRows([]);
+    await service.finalizeDuePreAdverseActions();
+    const sql = mockQuery.mock.calls[0]![0] as string;
+    expect(sql).toMatch(/ORDER BY a\.adverse_action_eligible_at ASC/);
+  });
+});

--- a/src/__tests__/adverse-action-service-pre-adverse.test.ts
+++ b/src/__tests__/adverse-action-service-pre-adverse.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Tests for AdverseActionService.sendPreAdverseNotice()
+ * (src/modules/adverse-action/service.ts — pre-adverse-action window).
+ *
+ * The pre-adverse notice is the flag-gated FCRA_PRE_ADVERSE_ENABLED courtesy:
+ * an intent-to-deny letter + copy-of-report/dispute rights + an N-business-day
+ * window, persisted as a stage='pre_adverse' row so the daily finalizer can
+ * carry its reason_detail into the final § 1681m notice (preview === sent).
+ *
+ * Legal framing (do not overstate): § 1681b(b)(3) is EMPLOYMENT screening; a
+ * landlord's federal duty is the § 1681m POST-action notice. The notice text
+ * must say we *intend* to deny — never claim a federal rental mandate.
+ *
+ * Key invariants under test:
+ *   - DB row written with stage='pre_adverse' (the legal evidence)
+ *   - notice text frames the decision as NOT YET FINAL + states the deadline
+ *   - audit action is pre_adverse_action_notice_sent with stage/windowDays
+ *   - Twilio SMS failure must NOT propagate
+ *   - system actor (actorId null) coerces to undefined for the audit FK
+ */
+
+import { AdverseActionService } from "../modules/adverse-action/service";
+
+// ── Mocks ─────────────────────────────────────────────────────────────────
+
+jest.mock("../config/database", () => ({ query: jest.fn(), transaction: jest.fn() }));
+jest.mock("../utils/logger", () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+jest.mock("../middleware/audit", () => ({
+  writeAuditLog: jest.fn().mockResolvedValue(undefined),
+}));
+// sendPreAdverseNotice never calls the chokepoint, but the module imports it;
+// mock it so requiring the service never pulls the tape/v2-stamp graph.
+jest.mock("../modules/screening/state-machine", () => ({
+  transitionApplicationStatus: jest.fn(),
+}));
+
+const mockNotifyDenied = jest.fn().mockResolvedValue(undefined);
+jest.mock("../modules/integrations/twilio", () => ({
+  TwilioService: jest.fn().mockImplementation(() => ({
+    notifyDenied: mockNotifyDenied,
+  })),
+}));
+
+import { query } from "../config/database";
+import { writeAuditLog } from "../middleware/audit";
+
+const mockQuery = query as jest.MockedFunction<typeof query>;
+const mockWriteAuditLog = writeAuditLog as jest.MockedFunction<typeof writeAuditLog>;
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+const APP_ID = "app-fcra-pre-001";
+const ACTOR_ID = "user-sm-001";
+const ACTOR_ROLE = "senior_manager";
+const NOTICE_ID = "notice-pre-001";
+const WINDOW_DAYS = 5;
+const ELIGIBLE_DATE = new Date("2026-06-15T12:00:00Z");
+
+function mockAppQuery(overrides: Partial<{ phone: string | null; propertyName: string }> = {}) {
+  mockQuery.mockResolvedValueOnce({
+    rows: [
+      {
+        first_name: "Jane",
+        last_name: "Doe",
+        email: "jane@example.com",
+        phone: overrides.phone !== undefined ? overrides.phone : "+17025550100",
+        property_name: overrides.propertyName ?? "Desert Oasis Apartments",
+      },
+    ],
+  } as any);
+}
+
+function mockInsertNotice() {
+  mockQuery.mockResolvedValueOnce({
+    rows: [{ id: NOTICE_ID, created_at: new Date("2026-06-09T12:00:00Z") }],
+  } as any);
+}
+
+describe("AdverseActionService.sendPreAdverseNotice()", () => {
+  let service: AdverseActionService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new AdverseActionService();
+  });
+
+  it("throws when the application is not found (no INSERT)", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] } as any);
+
+    await expect(
+      service.sendPreAdverseNotice(APP_ID, ACTOR_ID, ACTOR_ROLE, "screening_failed", WINDOW_DAYS, ELIGIBLE_DATE)
+    ).rejects.toThrow(`Application not found: ${APP_ID}`);
+
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+  });
+
+  it("inserts a stage='pre_adverse' notice row", async () => {
+    mockAppQuery();
+    mockInsertNotice();
+
+    await service.sendPreAdverseNotice(
+      APP_ID, ACTOR_ID, ACTOR_ROLE, "screening_failed", WINDOW_DAYS, ELIGIBLE_DATE, "failed background check"
+    );
+
+    const insertCall = mockQuery.mock.calls[1]!;
+    expect(insertCall[0]).toMatch(/INSERT INTO adverse_action_notices/i);
+    // stage is a SQL literal in the VALUES list, not a bound param.
+    expect(insertCall[0]).toMatch(/'pre_adverse'/);
+    // params: [applicationId, actorId, reason, reasonDetail, noticeText]
+    expect(insertCall[1]).toEqual(
+      expect.arrayContaining([APP_ID, ACTOR_ID, "screening_failed", "failed background check"])
+    );
+  });
+
+  it("passes null for reasonDetail when not provided", async () => {
+    mockAppQuery();
+    mockInsertNotice();
+
+    await service.sendPreAdverseNotice(APP_ID, ACTOR_ID, ACTOR_ROLE, "screening_failed", WINDOW_DAYS, ELIGIBLE_DATE);
+
+    const insertCall = mockQuery.mock.calls[1]!;
+    expect((insertCall[1] as any[])[3]).toBeNull();
+  });
+
+  it("frames the notice as intent-to-deny (NOT YET FINAL) with the dispute window + deadline", async () => {
+    mockAppQuery({ propertyName: "Sunrise Gardens" });
+    mockInsertNotice();
+
+    await service.sendPreAdverseNotice(
+      APP_ID, ACTOR_ID, ACTOR_ROLE, "screening_failed", WINDOW_DAYS, ELIGIBLE_DATE, "failed credit check"
+    );
+
+    const noticeText = (mockQuery.mock.calls[1]![1] as any[])[4] as string;
+    expect(noticeText).toContain("Sunrise Gardens");
+    expect(noticeText).toMatch(/INTEND to deny/);
+    expect(noticeText).toMatch(/not yet final/i);
+    expect(noticeText).toContain(`${WINDOW_DAYS} business days`);
+    // deadline rendered from eligibleDate (en-US long date)
+    expect(noticeText).toMatch(/June 15, 2026/);
+    expect(noticeText).toMatch(/Reason under consideration: failed credit check/);
+    // FCRA rights + CRA block carried over from the final-notice structure
+    expect(noticeText).toMatch(/FREE copy/);
+    expect(noticeText).toMatch(/[Dd]ispute/);
+    expect(noticeText).toMatch(/consumer[\s\S]*reporting agency/);
+  });
+
+  it("does NOT contain the final-denial language (it is not a § 1681m final notice)", async () => {
+    mockAppQuery();
+    mockInsertNotice();
+
+    await service.sendPreAdverseNotice(APP_ID, ACTOR_ID, ACTOR_ROLE, "screening_failed", WINDOW_DAYS, ELIGIBLE_DATE);
+
+    const noticeText = (mockQuery.mock.calls[1]![1] as any[])[4] as string;
+    expect(noticeText).not.toMatch(/has been denied/);
+  });
+
+  it("writes a pre_adverse_action_notice_sent audit log with stage + windowDays + eligibleAt", async () => {
+    mockAppQuery();
+    mockInsertNotice();
+
+    await service.sendPreAdverseNotice(APP_ID, ACTOR_ID, ACTOR_ROLE, "screening_failed", WINDOW_DAYS, ELIGIBLE_DATE, "x");
+
+    expect(mockWriteAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "pre_adverse_action_notice_sent",
+        actorId: ACTOR_ID,
+        actorRole: ACTOR_ROLE,
+        applicationId: APP_ID,
+        resourceType: "adverse_action_notice",
+        resourceId: NOTICE_ID,
+        details: expect.objectContaining({
+          stage: "pre_adverse",
+          windowDays: WINDOW_DAYS,
+          eligibleAt: ELIGIBLE_DATE.toISOString(),
+        }),
+      })
+    );
+  });
+
+  it("coerces a null (system) actorId to undefined for the audit FK", async () => {
+    mockAppQuery();
+    mockInsertNotice();
+
+    await service.sendPreAdverseNotice(APP_ID, null, "system", "screening_failed", WINDOW_DAYS, ELIGIBLE_DATE);
+
+    // INSERT still binds null for sent_by (nullable UUID FK)
+    expect((mockQuery.mock.calls[1]![1] as any[])[1]).toBeNull();
+    // audit actorId coerced null -> undefined (AuditEntry.actorId?: string)
+    const auditArg = mockWriteAuditLog.mock.calls[0]![0] as any;
+    expect(auditArg.actorId).toBeUndefined();
+  });
+
+  it("sends a non-blocking SMS when the applicant has a phone", async () => {
+    mockAppQuery({ phone: "+17025550199" });
+    mockInsertNotice();
+
+    await service.sendPreAdverseNotice(APP_ID, ACTOR_ID, ACTOR_ROLE, "screening_failed", WINDOW_DAYS, ELIGIBLE_DATE);
+
+    await new Promise((r) => setImmediate(r));
+    expect(mockNotifyDenied).toHaveBeenCalledWith("+17025550199", "Jane Doe");
+  });
+
+  it("resolves even when Twilio throws (SMS failure must not propagate)", async () => {
+    mockAppQuery({ phone: "+17025550100" });
+    mockInsertNotice();
+    mockNotifyDenied.mockRejectedValueOnce(new Error("Twilio down"));
+
+    await expect(
+      service.sendPreAdverseNotice(APP_ID, ACTOR_ID, ACTOR_ROLE, "screening_failed", WINDOW_DAYS, ELIGIBLE_DATE)
+    ).resolves.toMatchObject({ noticeId: NOTICE_ID });
+
+    await new Promise((r) => setImmediate(r));
+  });
+
+  it("returns { noticeId, applicationId, sentAt, reason }", async () => {
+    mockAppQuery();
+    mockInsertNotice();
+
+    const result = await service.sendPreAdverseNotice(
+      APP_ID, ACTOR_ID, ACTOR_ROLE, "screening_failed", WINDOW_DAYS, ELIGIBLE_DATE
+    );
+
+    expect(result.noticeId).toBe(NOTICE_ID);
+    expect(result.applicationId).toBe(APP_ID);
+    expect(result.sentAt).toBeInstanceOf(Date);
+    expect(result.reason).toBe("screening_failed");
+  });
+});

--- a/src/__tests__/scheduler-bp02-flag.test.ts
+++ b/src/__tests__/scheduler-bp02-flag.test.ts
@@ -45,6 +45,14 @@ jest.mock("../modules/tape/service", () => ({
 jest.mock("../modules/tape/repository", () => ({
   PgTapeRepository: jest.fn().mockImplementation(() => ({})),
 }));
+// scheduler.ts now instantiates AdverseActionService at module load for the
+// FCRA pre-adverse finalizer cron. Stub it so requiring the module never pulls
+// config/database (which opens a real pool) into the graph. This test never
+// sets FCRA_PRE_ADVERSE_ENABLED, so the finalizer cron stays unregistered and
+// BASELINE_CRON_JOBS is unchanged.
+jest.mock("../modules/adverse-action/service", () => ({
+  AdverseActionService: jest.fn().mockImplementation(() => ({})),
+}));
 
 // Number of cron.schedule calls made by the always-on jobs (everything except
 // the BP-02 verify-cron): recert reminders, TRACS, monthly rent, late fees,

--- a/src/__tests__/scheduler-fcra-flag.test.ts
+++ b/src/__tests__/scheduler-fcra-flag.test.ts
@@ -1,0 +1,129 @@
+/**
+ * FCRA pre-adverse finalizer-cron flag gate.
+ *
+ * The finalizer (daily 6:00 AM, cron "0 6 * * *") closes out pre-adverse holds
+ * whose dispute window has elapsed. Until FCRA_PRE_ADVERSE_ENABLED is on there
+ * are no pending_adverse_action rows to finalize, so the cron must stay
+ * unregistered — default OFF ⇒ byte-identical scheduler.
+ *
+ * Asserts all three flag-state branches:
+ *   - undefined        → skip (default OFF)
+ *   - "false" (string) → skip
+ *   - "true"           → register the "0 6 * * *" finalizer cron
+ *
+ * The finalizer expression "0 6 * * *" is distinct from the monthly rent job
+ * "0 6 1 * *", so its presence in cron.schedule's call list is an unambiguous
+ * signal. We pin COMPLIANCE_TAPE_V2_ENABLED OFF in every run so the BP-02
+ * verify-cron never perturbs the count.
+ */
+
+// Make this file a module so its top-level consts are module-scoped and do not
+// collide with the script-scoped scheduler-bp02-flag.test.ts (same BASELINE_*).
+export {};
+
+// node-cron is mocked so startScheduler() registers nothing real.
+jest.mock("node-cron", () => ({
+  __esModule: true,
+  default: { schedule: jest.fn() },
+}));
+
+jest.mock("../utils/logger", () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+// The scheduler instantiates services at module load; stub their constructors
+// so requiring the module never touches a real DB/connection pool.
+jest.mock("../modules/recertification/service", () => ({
+  RecertificationService: jest.fn().mockImplementation(() => ({})),
+}));
+jest.mock("../modules/ledger/service", () => ({
+  LedgerService: jest.fn().mockImplementation(() => ({})),
+}));
+jest.mock("../modules/renewal/service", () => ({
+  LeaseRenewalService: jest.fn().mockImplementation(() => ({})),
+}));
+jest.mock("../modules/tape/service", () => ({
+  createTapeService: jest.fn(() => ({ verify: jest.fn() })),
+}));
+jest.mock("../modules/tape/repository", () => ({
+  PgTapeRepository: jest.fn().mockImplementation(() => ({})),
+}));
+jest.mock("../modules/adverse-action/service", () => ({
+  AdverseActionService: jest.fn().mockImplementation(() => ({
+    finalizeDuePreAdverseActions: jest.fn(),
+  })),
+}));
+
+// Always-on jobs (BP-02 + FCRA finalizer both off): recert reminders, TRACS,
+// monthly rent, late fees, renewals. Keep in sync with src/scheduler.ts.
+const BASELINE_CRON_JOBS = 5;
+const FINALIZER_CRON = "0 6 * * *";
+
+const ORIGINAL_FCRA = process.env.FCRA_PRE_ADVERSE_ENABLED;
+const ORIGINAL_TAPE = process.env.COMPLIANCE_TAPE_V2_ENABLED;
+
+/**
+ * Set the FCRA flag (BP-02 forced off), re-import the scheduler fresh, run it,
+ * and return the mocked cron. The module must be required AFTER env is set
+ * because flags are read at registration time inside startScheduler().
+ */
+function runSchedulerWithFcraFlag(flag: string | undefined) {
+  jest.resetModules();
+  delete process.env.COMPLIANCE_TAPE_V2_ENABLED; // keep BP-02 cron out of the count
+  if (flag === undefined) {
+    delete process.env.FCRA_PRE_ADVERSE_ENABLED;
+  } else {
+    process.env.FCRA_PRE_ADVERSE_ENABLED = flag;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const cron = require("node-cron").default as { schedule: jest.Mock };
+  cron.schedule.mockClear();
+
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { startScheduler } = require("../scheduler");
+  startScheduler();
+
+  return cron;
+}
+
+afterEach(() => {
+  if (ORIGINAL_FCRA === undefined) delete process.env.FCRA_PRE_ADVERSE_ENABLED;
+  else process.env.FCRA_PRE_ADVERSE_ENABLED = ORIGINAL_FCRA;
+  if (ORIGINAL_TAPE === undefined) delete process.env.COMPLIANCE_TAPE_V2_ENABLED;
+  else process.env.COMPLIANCE_TAPE_V2_ENABLED = ORIGINAL_TAPE;
+  jest.clearAllMocks();
+});
+
+describe("FCRA pre-adverse finalizer-cron flag gate", () => {
+  it("does NOT register the finalizer cron when the flag is unset (default OFF)", () => {
+    const cron = runSchedulerWithFcraFlag(undefined);
+    expect(cron.schedule).toHaveBeenCalledTimes(BASELINE_CRON_JOBS);
+    const expressions = cron.schedule.mock.calls.map((c) => c[0]);
+    expect(expressions).not.toContain(FINALIZER_CRON);
+  });
+
+  it("does NOT register the finalizer cron when the flag is the string \"false\"", () => {
+    const cron = runSchedulerWithFcraFlag("false");
+    expect(cron.schedule).toHaveBeenCalledTimes(BASELINE_CRON_JOBS);
+    const expressions = cron.schedule.mock.calls.map((c) => c[0]);
+    expect(expressions).not.toContain(FINALIZER_CRON);
+  });
+
+  it("DOES register the \"0 6 * * *\" finalizer cron when the flag is \"true\"", () => {
+    const cron = runSchedulerWithFcraFlag("true");
+    expect(cron.schedule).toHaveBeenCalledTimes(BASELINE_CRON_JOBS + 1);
+    const expressions = cron.schedule.mock.calls.map((c) => c[0]);
+    expect(expressions).toContain(FINALIZER_CRON);
+  });
+
+  it("the finalizer expression is distinct from the monthly rent job (no collision)", () => {
+    const cron = runSchedulerWithFcraFlag("true");
+    const expressions = cron.schedule.mock.calls.map((c) => c[0]);
+    expect(expressions).toContain("0 6 1 * *"); // monthly rent — always on
+    expect(expressions).toContain(FINALIZER_CRON); // finalizer — flag on
+    // exactly one registration of each
+    expect(expressions.filter((e) => e === FINALIZER_CRON)).toHaveLength(1);
+    expect(expressions.filter((e) => e === "0 6 1 * *")).toHaveLength(1);
+  });
+});

--- a/src/__tests__/screening-pre-adverse-flag.test.ts
+++ b/src/__tests__/screening-pre-adverse-flag.test.ts
@@ -1,0 +1,315 @@
+/**
+ * Tests for the FCRA pre-adverse-action window flag gate in
+ * src/modules/screening/service.ts (automated runFullScreening fail path and
+ * manual resolveReview fail path).
+ *
+ * Flag default OFF ⇒ behaviour is byte-identical to today: a fail goes straight
+ * to screening_failed + the § 1681m final notice (sendNotice). Flag ON ⇒ a fail
+ * instead routes to pending_adverse_action, opens an N-business-day window
+ * (adverse_action_eligible_at), and sends the intent-to-deny notice
+ * (sendPreAdverseNotice). Every send stays gated on the CAS winning.
+ *
+ * Legal framing: best-practice / state-law-ready, NOT a federal rental mandate.
+ *
+ * NOTE: preAdverseConfig() reads process.env at call time, so each test sets the
+ * flag immediately before invoking the method and afterEach restores the
+ * original env (env persists across files under jest --runInBand).
+ */
+
+import { ScreeningService } from "../modules/screening/service";
+
+// ── Mocks (mirror screening-service.test.ts) ────────────────────────────────
+
+jest.mock("../config/database", () => ({ query: jest.fn() }));
+jest.mock("../middleware/audit", () => ({ writeAuditLog: jest.fn() }));
+jest.mock("../utils/logger", () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+jest.mock("../utils/encryption", () => ({
+  decrypt: jest.fn((v: string) => `decrypted:${v}`),
+}));
+jest.mock("../modules/screening/background-check", () => ({
+  BackgroundCheckService: jest.fn().mockImplementation(() => ({ runCheck: jest.fn() })),
+}));
+jest.mock("../modules/screening/credit-check", () => ({
+  CreditCheckService: jest.fn().mockImplementation(() => ({ runCheck: jest.fn() })),
+}));
+jest.mock("../modules/screening/compliance", () => ({
+  ComplianceService: jest.fn().mockImplementation(() => ({ runCheck: jest.fn() })),
+}));
+jest.mock("../modules/screening/identity-verification", () => ({
+  IdentityVerificationService: jest.fn().mockImplementation(() => ({
+    resolve: jest.fn(),
+    verify: jest.fn(),
+  })),
+}));
+jest.mock("../modules/screening/fraud-detection", () => ({
+  FraudDetectionService: jest.fn().mockImplementation(() => ({
+    checkDuplicateSSN: jest.fn().mockResolvedValue({ existingApplicationIds: [] }),
+    checkAddressFraud: jest.fn().mockResolvedValue(undefined),
+  })),
+}));
+jest.mock("../modules/adverse-action/service", () => ({
+  AdverseActionService: jest.fn().mockImplementation(() => ({
+    sendNotice: jest.fn().mockResolvedValue({
+      noticeId: "notice-001", applicationId: "app-001", sentAt: new Date(), reason: "screening_failed",
+    }),
+    sendPreAdverseNotice: jest.fn().mockResolvedValue({
+      noticeId: "pre-001", applicationId: "app-001", sentAt: new Date(), reason: "screening_failed",
+    }),
+    generateNoticeDraft: jest.fn().mockResolvedValue({
+      applicationId: "app-001", applicantName: "Jane Doe", propertyName: "X", noticeText: "DRAFT",
+    }),
+  })),
+}));
+jest.mock("../modules/screening/state-machine", () => ({
+  transitionApplicationStatus: jest.fn(),
+}));
+
+import { query } from "../config/database";
+import { transitionApplicationStatus } from "../modules/screening/state-machine";
+
+const mockQuery = query as jest.MockedFunction<typeof query>;
+const mockTransition = transitionApplicationStatus as jest.MockedFunction<
+  typeof transitionApplicationStatus
+>;
+
+// ── Fixtures ────────────────────────────────────────────────────────────────
+
+function makeApp(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "app-001", status: "submitted", first_name: "Jane", last_name: "Doe",
+    ssn_encrypted: "enc-ssn", date_of_birth_encrypted: "enc-dob",
+    current_state: "NV", property_id: "prop-001", annual_income: "40000",
+    ...overrides,
+  };
+}
+const result = (r: string, extra: Record<string, unknown> = {}) => ({
+  result: r,
+  details: { felonies: 0, sexOffenses: false, violentCrimes: false, misdemeanors: 0, riskScore: 10, ...extra },
+}) as any;
+const credit = (r: string) => ({
+  result: r, creditScore: 700,
+  details: { creditScore: 700, paymentHistory: "good", outstandingDebts: 0, collections: 0, evictions: 0, bankruptcies: 0 },
+}) as any;
+const compliance = (r: string) => ({
+  result: r,
+  details: { incomeWithinLimits: r === "pass", applicableAMILimit: 50000, householdIncome: 40000, amiPercentage: 80, assetVerification: "not_provided", regulatoryNotes: [] },
+}) as any;
+const identity = () => ({
+  result: "verified", confidence: 0.95, idType: "driver_license", livenessScore: 0.97,
+  details: { documentValid: true, selfieMatch: true, riskSignals: [] },
+}) as any;
+
+function eligibleAtUpdates() {
+  return mockQuery.mock.calls.filter(
+    ([sql]) => typeof sql === "string" && /SET adverse_action_eligible_at = \$2/.test(sql)
+  );
+}
+
+// ── Env restore (jest --runInBand persists env across files) ─────────────────
+
+const ORIGINAL_ENABLED = process.env.FCRA_PRE_ADVERSE_ENABLED;
+const ORIGINAL_WINDOW = process.env.FCRA_PRE_ADVERSE_WINDOW_DAYS;
+
+afterEach(() => {
+  if (ORIGINAL_ENABLED === undefined) delete process.env.FCRA_PRE_ADVERSE_ENABLED;
+  else process.env.FCRA_PRE_ADVERSE_ENABLED = ORIGINAL_ENABLED;
+  if (ORIGINAL_WINDOW === undefined) delete process.env.FCRA_PRE_ADVERSE_WINDOW_DAYS;
+  else process.env.FCRA_PRE_ADVERSE_WINDOW_DAYS = ORIGINAL_WINDOW;
+});
+
+// ── Automated path (runFullScreening) ────────────────────────────────────────
+
+describe("runFullScreening — pre-adverse flag gate (automated fail path)", () => {
+  let service: ScreeningService;
+  let bg: any, cr: any, co: any, id: any, aa: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    delete process.env.FCRA_PRE_ADVERSE_ENABLED;
+    delete process.env.FCRA_PRE_ADVERSE_WINDOW_DAYS;
+    (require("../middleware/audit").writeAuditLog as jest.Mock).mockResolvedValue(undefined);
+
+    service = new ScreeningService();
+    bg = (service as any).backgroundCheck;
+    cr = (service as any).creditCheck;
+    co = (service as any).compliance;
+    id = (service as any).identity;
+    aa = (service as any).adverseAction;
+
+    id.resolve.mockResolvedValue(identity());
+    bg.runCheck.mockResolvedValue(result("pass"));
+    cr.runCheck.mockResolvedValue(credit("pass"));
+    co.runCheck.mockResolvedValue(compliance("pass"));
+
+    mockQuery.mockResolvedValueOnce({ rows: [makeApp()] } as any).mockResolvedValue({ rows: [] } as any);
+    mockTransition.mockResolvedValue({ changed: true, status: "screening_passed" } as any);
+  });
+
+  it("flag OFF: a fail goes straight to screening_failed + final notice (byte-identical to today)", async () => {
+    bg.runCheck.mockResolvedValue(result("fail"));
+    mockTransition.mockResolvedValue({ changed: true, status: "screening_failed" } as any);
+
+    await service.runFullScreening("app-001", "user-1", "leasing_agent");
+
+    expect(mockTransition).toHaveBeenCalledWith(
+      expect.objectContaining({ to: "screening_failed", trigger: "any_check_failed" })
+    );
+    expect(aa.sendNotice).toHaveBeenCalledTimes(1);
+    expect(aa.sendPreAdverseNotice).not.toHaveBeenCalled();
+    expect(eligibleAtUpdates()).toHaveLength(0);
+  });
+
+  it("flag ON: a fail routes to pending_adverse_action, opens the window, sends the pre-adverse notice", async () => {
+    process.env.FCRA_PRE_ADVERSE_ENABLED = "true";
+    bg.runCheck.mockResolvedValue(result("fail"));
+    mockTransition.mockResolvedValue({ changed: true, status: "pending_adverse_action" } as any);
+
+    await service.runFullScreening("app-001", "user-1", "leasing_agent");
+
+    expect(mockTransition).toHaveBeenCalledWith(
+      expect.objectContaining({ to: "pending_adverse_action", trigger: "pre_adverse_action_started" })
+    );
+    // window opened
+    expect(eligibleAtUpdates()).toHaveLength(1);
+    // pre-adverse notice sent with default 5-day window + the automated reasonDetail
+    expect(aa.sendPreAdverseNotice).toHaveBeenCalledTimes(1);
+    const call = aa.sendPreAdverseNotice.mock.calls[0];
+    expect(call[0]).toBe("app-001");
+    expect(call[1]).toBe("user-1");
+    expect(call[3]).toBe("screening_failed");
+    expect(call[4]).toBe(5); // default windowDays
+    expect(call[5]).toBeInstanceOf(Date); // eligibleAt
+    expect(call[6]).toMatch(/Automated screening denial/);
+    // the final § 1681m notice is NOT sent up front
+    expect(aa.sendNotice).not.toHaveBeenCalled();
+  });
+
+  it("flag ON: honours a custom FCRA_PRE_ADVERSE_WINDOW_DAYS", async () => {
+    process.env.FCRA_PRE_ADVERSE_ENABLED = "true";
+    process.env.FCRA_PRE_ADVERSE_WINDOW_DAYS = "10";
+    bg.runCheck.mockResolvedValue(result("fail"));
+    mockTransition.mockResolvedValue({ changed: true, status: "pending_adverse_action" } as any);
+
+    await service.runFullScreening("app-001", "user-1", "leasing_agent");
+
+    expect(aa.sendPreAdverseNotice.mock.calls[0][4]).toBe(10);
+  });
+
+  it("flag ON: a lost CAS (changed:false) sends NO notice and opens NO window", async () => {
+    process.env.FCRA_PRE_ADVERSE_ENABLED = "true";
+    bg.runCheck.mockResolvedValue(result("fail"));
+    mockTransition.mockResolvedValue({ changed: false, status: "pending_adverse_action" } as any);
+
+    await service.runFullScreening("app-001", "user-1", "leasing_agent");
+
+    expect(aa.sendPreAdverseNotice).not.toHaveBeenCalled();
+    expect(aa.sendNotice).not.toHaveBeenCalled();
+    expect(eligibleAtUpdates()).toHaveLength(0);
+  });
+
+  it("flag ON: a PASS is unaffected — no pre-adverse hold, no notices", async () => {
+    process.env.FCRA_PRE_ADVERSE_ENABLED = "true";
+    mockTransition.mockResolvedValue({ changed: true, status: "screening_passed" } as any);
+
+    await service.runFullScreening("app-001", "user-1", "leasing_agent");
+
+    expect(mockTransition).toHaveBeenCalledWith(
+      expect.objectContaining({ to: "screening_passed", trigger: "all_checks_passed" })
+    );
+    expect(aa.sendPreAdverseNotice).not.toHaveBeenCalled();
+    expect(aa.sendNotice).not.toHaveBeenCalled();
+    expect(eligibleAtUpdates()).toHaveLength(0);
+  });
+
+  it("flag literally 'false' behaves as OFF", async () => {
+    process.env.FCRA_PRE_ADVERSE_ENABLED = "false";
+    bg.runCheck.mockResolvedValue(result("fail"));
+    mockTransition.mockResolvedValue({ changed: true, status: "screening_failed" } as any);
+
+    await service.runFullScreening("app-001", "user-1", "leasing_agent");
+
+    expect(mockTransition).toHaveBeenCalledWith(
+      expect.objectContaining({ to: "screening_failed", trigger: "any_check_failed" })
+    );
+    expect(aa.sendPreAdverseNotice).not.toHaveBeenCalled();
+  });
+});
+
+// ── Manual review path (resolveReview) ───────────────────────────────────────
+
+describe("resolveReview — pre-adverse flag gate (manual fail path, preview === sent)", () => {
+  let service: ScreeningService;
+  let aa: any;
+  const NOTES = "Identity documents could not be verified by the vendor.";
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    delete process.env.FCRA_PRE_ADVERSE_ENABLED;
+    delete process.env.FCRA_PRE_ADVERSE_WINDOW_DAYS;
+    service = new ScreeningService();
+    aa = (service as any).adverseAction;
+    mockQuery.mockResolvedValue({ rows: [] } as any);
+  });
+
+  it("flag OFF: a manual fail goes to screening_failed + final notice with RAW notes", async () => {
+    mockTransition.mockResolvedValue({ changed: true, status: "screening_failed" } as any);
+
+    await service.resolveReview("app-001", "fail", NOTES, "user-sm-001", "senior_manager");
+
+    expect(mockTransition).toHaveBeenCalledWith(
+      expect.objectContaining({ to: "screening_failed", trigger: "manual_override_fail" })
+    );
+    expect(aa.sendNotice).toHaveBeenCalledWith("app-001", "user-sm-001", "senior_manager", "screening_failed", NOTES);
+    expect(aa.sendPreAdverseNotice).not.toHaveBeenCalled();
+    expect(eligibleAtUpdates()).toHaveLength(0);
+  });
+
+  it("flag ON: a manual fail routes to pending_adverse_action + pre-adverse notice with the RAW notes (preview === sent)", async () => {
+    process.env.FCRA_PRE_ADVERSE_ENABLED = "true";
+    mockTransition.mockResolvedValue({ changed: true, status: "pending_adverse_action" } as any);
+
+    await service.resolveReview("app-001", "fail", NOTES, "user-sm-001", "senior_manager");
+
+    expect(mockTransition).toHaveBeenCalledWith(
+      expect.objectContaining({ to: "pending_adverse_action", trigger: "pre_adverse_action_started" })
+    );
+    expect(eligibleAtUpdates()).toHaveLength(1);
+    expect(aa.sendPreAdverseNotice).toHaveBeenCalledTimes(1);
+    const call = aa.sendPreAdverseNotice.mock.calls[0];
+    expect(call[0]).toBe("app-001");
+    expect(call[1]).toBe("user-sm-001");
+    expect(call[2]).toBe("senior_manager");
+    expect(call[3]).toBe("screening_failed");
+    expect(call[4]).toBe(5);
+    expect(call[5]).toBeInstanceOf(Date);
+    expect(call[6]).toBe(NOTES); // RAW notes — byte-identical to the previewed draft
+    expect(aa.sendNotice).not.toHaveBeenCalled();
+  });
+
+  it("flag ON: a lost CAS sends NO notice and opens NO window", async () => {
+    process.env.FCRA_PRE_ADVERSE_ENABLED = "true";
+    mockTransition.mockResolvedValue({ changed: false, status: "screening_review" } as any);
+
+    await service.resolveReview("app-001", "fail", NOTES, "user-sm-001", "senior_manager");
+
+    expect(aa.sendPreAdverseNotice).not.toHaveBeenCalled();
+    expect(aa.sendNotice).not.toHaveBeenCalled();
+    expect(eligibleAtUpdates()).toHaveLength(0);
+  });
+
+  it("flag ON: a manual PASS is unaffected (no hold, no notice)", async () => {
+    process.env.FCRA_PRE_ADVERSE_ENABLED = "true";
+    mockTransition.mockResolvedValue({ changed: true, status: "screening_passed" } as any);
+
+    await service.resolveReview("app-001", "pass", "Vendor recovered; verdict clear.", "user-sm-001", "senior_manager");
+
+    expect(mockTransition).toHaveBeenCalledWith(
+      expect.objectContaining({ to: "screening_passed", trigger: "manual_override_pass" })
+    );
+    expect(aa.sendPreAdverseNotice).not.toHaveBeenCalled();
+    expect(aa.sendNotice).not.toHaveBeenCalled();
+    expect(eligibleAtUpdates()).toHaveLength(0);
+  });
+});

--- a/src/__tests__/state-machine.test.ts
+++ b/src/__tests__/state-machine.test.ts
@@ -180,9 +180,20 @@ describe("transitionApplicationStatus (application_status chokepoint)", () => {
     // credit) is the analogous gate: the app waits for the applicant to authorize
     // the consumer-report pulls + pass KBA, then the CRA webhook advances it into
     // `screening` (or `screening_review` on could_not_screen).
+    // pending_adverse_action is a flag-gated hold (FCRA_PRE_ADVERSE_ENABLED): a
+    // denial parks there for the dispute window, is both a `to` (from screening/
+    // screening_review) and a `from` (finalizer -> screening_failed, or staff
+    // reopen -> screening_review).
     const froms = new Set(APP_STATUS_TRANSITIONS.map((t) => t.from));
     expect(froms).toEqual(
-      new Set(["submitted", "awaiting_identity", "awaiting_consumer_report", "screening", "screening_review"])
+      new Set([
+        "submitted",
+        "awaiting_identity",
+        "awaiting_consumer_report",
+        "screening",
+        "screening_review",
+        "pending_adverse_action",
+      ])
     );
     expect(
       APP_STATUS_TRANSITIONS.every((t) =>
@@ -193,9 +204,126 @@ describe("transitionApplicationStatus (application_status chokepoint)", () => {
           "screening_review",
           "screening_passed",
           "screening_failed",
+          "pending_adverse_action",
         ].includes(t.to)
       )
     ).toBe(true);
+  });
+
+  // ── pre-adverse-action window transitions (flag-gated FCRA_PRE_ADVERSE_ENABLED) ──
+
+  it("screening -> pending_adverse_action is valid ONLY with trigger 'pre_adverse_action_started'", async () => {
+    mockQuery.mockResolvedValue({ rows: [{ id: "app-paa" }] } as any);
+
+    await expect(
+      transitionApplicationStatus({
+        applicationId: "app-paa",
+        from: "screening",
+        to: "pending_adverse_action",
+        trigger: "pre_adverse_action_started",
+        actorId: "user-1",
+        actorRole: "leasing_agent",
+      })
+    ).resolves.toEqual({ changed: true, status: "pending_adverse_action" });
+  });
+
+  it("rejects screening -> pending_adverse_action under a wrong trigger", async () => {
+    await expect(
+      transitionApplicationStatus({
+        applicationId: "app-paa",
+        from: "screening",
+        to: "pending_adverse_action",
+        // any_check_failed is the immediate-path trigger; it must NOT open the
+        // pre-adverse hold.
+        trigger: "any_check_failed",
+      })
+    ).rejects.toThrow(/Invalid application_status transition/);
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  it("screening_review -> pending_adverse_action is valid ONLY with trigger 'pre_adverse_action_started'", async () => {
+    mockQuery.mockResolvedValue({ rows: [{ id: "app-paa" }] } as any);
+
+    await expect(
+      transitionApplicationStatus({
+        applicationId: "app-paa",
+        from: "screening_review",
+        to: "pending_adverse_action",
+        trigger: "pre_adverse_action_started",
+        actorId: "user-sm",
+        actorRole: "senior_manager",
+      })
+    ).resolves.toEqual({ changed: true, status: "pending_adverse_action" });
+  });
+
+  it("rejects screening_review -> pending_adverse_action under a wrong trigger", async () => {
+    await expect(
+      transitionApplicationStatus({
+        applicationId: "app-paa",
+        from: "screening_review",
+        to: "pending_adverse_action",
+        trigger: "manual_override_fail",
+      })
+    ).rejects.toThrow(/Invalid application_status transition/);
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  it("pending_adverse_action -> screening_failed is valid ONLY with trigger 'adverse_action_finalized' (system finalizer)", async () => {
+    mockQuery.mockResolvedValue({ rows: [{ id: "app-paa" }] } as any);
+
+    await expect(
+      transitionApplicationStatus({
+        applicationId: "app-paa",
+        from: "pending_adverse_action",
+        to: "screening_failed",
+        trigger: "adverse_action_finalized",
+        // system actor — nullable UUID FK; never the string "system"
+        actorId: undefined,
+        actorRole: "system",
+        evidence: { finalizedBy: "pre_adverse_window_scheduler" },
+      })
+    ).resolves.toEqual({ changed: true, status: "screening_failed" });
+  });
+
+  it("rejects pending_adverse_action -> screening_failed under a wrong trigger", async () => {
+    await expect(
+      transitionApplicationStatus({
+        applicationId: "app-paa",
+        from: "pending_adverse_action",
+        to: "screening_failed",
+        // any_check_failed / manual_override_fail are other paths into
+        // screening_failed; the finalizer must use its own trigger.
+        trigger: "any_check_failed",
+      })
+    ).rejects.toThrow(/Invalid application_status transition/);
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  it("pending_adverse_action -> screening_review is valid ONLY with trigger 'dispute_filed' (staff reopen)", async () => {
+    mockQuery.mockResolvedValue({ rows: [{ id: "app-paa" }] } as any);
+
+    await expect(
+      transitionApplicationStatus({
+        applicationId: "app-paa",
+        from: "pending_adverse_action",
+        to: "screening_review",
+        trigger: "dispute_filed",
+        actorId: "staff-1",
+        actorRole: "leasing_agent",
+      })
+    ).resolves.toEqual({ changed: true, status: "screening_review" });
+  });
+
+  it("rejects pending_adverse_action -> screening_review under a wrong trigger", async () => {
+    await expect(
+      transitionApplicationStatus({
+        applicationId: "app-paa",
+        from: "pending_adverse_action",
+        to: "screening_review",
+        trigger: "could_not_screen",
+      })
+    ).rejects.toThrow(/Invalid application_status transition/);
+    expect(mockQuery).not.toHaveBeenCalled();
   });
 
   // ── could_not_screen hold + staff-resolution transitions (Phase: screening_review) ──

--- a/src/db/migrations/2026-06-09-pre-adverse-action-window.sql
+++ b/src/db/migrations/2026-06-09-pre-adverse-action-window.sql
@@ -1,0 +1,30 @@
+-- 2026-06-09 pre-adverse-action-window
+--
+-- Adds the flag-gated (FCRA_PRE_ADVERSE_ENABLED) pre-adverse-action hold:
+-- a consumer-report-derived denial parks in 'pending_adverse_action', the
+-- applicant receives an intent-to-deny notice + copy-of-report/dispute rights +
+-- an N-business-day window, and a daily scheduler finalizes after the window to
+-- 'screening_failed' with the existing § 1681m final notice.
+--
+-- Legal framing: FCRA § 1681b(b)(3) (the pre-adverse subsection) governs
+-- EMPLOYMENT screening, not rental. Rental's federal duty is the § 1681m
+-- POST-action notice (already shipped). This window is therefore a configurable
+-- best-practice / HUD-aligned / state-law-ready hold, default OFF.
+--
+--   * application_status += 'pending_adverse_action'
+--   * applications.adverse_action_eligible_at — when the hold may be finalized
+--   * adverse_action_notices.stage — 'pre_adverse' vs 'adverse' (default keeps
+--     existing rows + the unchanged sendNotice INSERT byte-identical)
+--
+-- NOTE: ALTER TYPE ... ADD VALUE cannot run inside a transaction block.
+-- Apply this file OUTSIDE a transaction, e.g.:
+--   psql "$DATABASE_URL" -f src/db/migrations/2026-06-09-pre-adverse-action-window.sql
+-- (Do NOT wrap in BEGIN/COMMIT; do NOT run via a migration runner that opens a txn.)
+
+ALTER TYPE application_status ADD VALUE IF NOT EXISTS 'pending_adverse_action';
+
+ALTER TABLE applications
+  ADD COLUMN IF NOT EXISTS adverse_action_eligible_at TIMESTAMPTZ;
+
+ALTER TABLE adverse_action_notices
+  ADD COLUMN IF NOT EXISTS stage VARCHAR(20) NOT NULL DEFAULT 'adverse';

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -42,6 +42,12 @@ CREATE TYPE application_status AS ENUM (
   'screening_passed',
   'screening_failed',
   'screening_review',
+  -- Pre-adverse-action hold (flag-gated FCRA_PRE_ADVERSE_ENABLED, 2026-06-09):
+  -- a consumer-report-derived denial parks here while the applicant gets an
+  -- intent-to-deny notice + dispute window; a daily scheduler finalizes it to
+  -- 'screening_failed'. Best-practice/state-law-ready, NOT a federal rental
+  -- mandate (§ 1681b(b)(3) is employment-only; rental's duty is § 1681m POST).
+  'pending_adverse_action',
   'tier1_review',
   'tier1_approved',
   'tier1_denied',
@@ -460,6 +466,11 @@ CREATE TABLE IF NOT EXISTS applications (
   -- { from, to, trigger, actorId, actorRole, at, evidence }.
   status_history JSONB NOT NULL DEFAULT '[]'::jsonb,
 
+  -- When a 'pending_adverse_action' hold becomes finalizable (now + N business
+  -- days). NULL until the flag-gated pre-adverse window opens; the daily
+  -- finalizer only acts on rows where this is non-NULL and <= NOW().
+  adverse_action_eligible_at TIMESTAMPTZ,
+
   -- Screening results
   identity_verification_result screening_result,
   identity_verification_details JSONB,
@@ -852,6 +863,10 @@ CREATE TABLE IF NOT EXISTS adverse_action_notices (
   notice_text TEXT NOT NULL,          -- full FCRA-compliant notice text (PII-safe for log)
   sent_via VARCHAR(50) DEFAULT 'sms',
   sms_delivered BOOLEAN,
+  -- 'pre_adverse' (intent-to-deny, fires when the pre-adverse window opens) vs
+  -- 'adverse' (the § 1681m final notice). Default 'adverse' keeps existing rows
+  -- and the unchanged sendNotice INSERT (which never names stage) byte-identical.
+  stage VARCHAR(20) NOT NULL DEFAULT 'adverse',
   created_at TIMESTAMPTZ DEFAULT NOW()
 );
 

--- a/src/modules/adverse-action/service.ts
+++ b/src/modules/adverse-action/service.ts
@@ -2,6 +2,11 @@ import { query } from "../../config/database";
 import { writeAuditLog } from "../../middleware/audit";
 import { logger } from "../../utils/logger";
 import { TwilioService } from "../integrations/twilio";
+// No import cycle: state-machine imports audit/logger/database/tape, never
+// adverse-action. The finalizer below uses the same CAS chokepoint as the
+// screening pipeline so the pending_adverse_action -> screening_failed move is
+// exactly-once and gated on `changed`.
+import { transitionApplicationStatus } from "../screening/state-machine";
 
 /**
  * FCRA Adverse Action Notice Service
@@ -56,7 +61,7 @@ export class AdverseActionService {
    */
   async sendNotice(
     applicationId: string,
-    actorId: string,
+    actorId: string | null,
     actorRole: string,
     reason: string,
     reasonDetail?: string
@@ -97,7 +102,10 @@ export class AdverseActionService {
 
     await writeAuditLog({
       action: "adverse_action_notice_sent",
-      actorId,
+      // actorId may be null when the daily finalizer (system, no UUID) sends the
+      // § 1681m final notice — sent_by/actor_id are nullable FKs; coerce to
+      // undefined so writeAuditLog's `entry.actorId || null` types check.
+      actorId: actorId ?? undefined,
       actorRole,
       applicationId,
       resourceType: "adverse_action_notice",
@@ -262,6 +270,249 @@ export class AdverseActionService {
       ``,
       `The CRA listed above did not make this adverse action decision and is unable to`,
       `explain why the decision was made.`,
+      ``,
+      `For questions regarding your application, please contact us at:`,
+      `  ${PROPERTY_MGMT_CONTACT}`,
+      ``,
+      `Community Development Programs Center of Nevada`,
+    ]
+      .join("\n")
+      .replace(/\n{3,}/g, "\n\n"); // collapse any triple+ newlines from empty reasonDetail
+  }
+
+  // -------------------------------------------------------------------------
+  // Pre-adverse-action window (flag-gated FCRA_PRE_ADVERSE_ENABLED)
+  //
+  // Legal framing (do not overstate): FCRA § 1681b(b)(3) — the pre-adverse
+  // subsection — governs EMPLOYMENT screening, not rental. A landlord's federal
+  // duty is the § 1681m POST-action notice (sendNotice above). The pre-adverse
+  // notice + dispute window below is a configurable best-practice / HUD-aligned /
+  // state-law-ready courtesy, default OFF. The notice text says we *intend* to
+  // deny and gives the applicant time to obtain and dispute their report; it
+  // never claims a federal rental mandate.
+  // -------------------------------------------------------------------------
+
+  /**
+   * Send a PRE-adverse notice: intent-to-deny + copy-of-report/dispute rights +
+   * an N-business-day window (until eligibleDate). Persists a stage='pre_adverse'
+   * row in adverse_action_notices; the daily finalizer later carries this row's
+   * reason_detail into the final § 1681m notice so preview === sent across the
+   * whole window. Same applicant/property lookup + non-blocking SMS as sendNotice.
+   */
+  async sendPreAdverseNotice(
+    applicationId: string,
+    actorId: string | null,
+    actorRole: string,
+    reason: string,
+    windowDays: number,
+    eligibleDate: Date,
+    reasonDetail?: string
+  ): Promise<AdverseActionResult> {
+    const appResult = await query(
+      `SELECT a.first_name, a.last_name, a.email, a.phone,
+              p.name AS property_name
+       FROM applications a
+       JOIN properties p ON a.property_id = p.id
+       WHERE a.id = $1`,
+      [applicationId]
+    );
+
+    if (appResult.rows.length === 0) {
+      throw new Error(`Application not found: ${applicationId}`);
+    }
+
+    const app = appResult.rows[0];
+    const applicantName = `${app.first_name} ${app.last_name}`;
+
+    const noticeText = this.buildPreAdverseNoticeText(
+      applicantName,
+      app.property_name,
+      windowDays,
+      eligibleDate,
+      reasonDetail
+    );
+
+    const insertResult = await query(
+      `INSERT INTO adverse_action_notices
+         (application_id, sent_by, reason, reason_detail, notice_text, sent_via, stage)
+       VALUES ($1, $2, $3, $4, $5, 'sms', 'pre_adverse')
+       RETURNING id, created_at`,
+      [applicationId, actorId, reason, reasonDetail || null, noticeText]
+    );
+
+    const { id: noticeId, created_at: sentAt } = insertResult.rows[0];
+
+    await writeAuditLog({
+      action: "pre_adverse_action_notice_sent",
+      actorId: actorId ?? undefined,
+      actorRole,
+      applicationId,
+      resourceType: "adverse_action_notice",
+      resourceId: noticeId,
+      details: {
+        reason,
+        reasonDetail: reasonDetail || null,
+        noticeId,
+        stage: "pre_adverse",
+        windowDays,
+        eligibleAt: eligibleDate.toISOString(),
+        sentVia: "sms",
+        applicantName,
+      },
+    });
+
+    if (app.phone) {
+      this.twilio
+        .notifyDenied(app.phone, applicantName)
+        .catch((err: Error) =>
+          logger.warn("Pre-adverse action SMS notification failed", {
+            error: err.message,
+            applicationId,
+            noticeId,
+          })
+        );
+    } else {
+      logger.warn("Pre-adverse action notice: applicant has no phone number on file", {
+        applicationId,
+        noticeId,
+      });
+    }
+
+    logger.info("Pre-adverse action notice sent", {
+      applicationId,
+      noticeId,
+      reason,
+      windowDays,
+      eligibleAt: eligibleDate.toISOString(),
+    });
+
+    return { noticeId, applicationId, sentAt, reason };
+  }
+
+  /**
+   * Finalize every pre-adverse hold whose dispute window has elapsed: each due
+   * application is CAS-moved pending_adverse_action -> screening_failed
+   * (adverse_action_finalized, system actor) and — gated on the CAS winning —
+   * sent the final § 1681m notice carrying the stored pre_adverse reason_detail
+   * (preview === sent). Side effects are gated on the CAS result, not the SELECT,
+   * so overlapping scheduler runs / multiple instances finalize exactly once.
+   * Errors are caught per row so one bad application never stalls the sweep.
+   */
+  async finalizeDuePreAdverseActions(): Promise<{
+    scanned: number;
+    finalized: number;
+    noticesSent: number;
+  }> {
+    const due = await query(
+      `SELECT a.id,
+              (SELECT n.reason_detail
+                 FROM adverse_action_notices n
+                WHERE n.application_id = a.id AND n.stage = 'pre_adverse'
+                ORDER BY n.created_at DESC
+                LIMIT 1) AS pre_adverse_reason_detail
+         FROM applications a
+        WHERE a.status = 'pending_adverse_action'
+          AND a.adverse_action_eligible_at IS NOT NULL
+          AND a.adverse_action_eligible_at <= NOW()
+        ORDER BY a.adverse_action_eligible_at ASC`
+    );
+
+    let finalized = 0;
+    let noticesSent = 0;
+
+    for (const row of due.rows) {
+      const applicationId = row.id as string;
+      const reasonDetail = (row.pre_adverse_reason_detail as string | null) || undefined;
+
+      try {
+        // System actor: actorId undefined -> NULL in status_history + audit
+        // (actor_id is a nullable UUID FK; "system" is a non-UUID string and
+        // would violate the FK). actorRole carries the "system" attribution.
+        const { changed } = await transitionApplicationStatus({
+          applicationId,
+          from: "pending_adverse_action",
+          to: "screening_failed",
+          trigger: "adverse_action_finalized",
+          actorId: undefined,
+          actorRole: "system",
+          evidence: { finalizedBy: "pre_adverse_window_scheduler" },
+        });
+
+        if (!changed) continue; // lost the CAS — another run already finalized
+        finalized++;
+
+        // Final § 1681m notice — reuses the stored pre_adverse reason_detail so
+        // the applicant gets the exact denial reason they were forewarned of.
+        await this.sendNotice(
+          applicationId,
+          null,
+          "system",
+          "screening_failed",
+          reasonDetail
+        );
+        noticesSent++;
+      } catch (err) {
+        logger.error("Pre-adverse finalization failed for application", {
+          error: (err as Error).message,
+          applicationId,
+        });
+      }
+    }
+
+    return { scanned: due.rows.length, finalized, noticesSent };
+  }
+
+  /**
+   * Build the PRE-adverse notice text — intent-to-deny + dispute window. Mirrors
+   * buildNoticeText's structure (CRA block, FCRA rights, collapse triple
+   * newlines) but frames the decision as not-yet-final and gives a deadline.
+   * Intentionally excludes SSN/DOB/PII.
+   */
+  private buildPreAdverseNoticeText(
+    applicantName: string,
+    propertyName: string,
+    windowDays: number,
+    eligibleDate: Date,
+    reasonDetail?: string
+  ): string {
+    const today = new Date().toLocaleDateString("en-US", {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+    });
+    const deadline = eligibleDate.toLocaleDateString("en-US", {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+    });
+
+    return [
+      `Date: ${today}`,
+      ``,
+      `Dear ${applicantName},`,
+      ``,
+      `We are writing to inform you that we INTEND to deny your rental application`,
+      `for ${propertyName}. This decision is not yet final.`,
+      reasonDetail ? `\nReason under consideration: ${reasonDetail}` : "",
+      ``,
+      `This intended decision is based in whole or in part on information obtained`,
+      `from a consumer reporting agency (CRA):`,
+      ``,
+      `  ${CRA_NAME}`,
+      `  ${CRA_ADDRESS}`,
+      `  Phone: ${CRA_PHONE}`,
+      ``,
+      `Before we finalize this decision, you have ${windowDays} business days`,
+      `(until ${deadline}) to:`,
+      ``,
+      `  1. Obtain a FREE copy of your consumer report from the CRA listed above.`,
+      ``,
+      `  2. Dispute any inaccurate or incomplete information directly with the CRA,`,
+      `     and let us know you are disputing it.`,
+      ``,
+      `The CRA listed above did not make this intended decision and is unable to`,
+      `explain why it was made. If we do not hear from you within the window above,`,
+      `the decision may become final and you will receive a final notice.`,
       ``,
       `For questions regarding your application, please contact us at:`,
       `  ${PROPERTY_MGMT_CONTACT}`,

--- a/src/modules/screening/service.ts
+++ b/src/modules/screening/service.ts
@@ -19,6 +19,18 @@ import type { NsopwDirectResult } from "./nsopw-direct";
 import { AdverseActionService } from "../adverse-action/service";
 import { transitionApplicationStatus } from "./state-machine";
 import type { AppStatusTransitionResult } from "./state-machine";
+import { addBusinessDays } from "../../utils/business-days";
+
+// Pre-adverse-action window (flag-gated, default OFF ⇒ byte-identical). When ON,
+// a screening-driven denial routes through pending_adverse_action with an
+// intent-to-deny notice + dispute window instead of going straight to
+// screening_failed. Best-practice/state-law-ready, not a federal rental mandate.
+function preAdverseConfig(): { enabled: boolean; windowDays: number } {
+  const enabled = process.env.FCRA_PRE_ADVERSE_ENABLED === "true";
+  const parsed = parseInt(process.env.FCRA_PRE_ADVERSE_WINDOW_DAYS || "5", 10);
+  const windowDays = Number.isFinite(parsed) && parsed > 0 ? parsed : 5;
+  return { enabled, windowDays };
+}
 
 // IdentityVerificationResult.result uses verified/rejected/review_required/
 // could_not_screen; the `screening_result` enum + downstream overall-result
@@ -600,14 +612,23 @@ export class ScreeningService {
     const backgroundNeedsAssessment =
       backgroundResult.details.decision === "individualized_review";
 
-    // fail                          -> screening_failed  / any_check_failed
-    // could_not_screen              -> screening_review  / could_not_screen
-    // individualized assessment     -> screening_review  / individualized_assessment_required
-    // review_required (passthrough) -> screening_passed  / review_required_passthrough
-    // pass                          -> screening_passed  / all_checks_passed
+    // Pre-adverse window: when enabled, a fail routes through the hold instead
+    // of straight to screening_failed (flag off ⇒ identical to before).
+    const { enabled: preAdverseEnabled, windowDays: preAdverseWindowDays } =
+      preAdverseConfig();
+    const denyViaPreAdverse = preAdverseEnabled && overallResult === "fail";
+
+    // fail (flag off)               -> screening_failed        / any_check_failed
+    // fail (flag on)                -> pending_adverse_action  / pre_adverse_action_started
+    // could_not_screen              -> screening_review        / could_not_screen
+    // individualized assessment     -> screening_review        / individualized_assessment_required
+    // review_required (passthrough) -> screening_passed        / review_required_passthrough
+    // pass                          -> screening_passed        / all_checks_passed
     const finalStatus =
       overallResult === "fail"
-        ? "screening_failed"
+        ? denyViaPreAdverse
+          ? "pending_adverse_action"
+          : "screening_failed"
         : overallResult === "could_not_screen"
           ? "screening_review"
           : backgroundNeedsAssessment
@@ -615,7 +636,9 @@ export class ScreeningService {
             : "screening_passed";
     const finalTrigger =
       overallResult === "fail"
-        ? "any_check_failed"
+        ? denyViaPreAdverse
+          ? "pre_adverse_action_started"
+          : "any_check_failed"
         : overallResult === "could_not_screen"
           ? "could_not_screen"
           : backgroundNeedsAssessment
@@ -660,21 +683,49 @@ export class ScreeningService {
       ]
         .filter(Boolean)
         .join(", ");
+      const reasonDetail = `Automated screening denial: failed ${failedChecks}`;
 
-      this.adverseAction
-        .sendNotice(
-          applicationId,
-          initiatedBy,
-          initiatorRole,
-          "screening_failed",
-          `Automated screening denial: failed ${failedChecks}`
-        )
-        .catch((err: Error) =>
-          logger.error("Failed to send FCRA adverse action notice after screening failure", {
-            error: err.message,
-            applicationId,
-          })
+      if (denyViaPreAdverse) {
+        // Pre-adverse path: open the dispute window, then send the intent-to-deny
+        // notice. eligible_at is written AFTER the CAS wins; the finalizer skips
+        // rows where it is still NULL, so the brief gap is race-safe.
+        const eligibleAt = addBusinessDays(new Date(), preAdverseWindowDays);
+        await query(
+          "UPDATE applications SET adverse_action_eligible_at = $2 WHERE id = $1",
+          [applicationId, eligibleAt]
         );
+        this.adverseAction
+          .sendPreAdverseNotice(
+            applicationId,
+            initiatedBy,
+            initiatorRole,
+            "screening_failed",
+            preAdverseWindowDays,
+            eligibleAt,
+            reasonDetail
+          )
+          .catch((err: Error) =>
+            logger.error("Failed to send FCRA pre-adverse action notice after screening failure", {
+              error: err.message,
+              applicationId,
+            })
+          );
+      } else {
+        this.adverseAction
+          .sendNotice(
+            applicationId,
+            initiatedBy,
+            initiatorRole,
+            "screening_failed",
+            reasonDetail
+          )
+          .catch((err: Error) =>
+            logger.error("Failed to send FCRA adverse action notice after screening failure", {
+              error: err.message,
+              applicationId,
+            })
+          );
+      }
     }
 
     // Audit each check completion
@@ -806,8 +857,24 @@ export class ScreeningService {
     reviewerId: string,
     reviewerRole: string
   ): Promise<AppStatusTransitionResult> {
-    const to = decision === "pass" ? "screening_passed" : "screening_failed";
-    const trigger = decision === "pass" ? "manual_override_pass" : "manual_override_fail";
+    // Pre-adverse window: a manual fail routes through the hold when enabled
+    // (flag off ⇒ straight to screening_failed, exactly as before).
+    const { enabled: preAdverseEnabled, windowDays: preAdverseWindowDays } =
+      preAdverseConfig();
+    const denyViaPreAdverse = preAdverseEnabled && decision === "fail";
+
+    const to =
+      decision === "pass"
+        ? "screening_passed"
+        : denyViaPreAdverse
+          ? "pending_adverse_action"
+          : "screening_failed";
+    const trigger =
+      decision === "pass"
+        ? "manual_override_pass"
+        : denyViaPreAdverse
+          ? "pre_adverse_action_started"
+          : "manual_override_fail";
 
     const { changed, status } = await transitionApplicationStatus({
       applicationId,
@@ -829,20 +896,47 @@ export class ScreeningService {
     // in the manual_override_fail status-transition audit recorded above, not in
     // the applicant-facing letter.
     if (decision === "fail" && changed) {
-      this.adverseAction
-        .sendNotice(
-          applicationId,
-          reviewerId,
-          reviewerRole,
-          "screening_failed",
-          notes
-        )
-        .catch((err: Error) =>
-          logger.error("Failed to send FCRA adverse action notice after manual review denial", {
-            error: err.message,
-            applicationId,
-          })
+      if (denyViaPreAdverse) {
+        // Pre-adverse path: open the dispute window, then send the intent-to-deny
+        // notice with the RAW notes (preview === sent). The finalizer reuses this
+        // pre_adverse row's reason_detail for the final notice.
+        const eligibleAt = addBusinessDays(new Date(), preAdverseWindowDays);
+        await query(
+          "UPDATE applications SET adverse_action_eligible_at = $2 WHERE id = $1",
+          [applicationId, eligibleAt]
         );
+        this.adverseAction
+          .sendPreAdverseNotice(
+            applicationId,
+            reviewerId,
+            reviewerRole,
+            "screening_failed",
+            preAdverseWindowDays,
+            eligibleAt,
+            notes
+          )
+          .catch((err: Error) =>
+            logger.error("Failed to send FCRA pre-adverse action notice after manual review denial", {
+              error: err.message,
+              applicationId,
+            })
+          );
+      } else {
+        this.adverseAction
+          .sendNotice(
+            applicationId,
+            reviewerId,
+            reviewerRole,
+            "screening_failed",
+            notes
+          )
+          .catch((err: Error) =>
+            logger.error("Failed to send FCRA adverse action notice after manual review denial", {
+              error: err.message,
+              applicationId,
+            })
+          );
+      }
     }
 
     return { changed, status };

--- a/src/modules/screening/state-machine.ts
+++ b/src/modules/screening/state-machine.ts
@@ -152,7 +152,13 @@ export type AppStatus =
   | "screening"
   | "screening_passed"
   | "screening_failed"
-  | "screening_review";
+  | "screening_review"
+  // Pre-adverse-action hold (flag-gated FCRA_PRE_ADVERSE_ENABLED). A
+  // consumer-report-derived denial parks here while the applicant gets an
+  // intent-to-deny notice + dispute window; the daily finalizer then advances
+  // it to screening_failed. Best-practice/state-law-ready, not a federal
+  // rental mandate (§ 1681b(b)(3) is employment-only; rental = § 1681m POST).
+  | "pending_adverse_action";
 
 interface AppStatusTransition {
   from: AppStatus;
@@ -197,6 +203,16 @@ export const APP_STATUS_TRANSITIONS: ReadonlyArray<AppStatusTransition> = [
   { from: "screening", to: "screening_review", trigger: "individualized_assessment_required" },
   { from: "screening_review", to: "screening_passed", trigger: "manual_override_pass" },
   { from: "screening_review", to: "screening_failed", trigger: "manual_override_fail" },
+  // Pre-adverse-action window (flag-gated FCRA_PRE_ADVERSE_ENABLED). When the
+  // flag is ON, a denial routes through pending_adverse_action instead of going
+  // straight to screening_failed: it opens an intent-to-deny hold, and the daily
+  // finalizer (after the dispute window) advances it the rest of the way.
+  { from: "screening", to: "pending_adverse_action", trigger: "pre_adverse_action_started" },
+  { from: "screening_review", to: "pending_adverse_action", trigger: "pre_adverse_action_started" },
+  { from: "pending_adverse_action", to: "screening_failed", trigger: "adverse_action_finalized" },
+  // Staff-reopen edge — a dispute lands during the window and a reviewer pulls
+  // the hold back for manual handling. Applicant-facing dispute UI is v2.
+  { from: "pending_adverse_action", to: "screening_review", trigger: "dispute_filed" },
 ];
 
 export interface AppStatusTransitionInput {

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -4,12 +4,14 @@ import { LedgerService } from "./modules/ledger/service";
 import { LeaseRenewalService } from "./modules/renewal/service";
 import { createTapeService } from "./modules/tape/service";
 import { PgTapeRepository } from "./modules/tape/repository";
+import { AdverseActionService } from "./modules/adverse-action/service";
 import { logger } from "./utils/logger";
 
 const recertService = new RecertificationService();
 const ledgerService = new LedgerService();
 const renewalService = new LeaseRenewalService();
 const tapeService = createTapeService(new PgTapeRepository());
+const adverseActionService = new AdverseActionService();
 
 /**
  * Start daily scheduled jobs.
@@ -152,6 +154,31 @@ export function startScheduler() {
   } else {
     logger.info(
       "BP-02 verify-cron skipped — COMPLIANCE_TAPE_V2_ENABLED is off"
+    );
+  }
+
+  // FCRA pre-adverse-action finalizer — gated on FCRA_PRE_ADVERSE_ENABLED.
+  // Until the flag is on there are no pending_adverse_action holds to finalize,
+  // so the cron stays unregistered (default off ⇒ byte-identical scheduler).
+  if (process.env.FCRA_PRE_ADVERSE_ENABLED === "true") {
+    // Daily at 6:00 AM — finalize every pre-adverse hold whose dispute window
+    // has elapsed: CAS pending_adverse_action -> screening_failed + § 1681m
+    // final notice (exactly-once, gated on the CAS result per application).
+    cron.schedule("0 6 * * *", async () => {
+      logger.info("Scheduler: Finalizing due pre-adverse-action holds");
+      try {
+        const stats = await adverseActionService.finalizeDuePreAdverseActions();
+        logger.info("Scheduler: Pre-adverse-action finalization complete", stats);
+      } catch (err) {
+        logger.error("Scheduler: Pre-adverse-action finalization failed", {
+          error: (err as Error).message,
+        });
+      }
+    });
+    logger.info("FCRA pre-adverse finalizer cron registered (FCRA_PRE_ADVERSE_ENABLED=true)");
+  } else {
+    logger.info(
+      "FCRA pre-adverse finalizer cron skipped — FCRA_PRE_ADVERSE_ENABLED is off"
     );
   }
 

--- a/src/utils/__tests__/business-days.test.ts
+++ b/src/utils/__tests__/business-days.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Tests for src/utils/business-days.ts
+ *
+ * Pure date arithmetic for the FCRA pre-adverse-action window. All cases pass an
+ * explicit `from` date so the suite is deterministic regardless of the day the
+ * test runs. Weekends are skipped; holidays are intentionally out of scope (a
+ * skipped holiday can only LENGTHEN the window, never shorten it).
+ *
+ * Calendar anchors used below (all UTC-naive local dates):
+ *   2026-06-08 = Monday
+ *   2026-06-12 = Friday
+ *   2026-06-13 = Saturday
+ *   2026-06-14 = Sunday
+ */
+
+import { addBusinessDays, isBusinessDay } from "../business-days";
+
+describe("isBusinessDay", () => {
+  it("returns true Monday–Friday", () => {
+    // 2026-06-08 Mon … 2026-06-12 Fri
+    for (let d = 8; d <= 12; d++) {
+      expect(isBusinessDay(new Date(2026, 5, d))).toBe(true);
+    }
+  });
+
+  it("returns false on Saturday and Sunday", () => {
+    expect(isBusinessDay(new Date(2026, 5, 13))).toBe(false); // Sat
+    expect(isBusinessDay(new Date(2026, 5, 14))).toBe(false); // Sun
+  });
+});
+
+describe("addBusinessDays", () => {
+  it("adds N business days within a single work week (Mon + 4 = Fri)", () => {
+    const from = new Date(2026, 5, 8); // Mon
+    const out = addBusinessDays(from, 4);
+    expect(out.getFullYear()).toBe(2026);
+    expect(out.getMonth()).toBe(5);
+    expect(out.getDate()).toBe(12); // Fri
+  });
+
+  it("skips the weekend when the window crosses it (Thu + 2 = Mon)", () => {
+    const from = new Date(2026, 5, 11); // Thu
+    const out = addBusinessDays(from, 2); // Fri, then Mon (Sat/Sun skipped)
+    expect(out.getDate()).toBe(15); // Mon 2026-06-15
+  });
+
+  it("the default 5-day window from a Monday lands the next Monday", () => {
+    const from = new Date(2026, 5, 8); // Mon
+    const out = addBusinessDays(from, 5); // Tue..Fri = 4, then Mon = 5
+    expect(out.getDate()).toBe(15); // Mon 2026-06-15
+  });
+
+  it("starting on a Friday, +1 business day is the following Monday", () => {
+    const from = new Date(2026, 5, 12); // Fri
+    const out = addBusinessDays(from, 1);
+    expect(out.getDate()).toBe(15); // Mon
+  });
+
+  it("starting on a Saturday, +1 business day is Monday (does not count Sat/Sun)", () => {
+    const from = new Date(2026, 5, 13); // Sat
+    const out = addBusinessDays(from, 1);
+    expect(out.getDate()).toBe(15); // Mon
+  });
+
+  it("preserves the time-of-day of `from`", () => {
+    const from = new Date(2026, 5, 8, 14, 37, 12, 500); // Mon 14:37:12.500
+    const out = addBusinessDays(from, 3);
+    expect(out.getHours()).toBe(14);
+    expect(out.getMinutes()).toBe(37);
+    expect(out.getSeconds()).toBe(12);
+    expect(out.getMilliseconds()).toBe(500);
+  });
+
+  it("does not mutate the input date", () => {
+    const from = new Date(2026, 5, 8);
+    const before = from.getTime();
+    addBusinessDays(from, 5);
+    expect(from.getTime()).toBe(before);
+  });
+
+  it("returns a copy unchanged for n <= 0 (degenerate window finalizes next tick)", () => {
+    const from = new Date(2026, 5, 8, 9, 0, 0);
+    for (const n of [0, -1, -10]) {
+      const out = addBusinessDays(from, n);
+      expect(out.getTime()).toBe(from.getTime());
+      expect(out).not.toBe(from); // still a fresh object
+    }
+  });
+
+  it("returns a copy unchanged for non-finite n (NaN / Infinity)", () => {
+    const from = new Date(2026, 5, 8);
+    expect(addBusinessDays(from, NaN).getTime()).toBe(from.getTime());
+    expect(addBusinessDays(from, Infinity).getTime()).toBe(from.getTime());
+  });
+
+  it("never lands on a weekend for any N from a weekday start", () => {
+    const from = new Date(2026, 5, 8); // Mon
+    for (let n = 1; n <= 30; n++) {
+      expect(isBusinessDay(addBusinessDays(from, n))).toBe(true);
+    }
+  });
+});

--- a/src/utils/business-days.ts
+++ b/src/utils/business-days.ts
@@ -1,0 +1,35 @@
+/**
+ * Business-day arithmetic for the FCRA pre-adverse-action window.
+ *
+ * The pre-adverse hold gives an applicant N *business* days to obtain a copy of
+ * their consumer report and dispute it before a denial is finalized. Weekends
+ * are skipped; public holidays are intentionally OUT OF SCOPE — ignoring them
+ * can only make the window LONGER (more applicant-favorable / conservative),
+ * never shorter, so it never under-counts the dispute period.
+ *
+ * Pure functions, no DB, no env, no clock of their own (caller passes `from`).
+ */
+
+/** Saturday (6) and Sunday (0) are not business days. */
+export function isBusinessDay(d: Date): boolean {
+  const day = d.getDay();
+  return day !== 0 && day !== 6;
+}
+
+/**
+ * Return a new Date that is `n` business days after `from`, preserving the
+ * time-of-day of `from`. `n <= 0` (or non-finite) returns a copy of `from`
+ * unchanged — a degenerate window finalizes on the next scheduler tick rather
+ * than throwing.
+ */
+export function addBusinessDays(from: Date, n: number): Date {
+  const result = new Date(from.getTime());
+  if (!Number.isFinite(n) || n <= 0) return result;
+
+  let added = 0;
+  while (added < n) {
+    result.setDate(result.getDate() + 1);
+    if (isBusinessDay(result)) added++;
+  }
+  return result;
+}


### PR DESCRIPTION
## What

Adds a **configurable pre-adverse-action hold** between a consumer-report-derived denial and the final § 1681m notice, behind `FCRA_PRE_ADVERSE_ENABLED` (default **OFF** ⇒ byte-identical to today).

When ON, a screening **`fail`** (automated) or a manual review **`fail`** routes to a new `pending_adverse_action` status, sends an **intent-to-deny** notice (copy-of-report + dispute rights + an N-business-day window), and a daily 6 AM finalizer advances the hold → `screening_failed` + the existing final notice once the window elapses.

## Legal framing (deliberately not overstated)

§ 1681b(b)(3) — the FCRA pre-adverse subsection — is **employment** screening. A landlord's federal duty is the § 1681m **post-action** notice, which already ships. This is a **best-practice / HUD-aligned / state-law-ready** courtesy window, **not** a federal rental mandate. Comments, the notice body, and this PR say "best-practice / state-law-ready"; the notice text says we *intend* to deny and that the decision is **not yet final** — it never claims a federal rental requirement.

**Scope v1:** automated screening-`fail` + manual review-`fail` only. Tier1/2/3 policy denials stay on the immediate path.

## Changes

- **Migration delta** `2026-06-09-pre-adverse-action-window.sql` (applied outside a txn — `ALTER TYPE … ADD VALUE` can't run in one), **mirrored into base `schema.ts`**: `pending_adverse_action` enum value; `applications.adverse_action_eligible_at`; `adverse_action_notices.stage` (`DEFAULT 'adverse'` ⇒ existing rows + the unchanged `sendNotice` INSERT stay byte-identical).
- **state-machine**: 4 new transitions — `screening`/`screening_review` → `pending_adverse_action` (`pre_adverse_action_started`); `pending_adverse_action` → `screening_failed` (`adverse_action_finalized`) / `screening_review` (`dispute_filed`). The CAS chokepoint is unchanged (`$2::application_status` casts already handle the new value).
- **adverse-action/service**: `sendPreAdverseNotice` + `finalizeDuePreAdverseActions`. Every notice send is **gated on the CAS result** ⇒ exactly-once across overlapping/multi-instance runs; the final notice **reuses the stored `pre_adverse` `reason_detail`** ⇒ preview === sent. System actor → `actorId: undefined` (nullable UUID FK), never the string `"system"`.
- **screening/service**: both denial sites rewired behind the flag; **raw** `notes`/`reasonDetail` carried so preview === sent. Flag off ⇒ today's exact `screening_failed` + `sendNotice`.
- **scheduler**: finalizer cron `"0 6 * * *"` registered **only** when `FCRA_PRE_ADVERSE_ENABLED === "true"` (mirrors the `COMPLIANCE_TAPE_V2_ENABLED` gate).
- **.env.example**: `FCRA_PRE_ADVERSE_ENABLED` (default off) + `FCRA_PRE_ADVERSE_WINDOW_DAYS` (default 5).

## Tests

**149 green** (79 new/extended + 70 existing regression), `tsc` clean (locally; the only tsc noise is a stale shared `node_modules` stripe version unrelated to this branch — CI's fresh `npm ci` resolves it).

- `business-days` — weekend skips, time-of-day preservation, degenerate/non-finite N, never-lands-on-weekend.
- `sendPreAdverseNotice` — `stage='pre_adverse'` row, intent-to-deny framing + deadline, audit `pre_adverse_action_notice_sent`, system-actor null→undefined coercion, non-blocking SMS, no final-denial language.
- `finalizeDuePreAdverseActions` — CAS-gated exactly-once, preview===sent, per-row isolation, oldest-window-first, clean no-op.
- flag gate on **both** screening denial sites — off == today; on → `pending_adverse_action` + window + pre-adverse notice; CAS-lost → no notice; manual path raw notes (preview===sent).
- scheduler cron gate (off/false → skip; true → `"0 6 * * *"`, no collision with monthly rent `"0 6 1 * *"`).
- state-machine — all 4 new transitions + wrong-trigger rejections; structural `from`/`to` assertions updated.

## Arming (later, deliberate — NOT in this PR)

Run the delta in **every** environment and confirm `migrate` reports 0 pending **before** flipping the flag (the enum value must exist for the CAS casts). Ships dark; the new value is referenced only inside unreachable flag-gated branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)