### PR TITLE
fix(tape): route swallowed compliance-tape stamp failures to a DLQ + dark replay

### DIFF
--- a/src/__tests__/scheduler-bp02-flag.test.ts
+++ b/src/__tests__/scheduler-bp02-flag.test.ts
@@ -7,14 +7,17 @@
  * on a schedule just floods logs with errors. The cron must therefore only
  * register when COMPLIANCE_TAPE_V2_ENABLED === "true".
  *
+ * The same flag also gates the every-15-min compliance_tape_dlq replay-cron, so
+ * "true" registers BOTH (verify + replay) on top of the baseline.
+ *
  * These tests assert all three flag-state branches:
  *   - undefined        → skip (default OFF)
  *   - "false" (string) → skip
- *   - "true"           → register
+ *   - "true"           → register both flag-gated crons
  *
  * The other five scheduled jobs (rent, late fees, renewals, recerts, TRACS)
  * are always registered and are unaffected by the flag — we assert the
- * verify-cron registration by counting cron.schedule calls against that
+ * flag-gated cron registration by counting cron.schedule calls against that
  * fixed baseline.
  */
 
@@ -110,10 +113,13 @@ describe("BP-02 verify-cron flag gate", () => {
     expect(expressions).not.toContain("*/5 * * * *");
   });
 
-  it("DOES register the verify-cron when the flag is the string \"true\"", () => {
+  it("DOES register the verify-cron AND the tape-DLQ replay-cron when the flag is the string \"true\"", () => {
     const cron = runSchedulerWithFlag("true");
-    expect(cron.schedule).toHaveBeenCalledTimes(BASELINE_CRON_JOBS + 1);
+    // The flag gates TWO crons: the every-5-min chain-verify sweep and the
+    // every-15-min compliance_tape_dlq replay/reconciler. Both register together.
+    expect(cron.schedule).toHaveBeenCalledTimes(BASELINE_CRON_JOBS + 2);
     const expressions = cron.schedule.mock.calls.map((c) => c[0]);
-    expect(expressions).toContain("*/5 * * * *");
+    expect(expressions).toContain("*/5 * * * *"); // verify-cron
+    expect(expressions).toContain("*/15 * * * *"); // tape-DLQ replay-cron
   });
 });

--- a/src/__tests__/tape-dlq.test.ts
+++ b/src/__tests__/tape-dlq.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Unit tests for the compliance-tape dead-letter queue (src/modules/tape/dlq.ts).
+ *
+ * Mocked: DB (SQL-routed), logger, and the tape service (createTapeService) so
+ * replay's stamp() outcome is controllable. Exercises park (insert / cap /
+ * never-throw), replay (resolve on success, bump on failure), and stats mapping.
+ */
+
+jest.mock("../config/database", () => ({ query: jest.fn() }));
+jest.mock("../utils/logger", () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+const mockStamp = jest.fn();
+jest.mock("../modules/tape/service", () => ({
+  createTapeService: () => ({ stamp: mockStamp }),
+}));
+jest.mock("../modules/tape/repository", () => ({
+  PgTapeRepository: jest.fn().mockImplementation(() => ({})),
+}));
+
+import { query } from "../config/database";
+import { logger } from "../utils/logger";
+import {
+  parkFailedStamp,
+  replayTapeDlq,
+  getTapeDlqStats,
+} from "../modules/tape/dlq";
+import type { TapeEvent } from "../modules/tape/types";
+
+const mockQuery = query as jest.MockedFunction<typeof query>;
+
+function makeEvent(overrides: Partial<TapeEvent> = {}): TapeEvent {
+  return {
+    kind: "acq.award_recorded",
+    payload: {
+      "@context": "https://schema.org",
+      "@type": "AcquisitionComplianceEvent",
+      actorId: "staff-1",
+      subjectId: null,
+      ruleCitation: "IRC §42 + NV 2026 QAP §3",
+      evidence: { awardId: "award-1", propertyId: "prop-1" },
+    },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("parkFailedStamp", () => {
+  it("inserts the failed stamp when under the active-row cap", async () => {
+    mockQuery.mockImplementation(async (sql: string) => {
+      if (sql.includes("SELECT COUNT(*)")) return { rows: [{ count: 3 }] } as any;
+      return { rows: [] } as any; // the INSERT
+    });
+
+    await parkFailedStamp(makeEvent({ sessionId: "sess-9" }), new Error("tape down"));
+
+    const insert = mockQuery.mock.calls.find((c) =>
+      String(c[0]).includes("INSERT INTO compliance_tape_dlq")
+    );
+    expect(insert).toBeTruthy();
+    const params = insert![1] as unknown[];
+    expect(params[0]).toBe("acq.award_recorded"); // kind
+    expect(params[1]).toBe("sess-9"); // session_id
+    expect(JSON.parse(params[2] as string)).toMatchObject({
+      evidence: { awardId: "award-1" },
+    }); // payload json
+    expect(params[3]).toBe("tape down"); // error message
+  });
+
+  it("maps an absent sessionId to null", async () => {
+    mockQuery.mockImplementation(async (sql: string) => {
+      if (sql.includes("SELECT COUNT(*)")) return { rows: [{ count: 0 }] } as any;
+      return { rows: [] } as any;
+    });
+
+    await parkFailedStamp(makeEvent(), new Error("x"));
+
+    const insert = mockQuery.mock.calls.find((c) =>
+      String(c[0]).includes("INSERT INTO compliance_tape_dlq")
+    );
+    expect((insert![1] as unknown[])[1]).toBeNull();
+  });
+
+  it("skips the insert and warns when the DLQ is at capacity", async () => {
+    mockQuery.mockImplementation(async (sql: string) => {
+      if (sql.includes("SELECT COUNT(*)")) return { rows: [{ count: 10_000 }] } as any;
+      return { rows: [] } as any;
+    });
+
+    await parkFailedStamp(makeEvent(), new Error("x"));
+
+    const insert = mockQuery.mock.calls.find((c) =>
+      String(c[0]).includes("INSERT INTO compliance_tape_dlq")
+    );
+    expect(insert).toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledWith(
+      "compliance-tape DLQ at capacity — skipping new row",
+      expect.objectContaining({ cap: 10_000 })
+    );
+  });
+
+  it("never throws even when the DLQ write itself fails", async () => {
+    mockQuery.mockRejectedValue(new Error("db gone"));
+
+    await expect(
+      parkFailedStamp(makeEvent(), new Error("x"))
+    ).resolves.toBeUndefined();
+    expect(logger.error).toHaveBeenCalledWith(
+      "compliance-tape DLQ insert failed",
+      expect.objectContaining({ kind: "acq.award_recorded" })
+    );
+  });
+});
+
+describe("replayTapeDlq", () => {
+  const row = {
+    id: "dlq-1",
+    kind: "acq.units_designated",
+    session_id: null,
+    payload: makeEvent().payload,
+    attempt_count: 1,
+  };
+
+  it("re-stamps and marks the row resolved on success", async () => {
+    mockStamp.mockResolvedValue({ id: "tape-1" });
+    mockQuery.mockImplementation(async (sql: string) => {
+      if (sql.includes("SELECT id, kind")) return { rows: [row] } as any;
+      return { rows: [] } as any; // the UPDATE
+    });
+
+    const result = await replayTapeDlq();
+
+    expect(result).toEqual({ scanned: 1, replayed: 1, failed: 0 });
+    expect(mockStamp).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "acq.units_designated", sessionId: undefined })
+    );
+    const update = mockQuery.mock.calls.find((c) =>
+      String(c[0]).includes("SET resolved_at = NOW()")
+    );
+    expect(update![1]).toEqual(["dlq-1"]);
+  });
+
+  it("bumps attempt_count and does not resolve on a repeat failure", async () => {
+    mockStamp.mockRejectedValue(new Error("still down"));
+    mockQuery.mockImplementation(async (sql: string) => {
+      if (sql.includes("SELECT id, kind")) return { rows: [row] } as any;
+      return { rows: [] } as any;
+    });
+
+    const result = await replayTapeDlq();
+
+    expect(result).toEqual({ scanned: 1, replayed: 0, failed: 1 });
+    const resolved = mockQuery.mock.calls.find((c) =>
+      String(c[0]).includes("SET resolved_at = NOW()")
+    );
+    expect(resolved).toBeUndefined();
+    const bump = mockQuery.mock.calls.find((c) =>
+      String(c[0]).includes("SET attempt_count = attempt_count + 1")
+    );
+    expect(bump![1]).toEqual(["dlq-1", "still down"]);
+  });
+
+  it("returns a zero result when nothing is parked", async () => {
+    mockQuery.mockResolvedValue({ rows: [] } as any);
+    const result = await replayTapeDlq();
+    expect(result).toEqual({ scanned: 0, replayed: 0, failed: 0 });
+    expect(mockStamp).not.toHaveBeenCalled();
+  });
+
+  it("only scans rows under the attempt cap (MAX_REPLAY_ATTEMPTS bind param)", async () => {
+    mockQuery.mockResolvedValue({ rows: [] } as any);
+    await replayTapeDlq({ limit: 25 });
+    const select = mockQuery.mock.calls.find((c) =>
+      String(c[0]).includes("SELECT id, kind")
+    );
+    expect(select![1]).toEqual([5, 25]); // [MAX_REPLAY_ATTEMPTS, limit]
+  });
+});
+
+describe("getTapeDlqStats", () => {
+  it("maps the aggregate counts", async () => {
+    mockQuery.mockResolvedValue({
+      rows: [{ unresolved: 2, resolved: 7, exhausted: 1 }],
+    } as any);
+    const stats = await getTapeDlqStats();
+    expect(stats).toEqual({ unresolved: 2, resolved: 7, exhausted: 1 });
+  });
+});

--- a/src/db/migrations/2026-06-09-compliance-tape-dlq.sql
+++ b/src/db/migrations/2026-06-09-compliance-tape-dlq.sql
@@ -1,0 +1,36 @@
+-- Compliance-tape stamp dead-letter queue (BP-02).
+--
+-- The acquisitions stamp sites (award-service.ts stampSafe, recert-compliance.ts
+-- stampNau + stampSafe) deliberately swallow tape failures so a tape outage can
+-- never block a durable management-side write (units.ami_designation, a recert
+-- review). Until now that swallow was log-only: a failed stamp vanished into the
+-- logs and the compliance record was silently lost — the exact gap the
+-- 2026-05-23-compliance-tape.sql migration comment flagged.
+--
+-- This table makes the failure durable + queryable + replayable. parkFailedStamp()
+-- (src/modules/tape/dlq.ts) writes the full TapeEvent here on a swallowed error;
+-- replayTapeDlq() re-stamps unresolved rows (dark cron, gated on
+-- COMPLIANCE_TAPE_V2_ENABLED). Same DLQ pattern as cra_webhook_dlq, minus the
+-- event_id idempotency key (acq stamps carry no natural delivery id — each failed
+-- stamp is a discrete row; the active-row cap is the runaway backstop).
+--
+-- What's stored is exactly the payload the tape itself would have held
+-- (compliance metadata: award/recert/unit ids + categorical verdicts) — no SSN,
+-- DOB, name, or other raw PII ever reaches this table.
+
+CREATE TABLE IF NOT EXISTS compliance_tape_dlq (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  kind            TEXT NOT NULL,
+  session_id      TEXT,
+  payload         JSONB NOT NULL,
+  error_message   TEXT,
+  attempt_count   INT NOT NULL DEFAULT 1,
+  first_failed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  last_failed_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  resolved_at     TIMESTAMPTZ
+);
+
+-- Drives both the replay scan (unresolved, oldest first) and the active-row cap.
+CREATE INDEX IF NOT EXISTS idx_compliance_tape_dlq_unresolved
+  ON compliance_tape_dlq (first_failed_at)
+  WHERE resolved_at IS NULL;

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -784,6 +784,30 @@ CREATE TRIGGER compliance_tape_no_truncate
   FOR EACH STATEMENT
   EXECUTE FUNCTION compliance_tape_reject_mutation();
 
+-- Dead-letter queue for compliance-tape stamps that the acquisitions stamp sites
+-- (award/recert) swallow so a tape outage can't block a durable management write.
+-- parkFailedStamp() lands the failed TapeEvent here; replayTapeDlq() re-stamps
+-- unresolved rows (dark cron, gated on COMPLIANCE_TAPE_V2_ENABLED). Same pattern
+-- as cra_webhook_dlq, minus the event_id idempotency key (acq stamps have no
+-- natural delivery id). Stores only the tape payload (compliance metadata) — no
+-- raw PII. See src/modules/tape/dlq.ts and
+-- src/db/migrations/2026-06-09-compliance-tape-dlq.sql.
+CREATE TABLE IF NOT EXISTS compliance_tape_dlq (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  kind            TEXT NOT NULL,
+  session_id      TEXT,
+  payload         JSONB NOT NULL,
+  error_message   TEXT,
+  attempt_count   INT NOT NULL DEFAULT 1,
+  first_failed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  last_failed_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  resolved_at     TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_compliance_tape_dlq_unresolved
+  ON compliance_tape_dlq (first_failed_at)
+  WHERE resolved_at IS NULL;
+
 -- Tenant/applicant join to applications (multiple users per application: primary, co-applicant, household member)
 CREATE TABLE IF NOT EXISTS user_applications (
   id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),

--- a/src/modules/acquisitions/award-service.ts
+++ b/src/modules/acquisitions/award-service.ts
@@ -11,6 +11,8 @@ import { query, transaction } from '../../config/database';
 import { logger } from '../../utils/logger';
 import { createTapeService } from '../tape/service';
 import { PgTapeRepository } from '../tape/repository';
+import { parkFailedStamp } from '../tape/dlq';
+import type { TapeEvent } from '../tape/types';
 import {
   buildDesignationPlan,
   validateAssignments,
@@ -123,20 +125,24 @@ async function stampSafe(
   actorId: string | null,
   evidence: Record<string, unknown>,
 ): Promise<void> {
+  const event: TapeEvent = {
+    kind,
+    payload: {
+      '@context': 'https://schema.org',
+      '@type': 'AcquisitionComplianceEvent',
+      actorId,
+      subjectId: null, // global-scope admin event
+      ruleCitation: kind === 'acq.award_recorded' ? 'IRC §42 + NV 2026 QAP §3' : 'IRC §42(g) + 26 CFR 1.42-5',
+      evidence,
+    },
+  };
   try {
-    await tape.stamp({
-      kind,
-      payload: {
-        '@context': 'https://schema.org',
-        '@type': 'AcquisitionComplianceEvent',
-        actorId,
-        subjectId: null, // global-scope admin event
-        ruleCitation: kind === 'acq.award_recorded' ? 'IRC §42 + NV 2026 QAP §3' : 'IRC §42(g) + 26 CFR 1.42-5',
-        evidence,
-      },
-    });
+    await tape.stamp(event);
   } catch (err) {
+    // Swallow so a tape outage can't lose a durable units.ami_designation write,
+    // but park the failed stamp so the compliance record is recoverable, not lost.
     logger.error('acquisitions: compliance-tape stamp failed (non-fatal)', { kind, err });
+    await parkFailedStamp(event, err as Error);
   }
 }
 

--- a/src/modules/acquisitions/recert-compliance.ts
+++ b/src/modules/acquisitions/recert-compliance.ts
@@ -16,6 +16,8 @@ import { query } from '../../config/database';
 import { logger } from '../../utils/logger';
 import { createTapeService } from '../tape/service';
 import { PgTapeRepository } from '../tape/repository';
+import { parkFailedStamp } from '../tape/dlq';
+import type { TapeEvent } from '../tape/types';
 import {
   evaluateRecertIncome,
   comparableUnit,
@@ -508,30 +510,34 @@ export class RecertComplianceService {
     actorId: string | null,
     evidence: Record<string, unknown>,
   ): Promise<void> {
-    try {
-      await tape.stamp({
-        kind,
-        payload: {
-          '@context': 'https://schema.org',
-          '@type': 'AcquisitionComplianceEvent',
-          actorId,
-          subjectId: null, // global-scope: applicant_id is FK'd to users(id); ids live in evidence
-          ruleCitation: 'IRC §42(g)(2)(D)(ii) (Next Available Unit Rule)',
-          evidence: {
-            recertId: context.recertId,
-            propertyId: context.propertyId,
-            unitId: context.unitId,
-            unitNumber: context.unitNumber,
-            ...evidence,
-          },
+    const event: TapeEvent = {
+      kind,
+      payload: {
+        '@context': 'https://schema.org',
+        '@type': 'AcquisitionComplianceEvent',
+        actorId,
+        subjectId: null, // global-scope: applicant_id is FK'd to users(id); ids live in evidence
+        ruleCitation: 'IRC §42(g)(2)(D)(ii) (Next Available Unit Rule)',
+        evidence: {
+          recertId: context.recertId,
+          propertyId: context.propertyId,
+          unitId: context.unitId,
+          unitNumber: context.unitNumber,
+          ...evidence,
         },
-      });
+      },
+    };
+    try {
+      await tape.stamp(event);
     } catch (err) {
+      // Swallow so a tape outage can't block a recert review, but park the failed
+      // stamp so the NAU compliance record is recoverable, not silently lost.
       logger.error('acquisitions: NAU tape stamp failed (non-fatal)', {
         recertId: context.recertId,
         kind,
         err,
       });
+      await parkFailedStamp(event, err as Error);
     }
   }
 
@@ -591,39 +597,43 @@ export class RecertComplianceService {
     check: RecertIncomeCheck,
     actorId: string | null,
   ): Promise<void> {
-    try {
-      await tape.stamp({
-        kind: 'acq.recert_income_checked',
-        payload: {
-          '@context': 'https://schema.org',
-          '@type': 'AcquisitionComplianceEvent',
-          actorId,
-          subjectId: null, // global-scope admin event — subjectId is FK'd to users(id); the recert id lives in evidence
-          ruleCitation: 'IRC §42(g)(2)(D)(ii) (Available Unit Rule) + 26 CFR 1.42-5',
-          evidence: {
-            recertId: context.recertId,
-            propertyId: context.propertyId,
-            unitId: context.unitId,
-            unitNumber: context.unitNumber,
-            designation: context.designation,
-            amiArea: context.amiArea,
-            householdSize: context.householdSize,
-            limitYear: context.limitYear,
-            verdict: check.verdict,
-            ceilingAmiPct: check.ceilingAmiPct,
-            applicableLimit: check.applicableLimit,
-            aurThreshold: check.aurThreshold,
-            householdIncome: check.householdIncome,
-            pctOfLimit: check.pctOfLimit,
-            note: check.note,
-          },
+    const event: TapeEvent = {
+      kind: 'acq.recert_income_checked',
+      payload: {
+        '@context': 'https://schema.org',
+        '@type': 'AcquisitionComplianceEvent',
+        actorId,
+        subjectId: null, // global-scope admin event — subjectId is FK'd to users(id); the recert id lives in evidence
+        ruleCitation: 'IRC §42(g)(2)(D)(ii) (Available Unit Rule) + 26 CFR 1.42-5',
+        evidence: {
+          recertId: context.recertId,
+          propertyId: context.propertyId,
+          unitId: context.unitId,
+          unitNumber: context.unitNumber,
+          designation: context.designation,
+          amiArea: context.amiArea,
+          householdSize: context.householdSize,
+          limitYear: context.limitYear,
+          verdict: check.verdict,
+          ceilingAmiPct: check.ceilingAmiPct,
+          applicableLimit: check.applicableLimit,
+          aurThreshold: check.aurThreshold,
+          householdIncome: check.householdIncome,
+          pctOfLimit: check.pctOfLimit,
+          note: check.note,
         },
-      });
+      },
+    };
+    try {
+      await tape.stamp(event);
     } catch (err) {
+      // Swallow so a tape outage can't block a recert review, but park the failed
+      // stamp so the income-check compliance record is recoverable, not lost.
       logger.error('acquisitions: recert income-check tape stamp failed (non-fatal)', {
         recertId: context.recertId,
         err,
       });
+      await parkFailedStamp(event, err as Error);
     }
   }
 }

--- a/src/modules/tape/dlq.ts
+++ b/src/modules/tape/dlq.ts
@@ -1,0 +1,176 @@
+/**
+ * BP-02 Compliance Tape — dead-letter queue + reconciliation.
+ *
+ * The acquisitions stamp sites (award-service.ts `stampSafe`,
+ * recert-compliance.ts `stampNau` + `stampSafe`) deliberately swallow tape
+ * failures: a tape outage must never block a durable management-side write
+ * (a units.ami_designation designation, a recert review). The cost of that
+ * deliberate swallow used to be a *silently lost compliance record* — the gap
+ * the 2026-05-23-compliance-tape.sql migration comment called out.
+ *
+ * This module closes that gap without changing the swallow contract:
+ *   - parkFailedStamp(event, err) — called from each swallow's catch. Persists
+ *     the failed TapeEvent to compliance_tape_dlq. Never throws (it is itself
+ *     wrapped in try/catch): a DLQ outage must not turn a swallowed tape failure
+ *     into a thrown one.
+ *   - replayTapeDlq(opts?)  — re-stamps unresolved rows. Replay is safe because
+ *     stamp() commits its row as the last statement before returning, so a
+ *     thrown (= parked) stamp committed nothing → re-stamping never double-writes
+ *     a row that already exists. Marks rows resolved on success, bumps
+ *     attempt_count on repeat failure.
+ *   - getTapeDlqStats() — counts for an ops view / tests.
+ *
+ * Mirrors the cra_webhook_dlq pattern (src/modules/screening/cra-webhook.ts),
+ * minus the event_id idempotency key: acq stamps carry no natural delivery id,
+ * so each failed stamp is a discrete row and the active-row cap is the runaway
+ * backstop. What's stored is exactly the payload the tape itself would have held
+ * (compliance metadata) — never raw PII.
+ */
+
+import { query } from "../../config/database";
+import { logger } from "../../utils/logger";
+import { createTapeService } from "./service";
+import { PgTapeRepository } from "./repository";
+import type { TapeEvent, TapeStampKind } from "./types";
+
+const tape = createTapeService(new PgTapeRepository());
+
+/** Stop accepting new parked rows past this many unreplayed/unexhausted entries.
+ *  A standing tape outage would otherwise grow this table unbounded. Matches the
+ *  cra_webhook_dlq cap. */
+const DLQ_ACTIVE_ROW_CAP = 10_000;
+
+/** A row past this many failed replays is left for manual triage (it stops
+ *  counting against the active cap and is skipped by replay). */
+const MAX_REPLAY_ATTEMPTS = 5;
+
+/** Count rows still eligible for replay (unresolved and under the attempt cap). */
+async function activeDlqRowCount(): Promise<number> {
+  const result = await query(
+    `SELECT COUNT(*)::int AS count
+       FROM compliance_tape_dlq
+      WHERE resolved_at IS NULL
+        AND attempt_count < $1`,
+    [MAX_REPLAY_ATTEMPTS]
+  );
+  return Number(result.rows[0]?.count ?? 0);
+}
+
+/**
+ * Park a tape stamp that a stamp site swallowed. Best-effort and silent: this
+ * runs inside an already-swallowed catch, so it must never throw.
+ */
+export async function parkFailedStamp(event: TapeEvent, err: Error): Promise<void> {
+  try {
+    const activeCount = await activeDlqRowCount();
+    if (activeCount >= DLQ_ACTIVE_ROW_CAP) {
+      logger.warn("compliance-tape DLQ at capacity — skipping new row", {
+        kind: event.kind,
+        activeCount,
+        cap: DLQ_ACTIVE_ROW_CAP,
+      });
+      return;
+    }
+    await query(
+      `INSERT INTO compliance_tape_dlq (kind, session_id, payload, error_message)
+       VALUES ($1, $2, $3::jsonb, $4)`,
+      [event.kind, event.sessionId ?? null, JSON.stringify(event.payload), err.message]
+    );
+  } catch (dlqErr) {
+    logger.error("compliance-tape DLQ insert failed", {
+      kind: event.kind,
+      error: (dlqErr as Error).message,
+    });
+  }
+}
+
+interface DlqRow {
+  id: string;
+  kind: string;
+  session_id: string | null;
+  payload: TapeEvent["payload"];
+  attempt_count: number;
+}
+
+export interface ReplayResult {
+  scanned: number;
+  replayed: number;
+  failed: number;
+}
+
+/**
+ * Re-stamp unresolved DLQ rows. Oldest-first, capped per run. On success marks
+ * the row resolved; on failure bumps attempt_count (a row that exhausts
+ * MAX_REPLAY_ATTEMPTS drops out of scope for manual triage).
+ */
+export async function replayTapeDlq(opts?: { limit?: number }): Promise<ReplayResult> {
+  const limit = opts?.limit ?? 100;
+  const { rows } = await query(
+    `SELECT id, kind, session_id, payload, attempt_count
+       FROM compliance_tape_dlq
+      WHERE resolved_at IS NULL
+        AND attempt_count < $1
+      ORDER BY first_failed_at ASC
+      LIMIT $2`,
+    [MAX_REPLAY_ATTEMPTS, limit]
+  );
+
+  let replayed = 0;
+  let failed = 0;
+  for (const row of rows as DlqRow[]) {
+    try {
+      await tape.stamp({
+        kind: row.kind as TapeStampKind,
+        payload: row.payload,
+        sessionId: row.session_id ?? undefined,
+      });
+      await query(
+        `UPDATE compliance_tape_dlq SET resolved_at = NOW() WHERE id = $1`,
+        [row.id]
+      );
+      replayed++;
+    } catch (err) {
+      failed++;
+      await query(
+        `UPDATE compliance_tape_dlq
+            SET attempt_count = attempt_count + 1,
+                last_failed_at = NOW(),
+                error_message = $2
+          WHERE id = $1`,
+        [row.id, (err as Error).message]
+      );
+      logger.warn("compliance-tape DLQ replay failed for row", {
+        id: row.id,
+        kind: row.kind,
+        attempt: row.attempt_count + 1,
+        error: (err as Error).message,
+      });
+    }
+  }
+
+  return { scanned: rows.length, replayed, failed };
+}
+
+export interface DlqStats {
+  unresolved: number;
+  resolved: number;
+  exhausted: number;
+}
+
+/** Snapshot counts for an ops view: replayable, resolved, and exhausted. */
+export async function getTapeDlqStats(): Promise<DlqStats> {
+  const { rows } = await query(
+    `SELECT
+       COUNT(*) FILTER (WHERE resolved_at IS NULL AND attempt_count < $1)::int  AS unresolved,
+       COUNT(*) FILTER (WHERE resolved_at IS NOT NULL)::int                     AS resolved,
+       COUNT(*) FILTER (WHERE resolved_at IS NULL AND attempt_count >= $1)::int AS exhausted
+     FROM compliance_tape_dlq`,
+    [MAX_REPLAY_ATTEMPTS]
+  );
+  const r = rows[0] ?? {};
+  return {
+    unresolved: Number(r.unresolved ?? 0),
+    resolved: Number(r.resolved ?? 0),
+    exhausted: Number(r.exhausted ?? 0),
+  };
+}

--- a/src/modules/tape/dlq.ts
+++ b/src/modules/tape/dlq.ts
@@ -33,7 +33,15 @@ import { createTapeService } from "./service";
 import { PgTapeRepository } from "./repository";
 import type { TapeEvent, TapeStampKind } from "./types";
 
-const tape = createTapeService(new PgTapeRepository());
+// Lazily constructed: parkFailedStamp (the always-on hot path) does a raw INSERT
+// and never needs the tape service, so importing this module — which the acq
+// stamp sites do eagerly — must not pull a TapeService into existence. Only
+// replayTapeDlq() (dark, flag-gated) re-stamps, so it builds the service on first
+// use and memoizes it.
+let tapeSingleton: ReturnType<typeof createTapeService> | undefined;
+function getTape(): ReturnType<typeof createTapeService> {
+  return (tapeSingleton ??= createTapeService(new PgTapeRepository()));
+}
 
 /** Stop accepting new parked rows past this many unreplayed/unexhausted entries.
  *  A standing tape outage would otherwise grow this table unbounded. Matches the
@@ -119,7 +127,7 @@ export async function replayTapeDlq(opts?: { limit?: number }): Promise<ReplayRe
   let failed = 0;
   for (const row of rows as DlqRow[]) {
     try {
-      await tape.stamp({
+      await getTape().stamp({
         kind: row.kind as TapeStampKind,
         payload: row.payload,
         sessionId: row.session_id ?? undefined,

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -4,7 +4,6 @@ import { LedgerService } from "./modules/ledger/service";
 import { LeaseRenewalService } from "./modules/renewal/service";
 import { createTapeService } from "./modules/tape/service";
 import { PgTapeRepository } from "./modules/tape/repository";
-import { replayTapeDlq } from "./modules/tape/dlq";
 import { AdverseActionService } from "./modules/adverse-action/service";
 import { logger } from "./utils/logger";
 
@@ -160,6 +159,7 @@ export function startScheduler() {
     // replayTapeDlq() call — recoverable, never silently lost.
     cron.schedule("*/15 * * * *", async () => {
       try {
+        const { replayTapeDlq } = await import("./modules/tape/dlq");
         const stats = await replayTapeDlq();
         if (stats.scanned > 0) {
           logger.info("BP-02 tape-DLQ replay tick", stats);

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -4,6 +4,7 @@ import { LedgerService } from "./modules/ledger/service";
 import { LeaseRenewalService } from "./modules/renewal/service";
 import { createTapeService } from "./modules/tape/service";
 import { PgTapeRepository } from "./modules/tape/repository";
+import { replayTapeDlq } from "./modules/tape/dlq";
 import { AdverseActionService } from "./modules/adverse-action/service";
 import { logger } from "./utils/logger";
 
@@ -151,6 +152,25 @@ export function startScheduler() {
       }
     });
     logger.info("BP-02 verify-cron registered (COMPLIANCE_TAPE_V2_ENABLED=true)");
+
+    // Every 15 minutes — re-stamp compliance-tape failures the acq stamp sites
+    // swallowed into compliance_tape_dlq. Dark by default (same flag as the
+    // verify-cron): parking is always-on so failures are durable, but auto-drain
+    // is opt-in. Until the flag is on, parked rows wait for this cron or a manual
+    // replayTapeDlq() call — recoverable, never silently lost.
+    cron.schedule("*/15 * * * *", async () => {
+      try {
+        const stats = await replayTapeDlq();
+        if (stats.scanned > 0) {
+          logger.info("BP-02 tape-DLQ replay tick", stats);
+        }
+      } catch (err) {
+        logger.error("BP-02 tape-DLQ replay failed", {
+          error: (err as Error).message,
+        });
+      }
+    });
+    logger.info("BP-02 tape-DLQ replay-cron registered (COMPLIANCE_TAPE_V2_ENABLED=true)");
   } else {
     logger.info(
       "BP-02 verify-cron skipped — COMPLIANCE_TAPE_V2_ENABLED is off"


### PR DESCRIPTION
## What

The acquisitions compliance-tape stamp sites (`award-service` `stampSafe`, `recert-compliance` `stampNau` + `stampSafe`) catch `tape.stamp()` failures so a tape outage can't block a staff review. That catch was a **silent swallow** — a failed stamp left no compliance record and no trace, punching a hole in the BP-02 append-only chain. (Flagged in memory as `⚠️stampSafe SILENTLY swallows tape if table absent`.)

This routes every swallowed stamp to a **dead-letter queue + dark reconciler**, mirroring the existing `cra_webhook_dlq` pattern.

## How

- **`parkFailedStamp(event, err)`** — runs inside the already-swallowed catch, inserts the failed stamp into `compliance_tape_dlq`, and **never throws** (active-row cap of 10k is the runaway backstop). Stored payload is exactly what the tape row would have held: compliance metadata only (award/recert/unit ids + categorical verdicts) — **no SSN/DOB/name**, safe to persist.
- **`replayTapeDlq()`** — re-stamps unresolved rows under an attempt cap (5), resolves on success. Idempotent: `stamp()` inserts its row as the last pre-return statement, so a throw commits nothing and replay never double-writes.
- **Dark drain** — `*/15` replay-cron gated on `COMPLIANCE_TAPE_V2_ENABLED` (same flag as the verify-cron). **Parking is always-on** so failures are durable; **auto-replay is opt-in**. Flag-off scheduler is byte-identical.
- New `compliance_tape_dlq` table lands in **both** a tracked delta (`2026-06-09-compliance-tape-dlq.sql`) and the `SCHEMA_SQL` snapshot.

## Verification

- `npx tsc --noEmit` clean (modulo the known stripe@17 worktree env noise).
- 9 new unit tests (`tape-dlq.test.ts`) — park insert/cap/never-throw, replay resolve/bump/attempt-cap, stats. Plus 55 existing acq/compliance tests still green.
- **End-to-end against real PG**: migrate (37 applied, 0 pending; idempotent on re-run) → `parkFailedStamp` → 1 unresolved DLQ row → `replayTapeDlq` re-stamped it (one real `compliance_tape` row, `applicant_id: null` global scope) → DLQ row resolved → second replay scans 0 (no double-write).

No prod action required; behavior-neutral with the flag off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)